### PR TITLE
Shallow-water Test Case: Barotropic Instability

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -345,6 +345,28 @@ steps:
       queue: central
       slurm_ntasks: 1
 
+  - label: ":computer: Shallow water 2D CG sphere barotropic instability alpha0"
+    key: "cpu_shallowwater_2d_cg_sphere_barotropic_alpha0"
+    command:
+      - "julia --color=yes --project=examples/sphere examples/sphere/shallow_water.jl barotropic_instability"
+    artifact_paths:
+      - "examples/sphere/output/cg_sphere_shallowwater_barotropic_instability_alpha0/*"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
+  - label: ":computer: Shallow water 2D CG sphere barotropic instability alpha30"
+    key: "cpu_shallowwater_2d_cg_sphere_barotropic_alpha30"
+    command:
+      - "julia --color=yes --project=examples/sphere examples/sphere/shallow_water.jl barotropic_instability alpha30"
+    artifact_paths:
+      - "examples/sphere/output/cg_sphere_shallowwater_barotropic_instability_alpha30/*"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
   - label: ":computer: Non-uniform shallow water 2D CG sphere alpha0"
     key: "cpu_nonuniform_shallowwater_2d_cg_sphere"
     command:


### PR DESCRIPTION
This PR concludes the suite of recommended shallow-water test cases. 
This adds the Barotropic Instability test case (see refs: Galewsky et al, "An initial-value problem for testing numerical models of the global shallow-water equations", 2004 (also in Sec. 7.6 of Ullirch et al, "High-order ﬁnite-volume methods for the shallow-water equations on  the sphere", 2010). 
This is an unsteady test case, so no error checking and plotting in this case, but artifacts for the final height field for both  α = 0 and α = 30 degrees are produced.