### PR TITLE
Fix sgeom⁺ in SpectralElementSpace2D

### DIFF
--- a/src/Spaces/spectralelement.jl
+++ b/src/Spaces/spectralelement.jl
@@ -211,7 +211,7 @@ function SpectralElementSpace2D(topology, quadrature_style)
                 false,
             )
             sgeom⁺ = compute_surface_geometry(
-                local_geometry_slab⁻,
+                local_geometry_slab⁺,
                 quad_weights,
                 face⁺,
                 q,


### PR DESCRIPTION
This was spotted while I was testing spectral operators with an irregular, warped mesh. 