### PR TITLE
Docs: improve doc string

### DIFF
--- a/src/DataLayouts/DataLayouts.jl
+++ b/src/DataLayouts/DataLayouts.jl
@@ -4,9 +4,9 @@
 Notation:
 - `i,j` are horizontal node indices within an element
 - `k` is the vertical node index within an element
+- `f` is the field index
 - `v` is the vertical element index in a stack
 - `h` is the element stack index
-- `f` is the field index
 
 Data layout is specified by the order in which they appear, e.g. `IJKFVH`
 indexes the underlying array as `[i,j,k,f,v,h]`


### PR DESCRIPTION
Sorry, I was reading this bit of code and my little OCD bugs me, seeing the order of the listed indices in the doc string not matching their position in the underlying array.