### PR TITLE
fix visual artifact in interpolated slice plots with topo

### DIFF
--- a/src/Operators/spectralelement.jl
+++ b/src/Operators/spectralelement.jl
@@ -1223,7 +1223,7 @@ end
 
 function matrix_interpolate(
     field::Fields.ExtrudedFiniteDifferenceField,
-    Q_interp::Quadratures.Uniform{Nu},
+    Q_interp::Union{Quadratures.Uniform{Nu}, Quadratures.ClosedUniform{Nu}},
 ) where {Nu}
     S = eltype(field)
     space = axes(field)

--- a/src/Plots/plots.jl
+++ b/src/Plots/plots.jl
@@ -336,11 +336,13 @@ RecipesBase.@recipe function f(
 
     if hinterpolate ≥ 1
         Nu = hinterpolate
-        M_hcoord = Operators.matrix_interpolate(hcoord_field, Nu)
-        M_data = Operators.matrix_interpolate(field, Nu)
+        uquad = Spaces.Quadratures.ClosedUniform{Nu}()
+        M_hcoord = Operators.matrix_interpolate(hcoord_field, uquad)
+        M_vcoord = Operators.matrix_interpolate(vcoord_field, uquad)
+        M_data = Operators.matrix_interpolate(field, uquad)
 
         hcoord_data = vec(M_hcoord)
-        vcoord_data = vec(parent(vcoord_field))
+        vcoord_data = vec(M_vcoord)
         data = vec(M_data)
         triangles = triangulate(Nu, Nv, Nh)
     else
@@ -349,8 +351,8 @@ RecipesBase.@recipe function f(
         data = vec(parent(data))
         triangles = triangulate(Ni, Nv, Nh)
     end
-
     cmap = range(extrema(data)..., length = ncolors)
+
     z = TriplotBase.tripcolor(
         hcoord_data,
         vcoord_data,


### PR DESCRIPTION
FIxes visual banding artifacts for triangulation when there are not shared vertex points under interpolation.

![interp_error](https://user-images.githubusercontent.com/1157798/145154840-92626114-4578-41d0-90df-4a43b7a4a5fa.png)

![fixed_interp](https://user-images.githubusercontent.com/1157798/145154833-f1e3111f-617a-4233-b890-ac0348684d31.png


