### PR TITLE
Solid body rotation on a sphere: Gaussian blob 

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -268,12 +268,45 @@ steps:
       queue: central
       slurm_ntasks: 1
 
-  - label: ":computer: Solid body 2D CG sphere"
-    key: "cpu_solidbody_2d_cg_sphere"
+  - label: ":computer: Solid body CG sphere cosine bell alpha0"
+    key: "cpu_solidbody_cg_sphere_cosine_bell_alpha0"
     command:
       - "julia --color=yes --project=examples/sphere examples/sphere/solidbody.jl"
     artifact_paths:
-      - "examples/sphere/output/cg_sphere_solidbody/*"
+      - "examples/sphere/output/cg_sphere_solidbody_cosine_bell_alpha0/*"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
+  - label: ":computer: Solid body CG sphere cosine bell alpha45"
+    key: "cpu_solidbody_cg_sphere_cosine_bell_alpha45"
+    command:
+      - "julia --color=yes --project=examples/sphere examples/sphere/solidbody.jl"
+    artifact_paths:
+      - "examples/sphere/output/cg_sphere_solidbody_cosine_bell_alpha45/*"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
+  - label: ":computer: Solid body CG sphere gaussian bell alpha0"
+    key: "cpu_solidbody_cg_sphere_gaussian_bell_alpha0"
+    command:
+      - "julia --color=yes --project=examples/sphere examples/sphere/solidbody.jl"
+    artifact_paths:
+      - "examples/sphere/output/cg_sphere_solidbody_gaussian_bell_alpha0/*"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
+  - label: ":computer: Solid body CG sphere gaussian bell alpha45"
+    key: "cpu_solidbody_cg_sphere_gaussian_bell_alpha45"
+    command:
+      - "julia --color=yes --project=examples/sphere examples/sphere/solidbody.jl"
+    artifact_paths:
+      - "examples/sphere/output/cg_sphere_solidbody_gaussian_bell_alpha45/*"
     agents:
       config: cpu
       queue: central

--- a/examples/sphere/solidbody.jl
+++ b/examples/sphere/solidbody.jl
@@ -12,78 +12,113 @@ using Logging: global_logger
 using TerminalLoggers: TerminalLogger
 global_logger(TerminalLogger())
 
+"""
+    convergence_rate(err, Δh)
+
+Estimate convergence rate given vectors `err` and `Δh`
+
+    err = C Δh^p+ H.O.T
+    err_k ≈ C Δh_k^p
+    err_k/err_m ≈ Δh_k^p/Δh_m^p
+    log(err_k/err_m) ≈ log((Δh_k/Δh_m)^p)
+    log(err_k/err_m) ≈ p*log(Δh_k/Δh_m)
+    log(err_k/err_m)/log(Δh_k/Δh_m) ≈ p
+
+"""
+convergence_rate(err, Δh) =
+    [log(err[i] / err[i - 1]) / log(Δh[i] / Δh[i - 1]) for i in 2:length(Δh)]
+
+# Advection problem on a sphere. The initial condition can be set via a command line
+# argument. Possible test cases are: cosine_bell (default) and gaussian_bell
+
 const R = 6.37122e6
 const h0 = 1000.0
 const r0 = R / 3
 const α0 = 0.0
 const u0 = 2 * pi * R / (86400 * 12)
 const center = Geometry.LatLongPoint(0.0, 270.0)
+const test_name = get(ARGS, 1, "cosine_bell") # default test case to run
+const cosine_test_name = "cosine_bell"
+const gaussian_test_name = "gaussian_bell"
 
-ne = 4
+
+FT = Float64
+ne_seq = 2 .^ (2, 3, 4, 5)
+err, Δh = zeros(FT, length(ne_seq)), zeros(FT, length(ne_seq))
 Nq = 4
 
-domain = Domains.SphereDomain(R)
-mesh = Meshes.Mesh2D(domain, Meshes.EquiangularSphereWarp(), ne)
-grid_topology = Topologies.Grid2DTopology(mesh)
-quad = Spaces.Quadratures.GLL{Nq}()
-space = Spaces.SpectralElementSpace2D(grid_topology, quad)
+# h-refinement study
+for (k, ne) in enumerate(ne_seq)
+    domain = Domains.SphereDomain(R)
+    mesh = Meshes.Mesh2D(domain, Meshes.EquiangularSphereWarp(), ne)
+    grid_topology = Topologies.Grid2DTopology(mesh)
+    quad = Spaces.Quadratures.GLL{Nq}()
+    space = Spaces.SpectralElementSpace2D(grid_topology, quad)
 
-coords = Fields.coordinate_field(space)
+    coords = Fields.coordinate_field(space)
 
-h_init = map(coords) do coord
-    n_coord = Geometry.components(Geometry.Cartesian123Point(coord))
-    n_center = Geometry.components(Geometry.Cartesian123Point(center))
-    # https://en.wikipedia.org/wiki/Great-circle_distance
-    rd = R * atan(norm(n_coord × n_center), dot(n_coord, n_center))
+    Δh[k] = 2 * R / ne
 
-    cosine_bell_test = false
-    if cosine_bell_test
-        if rd < r0
-            h0 / 2 * (1 + cospi(rd / r0))
-        else
-            0.0
+    h_init = map(coords) do coord
+        n_coord = Geometry.components(Geometry.Cartesian123Point(coord))
+        n_center = Geometry.components(Geometry.Cartesian123Point(center))
+        # https://en.wikipedia.org/wiki/Great-circle_distance
+        rd = R * atan(norm(n_coord × n_center), dot(n_coord, n_center))
+
+        if test_name == gaussian_test_name
+            h0 * exp(-(rd / r0)^2 / 2)
+        else # default test case, cosine bell
+            if rd < r0
+                h0 / 2 * (1 + cospi(rd / r0))
+            else
+                0.0
+            end
         end
-    else
-        h0 * exp(-(rd / r0)^2 / 2)
+
     end
 
+    u = map(coords) do coord
+        ϕ = coord.lat
+        λ = coord.long
+
+        uu = u0 * (cosd(α0) * cosd(ϕ) + sind(α0) * cosd(λ) * sind(ϕ))
+        uv = -u0 * sind(α0) * sind(λ)
+        Geometry.UVVector(uu, uv)
+    end
+
+    function rhs!(dh, h, u, t)
+        div = Operators.Divergence()
+
+        # add in pieces
+        @. dh = -div(h * u)
+        Spaces.weighted_dss!(dh)
+    end
+    rhs!(similar(h_init), h_init, u, 0.0)
+
+    # Solve the ODE operator
+    T = 86400 * 12
+    dt = 30 * 60
+    prob = ODEProblem(rhs!, h_init, (0.0, T), u)
+    sol = solve(
+        prob,
+        SSPRK33(),
+        dt = dt,
+        saveat = dt,
+        progress = true,
+        adaptive = false,
+        progress_message = (dt, u, p, t) -> t,
+    )
+    err[k] = norm(sol.u[end] .- h_init) / length(h_init)
+
+    @info "Test case: $(test_name)"
+    @info "Number of elements per cube panel: $(ne) x $(ne)"
+    @info "Solution norm at t = 0: ", norm(h_init)
+    @info "Solution norm at t = $(T): ", norm(sol.u[end])
+    @info "L2 error at t = $(T): ", norm(sol.u[end] .- h_init)
+
 end
 
-u = map(coords) do coord
-    ϕ = coord.lat
-    λ = coord.long
-
-    u = u0 * (cosd(α0) * cosd(ϕ) + sind(α0) * cosd(λ) * sind(ϕ))
-    v = -u0 * sind(α0) * sind(λ)
-    Geometry.UVVector(u, v)
-end
-
-function rhs!(dh, h, u, t)
-    div = Operators.Divergence()
-
-    # add in pieces
-    @. dh = -div(h * u)
-    Spaces.weighted_dss!(dh)
-end
-rhs!(similar(h_init), h_init, u, 0.0)
-
-# Solve the ODE operator
-T = 86400 * 12
-dt = 30 * 60
-prob = ODEProblem(rhs!, h_init, (0.0, T), u)
-sol = solve(
-    prob,
-    SSPRK33(),
-    dt = dt,
-    saveat = dt,
-    progress = true,
-    adaptive = false,
-    progress_message = (dt, u, p, t) -> t,
-)
-
-@info "Solution norm at t = 0: ", norm(h_init)
-@info "Solution norm at t = $(T): ", norm(sol.u[end])
-@info "L2 error at t = $(T): ", norm(sol.u[end] .- h_init)
+conv = convergence_rate(err, Δh)
 
 ENV["GKSwstype"] = "nul"
 import Plots

--- a/examples/sphere/solidbody.jl
+++ b/examples/sphere/solidbody.jl
@@ -165,7 +165,11 @@ Plots.png(
     ),
     joinpath(path, "L1error.png"),
 )
-linkfig(relpath(joinpath(path, "L1error.png"), "../.."), "L₁ error Vs Nₑ")
+linkfig(
+    relpath(joinpath(path, "L1error.png"), joinpath(@__DIR__, "../..")),
+    "L₁ error Vs Nₑ",
+)
+
 
 # L₂ error Vs number of elements
 Plots.png(
@@ -179,7 +183,10 @@ Plots.png(
     ),
     joinpath(path, "L2error.png"),
 )
-linkfig(relpath(joinpath(path, "L2error.png"), "../.."), "L₂ error Vs Nₑ")
+linkfig(
+    relpath(joinpath(path, "L2error.png"), joinpath(@__DIR__, "../..")),
+    "L₂ error Vs Nₑ",
+)
 
 # L∞ error Vs number of elements
 Plots.png(
@@ -193,4 +200,7 @@ Plots.png(
     ),
     joinpath(path, "Linferror.png"),
 )
-linkfig(relpath(joinpath(path, "Linferror.png"), "../.."), "L∞ error Vs Nₑ")
+linkfig(
+    relpath(joinpath(path, "Linferror.png"), joinpath(@__DIR__, "../..")),
+    "L∞ error Vs Nₑ",
+)

--- a/examples/sphere/solidbody.jl
+++ b/examples/sphere/solidbody.jl
@@ -69,7 +69,9 @@ end
 FT = Float64
 ne_seq = 2 .^ (2, 3, 4, 5)
 Δh = zeros(FT, length(ne_seq))
-L1err, L2err, Linferr = zeros(FT, length(ne_seq)), zeros(FT, length(ne_seq)), zeros(FT, length(ne_seq))
+L1err, L2err, Linferr = zeros(FT, length(ne_seq)),
+zeros(FT, length(ne_seq)),
+zeros(FT, length(ne_seq))
 Nq = 4
 
 # h-refinement study
@@ -147,11 +149,41 @@ for (k, ne) in enumerate(ne_seq)
 end
 
 # Plot the errors
-Plots.png(Plots.plot(1:length(ne_seq), L1err, xscale = :log, yscale = :log, xlabel = "Nₑ", ylabel = "L₁ err"), joinpath(path, "L1error.png"))
+Plots.png(
+    Plots.plot(
+        1:length(ne_seq),
+        L1err,
+        xscale = :log,
+        yscale = :log,
+        xlabel = "Nₑ",
+        ylabel = "L₁ err",
+    ),
+    joinpath(path, "L1error.png"),
+)
 linkfig("output/$(dirname)/L1error.png", "L₁ error Vs Nₑ")
-Plots.png(Plots.plot(1:length(ne_seq), L2err, xscale = :log, yscale = :log, xlabel = "Nₑ", ylabel = "L₂ err"), joinpath(path, "L2error.png"))
+Plots.png(
+    Plots.plot(
+        1:length(ne_seq),
+        L2err,
+        xscale = :log,
+        yscale = :log,
+        xlabel = "Nₑ",
+        ylabel = "L₂ err",
+    ),
+    joinpath(path, "L2error.png"),
+)
 linkfig("output/$(dirname)/L2error.png", "L₂ error Vs Nₑ")
-Plots.png(Plots.plot(1:length(ne_seq), Linferr, xscale = :log, yscale = :log, xlabel = "Nₑ", ylabel = "L∞ err"), joinpath(path, "Linferror.png"))
+Plots.png(
+    Plots.plot(
+        1:length(ne_seq),
+        Linferr,
+        xscale = :log,
+        yscale = :log,
+        xlabel = "Nₑ",
+        ylabel = "L∞ err",
+    ),
+    joinpath(path, "Linferror.png"),
+)
 linkfig("output/$(dirname)/Linferror.png", "L∞ error Vs Nₑ")
 
 conv = convergence_rate(L2err, Δh)

--- a/examples/sphere/solidbody.jl
+++ b/examples/sphere/solidbody.jl
@@ -67,7 +67,7 @@ function linkfig(figpath, alt = "")
 end
 
 FT = Float64
-ne_seq = 2 .^ (2, 3, 4, 5)
+ne_seq = (5, 9, 17, 33)
 Δh = zeros(FT, length(ne_seq))
 L1err, L2err, Linferr = zeros(FT, length(ne_seq)),
 zeros(FT, length(ne_seq)),

--- a/examples/sphere/solidbody.jl
+++ b/examples/sphere/solidbody.jl
@@ -148,43 +148,49 @@ for (k, ne) in enumerate(ne_seq)
     @info "L∞ error at t = $(T): ", Linferr[k]
 end
 
+# Print convergence rate info
+conv = convergence_rate(L2err, Δh)
+@info "Converge rates for this test case are: ", conv
+
 # Plot the errors
+# L₁ error Vs number of elements
 Plots.png(
     Plots.plot(
-        1:length(ne_seq),
+        collect(ne_seq),
         L1err,
-        xscale = :log,
-        yscale = :log,
+        yscale = :log10,
         xlabel = "Nₑ",
-        ylabel = "L₁ err",
+        ylabel = "log₁₀(L₁ err)",
+        label = "",
     ),
     joinpath(path, "L1error.png"),
 )
-linkfig("output/$(dirname)/L1error.png", "L₁ error Vs Nₑ")
+linkfig(relpath(joinpath(path, "L1error.png"), "../.."), "L₁ error Vs Nₑ")
+
+# L₂ error Vs number of elements
 Plots.png(
     Plots.plot(
-        1:length(ne_seq),
+        collect(ne_seq),
         L2err,
-        xscale = :log,
-        yscale = :log,
+        yscale = :log10,
         xlabel = "Nₑ",
-        ylabel = "L₂ err",
+        ylabel = "log₁₀(L₂ err)",
+        label = "",
     ),
     joinpath(path, "L2error.png"),
 )
-linkfig("output/$(dirname)/L2error.png", "L₂ error Vs Nₑ")
+linkfig(relpath(joinpath(path, "L2error.png"), "../.."), "L₂ error Vs Nₑ")
+
+# L∞ error Vs number of elements
 Plots.png(
     Plots.plot(
-        1:length(ne_seq),
+        collect(ne_seq),
         Linferr,
-        xscale = :log,
-        yscale = :log,
+        yscale = :log10,
         xlabel = "Nₑ",
-        ylabel = "L∞ err",
+        ylabel = "log₁₀(L∞ err)",
+        label = "",
     ),
     joinpath(path, "Linferror.png"),
 )
-linkfig("output/$(dirname)/Linferror.png", "L∞ error Vs Nₑ")
-
-conv = convergence_rate(L2err, Δh)
-@info "Converge rates for this test case are: ", conv
+linkfig(relpath(joinpath(path, "Linferror.png"), "../.."), "L∞ error Vs Nₑ")

--- a/examples/sphere/solidbody.jl
+++ b/examples/sphere/solidbody.jl
@@ -67,7 +67,7 @@ function linkfig(figpath, alt = "")
 end
 
 FT = Float64
-ne_seq = (5, 9, 17, 33)
+ne_seq = 2 .^ (2, 3, 4, 5)
 Δh = zeros(FT, length(ne_seq))
 L1err, L2err, Linferr = zeros(FT, length(ne_seq)),
 zeros(FT, length(ne_seq)),


### PR DESCRIPTION
This PR adds another IC to the solid body example on the sphere. It also adds the possibility to specify the IC (or test case to run) via CL. The default one is still the cosine bell, i.e., the only existing case before. 

Since hyperdiffusion was not used in the solid body test case (advection equation only), it was decided that we remove the hyperdiffusion part in the operator. 

I also added a convergence study under mesh refinement. 