### PR TITLE
Skip annotations check

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -6,3 +6,6 @@ coverage:
         target: auto
         # this allows a 10% drop from the previous base commit coverage
         threshold: 10%
+
+github_checks:
+    annotations: false


### PR DESCRIPTION
This seemed to do the trick over at TurbulenceConvection.jl. On this repo, I still see annotations on every PR. [Ref](https://docs.codecov.com/docs/github-checks#disabling-github-checks-patch-annotations-via-yaml)