### PR TITLE
change theta to phi for latitude

### DIFF
--- a/src/Spaces/spectralelement.jl
+++ b/src/Spaces/spectralelement.jl
@@ -345,11 +345,11 @@ function SpectralElementSpace2D(
                 # at the pole: choose u to line with x1, v to line with x2
                 ∂u∂ξ = ∂x∂ξ[SOneTo(2), :]
             else
-                θ = xl.lat
+                ϕ = xl.lat
                 λ = xl.long
                 F = @SMatrix [
                     -sind(λ) cosd(λ) 0
-                    0 0 1/cosd(θ)
+                    0 0 1/cosd(ϕ)
                 ]
                 ∂u∂ξ = F * ∂x∂ξ
             end

--- a/test/sphere.jl
+++ b/test/sphere.jl
@@ -14,14 +14,14 @@ function rotational_field(space, axis::Geometry.LatLongPoint)
     map(coords) do coord
         n_coord = Geometry.components(Geometry.Cartesian123Point(coord))
         u_cart = n_axis × n_coord
-        θ = coord.lat
+        ϕ = coord.lat
         λ = coord.long
         F = @SMatrix [
             -sind(λ) cosd(λ) 0
-            0 0 1/cosd(θ)
+            0 0 1/cosd(ϕ)
         ]
         uv = F * u_cart
-        if abs(θ) ≈ 90
+        if abs(ϕ) ≈ 90
             Geometry.UVVector(u_cart[1], u_cart[2])
         else
 


### PR DESCRIPTION
This PR changes the notation for latitude from θ to ϕ. I think I've changed all the occurrences (not many). @simonbyrne Could you check? 

Edit: Valeria looked at it.