### PR TITLE
Add a more compact show method for DataLayouts

### DIFF
--- a/src/DataLayouts/DataLayouts.jl
+++ b/src/DataLayouts/DataLayouts.jl
@@ -30,6 +30,24 @@ abstract type AbstractData{S} end
 
 Base.size(data::AbstractData, i::Integer) = size(data)[i]
 
+function Base.show(io::IO, data::AbstractData)
+    indent_width = 2
+    (rows, cols) = displaysize(io)
+    println(io, summary(data))
+    print(io, " "^indent_width)
+    print(
+        IOContext(
+            io,
+            :compact => true,
+            :limit => true,
+            :displaysize => (rows, cols - indent_width),
+        ),
+        vec(parent(data)),
+    )
+    return io
+end
+
+
 """
     DataColumn{S}
 


### PR DESCRIPTION
Roughly matches the style of compact field printing.