### PR TITLE
Implement 2D extruded domain support (1D SE, 1D FV)

### DIFF
--- a/src/DataLayouts/DataLayouts.jl
+++ b/src/DataLayouts/DataLayouts.jl
@@ -23,11 +23,13 @@ import StaticArrays: SOneTo, MArray
 #  - should some of these be subtypes of AbstractArray?
 
 import ..slab, ..column
-export slab, column, IJFH, IJF, VF
+export slab, column, IJFH, IJF, IFH, VF, VIFH
 
 include("struct.jl")
 
 abstract type AbstractData{S} end
+
+Base.size(data::AbstractData, i::Integer) = size(data)[i]
 
 """
     DataColumn{S}
@@ -71,6 +73,16 @@ Objects `data` should define `slab(data, h)` to return a `DataSlab2D{S,Nij}` obj
 """
 abstract type Data2D{S, Nij} <: AbstractData{S} end
 
+"""
+    Data1DX{S,Ni}
+
+Abstract type for data storage for 1D field, with extruded columns. The horizontal made up of `Ni` values in , of type `S`.
+
+Objects `data` should define `slab(data, v, h)` to return a `DataSlab1D{S,Nij}` object, and a `column(data, i, h)` to return a `DataColumn`.
+"""
+abstract type Data1DX{S, Nij} <: AbstractData{S} end
+
+
 
 """
     Data3D{S,Nij,Nk}
@@ -88,6 +100,10 @@ Base.similar(data::AbstractData{S}) where {S} = similar(data, S)
 function Base.copyto!(dest::D, src::D) where {D <: AbstractData}
     copyto!(parent(dest), parent(src))
     return dest
+end
+
+function nfields(data::AbstractData{S}) where {S}
+    typesize(eltype(parent(data)), S)
 end
 
 # TODO: if this gets used inside kernels, move to a generated function?
@@ -146,6 +162,11 @@ end
     IJKFVH{SS, Nij, Nk}(view(array, :, :, :, (offset + 1):(offset + len), :, :))
 end
 
+function Base.size(data::IJKFVH{S, Nij, Nk}) where {S, Nij, Nk}
+    Nv = size(parent(data), 5)
+    Nh = size(parent(data), 6)
+    return (Nij, Nij, Nk, Nv, Nh)
+end
 
 struct IJFH{S, Nij, A} <: Data2D{S, Nij}
     array::A
@@ -159,8 +180,11 @@ end
 
 rebuild(data::IJFH{S, Nij}, array) where {S, Nij} = IJFH{S, Nij}(array)
 Base.copy(data::IJFH{S, Nij}) where {S, Nij} = IJFH{S, Nij}(copy(parent(data)))
-
-
+function Base.size(data::IJFH{S, Nij}) where {S, Nij}
+    Nv = 1
+    Nh = size(parent(data), 4)
+    (Nij, Nij, 1, Nv, Nh)
+end
 """
     IJFH{S,Nij}(ArrayType, nelements)
 
@@ -174,7 +198,6 @@ function IJFH{S, Nij}(ArrayType, nelements) where {S, Nij}
 end
 
 Base.length(data::IJFH) = size(parent(data), 4)
-Base.size(data::Data2D) = (length(data),)
 
 @generated function _property_view(
     data::IJFH{S, Nij},
@@ -188,7 +211,6 @@ Base.size(data::Data2D) = (length(data),)
     return :(IJFH{$SS, $Nij}(view(parent(data), :, :, $field_byterange, :)))
 end
 
-
 @inline function Base.getproperty(data::IJFH{S, Nij}, i::Integer) where {S, Nij}
     array = parent(data)
     T = eltype(array)
@@ -198,10 +220,17 @@ end
     IJFH{SS, Nij}(view(array, :, :, (offset + 1):(offset + len), :))
 end
 
+# 1D Data Layouts
+Base.length(data::Data1D) = size(parent(data), 3)
+
 struct IFH{S, Ni, A} <: Data1D{S, Ni}
     array::A
 end
-
+function Base.size(data::IFH{S, Ni}) where {S, Ni}
+    Nv = 1
+    Nh = size(parent(data), 3)
+    (Ni, 1, 1, Nv, Nh)
+end
 function IFH{S, Ni}(array::AbstractArray{T, 3}) where {S, Ni, T}
     @assert size(array, 1) == Ni
     IFH{S, Ni, typeof(array)}(array)
@@ -217,12 +246,11 @@ function IFH{S, Ni}(ArrayType, nelements) where {S, Ni}
     IFH{S, Ni}(ArrayType(undef, Ni, typesize(FT, S), nelements))
 end
 
-Base.length(data::IFH) = size(parent(data), 3)
-
 @inline function slab(data::IFH{S, Ni}, h::Integer) where {S, Ni}
     @boundscheck (1 <= h <= length(data)) || throw(BoundsError(data, (h,)))
     IF{S, Ni}(view(parent(data), :, :, h))
 end
+@inline slab(data::IFH, v::Integer, h::Integer) = slab(data, h)
 
 @generated function _property_view(
     data::IFH{S, Ni},
@@ -235,7 +263,6 @@ end
     field_byterange = (offset + 1):(offset + nbytes)
     return :(IFH{$SS, $Ni}(view(parent(data), :, $field_byterange, :)))
 end
-
 
 @inline function Base.getproperty(data::IFH{S, Ni}, f::Integer) where {S, Ni}
     array = parent(data)
@@ -255,6 +282,11 @@ The primary use is for interpolation to a regular grid.
 """
 struct IH1JH2{S, Nij, A} <: Data2D{S, Nij}
     array::A
+end
+function Base.size(data::IH1JH2{S, Nij}) where {S, Nij}
+    Nv = 1
+    Nh = div(length(parent(data)), Nij * Nij)
+    (Nij, Nij, 1, Nv, Nh)
 end
 
 function IH1JH2{S, Nij}(array::AbstractMatrix{S}) where {S, Nij}
@@ -310,7 +342,7 @@ function IJF{S, Nij}(array::AbstractArray{T, 3}) where {S, Nij, T}
 end
 
 function Base.size(data::IJF{S, Nij}) where {S, Nij}
-    return (Nij, Nij)
+    return (Nij, Nij, 1, 1, 1)
 end
 
 @generated function _property_view(
@@ -364,6 +396,24 @@ end
     set_struct!(view(parent(ijf), i, j, :), val)
 end
 
+function Base.size(::DataSlab1D{<:Any, Ni}) where {Ni}
+    return (Ni, 1, 1, 1, 1)
+end
+
+@propagate_inbounds function Base.getindex(slab::DataSlab1D, I::CartesianIndex)
+    slab[I[1]]
+end
+
+@propagate_inbounds function Base.setindex!(
+    slab::DataSlab1D,
+    val,
+    I::CartesianIndex,
+)
+    slab[I[1]] = val
+end
+
+Base.lastindex(::DataSlab1D{S, Ni}) where {S, Ni} = Ni
+
 struct IF{S, Ni, A} <: DataSlab1D{S, Ni}
     array::A
 end
@@ -371,10 +421,6 @@ end
 function IF{S, Ni}(array::AbstractArray{T, 2}) where {S, Ni, T}
     @assert size(array, 1) == Ni
     IF{S, Ni, typeof(array)}(array)
-end
-
-function Base.size(::IF{S, Ni}) where {S, Ni}
-    return (Ni,)
 end
 
 @inline function Base.getproperty(data::IF{S, Ni}, f::Integer) where {S, Ni}
@@ -403,22 +449,39 @@ function column(ijfh::IJFH{S}, i::Integer, j::Integer, h) where {S}
     get_struct(view(parent(ijfh), i, j, :, h), S)
 end
 
-@inline function slab(ijfh::IJFH{S, Nij}, h::Integer) where {S, Nij} # k,v are unused
+@inline function slab(ijfh::IJFH{S, Nij}, h::Integer) where {S, Nij}
     @boundscheck (1 <= h <= length(ijfh)) || throw(BoundsError(ijfh, (h,)))
     IJF{S, Nij}(view(parent(ijfh), :, :, :, h))
 end
 
+@inline function slab(ijfh::IJFH{S, Nij}, v::Integer, h::Integer) where {S, Nij}
+    @boundscheck (1 <= h <= length(ijfh)) || throw(BoundsError(ijfh, (h,)))
+    IJF{S, Nij}(view(parent(ijfh), :, :, :, h))
+end
+
+
 @propagate_inbounds function Base.getindex(
     slab::DataSlab2D{S},
-    I::CartesianIndex{2},
+    I::CartesianIndex,
 ) where {S}
     slab[I[1], I[2]]
 end
 
-Base.size(::DataSlab2D{S, Nij}) where {S, Nij} = (Nij, Nij)
+@propagate_inbounds function Base.setindex!(
+    slab::DataSlab2D{S},
+    val,
+    I::CartesianIndex,
+) where {S}
+    slab[I[1], I[2]] = val
+end
+
+Base.size(::DataSlab2D{S, Nij}) where {S, Nij} = (Nij, Nij, 1, 1, 1)
 Base.axes(::DataSlab2D{S, Nij}) where {S, Nij} = (SOneTo(Nij), SOneTo(Nij))
 
 # Data column
+Base.length(data::DataColumn) = size(parent(data), 1)
+Base.size(data::DataColumn) = (1, 1, 1, length(data), 1)
+
 struct VF{S, A} <: DataColumn{S}
     array::A
 end
@@ -437,8 +500,6 @@ function VF{S}(ArrayType, nelements) where {S}
     VF{S}(ArrayType(undef, nelements, typesize(FT, S)))
 end
 
-Base.length(data::VF) = size(parent(data), 1)
-Base.size(data::VF) = (length(data),)
 Base.copy(data::VF{S}) where {S} = VF{S}(copy(parent(data)))
 Base.lastindex(data::VF) = length(data)
 
@@ -465,14 +526,84 @@ end
 end
 
 @propagate_inbounds function Base.getindex(
-    data::VF{S},
-    I::CartesianIndex{1},
+    col::DataColumn{S},
+    I::CartesianIndex{5},
 ) where {S}
-    getindex(data, I[1])
+    col[I[4]]
+end
+
+@propagate_inbounds function Base.setindex!(
+    col::DataColumn{S},
+    val,
+    I::CartesianIndex{5},
+) where {S}
+    col[I[4]] = val
 end
 
 @inline function Base.setindex!(data::VF{S}, val, v::Integer) where {S}
     set_struct!(view(parent(data), v, :), val)
+end
+
+# combined 1D spectral element + extruded 1D FV column data layout
+
+struct VIFH{S, Ni, A} <: Data1DX{S, Ni}
+    array::A
+end
+
+function VIFH{S, Ni}(array::AbstractArray{T, 4}) where {S, Ni, T}
+    @assert size(array, 2) == Ni
+    VIFH{S, Ni, typeof(array)}(array)
+end
+
+function VIFH{S}(ArrayType, nelements) where {S}
+    FT = eltype(ArrayType)
+    VIFH{S}(ArrayType(undef, nelements, typesize(FT, S)))
+end
+
+function Base.size(data::VIFH{<:Any, Ni}) where {Ni}
+    Nv = size(parent(data), 1)
+    Nh = size(parent(data), 4)
+    return (Ni, 1, 1, Nv, Nh)
+end
+
+Base.length(data::VIFH) = size(parent(data), 1) * size(parent(data), 4)
+Base.copy(data::VIFH{S, Ni}) where {S, Ni} = VIFH{S, Ni}(copy(parent(data)))
+
+@generated function _property_view(
+    data::VIFH{S, Ni},
+    idx::Val{Idx},
+) where {S, Ni, Idx}
+    SS = fieldtype(S, Idx)
+    T = basetype(SS)
+    offset = fieldtypeoffset(T, S, Idx)
+    nbytes = typesize(T, SS)
+    field_byterange = (offset + 1):(offset + nbytes)
+    return :(VIFH{$SS, Ni}(view(parent(data), :, :, $field_byterange, :)))
+end
+
+@inline function Base.getproperty(data::VIFH{S, Ni}, i::Integer) where {S, Ni}
+    array = parent(data)
+    T = eltype(array)
+    SS = fieldtype(S, i)
+    offset = fieldtypeoffset(T, S, i)
+    len = typesize(T, SS)
+    VIFH{SS, Ni}(view(array, :, :, (offset + 1):(offset + len), :))
+end
+
+function slab(data::VIFH{S, Ni}, v, h) where {S, Ni}
+    IF{S, Ni}(view(parent(data), v, :, :, h))
+end
+
+function column(data::VIFH{S}, i, h) where {S}
+    VF{S}(view(parent(data), :, i, :, h))
+end
+
+@propagate_inbounds function Base.getindex(col::VIFH, I::CartesianIndex)
+    col[I[1], I[4]]
+end
+
+@propagate_inbounds function Base.setindex!(col::VIFH, val, I::CartesianIndex)
+    col[I[1], I[4]] = val
 end
 
 # broadcast machinery

--- a/src/DataLayouts/broadcast.jl
+++ b/src/DataLayouts/broadcast.jl
@@ -1,16 +1,24 @@
 # Broadcasting of AbstractData objects
 # https://docs.julialang.org/en/v1/manual/interfaces/#Broadcast-Styles
 
-# determine the parent type underlying any SubArrays
-parent_array_type(::Type{A}) where {A <: AbstractArray} = A
-parent_array_type(::Type{S}) where {S <: SubArray{T, N, A}} where {T, N, A} =
-    parent_array_type(A)
-
 abstract type DataStyle <: Base.BroadcastStyle end
 
 abstract type DataColumnStyle <: DataStyle end
 struct VFStyle{A} <: DataColumnStyle end
 DataStyle(::Type{VF{S, A}}) where {S, A} = VFStyle{parent_array_type(A)}()
+DataColumnStyle(::Type{VFStyle{A}}) where {A} = VFStyle{A}
+
+abstract type Data1DStyle{Ni} <: DataStyle end
+struct IFHStyle{Ni, A} <: Data1DStyle{Ni} end
+DataStyle(::Type{IFH{S, Ni, A}}) where {S, Ni, A} =
+    IFHStyle{Ni, parent_array_type(A)}()
+
+abstract type DataSlab1DStyle{Ni} <: DataStyle end
+DataSlab1DStyle(::Type{IFHStyle{Ni, A}}) where {Ni, A} = IFStyle{Ni, A}
+
+struct IFStyle{Ni, A} <: DataSlab1DStyle{Ni} end
+DataStyle(::Type{IF{S, Ni, A}}) where {S, Ni, A} =
+    IFStyle{Ni, parent_array_type(A)}()
 
 abstract type DataSlab2DStyle{Nij} <: DataStyle end
 struct IJFStyle{Nij, A} <: DataSlab2DStyle{Nij} end
@@ -23,6 +31,15 @@ DataStyle(::Type{IJFH{S, Nij, A}}) where {S, Nij, A} =
     IJFHStyle{Nij, parent_array_type(A)}()
 DataSlab2DStyle(::Type{IJFHStyle{Nij, A}}) where {Nij, A} = IJFStyle{Nij, A}
 
+abstract type Data1DXStyle{Ni} <: DataStyle end
+struct VIFHStyle{Ni, A} <: Data1DXStyle{Ni} end
+DataStyle(::Type{VIFH{S, Ni, A}}) where {S, Ni, A} =
+    VIFHStyle{Ni, parent_array_type(A)}()
+Data1DXStyle(::Type{VIFHStyle{Ni, A}}) where {Ni, A} = VIFHStyle{Ni, A}
+DataColumnStyle(::Type{VIFHStyle{Ni, A}}) where {Ni, A} = VFStyle{A}
+DataSlab1DStyle(::Type{VIFHStyle{Ni, A}}) where {Ni, A} = IFStyle{Ni, A}
+
+
 abstract type Data3DStyle <: DataStyle end
 
 Base.Broadcast.BroadcastStyle(::Type{D}) where {D <: AbstractData} =
@@ -31,11 +48,30 @@ Base.Broadcast.BroadcastStyle(::Type{D}) where {D <: AbstractData} =
 # precedence rules
 # scalars are broadcast over the data object
 Base.Broadcast.BroadcastStyle(
-    a::Base.Broadcast.AbstractArrayStyle{0},
-    b::DataStyle,
-) = b
+    ::Base.Broadcast.AbstractArrayStyle{0},
+    ds::DataStyle,
+) = ds
+
+Base.Broadcast.BroadcastStyle(::VFStyle{A}, ::IFHStyle{Ni, A}) where {Ni, A} =
+    VIFHStyle{Ni, A}()
+
+Base.Broadcast.BroadcastStyle(::VFStyle{A}, ::VIFHStyle{Ni, A}) where {Ni, A} =
+    VIFHStyle{Ni, A}()
+Base.Broadcast.BroadcastStyle(
+    ::IFHStyle{Ni, A},
+    ::VIFHStyle{Ni, A},
+) where {Ni, A} = VIFHStyle{Ni, A}()
 
 Base.Broadcast.broadcastable(data::AbstractData) = data
+
+function slab(
+    bc::Base.Broadcast.Broadcasted{DS},
+    inds...,
+) where {Ni, DS <: Data1DStyle{Ni}}
+    args = map(arg -> slab(arg, inds...), bc.args)
+    axes = (SOneTo(Ni),)
+    Base.Broadcast.Broadcasted{DataSlab1DStyle(DS)}(bc.f, args, axes)
+end
 
 function slab(
     bc::Base.Broadcast.Broadcasted{DS},
@@ -46,57 +82,104 @@ function slab(
     Base.Broadcast.Broadcasted{DataSlab2DStyle(DS)}(bc.f, args, axes)
 end
 
-function Base.similar(
-    data::IJFH{<:Any, Nij, A},
-    ::Type{Eltype},
-) where {Nij, A, Eltype}
-    Nh = length(data)
-    array = similar(parent(data), (Nij, Nij, typesize(eltype(A), Eltype), Nh))
-    return IJFH{Eltype, Nij}(array)
+function slab(
+    bc::Base.Broadcast.Broadcasted{DS},
+    inds...,
+) where {Ni, DS <: Data1DXStyle{Ni}}
+    args = map(arg -> slab(arg, inds...), bc.args)
+    axes = (SOneTo(Ni),)
+    Base.Broadcast.Broadcasted{DataSlab1DStyle(DS)}(bc.f, args, axes)
 end
+
+function column(
+    bc::Base.Broadcast.Broadcasted{DS},
+    inds...,
+) where {Ni, DS <: Data1DXStyle{Ni}}
+    args = map(arg -> column(arg, inds...), bc.args)
+    axes = nothing
+    Base.Broadcast.Broadcasted{DataColumnStyle(DS)}(bc.f, args, axes)
+end
+
+function column(
+    bc::Base.Broadcast.Broadcasted{DS},
+    inds...,
+) where {DS <: DataColumnStyle}
+    bc
+end
+
+function column(bc::Union{Data1D, Base.Broadcast.Broadcasted{<:Data1D}}, i, h)
+    Ref(slab(bc, h)[i])
+end
+
 function Base.similar(
-    bc::Broadcast.Broadcasted{IJFHStyle{Nij, A}},
+    bc::Union{IJFH{<:Any, Nij, A}, Broadcast.Broadcasted{IJFHStyle{Nij, A}}},
     ::Type{Eltype},
 ) where {Nij, A, Eltype}
-    Nh = length(bc)
-    # this won't work for A <: SubArray
-    array = similar(A, (Nij, Nij, typesize(eltype(A), Eltype), Nh))
+    _, _, _, _, Nh = size(bc)
+    PA = parent_array_type(A)
+    array = similar(PA, (Nij, Nij, typesize(eltype(A), Eltype), Nh))
     return IJFH{Eltype, Nij}(array)
 end
 
+function Base.similar(
+    bc::Union{IFH{<:Any, Ni, A}, Broadcast.Broadcasted{IFHStyle{Ni, A}}},
+    ::Type{Eltype},
+) where {Ni, A, Eltype}
+    _, _, _, _, Nh = size(bc)
+    PA = parent_array_type(A)
+    array = similar(PA, (Ni, typesize(eltype(A), Eltype), Nh))
+    return IFH{Eltype, Ni}(array)
+end
 
 function Base.similar(
     ::Union{IJF{<:Any, Nij, A}, Broadcast.Broadcasted{IJFStyle{Nij, A}}},
     ::Type{Eltype},
-) where {S, Nij, A, Eltype}
+) where {Nij, A, Eltype}
     Nf = typesize(eltype(A), Eltype)
-    #array = similar(A, (Nij, Nij, typesize(eltype(A), Eltype)))
     array = MArray{Tuple{Nij, Nij, Nf}, eltype(A), 3, Nij * Nij * Nf}(undef)
     return IJF{Eltype, Nij}(array)
+end
+
+function Base.similar(
+    ::Union{IF{<:Any, Ni, A}, Broadcast.Broadcasted{IFStyle{Ni, A}}},
+    ::Type{Eltype},
+) where {S, Ni, A, Eltype}
+    Nf = typesize(eltype(A), Eltype)
+    array = MArray{Tuple{Ni, Nf}, eltype(A), 2, Ni * Nf}(undef)
+    return IF{Eltype, Ni}(array)
 end
 
 function Base.similar(
     bc::Union{VF{<:Any, A}, Broadcast.Broadcasted{VFStyle{A}}},
     ::Type{Eltype},
 ) where {A, Eltype}
-    Nh = length(bc)
-    AA = A <: SubArray ? Array{eltype(A), 2} : A
-    array = similar(AA, (Nh, typesize(eltype(A), Eltype)))
-    return VF{Eltype, AA}(array)
+    _, _, _, Nv, _ = size(bc)
+    PA = parent_array_type(A)
+    array = similar(PA, (Nv, typesize(eltype(A), Eltype)))
+    return VF{Eltype}(array)
+end
+
+function Base.similar(
+    bc::Union{VIFH{<:Any, Ni, A}, Broadcast.Broadcasted{VIFHStyle{Ni, A}}},
+    ::Type{Eltype},
+) where {Ni, A, Eltype}
+    _, _, _, Nv, Nh = size(bc)
+    PA = parent_array_type(A)
+    array = similar(PA, (Nv, Ni, typesize(eltype(A), Eltype), Nh))
+    return VIFH{Eltype, Ni}(array)
 end
 
 function Base.mapreduce(
     fn::F,
     op::Op,
-    bc::Base.Broadcast.Broadcasted{IJFHStyle{Nij, A}},
+    bc::Union{
+        IJFH{<:Any, Nij, A},
+        Base.Broadcast.Broadcasted{IJFHStyle{Nij, A}},
+    },
 ) where {F, Op, Nij, A}
-    mapreduce(op, 1:length(bc)) do h
-        mapreduce(fn, op, slab(bc, h))
-    end
-end
-
-function Base.mapreduce(fn::F, op::Op, bc::IJFH) where {F, Op}
-    mapreduce(op, 1:length(bc)) do h
+    # mapreduce across slabs
+    _, _, _, _, Nh = size(bc)
+    mapreduce(op, 1:Nh) do h
         mapreduce(fn, op, slab(bc, h))
     end
 end
@@ -104,25 +187,71 @@ end
 function Base.mapreduce(
     fn::F,
     op::Op,
-    slab_bc::IJF{S, Nij},
-) where {F, Op, S, Nij}
-    mapreduce(op, Iterators.product(1:Nij, 1:Nij)) do (i, j)
-        fn(slab_bc[i, j])
+    bc::Union{IFH{<:Any, Ni, A}, Base.Broadcast.Broadcasted{IFHStyle{Ni, A}}},
+) where {F, Op, Ni, A}
+    _, _, _, _, Nh = size(bc)
+    mapreduce(op, 1:Nh) do h
+        mapreduce(fn, op, slab(bc, h))
     end
 end
 
-function Base.mapreduce(fn::F, op::Op, column_bc::VF{S}) where {F, Op, S}
-    mapreduce(op, axes(parent(column_bc), 1)) do i
-        fn(column_bc[i])
+function Base.mapreduce(fn::F, op::Op, bc::IJF{S, Nij}) where {F, Op, S, Nij}
+    mapreduce(op, Iterators.product(1:Nij, 1:Nij)) do (i, j)
+        idx = CartesianIndex(i, j, 1, 1, 1)
+        fn(bc[idx])
+    end
+end
+
+function Base.mapreduce(fn::F, op::Op, bc::IF{S, Ni}) where {F, Op, S, Ni}
+    mapreduce(op, 1:Ni) do i
+        idx = CartesianIndex(i, 1, 1, 1, 1)
+        fn(bc[idx])
+    end
+end
+
+function Base.mapreduce(
+    fn::F,
+    op::Op,
+    bc::Union{VF{<:Any, A}, Base.Broadcast.Broadcasted{VFStyle{A}}},
+) where {F, Op, A}
+    _, _, _, Nv, _ = size(bc)
+    mapreduce(op, 1:Nv) do v
+        idx = CartesianIndex(1, 1, 1, v, 1)
+        fn(bc[idx])
+    end
+end
+
+function Base.mapreduce(
+    fn::F,
+    op::Op,
+    bc::Union{VIFH{<:Any, Ni, A}, Base.Broadcast.Broadcasted{VIFHStyle{Ni, A}}},
+) where {F, Op, Ni, A}
+    # mapreduce across columns
+    _, _, _, _, Nh = size(bc)
+    mapreduce(op, Iterators.product(1:Ni, 1:Nh)) do (i, h)
+        mapreduce(fn, op, column(bc, i, h))
     end
 end
 
 function Base.copyto!(
     dest::IJFH{S, Nij},
-    bc::Base.Broadcast.Broadcasted{IJFHStyle{Nij, A}},
+    bc::Union{IJFH{S, Nij}, Base.Broadcast.Broadcasted{IJFHStyle{Nij, A}}},
 ) where {S, Nij, A}
-    nh = length(dest)
-    for h in 1:nh
+    _, _, _, _, Nh = size(bc)
+    for h in 1:Nh
+        slab_dest = slab(dest, h)
+        slab_bc = slab(bc, h)
+        copyto!(slab_dest, slab_bc)
+    end
+    return dest
+end
+
+function Base.copyto!(
+    dest::IFH{S, Ni},
+    bc::Union{IFH{S, Ni}, Base.Broadcast.Broadcasted{IFHStyle{Ni, A}}},
+) where {S, Ni, A}
+    _, _, _, _, Nh = size(bc)
+    for h in 1:Nh
         slab_dest = slab(dest, h)
         slab_bc = slab(bc, h)
         copyto!(slab_dest, slab_bc)
@@ -132,26 +261,54 @@ end
 
 function Base.copyto!(
     dest::IJF{S, Nij},
-    bc::Base.Broadcast.Broadcasted{IJFStyle{Nij, A}},
+    bc::Union{IJF{S, Nij, A}, Base.Broadcast.Broadcasted{IJFStyle{Nij, A}}},
 ) where {S, Nij, A}
     @inbounds for j in 1:Nij, i in 1:Nij
-        dest[i, j] = convert(S, bc[i, j])
+        idx = CartesianIndex(i, j, 1, 1, 1)
+        dest[idx] = convert(S, bc[idx])
     end
     return dest
 end
 
 function Base.copyto!(
-    dest::VF{S, A},
-    bc::Base.Broadcast.Broadcasted{VFStyle{A}},
+    dest::IF{S, Ni},
+    bc::Base.Broadcast.Broadcasted{IFStyle{Ni, A}},
+) where {S, Ni, A}
+    @inbounds for i in 1:Ni
+        idx = CartesianIndex(i, 1, 1, 1, 1)
+        dest[idx] = convert(S, bc[idx])
+    end
+    return dest
+end
+
+function Base.copyto!(
+    dest::VF{S},
+    bc::Union{VF{S, A}, Base.Broadcast.Broadcasted{VFStyle{A}}},
 ) where {S, A}
-    @inbounds for i in 1:length(bc)
-        dest[i] = convert(S, bc[i])
+    _, _, _, Nv, _ = size(bc)
+    @inbounds for v in 1:Nv
+        idx = CartesianIndex(1, 1, 1, v, 1)
+        dest[idx] = convert(S, bc[idx])
+    end
+    return dest
+end
+
+function Base.copyto!(
+    dest::VIFH{S, Ni},
+    bc::Union{VIFH{S, Ni, A}, Base.Broadcast.Broadcasted{VIFHStyle{Ni, A}}},
+) where {S, Ni, A}
+    # copy contiguous columns
+    _, _, _, _, Nh = size(dest)
+    @inbounds for h in 1:Nh, i in 1:Ni
+        col_dest = column(dest, i, h)
+        col_bc = column(bc, i, h)
+        copyto!(col_dest, col_bc)
     end
     return dest
 end
 
 # broadcasting scalar assignment
-@inline function Base.Broadcast.materialize!(
+function Base.Broadcast.materialize!(
     ::DS,
     dest,
     bc::Base.Broadcast.Broadcasted{Style},

--- a/src/DataLayouts/struct.jl
+++ b/src/DataLayouts/struct.jl
@@ -37,7 +37,7 @@ Returns the parent array type underlying the `SubArray` wrapper type
 """
 parent_array_type(::Type{A}) where {A <: AbstractArray{FT}} where {FT} =
     Array{FT}
-# TODO: extend for device arrays (e.g CuArray)
+# TODO: extract interface to overload for backends into separate file
 
 """
     StructArrays.bypass_constructor(T, args)

--- a/src/DataLayouts/struct.jl
+++ b/src/DataLayouts/struct.jl
@@ -31,6 +31,15 @@ function basetype(::Type{S1}, Sx...) where {S1}
 end
 
 """
+    parent_array_type(::Type{<:AbstractArray})
+
+Returns the parent array type underlying the `SubArray` wrapper type
+"""
+parent_array_type(::Type{A}) where {A <: AbstractArray{FT}} where {FT} =
+    Array{FT}
+# TODO: extend for device arrays (e.g CuArray)
+
+"""
     StructArrays.bypass_constructor(T, args)
 
 Create an instance of type `T` from a tuple of field values `args`, bypassing

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -32,16 +32,28 @@ Field(::Type{T}, space::S) where {T, S <: AbstractSpace} =
 
 const SpectralElementField2D{V, S} =
     Field{V, S} where {V <: AbstractData, S <: Spaces.SpectralElementSpace2D}
+
 const FiniteDifferenceField{V, S} =
     Field{V, S} where {V <: AbstractData, S <: Spaces.FiniteDifferenceSpace}
-
-
 const FaceFiniteDifferenceField{V, S} =
     Field{V, S} where {V <: AbstractData, S <: Spaces.FaceFiniteDifferenceSpace}
 const CenterFiniteDifferenceField{V, S} = Field{
     V,
     S,
 } where {V <: AbstractData, S <: Spaces.CenterFiniteDifferenceSpace}
+
+const ExtrudedFiniteDifferenceField{V, S} = Field{
+    V,
+    S,
+} where {V <: AbstractData, S <: Spaces.ExtrudedFiniteDifferenceSpace}
+const FaceExtrudedFiniteDifferenceField{V, S} = Field{
+    V,
+    S,
+} where {V <: AbstractData, S <: Spaces.FaceExtrudedFiniteDifferenceSpace}
+const CenterExtrudedFiniteDifferenceField{V, S} = Field{
+    V,
+    S,
+} where {V <: AbstractData, S <: Spaces.CenterExtrudedFiniteDifferenceSpace}
 
 
 Base.propertynames(field::Field) = propertynames(getfield(field, :values))

--- a/src/Geometry/coordinates.jl
+++ b/src/Geometry/coordinates.jl
@@ -1,12 +1,45 @@
-abstract type Abstract1DPoint end
+abstract type AbstractPoint{FT} end
 
-struct Cartesian3Point{FT} <: Abstract1DPoint
-    x3::FT
+abstract type Abstract1DPoint{FT} <: AbstractPoint{FT} end
+abstract type Abstract2DPoint{FT} <: AbstractPoint{FT} end
+
+"""
+    @pointtype name fieldname1 ...
+
+Define a subtype `name` of `AbstractPoint` with appropriate conversion functions.
+"""
+macro pointtype(name, fields...)
+    if length(fields) == 1
+        supertype = :(Abstract1DPoint{FT})
+    elseif length(fields) == 2
+        supertype = :(Abstract2DPoint{FT})
+    end
+
+    esc(quote
+        struct $name{FT} <: $supertype
+            $([:($field::FT) for field in fields]...)
+        end
+        Base.eltype(::$name{FT}) where {FT} = FT
+        Base.eltype(::Type{$name{FT}}) where {FT} = FT
+        unionalltype(::$name{FT}) where {FT} = $name
+        unionalltype(::Type{$name{FT}}) where {FT} = $name
+    end)
 end
+@pointtype XPoint x
+@pointtype YPoint y
+@pointtype ZPoint z
+
+@pointtype XZPoint x z
+
+product_coordinates(xp::XPoint, zp::ZPoint) = XZPoint(xp.x, zp.z)
+product_coordinates(xp::XPoint, z::Float64) = XZPoint(xp.x, z)
+
+
+@pointtype Cartesian3Point x3
+@pointtype Cartesian2DPoint x1 x2
 
 
 
-abstract type Abstract2DPoint end
 
 components(p::Abstract2DPoint) =
     SVector(ntuple(i -> getfield(p, i), nfields(p)))
@@ -19,13 +52,6 @@ function Base.isapprox(p1::T, p2::T; kwargs...) where {T <: Abstract2DPoint}
     return isapprox(components(p1), components(p2); kwargs...)
 end
 
-struct Cartesian2DPoint{FT} <: Abstract2DPoint
-    x1::FT
-    x2::FT
-end
-
-Base.eltype(::Type{Cartesian2DPoint{FT}}) where {FT} = FT
-
 """
     interpolate(coords::NTuple{4}, ξ1, ξ2)
 
@@ -34,15 +60,29 @@ Interpolate between `coords` by parameters `ξ1, ξ2` in the interval `[-1,1]`.
 The type of interpolation is determined by the element type of `coords`:
 - `SVector`: use bilinear interpolation
 """
-function interpolate(coords::NTuple{4, V}, ξ1, ξ2) where {V <: Cartesian2DPoint}
-    Cartesian2DPoint(
-        ((1 - ξ1) * (1 - ξ2)) / 4 * coords[1].x1 +
-        ((1 + ξ1) * (1 - ξ2)) / 4 * coords[2].x1 +
-        ((1 - ξ1) * (1 + ξ2)) / 4 * coords[3].x1 +
-        ((1 + ξ1) * (1 + ξ2)) / 4 * coords[4].x1,
-        ((1 - ξ1) * (1 - ξ2)) / 4 * coords[1].x2 +
-        ((1 + ξ1) * (1 - ξ2)) / 4 * coords[2].x2 +
-        ((1 - ξ1) * (1 + ξ2)) / 4 * coords[3].x2 +
-        ((1 + ξ1) * (1 + ξ2)) / 4 * coords[4].x2,
+function interpolate(coords::NTuple{4, V}, ξ1, ξ2) where {V <: Abstract2DPoint}
+    VV = unionalltype(V)
+    VV(
+        ((1 - ξ1) * (1 - ξ2)) / 4 * getfield(coords[1], 1) +
+        ((1 + ξ1) * (1 - ξ2)) / 4 * getfield(coords[2], 1) +
+        ((1 - ξ1) * (1 + ξ2)) / 4 * getfield(coords[3], 1) +
+        ((1 + ξ1) * (1 + ξ2)) / 4 * getfield(coords[4], 1),
+        ((1 - ξ1) * (1 - ξ2)) / 4 * getfield(coords[1], 2) +
+        ((1 + ξ1) * (1 - ξ2)) / 4 * getfield(coords[2], 2) +
+        ((1 - ξ1) * (1 + ξ2)) / 4 * getfield(coords[3], 2) +
+        ((1 + ξ1) * (1 + ξ2)) / 4 * getfield(coords[4], 2),
+    )
+end
+
+"""
+    interpolate(coords::NTuple{2}, ξ1)
+Interpolate between `coords` by parameters `ξ1` in the interval `[-1,1]`.
+The type of interpolation is determined by the element type of `coords`
+"""
+function interpolate(coords::NTuple{2, V}, ξ1) where {V <: Abstract1DPoint}
+    VV = unionalltype(V)
+    VV(
+        (1 - ξ1) / 2 * getfield(coords[1], 1) +
+        (1 + ξ1) / 2 * getfield(coords[2], 1),
     )
 end

--- a/src/Meshes/Meshes.jl
+++ b/src/Meshes/Meshes.jl
@@ -77,6 +77,30 @@ function Base.show(io::IO, mesh::IntervalMesh)
     print(io, mesh.domain)
 end
 
+
+struct EquispacedLineMesh{FT, ID <: IntervalDomain{FT}, R} <: AbstractMesh{FT}
+    domain::ID
+    n1::Int64 # number of elements in x1 direction
+    n2::Int64 # always 1
+    range1::R
+    range2::R # always 1:1
+end
+
+function EquispacedLineMesh(domain::IntervalDomain, n1)
+    range1 = range(domain.x3min, domain.x3max; length = n1 + 1)
+    range2 = range(
+        one(domain.x3min),
+        one(domain.x3max) + one(domain.x3max);
+        length = 2,
+    )
+    return EquispacedLineMesh(domain, n1, one(n1), range1, range2)
+end
+
+function Base.show(io::IO, mesh::EquispacedLineMesh)
+    print(io, "(", mesh.n1, " × ", " ) EquispacedLineMesh of ")
+    print(io, mesh.domain)
+end
+
 """
     EquispacedRectangleMesh(domain::RectangleDomain, n1::Integer, n2::Integer)
 

--- a/src/Plots/plots.jl
+++ b/src/Plots/plots.jl
@@ -123,6 +123,24 @@ RecipesBase.@recipe function f(field::Fields.SpectralElementField2D)
     (r1, r2, M')
 end
 
+RecipesBase.@recipe function f(field::Fields.ExtrudedFiniteDifferenceField)
+    data = Fields.field_values(field)
+    Ni, _, _, Nv, Nh = size(data)
+    space = axes(field)
+    hcoord = vec(parent(Fields.coordinate_field(space).x)[1, :, 1, :])
+    vcoord = vec(parent(Fields.coordinate_field(space).z)[:, 1, 1, 1])
+
+    # assumes VIFH layout
+    # set the plot attributes
+    seriestype := :heatmap
+
+    xguide --> "x"
+    yguide --> "z"
+    seriescolor --> :balance
+
+    (hcoord, vcoord, reshape(parent(data), (Nv, Ni * Nh)))
+end
+
 function play(
     timesteps::Vector;
     name::Union{Nothing, Symbol} = nothing,

--- a/src/Spaces/Spaces.jl
+++ b/src/Spaces/Spaces.jl
@@ -28,9 +28,9 @@ coordinates_data(space::AbstractSpace) = local_geometry_data(space).coordinates
 include("quadrature.jl")
 import .Quadratures
 
-include("dss.jl")
 include("spectralelement.jl")
 include("finitedifference.jl")
 include("hybrid.jl")
+include("dss.jl")
 
 end # module

--- a/src/Spaces/finitedifference.jl
+++ b/src/Spaces/finitedifference.jl
@@ -88,6 +88,8 @@ end
 
 Base.length(space::FiniteDifferenceSpace) = length(coordinate_data(space))
 
+nlevels(space::FiniteDifferenceSpace) = length(space)
+
 local_geometry_data(space::CenterFiniteDifferenceSpace) =
     space.center_local_geometry
 local_geometry_data(space::FaceFiniteDifferenceSpace) =

--- a/src/Spaces/hybrid.jl
+++ b/src/Spaces/hybrid.jl
@@ -2,7 +2,83 @@
 ##### Hybrid mesh
 #####
 
-struct Hybrid3DSpace{M2D, MCOL}
-    space_horizontal::M2D
-    space_column::MCOL
+struct ExtrudedFiniteDifferenceSpace{S <: Staggering, H <: AbstractSpace, G} <:
+       AbstractSpace
+    staggering::S
+    horizontal_space::H
+    center_local_geometry::G
+    face_local_geometry::G
+end
+
+const CenterExtrudedFiniteDifferenceSpace =
+    ExtrudedFiniteDifferenceSpace{CellCenter}
+const FaceExtrudedFiniteDifferenceSpace =
+    ExtrudedFiniteDifferenceSpace{CellFace}
+
+local_geometry_data(space::CenterExtrudedFiniteDifferenceSpace) =
+    space.center_local_geometry
+local_geometry_data(space::FaceExtrudedFiniteDifferenceSpace) =
+    space.center_local_geometry
+
+function ExtrudedFiniteDifferenceSpace(
+    horizontal_space::H,
+    vertical_space::V,
+) where {H <: AbstractSpace, V <: FiniteDifferenceSpace}
+    staggering = vertical_space.staggering
+    center_local_geometry =
+        product_geometry.(
+            horizontal_space.local_geometry,
+            vertical_space.center_local_geometry,
+        )
+    face_local_geometry =
+        product_geometry.(
+            horizontal_space.local_geometry,
+            vertical_space.face_local_geometry,
+        )
+    return ExtrudedFiniteDifferenceSpace(
+        staggering,
+        horizontal_space,
+        center_local_geometry,
+        face_local_geometry,
+    )
+end
+
+quadrature_style(space::ExtrudedFiniteDifferenceSpace) =
+    space.horizontal_space.quadrature_style
+
+topology(space::ExtrudedFiniteDifferenceSpace) = space.horizontal_space.topology
+
+nlevels(space::CenterExtrudedFiniteDifferenceSpace) =
+    size(space.center_local_geometry, 4)
+nlevels(space::FaceExtrudedFiniteDifferenceSpace) =
+    size(space.face_local_geometry, 4)
+
+blockmat(a::SMatrix{1, 1, FT}, b::SMatrix{1, 1, FT}) where {FT} =
+    SMatrix{2, 2}(a[1, 1], zero(FT), zero(FT), b[1, 1])
+
+function product_geometry(
+    horizontal_local_geometry::Geometry.LocalGeometry,
+    vertical_local_geometry::Geometry.LocalGeometry,
+)
+    coordinates = Geometry.product_coordinates(
+        horizontal_local_geometry.coordinates,
+        vertical_local_geometry.coordinates,
+    )
+    J = horizontal_local_geometry.J * vertical_local_geometry.J
+    WJ = horizontal_local_geometry.WJ * vertical_local_geometry.WJ
+    ∂x∂ξ =
+        blockmat(horizontal_local_geometry.∂x∂ξ, vertical_local_geometry.∂x∂ξ)
+    ∂ξ∂x = inv(∂x∂ξ)
+    return Geometry.LocalGeometry(coordinates, J, WJ, ∂x∂ξ, ∂ξ∂x)
+end
+
+function eachslabindex(cspace::CenterExtrudedFiniteDifferenceSpace)
+    h_iter = eachslabindex(cspace.horizontal_space)
+    Nv = size(cspace.center_local_geometry, 4)
+    return Iterators.product(1:Nv, h_iter)
+end
+function eachslabindex(fspace::FaceExtrudedFiniteDifferenceSpace)
+    h_iter = eachslabindex(fspace.horizontal_space)
+    Nv = size(fspace.face_local_geometry, 4)
+    return Iterators.product(1:Nv, h_iter)
 end

--- a/src/Spaces/spectralelement.jl
+++ b/src/Spaces/spectralelement.jl
@@ -1,24 +1,93 @@
+abstract type AbstractSpectralElementSpace <: AbstractSpace end
+
+Topologies.nlocalelems(space::AbstractSpectralElementSpace) =
+    Topologies.nlocalelems(Spaces.topology(space))
+
+local_geometry_data(space::AbstractSpectralElementSpace) = space.local_geometry
+
+eachslabindex(space::AbstractSpectralElementSpace) =
+    1:Topologies.nlocalelems(Spaces.topology(space))
+
+function Base.show(io::IO, space::AbstractSpectralElementSpace)
+    typname = Base.typename(typeof(space)).name
+    println(io, "$(typname):")
+    println(io, "  topology: ", space.topology)
+    println(io, "  quadrature: ", space.quadrature_style)
+end
+
+topology(space::AbstractSpectralElementSpace) = space.topology
+quadrature_style(space::AbstractSpectralElementSpace) = space.quadrature_style
+
+"""
+    SpectralElementSpace1D <: AbstractSpace
+A one-dimensional space: within each element the space is represented as a polynomial.
+"""
+struct SpectralElementSpace1D{T, Q, G, D, M} <: AbstractSpectralElementSpace
+    topology::T
+    quadrature_style::Q
+    local_geometry::G
+    dss_weights::D
+    inverse_mass_matrix::M
+end
+
+function SpectralElementSpace1D(topology, quadrature_style)
+    FT = eltype(topology.mesh)
+    CT = Geometry.XPoint{FT} # Domains.coordinate_type(topology)
+    nelements = Topologies.nlocalelems(topology)
+    Nq = Quadratures.degrees_of_freedom(quadrature_style)
+
+    LG = Geometry.LocalGeometry{CT, FT, SMatrix{1, 1, FT, 1}}
+    local_geometry = DataLayouts.IFH{LG, Nq}(Array{FT}, nelements)
+    quad_points, quad_weights =
+        Quadratures.quadrature_points(FT, quadrature_style)
+
+    for elem in 1:nelements
+        local_geometry_slab = slab(local_geometry, elem)
+        for i in 1:Nq
+            ξ = quad_points[i]
+            # TODO: we need to reconsruct the points becuase the grid is assumed 2D
+            vcoords = Topologies.vertex_coordinates(topology, elem)
+            vcoords1D = (CT(vcoords[1].x1), CT(vcoords[2].x1))
+            x = Geometry.interpolate(vcoords1D, ξ)
+            ∂x∂ξ = (vcoords1D[2].x - vcoords1D[1].x) / 2
+            J = abs(∂x∂ξ)
+            ∂ξ∂x = inv(∂x∂ξ)
+            WJ = J * quad_weights[i]
+            local_geometry_slab[i] =
+                Geometry.LocalGeometry(x, J, WJ, ∂x∂ξ, ∂ξ∂x)
+        end
+    end
+    dss_weights = copy(local_geometry.J)
+    dss_weights .= one(FT)
+    dss_1d!(dss_weights, dss_weights, topology, Nq)
+    dss_weights = one(FT) ./ dss_weights
+
+    inverse_mass_matrix = copy(local_geometry.WJ)
+    dss_1d!(inverse_mass_matrix, inverse_mass_matrix, topology, Nq)
+    inverse_mass_matrix = one(FT) ./ inverse_mass_matrix
+
+    return SpectralElementSpace1D(
+        topology,
+        quadrature_style,
+        local_geometry,
+        dss_weights,
+        inverse_mass_matrix,
+    )
+end
+
 """
     SpectralElementSpace2D <: AbstractSpace
 
 A two-dimensional space: within each element the space is represented as a polynomial.
 """
-struct SpectralElementSpace2D{T, Q, G, D, IS, BS} <: AbstractSpace
+struct SpectralElementSpace2D{T, Q, G, D, IS, BS} <:
+       AbstractSpectralElementSpace
     topology::T
     quadrature_style::Q
     local_geometry::G
     dss_weights::D
     internal_surface_geometry::IS
     boundary_surface_geometries::BS
-end
-
-Topologies.nlocalelems(Space::SpectralElementSpace2D) =
-    Topologies.nlocalelems(Space.topology)
-
-function Base.show(io::IO, Space::SpectralElementSpace2D)
-    println(io, "SpectralElementSpace2D:")
-    println(io, "  topology: ", Space.topology)
-    println(io, "  quadrature: ", Space.quadrature_style)
 end
 
 """
@@ -57,7 +126,7 @@ function SpectralElementSpace2D(topology, quadrature_style)
                     ξ[1],
                     ξ[2],
                 )
-                SVector(x.x1, x.x2)
+                SVector(getfield(x, 1), getfield(x, 2))
             end
             J = det(∂x∂ξ)
             ∂ξ∂x = inv(∂x∂ξ)
@@ -70,7 +139,7 @@ function SpectralElementSpace2D(topology, quadrature_style)
 
     # dss_weights = J ./ dss(J)
     dss_weights = copy(local_geometry.J)
-    horizontal_dss!(dss_weights, local_geometry.J, topology, Nq)
+    dss_2d!(dss_weights, local_geometry.J, topology, Nq)
     dss_weights .= local_geometry.J ./ dss_weights
 
     SG = Geometry.SurfaceGeometry{FT, Geometry.Cartesian12Vector{FT}}
@@ -149,7 +218,7 @@ function compute_surface_geometry(
     reversed = false,
 )
     Nq = length(quad_weights)
-    @assert size(local_geometry_slab) == (Nq, Nq)
+    @assert size(local_geometry_slab) == (Nq, Nq, 1, 1, 1)
     i, j = Topologies.face_node_index(face, Nq, q, reversed)
 
     local_geometry = local_geometry_slab[i, j]
@@ -170,8 +239,6 @@ function compute_surface_geometry(
     return Geometry.SurfaceGeometry(sWJ, Geometry.Cartesian12Vector(n...))
 end
 
-local_geometry_data(space::SpectralElementSpace2D) = space.local_geometry
-
 function variational_solve!(data, space::AbstractSpace)
     data .= RecursiveApply.rdiv.(data, space.local_geometry.WJ)
 end
@@ -181,7 +248,7 @@ end
 
 A view into a `SpectralElementSpace2D` for a single slab.
 """
-struct SpectralElementSpaceSlab{Q, G} <: AbstractSpace
+struct SpectralElementSpaceSlab{Q, G} <: AbstractSpectralElementSpace
     quadrature_style::Q
     local_geometry::G
 end
@@ -192,5 +259,3 @@ function slab(space::SpectralElementSpace2D, h)
         slab(space.local_geometry, h),
     )
 end
-
-local_geometry_data(space::SpectralElementSpaceSlab) = space.local_geometry

--- a/src/Topologies/Topologies.jl
+++ b/src/Topologies/Topologies.jl
@@ -19,8 +19,8 @@ x2    |       |
 module Topologies
 
 import ..Geometry
-import ..Domains: coordinate_type
-import ..Meshes: EquispacedRectangleMesh
+import ..Domains: Domains, coordinate_type
+import ..Meshes: Meshes, EquispacedRectangleMesh
 
 # TODO: seperate types for MPI/non-MPI topologies
 """

--- a/src/Topologies/grid.jl
+++ b/src/Topologies/grid.jl
@@ -27,6 +27,14 @@ function GridTopology(mesh::EquispacedRectangleMesh)
     GridTopology(mesh, boundaries)
 end
 
+function GridTopology1D(mesh::Meshes.EquispacedLineMesh)
+    x1boundary = mesh.domain.x3boundary
+    x2boundary = nothing
+    boundaries =
+        isnothing(x1boundary) ? NamedTuple() : NamedTuple{x1boundary}((1, 2))
+    return GridTopology(mesh, boundaries)
+end
+
 function Base.show(io::IO, topology::GridTopology)
     print(io, "GridTopology on ", topology.mesh)
 end
@@ -37,6 +45,7 @@ function nlocalelems(topology::GridTopology)
     n2 = topology.mesh.n2
     return n1 * n2
 end
+eachslabindex(topology::GridTopology) = 1:nlocalelems(topology)
 
 function vertex_coordinates(topology::GridTopology, elem::Integer)
     @assert 1 <= elem <= nlocalelems(topology)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,5 +1,4 @@
 
-
 """
     slab(data::AbstractData, h::Integer)
 
@@ -8,9 +7,17 @@ data layout `data` at location `h`.
 """
 function slab end
 
-
 # TODO: this could cause problems when it fails...
 slab(x, inds...) = x
 slab(tup::Tuple, inds...) = map(x -> slab(x, inds...), tup)
 
+"""
+    column(data::AbstractData, i::Integer)
+
+A contiguous "column" view into an underlying
+data layout `data` at nodal point index `i`.
+"""
 function column end
+
+column(x, inds...) = x
+column(tup::Tuple, inds...) = map(x -> column(x, inds...), tup)

--- a/test/data1dx.jl
+++ b/test/data1dx.jl
@@ -1,0 +1,73 @@
+using Test
+using StaticArrays
+
+import ClimaCore.DataLayouts: VIFH, slab, column
+
+@testset "VIFH" begin
+    TestFloatTypes = (Float32, Float64)
+    for FT in TestFloatTypes
+        S = Tuple{Complex{FT}, FT}
+        Nv = 10 # number of vertical levels
+        Ni = 4  # number of nodal points
+        Ne = 10 # number of elements
+
+        # construct a data object with 10 cells in vertical and
+        # 10 elements in horizontal with 4 nodal points per element in horizontal
+        array = rand(FT, Nv, Ni, 3, Ne)
+
+        data = VIFH{S, Ni}(array)
+        sum(x -> x[2], data)
+
+        @test getfield(data.:1, :array) == @view(array[:, :, 1:2, :])
+        @test getfield(data.:2, :array) == @view(array[:, :, 3:3, :])
+
+        @test size(data) == (Ni, 1, 1, Nv, Ne)
+
+        # test tuple assignment on columns
+        val = (Complex{FT}(-1.0, -2.0), FT(-3.0))
+        column(data, 1, 1)[1] = val
+        @test array[1, 1, 1, 1] == -1.0
+        @test array[1, 1, 2, 1] == -2.0
+        @test array[1, 1, 3, 1] == -3.0
+
+        # test value of assing tuple on slab
+        sdata = slab(data, 1, 1)
+        @test sdata[1] == val
+
+        # sum of all the first field elements
+        @test sum(data.:1) ≈
+              Complex{FT}(sum(array[:, :, 1, :]), sum(array[:, :, 2, :]))
+        @test sum(x -> x[2], data) ≈ sum(array[:, :, 3, :])
+    end
+end
+
+@testset "broadcasting between VIFH data object + scalars" begin
+    FT = Float64
+    data1 = ones(FT, 2, 2, 2, 2)
+    S = Complex{Float64}
+    data1 = VIFH{S, 2}(data1)
+    res = data1 .+ 1
+    @test res isa VIFH{S}
+    @test parent(res) ==
+          FT[f == 1 ? 2 : 1 for i in 1:2, j in 1:2, f in 1:2, h in 1:2]
+    @test sum(res) == Complex(16.0, 8.0)
+    @test sum(Base.Broadcast.broadcasted(+, data1, 1)) == Complex(16.0, 8.0)
+end
+
+@testset "broadcasting between VF + IFH data object => VIFH" begin
+    FT = Float64
+    S = Complex{FT}
+    data_vf = VF{S}(ones(FT, 3, 2))
+    data_ifh = IFH{FT, 2}(ones(FT, 2, 1, 2))
+    data_vifh = data_vf .+ data_ifh
+    @test data_vifh isa VIFH{S}
+    @test size(data_vifh) == (2, 1, 1, 3, 2)
+    @test parent(data_vifh) ==
+          FT[f == 1 ? 2 : 1 for v in 1:3, i in 1:2, f in 1:2, h in 1:2]
+
+    @test parent(data_vifh .+ data_vf) ==
+          FT[f == 1 ? 3 : 2 for v in 1:3, i in 1:2, f in 1:2, h in 1:2]
+    @test parent(data_vifh .+ data_ifh) ==
+          FT[f == 1 ? 3 : 1 for v in 1:3, i in 1:2, f in 1:2, h in 1:2]
+
+end

--- a/test/diffusion2d.jl
+++ b/test/diffusion2d.jl
@@ -56,5 +56,7 @@ using OrdinaryDiffEq
     # Reconstruct the result Field at the last timestep
     y1 = sol(1.0)
 
-    @test y1 ≈ f.(Fields.coordinate_field(space), 1.0) rtol = 1e-6
+    @show y1 .- f.(Fields.coordinate_field(space), 1.0)
+
+    @test y1 ≈ f.(Fields.coordinate_field(space), 1.0) rtol = 5e-5
 end

--- a/test/hybrid.jl
+++ b/test/hybrid.jl
@@ -1,0 +1,105 @@
+using Test
+using StaticArrays, IntervalSets, LinearAlgebra
+
+import ClimaCore:
+    ClimaCore,
+    slab,
+    Spaces,
+    Domains,
+    Meshes,
+    Topologies,
+    Spaces,
+    Fields,
+    Operators
+import ClimaCore.Domains.Geometry: Cartesian2DPoint
+
+@testset "1D SE, 1D FV Extruded Domain ∇ ODE Solve" begin
+    FT = Float64
+    vertdomain =
+        Domains.IntervalDomain(FT(0), FT(2π); x3boundary = (:bottom, :top))
+    vertmesh = Meshes.IntervalMesh(
+        vertdomain,
+        Meshes.ExponentialStretching(π / 2),
+        nelems = 20,
+    )
+    vert_center_space = Spaces.CenterFiniteDifferenceSpace(vertmesh)
+
+    horzdomain = Domains.RectangleDomain(
+        -π..π,
+        -0..0,
+        x1periodic = true,
+        x2boundary = (:a, :b),
+    )
+    horzmesh = Meshes.EquispacedRectangleMesh(horzdomain, 20, 1)
+    horztopology = Topologies.GridTopology(horzmesh)
+
+    quad = Spaces.Quadratures.GLL{4}()
+    horzspace = Spaces.SpectralElementSpace1D(horztopology, quad)
+
+    hvspace = Spaces.ExtrudedFiniteDifferenceSpace(horzspace, vert_center_space)
+
+    function slab_gradient!(∇data, data, space)
+        # all derivatives calculated in the reference local geometry FT precision
+        FT = ClimaCore.Spaces.undertype(space)
+        D = ClimaCore.Spaces.Quadratures.differentiation_matrix(
+            FT,
+            Spaces.quadrature_style(space),
+        )
+        Nq = ClimaCore.Spaces.Quadratures.degrees_of_freedom(
+            Spaces.quadrature_style(space),
+        )
+        # for each element in the element stack
+        ∂f∂ξ₁ = zeros(StaticArrays.MVector{Nq, FT})
+        Nv = Spaces.nlevels(space)
+        for h in 1:Topologies.nlocalelems(space.horizontal_space)
+            for v in 1:Nv
+                data_slab = ClimaCore.slab(data, v, h)
+                ∇data_slab = ClimaCore.slab(∇data, v, h)
+                ∂f∂ξ₁ .= zero(FT)
+                local_geometry_slab =
+                    slab(Spaces.local_geometry_data(space), v, h)
+                @inbounds for i in 1:Nq
+                    # compute covariant derivatives
+                    ∂ξ∂x = local_geometry_slab[i].∂ξ∂x
+                    ∂f∂ξ₁ .+= ∂ξ∂x[1, 1] * D[:, i] * data_slab[i]
+                end
+                # convert to desired basis
+                @inbounds for i in 1:Nq
+                    ∇data_slab[i] = ∂f∂ξ₁[i]
+                end
+            end
+        end
+        return ∇data
+    end
+
+    # Advection Equation
+    # ∂_t f + c ∂_x f  = 0
+    # the solution translates to the right at speed c,
+    # so if you you have a periodic domain of size [-π, π]
+    # at time t, the solution is f(x - c * t, y)
+    # here c == 1, integrate t == 2π or one full period
+
+    function rhs!(dudt, u, _, t)
+        space = axes(u)
+        slab_gradient!(Fields.field_values(dudt), Fields.field_values(u), space)
+        ClimaCore.Spaces.weighted_dss!(dudt)
+    end
+
+
+    U = sin.(Fields.coordinate_field(hvspace).x)
+    dudt = zeros(eltype(U), hvspace)
+    rhs!(dudt, U, nothing, 0.0)
+
+    using OrdinaryDiffEq
+    Δt = 0.01
+    prob = ODEProblem(rhs!, U, (0.0, 2π))
+    sol = solve(
+        prob,
+        SSPRK33(),
+        dt = Δt,
+        #progress = true,
+        #saveat = 100 * Δt,
+    )
+
+    @test norm(U .- sol.u[end]) ≤ 5e-5
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Base: operator_associativity
 include("recursive.jl")
 include("data1d.jl")
 include("data.jl")
+include("data1dx.jl")
 include("grid.jl")
 include("quadrature.jl")
 include("spaces.jl")
@@ -10,7 +11,8 @@ include("field.jl")
 include("spectraloperators.jl")
 include("fdspaces.jl")
 include("fielddiffeq.jl")
-#include("diffusion.jl")
+include("hybrid.jl")
+#include("diffusion2d.jl")
 
 if "CUDA" in ARGS
     include("gpu/cuda.jl")


### PR DESCRIPTION
* Refactor datalayout to support product domains (mixed SE and FV)
* Implement face, center extruded spaces in 2D
* Add simple advection test case for hybird (extruded) space

Co-authored-by: Simon Byrne <simonbyrne@gmail.com>
Co-authored-by: Jake Bolewski <jakebolewski@gmail.com>