### PR TITLE
Fix an error in the hydrostatic ekman column example

### DIFF
--- a/examples/column/hydrostatic_ekman.jl
+++ b/examples/column/hydrostatic_ekman.jl
@@ -120,7 +120,7 @@ function tendency!(dY, Y, _, t)
         top = Operators.SetValue(Geometry.Cartesian3Vector(zero(FT))),
     )
     # TODO!: Undesirable casting to vector required
-    @. dρθ = -∂c(w * If(ρθ) + Geometry.CartesianVector(ν * ∂f(ρθ / ρ)))
+    @. dρθ = -∂c(w * If(ρθ)) + ρ * ∂c(Geometry.CartesianVector(ν * ∂f(ρθ / ρ)))
 
     uv_1 = Operators.getidx(uv, Operators.Interior(), 1)
     u_wind = LinearAlgebra.norm(uv_1)


### PR DESCRIPTION
This PR fixes a bug in the rho_theta equation in hydrostatic_ekman.jl. The bug doesn't seem to affect the result.