### PR TITLE
Add FieldVector wrapper

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/examples/column/Project.toml
+++ b/examples/column/Project.toml
@@ -1,4 +1,6 @@
 [deps]
+ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"

--- a/src/DataLayouts/DataLayouts.jl
+++ b/src/DataLayouts/DataLayouts.jl
@@ -499,6 +499,11 @@ function VF{S}(ArrayType, nelements) where {S}
     FT = eltype(ArrayType)
     VF{S}(ArrayType(undef, nelements, typesize(FT, S)))
 end
+function replace_basetype(data::VF{S}, ::Type{FT}) where {S, FT}
+    SS = replace_basetype(S, FT)
+    VF{SS}(similar(parent(data), FT))
+end
+
 
 Base.copy(data::VF{S}) where {S} = VF{S}(copy(parent(data)))
 Base.lastindex(data::VF) = length(data)

--- a/src/DataLayouts/struct.jl
+++ b/src/DataLayouts/struct.jl
@@ -30,6 +30,19 @@ function basetype(::Type{S1}, Sx...) where {S1}
     return FT1
 end
 
+replace_basetype(::Type{S}, ::Type{FT}) where {S <: AbstractFloat, FT} = FT
+function replace_basetype(::Type{S}, ::Type{FT}) where {S <: Tuple, FT}
+    Tuple{ntuple(i -> replace_basetype(fieldtype(S, i), FT), fieldcount(S))...}
+end
+function replace_basetype(
+    ::Type{NamedTuple{names, T}},
+    ::Type{FT},
+) where {names, T, FT}
+    NamedTuple{names, replace_basetype(T, FT)}
+end
+
+
+
 """
     parent_array_type(::Type{<:AbstractArray})
 

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -122,7 +122,7 @@ end
 
 Base.similar(field::Field, ::Type{Eltype}) where {Eltype} =
     Field(Eltype, axes(field))
-Base.similar(field::Field) = similar(field, eltype(field))
+Base.similar(field::Field) = Field(similar(field_values(field)), axes(field))
 
 
 # fields on different spaces
@@ -192,6 +192,7 @@ local_geometry_field(field::Field) = local_geometry(axes(field))
 include("broadcast.jl")
 include("mapreduce.jl")
 include("compat_diffeq.jl")
+include("fieldvector.jl")
 
 function interpcoord(elemrange, x::Real)
     n = length(elemrange) - 1

--- a/src/Fields/broadcast.jl
+++ b/src/Fields/broadcast.jl
@@ -185,3 +185,23 @@ function Base.Broadcast.broadcasted(
     # wrap in a Field so that the axes line up correctly (it just get's unwraped so effectively a no-op)
     Base.Broadcast.broadcasted(fs, V, arg, local_geometry_field(space))
 end
+
+function Base.Broadcast.copyto!(
+    field::Field,
+    bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}},
+)
+    copyto!(Fields.field_values(field), bc)
+    return field
+end
+function Base.Broadcast.copyto!(field::Field, nt::NamedTuple)
+    copyto!(
+        field,
+        Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}}(
+            identity,
+            (nt,),
+            axes(field),
+        ),
+    )
+end
+
+Base.fill!(field::Fields.Field, val) = field .= val

--- a/src/Fields/compat_diffeq.jl
+++ b/src/Fields/compat_diffeq.jl
@@ -14,6 +14,9 @@ Base.muladd(x, field::Field) = muladd.(x, field)
 
 Base.similar(field::F, ::Type{F}) where {F <: Field} = similar(field)
 
+Base.vec(field::Field) = vec(parent(field))
+
+
 RecursiveArrayTools.recursive_unitless_eltype(field::Field) = typeof(field)
 
 RecursiveArrayTools.recursive_unitless_bottom_eltype(field::Field) =
@@ -65,6 +68,12 @@ function DiffEqBase.calculate_residuals!(
         t,
     )
 end
+
+@inline function calculate_residuals!(out, ũ, u₀, u₁, α, ρ, internalnorm, t)
+    @. out = calculate_residuals(ũ, u₀, u₁, α, ρ, internalnorm, t)
+    nothing
+end
+
 
 # Play nice with DiffEq ArrayPartition
 DiffEqBase.UNITLESS_ABS2(field::Field) =

--- a/src/Fields/fieldvector.jl
+++ b/src/Fields/fieldvector.jl
@@ -1,0 +1,83 @@
+import BlockArrays
+
+struct FieldVector{T, M} <: BlockArrays.AbstractBlockVector{T}
+    values::M
+end
+FieldVector{T}(values::M) where {T, M} = FieldVector{T, M}(values)
+
+_values(fv::FieldVector) = getfield(fv, :values)
+_parent_values(fv::FieldVector) = map(parent, _values(fv))
+
+BlockArrays.blockaxes(fv::FieldVector) =
+    (BlockArrays.BlockRange(1:length(_values(fv))),)
+Base.axes(fv::FieldVector) =
+    (BlockArrays.blockedrange(map(length ∘ parent, Tuple(_values(fv)))),)
+
+Base.getindex(fv::FieldVector, block::BlockArrays.Block{1}) =
+    parent(_values(fv)[block.n...])
+Base.getindex(fv::FieldVector, bidx::BlockArrays.BlockIndex{1}) =
+    fv[BlockArrays.block(bidx)][bidx.α...]
+Base.getindex(fv::FieldVector, i::Integer) =
+    getindex(fv, BlockArrays.findblockindex(axes(fv, 1), i))
+
+function Base.setindex!(fv::FieldVector, val, bidx::BlockArrays.BlockIndex{1})
+    X = fv[BlockArrays.block(bidx)]
+    X[bidx.α...] = val
+end
+Base.setindex!(fv::FieldVector, val, i::Integer) =
+    setindex!(fv, val, BlockArrays.findblockindex(axes(fv, 1), i))
+
+
+function FieldVector(; kwargs...)
+    values = NamedTuple(kwargs)
+    T = promote_type(
+        map(RecursiveArrayTools.recursive_bottom_eltype, values)...,
+    )
+    return FieldVector{T}(values)
+end
+
+@inline function Base.getproperty(fv::FieldVector, name::Symbol)
+    getfield(_values(fv), name)
+end
+
+Base.similar(fv::FieldVector{T}) where {T} =
+    FieldVector{T}(map(similar, _values(fv)))
+Base.similar(fv::FieldVector{T}, ::Type{T}) where {T} =
+    FieldVector{T}(map(similar, _values(fv)))
+function Base.similar(fv::FieldVector{T}, ::Type{FT}) where {T, FT}
+    FieldVector{FT}(
+        map(_values(fv)) do x
+            Field(DataLayouts.replace_basetype(field_values(x), FT), axes(x))
+        end,
+    )
+end
+
+Base.copy(fv::FieldVector{T}) where {T} = FieldVector{T}(map(copy, _values(fv)))
+Base.zero(fv::FieldVector{T}) where {T} = FieldVector{T}(map(zero, _values(fv)))
+
+
+
+
+Base.mapreduce(f, op, fv::FieldVector) =
+    mapreduce(x -> mapreduce(f, op, x), op, _parent_values(fv))
+
+Base.any(f, fv::FieldVector) = any(x -> any(f, x), _parent_values(fv))
+Base.any(f::Function, fv::FieldVector) = # avoid ambiguities
+    any(x -> any(f, x), _parent_values(fv))
+Base.any(fv::FieldVector) = any(identity, A)
+
+Base.all(f, fv::FieldVector) = all(x -> all(f, x), _parent_values(fv))
+Base.all(f::Function, fv::FieldVector) = all(x -> all(f, x), _parent_values(fv))
+Base.all(fv::FieldVector) = all(identity, fv)
+
+# TODO: figure out a better way to handle these
+# https://github.com/JuliaArrays/BlockArrays.jl/issues/185
+function LinearAlgebra.ldiv!(
+    x::FieldVector,
+    A::LinearAlgebra.QRCompactWY,
+    b::FieldVector,
+)
+    v = Vector(b)
+    LinearAlgebra.ldiv!(A, v)
+    x .= v
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/test/fielddiffeq.jl
+++ b/test/fielddiffeq.jl
@@ -5,6 +5,7 @@ import ClimaCore: Domains, Topologies, Meshes, Fields, Spaces
 using LinearAlgebra, IntervalSets
 
 
+
 domain = Domains.RectangleDomain(
     -2π..2π,
     -2π..2π,
@@ -38,3 +39,38 @@ prob = ODEProblem(dfdt!, y0, (0.0, 1.0))
 sol = solve(prob, Tsit5(), reltol = 1e-6)
 
 @test norm(sol(1.0) .- y1) <= 1e-6 * norm(y1)
+
+
+# implicit solvers
+# require use of FieldVector
+
+
+
+domain = Domains.IntervalDomain(0.0, Float64(pi); x3boundary = (:left, :right))
+
+mesh = Meshes.IntervalMesh(domain; nelems = 16)
+
+center_space = Spaces.CenterFiniteDifferenceSpace(mesh)
+
+# y(z, t) = z*exp(α*t)
+# dydt(z, t) = α*y(t)
+y = Fields.FieldVector(z = Fields.coordinate_field(center_space))
+
+function f!(dydt, y, α, t)
+    dydt.z .= α .* y.z
+end
+
+function f_jac!(J, y, α, t)
+    copyto!(J, α * LinearAlgebra.I)
+end
+
+
+prob = ODEProblem(ODEFunction(f!), copy(y), (0.0, 1.0), 0.1)
+sol = solve(prob, SSPRK22(), dt = 0.01)
+
+
+sol = solve(prob, ImplicitEuler(), reltol = 1e-6)
+y1 = similar(y)
+y1 .= y .* exp(0.1)
+
+@test norm(sol[end] .- y1) <= 1e-4 * norm(y1)


### PR DESCRIPTION
This wraps multiple fields as an OrdinaryDiffEq-compatible vector, replacing PartitionArray. Is compatible with implicit solvers.

Fixes #87.