### PR TITLE
unit tests and convergence tests for vector diffusion and hyperdiffusion

### DIFF
--- a/test/sphere_diffusion_vec.jl
+++ b/test/sphere_diffusion_vec.jl
@@ -1,0 +1,104 @@
+using Test
+using StaticArrays, IntervalSets
+import ClimaCore.DataLayouts: IJFH
+import ClimaCore:
+    Fields, Domains, Meshes, Topologies, Spaces, Operators, Geometry
+using StaticArrays, IntervalSets, LinearAlgebra
+
+include("sphere_sphericalharmonics.jl")
+
+# diffusion on vector: input covariant vecotor
+function ∇²(u)
+    scurl = Operators.Curl()
+    sdiv = Operators.Divergence()
+    wcurl = Operators.WeakCurl()
+    wgrad = Operators.WeakGradient()
+
+    χ = Spaces.weighted_dss!(
+        @. wgrad(sdiv(u)) - Geometry.Covariant12Vector(
+            wcurl(Geometry.Covariant3Vector(scurl(u))),
+        )
+    )
+    return χ
+end
+
+@testset "diffusion on vectors" begin
+    FT = Float64
+
+    l = Int(7)
+    m = Int(4)
+
+    Ne = 7
+    Nq = 6
+
+    radius = FT(1)
+    domain = Domains.SphereDomain(radius)
+    mesh = Meshes.Mesh2D(domain, Meshes.EquiangularSphereWarp(), Ne)
+    grid_topology = Topologies.Grid2DTopology(mesh)
+
+    quad = Spaces.Quadratures.GLL{Nq}()
+    space = Spaces.SpectralElementSpace2D(grid_topology, quad)
+    coords = Fields.coordinate_field(space)
+
+    # compute vector spherical harmonics (VSH) as the gradient of scalar spherical harmonics 
+    # eigenfunction properties of VSH: ∇² VSH(l,m) = -l(l+1) VSH(l,m) 
+    VSH_local = map(coords) do coord
+        Geometry.UVVector(VSH(l, m, coord.lat, coord.long)...)
+    end
+    VSH_cov = Geometry.transform.(Ref(Geometry.Covariant12Axis()), VSH_local)
+
+    # diffusion
+    ∇²VSH_cov = ∇²(VSH_cov)
+    ∇²VSH_local = Geometry.transform.(Ref(Geometry.UVAxis()), ∇²VSH_cov)
+
+    # exact solution
+    ∇²VSH_exact = @. -l * (l + 1) * VSH_local
+
+    @test ∇²VSH_local ≈ ∇²VSH_exact rtol = 2e-2
+end
+
+convergence_rate(err, Δh) =
+    [log(err[i] / err[i - 1]) / log(Δh[i] / Δh[i - 1]) for i in 2:length(Δh)]
+
+@testset "convergence tests for vector diffusions on the sphere" begin
+    FT = Float64
+
+    Nes = [4, 8, 16]
+    Nqs = [3, 4, 5, 6]
+
+    l = Int(7)
+    m = Int(4)
+
+    radius = FT(1)
+    domain = Domains.SphereDomain(radius)
+    for (Iq, Nq) in enumerate(Nqs)
+        err_diffusion = Array{FT}(undef, length(Nes))
+        Δh = Array{FT}(undef, length(Nes))
+
+        for (Ie, Ne) in enumerate(Nes)
+            mesh = Meshes.Mesh2D(domain, Meshes.EquiangularSphereWarp(), Ne)
+            grid_topology = Topologies.Grid2DTopology(mesh)
+
+            quad = Spaces.Quadratures.GLL{Nq}()
+            space = Spaces.SpectralElementSpace2D(grid_topology, quad)
+            coords = Fields.coordinate_field(space)
+
+            VSH_local = map(coords) do coord
+                Geometry.UVVector(VSH(l, m, coord.lat, coord.long)...)
+            end
+            VSH_cov =
+                Geometry.transform.(Ref(Geometry.Covariant12Axis()), VSH_local)
+            ∇²VSH_cov = ∇²(VSH_cov)
+            ∇²VSH_local = Geometry.transform.(Ref(Geometry.UVAxis()), ∇²VSH_cov)
+            ∇²VSH_exact = @. -l * (l + 1) * VSH_local
+
+            err_diffusion[Ie] = norm(∇²VSH_local .- ∇²VSH_exact)
+            Δh[Ie] = 1 / Ne
+        end
+
+        convergence_rate_∇² = convergence_rate(err_diffusion, Δh)
+        for Ie in range(1, length = length(Nes) - 1)
+            @test convergence_rate_∇²[Ie] > (Nq - 2)
+        end
+    end
+end

--- a/test/sphere_hyperdiffusion_vec.jl
+++ b/test/sphere_hyperdiffusion_vec.jl
@@ -1,0 +1,110 @@
+using Test
+using StaticArrays, IntervalSets
+import ClimaCore.DataLayouts: IJFH
+import ClimaCore:
+    Fields, Domains, Meshes, Topologies, Spaces, Operators, Geometry
+using StaticArrays, IntervalSets, LinearAlgebra
+
+include("sphere_sphericalharmonics.jl")
+
+function ∇⁴(u)
+    scurl = Operators.Curl()
+    sdiv = Operators.Divergence()
+    wcurl = Operators.WeakCurl()
+    wgrad = Operators.WeakGradient()
+
+    χ = Spaces.weighted_dss!(
+        @. wgrad(sdiv(u)) - Geometry.Covariant12Vector(
+            wcurl(Geometry.Covariant3Vector(scurl(u))),
+        )
+    )
+
+    ∇⁴ = Spaces.weighted_dss!(
+        @. wgrad(sdiv(χ)) - Geometry.Covariant12Vector(
+            wcurl(Geometry.Covariant3Vector(scurl(χ))),
+        )
+    )
+
+    return ∇⁴
+end
+
+@testset "hyperdiffusion on vectors" begin
+    FT = Float64
+
+    l = Int(7)
+    m = Int(4)
+
+    Ne = 6
+    Nq = 7
+
+    radius = FT(1)
+    domain = Domains.SphereDomain(radius)
+    mesh = Meshes.Mesh2D(domain, Meshes.EquiangularSphereWarp(), Ne)
+    grid_topology = Topologies.Grid2DTopology(mesh)
+
+    quad = Spaces.Quadratures.GLL{Nq}()
+    space = Spaces.SpectralElementSpace2D(grid_topology, quad)
+    coords = Fields.coordinate_field(space)
+
+    # compute vector spherical harmonics (VSH) as the gradient of scalar spherical harmonics 
+    # eigenfunction properties of VSH: ∇⁴ VSH(l,m) = l²(l+1)² VSH(l,m)
+    VSH_local = map(coords) do coord
+        Geometry.UVVector(VSH(l, m, coord.lat, coord.long)...)
+    end
+    VSH_cov = Geometry.transform.(Ref(Geometry.Covariant12Axis()), VSH_local)
+
+    # hyperdiffusion operator
+    ∇⁴VSH_cov = ∇⁴(VSH_cov)
+    ∇⁴VSH_local = Geometry.transform.(Ref(Geometry.UVAxis()), ∇⁴VSH_cov)
+
+    # exact solution
+    ∇⁴VSH_exact = @. l^2 * (l + 1)^2 * VSH_local
+
+    @test ∇⁴VSH_local ≈ ∇⁴VSH_exact rtol = 2e-2
+end
+
+convergence_rate(err, Δh) =
+    [log(err[i] / err[i - 1]) / log(Δh[i] / Δh[i - 1]) for i in 2:length(Δh)]
+
+@testset "convergence tests for vector hyperdiffusions on the sphere" begin
+    FT = Float64
+
+    Nes = [4, 8, 16]
+    Nqs = [4, 5, 6, 7, 8, 9, 10]
+
+    l = Int(7)
+    m = Int(4)
+
+    radius = FT(1)
+    domain = Domains.SphereDomain(radius)
+    for (Iq, Nq) in enumerate(Nqs)
+        err_∇⁴ = Array{FT}(undef, length(Nes))
+        Δh = Array{FT}(undef, length(Nes))
+
+        for (Ie, Ne) in enumerate(Nes)
+            mesh = Meshes.Mesh2D(domain, Meshes.EquiangularSphereWarp(), Ne)
+            grid_topology = Topologies.Grid2DTopology(mesh)
+
+            quad = Spaces.Quadratures.GLL{Nq}()
+            space = Spaces.SpectralElementSpace2D(grid_topology, quad)
+            coords = Fields.coordinate_field(space)
+
+            VSH_local = map(coords) do coord
+                Geometry.UVVector(VSH(l, m, coord.lat, coord.long)...)
+            end
+            VSH_cov =
+                Geometry.transform.(Ref(Geometry.Covariant12Axis()), VSH_local)
+            ∇⁴VSH_cov = ∇⁴(VSH_cov)
+            ∇⁴VSH_local = Geometry.transform.(Ref(Geometry.UVAxis()), ∇⁴VSH_cov)
+            ∇⁴VSH_exact = @. l^2 * (l + 1)^2 * VSH_local
+
+            err_∇⁴[Ie] = norm(∇⁴VSH_local .- ∇⁴VSH_exact)
+            Δh[Ie] = 1 / Ne
+        end
+
+        convergence_rate_∇⁴ = convergence_rate(err_∇⁴, Δh)
+        for Ie in range(1, length = length(Nes) - 1)
+            @test convergence_rate_∇⁴[Ie] > (Nq - 4)
+        end
+    end
+end

--- a/test/sphere_sphericalharmonics.jl
+++ b/test/sphere_sphericalharmonics.jl
@@ -1,0 +1,59 @@
+# using Legendre
+# # input lat and long in degrees
+
+# function Ylm(l,m,lat,long) 
+# 	return real(
+# 		λlm(l,m,sind(lat)) * exp(im * m * deg2rad(long)),
+# 	)
+# end
+
+using SphericalHarmonics
+# input lat and long in degrees
+
+function Ylm(l, m, lat, long)
+    return real(computeYlm(deg2rad(90 - lat), deg2rad(long), lmax = l)[(l, m)])
+end
+
+function Plm(l, m, x)
+    return computePlmx(x, lmax = l)[(l, m)] *
+           sqrt(2 * π * factorial(l + m) / (2 * l + 1) / factorial(l - m))
+end
+
+# V and W for vector spherical harmonics
+function Vlm(l, m, lat)
+    return 0.5 * (
+        Plm(l, m + 1, sind(lat)) -
+        (l + m) * (l - m + 1) * Plm(l, m - 1, sind(lat))
+    ) / sqrt(l * (l + 1))
+end
+
+function Wlm(l, m, lat)
+    return 0.5 * (
+        Plm(l - 1, m + 1, sind(lat)) +
+        (l + m) * (l + m - 1) * Plm(l - 1, m - 1, sind(lat))
+    ) / sqrt(l * (l + 1))
+end
+
+function Blm(l, m, lat, long)
+    C = 1 / sqrt(2 * pi)
+    E = exp((im * m) * deg2rad(long))
+    W = Wlm(l, m, lat)
+    V = Vlm(l, m, lat)
+    return (real(C * im * W * E), real(C * V * E))
+end
+
+function Clm(l, m, lat, long)
+    C = 1 / sqrt(2 * pi)
+    E = exp((im * m) * deg2rad(long))
+    W = Wlm(l, m, lat)
+    V = Vlm(l, m, lat)
+    return (real(-C * V * E), real(C * im * W * E))
+end
+
+function VSH(l, m, lat, long)
+    C = 1 / sqrt(2 * pi)
+    E = exp((im * m) * deg2rad(long))
+    W = Wlm(l, m, lat)
+    V = Vlm(l, m, lat)
+    return (real(C * (im * W - V) * E), real(C * (V + im * W) * E))
+end


### PR DESCRIPTION
This PR adds 
- the legendre and vsh (vector spherical harmonics) functions, used for construct eigenfunctions on the sphere;
- unit tests and convergence tests for the vector diffusion and hyperdiffusion.

Close #220 