### PR TITLE
ClimaCoreVTK writevtk for NamedTuples of time series fields

### DIFF
--- a/lib/ClimaCoreVTK/src/ClimaCoreVTK.jl
+++ b/lib/ClimaCoreVTK/src/ClimaCoreVTK.jl
@@ -100,7 +100,7 @@ end
         basename::String,
         times,
         fields,
-        [ispace=vtk_space(fields)];
+        [ispace=vtk_space(first(fields))];
         vtkargs...
     )
 
@@ -123,6 +123,41 @@ function writevtk(
                 ispace;
                 vtkargs...,
             )
+        end
+    end
+end
+
+"""
+    writevtk(
+        basename::String,
+        times,
+        fields,
+        [ispace=vtk_space(first(first(fields)));
+        vtkargs...
+    )
+
+Write a sequence of NamedTuple fields `fields` at times `times` as a Paraview collection.
+"""
+function writevtk(
+    basename::String,
+    times,
+    fields::NamedTuple,
+    ispace = vtk_space(first(first(fields)));
+    vtkargs...,
+)
+    npad = ndigits(length(times); pad = 3)
+
+    for (key, val) in pairs(fields)
+        paraview_collection(basename) do pvd
+            for (n, time) in enumerate(times)
+                field = NamedTuple{(key,)}([val[n]])
+                pvd[time] = vtk_file(
+                    basename * "_" * string(n, pad = npad),
+                    field,
+                    ispace;
+                    vtkargs...,
+                )
+            end
         end
     end
 end

--- a/lib/ClimaCoreVTK/src/ClimaCoreVTK.jl
+++ b/lib/ClimaCoreVTK/src/ClimaCoreVTK.jl
@@ -147,10 +147,9 @@ function writevtk(
 )
     npad = ndigits(length(times); pad = 3)
 
-    for (key, val) in pairs(fields)
         paraview_collection(basename) do pvd
             for (n, time) in enumerate(times)
-                field = NamedTuple{(key,)}([val[n]])
+                field = NamedTuple(key => val[n] for (key, val) in pairs(fields))
                 pvd[time] = vtk_file(
                     basename * "_" * string(n, pad = npad),
                     field,
@@ -159,7 +158,6 @@ function writevtk(
                 )
             end
         end
-    end
 end
 
 

--- a/lib/ClimaCoreVTK/src/ClimaCoreVTK.jl
+++ b/lib/ClimaCoreVTK/src/ClimaCoreVTK.jl
@@ -147,17 +147,17 @@ function writevtk(
 )
     npad = ndigits(length(times); pad = 3)
 
-        paraview_collection(basename) do pvd
-            for (n, time) in enumerate(times)
-                field = NamedTuple(key => val[n] for (key, val) in pairs(fields))
-                pvd[time] = vtk_file(
-                    basename * "_" * string(n, pad = npad),
-                    field,
-                    ispace;
-                    vtkargs...,
-                )
-            end
+    paraview_collection(basename) do pvd
+        for (n, time) in enumerate(times)
+            field = NamedTuple(key => val[n] for (key, val) in pairs(fields))
+            pvd[time] = vtk_file(
+                basename * "_" * string(n, pad = npad),
+                field,
+                ispace;
+                vtkargs...,
+            )
         end
+    end
 end
 
 

--- a/lib/ClimaCoreVTK/test/runtests.jl
+++ b/lib/ClimaCoreVTK/test/runtests.jl
@@ -1,7 +1,8 @@
 using Test
 using ClimaCoreVTK
 using IntervalSets
-import ClimaCore: Geometry, Domains, Meshes, Topologies, Spaces, Fields
+import ClimaCore:
+    Geometry, Domains, Meshes, Topologies, Spaces, Fields, Operators
 
 
 dir = mktempdir()
@@ -36,7 +37,23 @@ dir = mktempdir()
             (sind(coord.long) * sind(α) + cosd(coord.long) * cosd(α))
         end for α in times
     ]
-    writevtk(joinpath(dir, "sphere_series"), times, (A = A,))
+    writevtk(joinpath(dir, "sphere_scalar_series"), times, (A = A, B = A))
+
+    U = Array{Fields.Field}(undef, length(times))
+    for t in 1:(div(350, 10) + 1)
+        u = map(coords) do coord
+            u0 = 20.0
+            α0 = 45.0
+            ϕ = coord.lat
+            λ = coord.long
+
+            uu = u0 * (cosd(α0) * cosd(ϕ) + sind(α0) * cosd(λ) * sind(ϕ))
+            uv = -u0 * sind(α0) * sind(λ)
+            Geometry.UVVector(uu, uv)
+        end
+        U[t] = u
+    end
+    writevtk(joinpath(dir, "sphere_vector_series"), times, (U = U,))
 
 end
 

--- a/lib/ClimaCoreVTK/test/runtests.jl
+++ b/lib/ClimaCoreVTK/test/runtests.jl
@@ -36,7 +36,7 @@ dir = mktempdir()
             (sind(coord.long) * sind(α) + cosd(coord.long) * cosd(α))
         end for α in times
     ]
-    writevtk(joinpath(dir, "sphere_series"), times, A)
+    writevtk(joinpath(dir, "sphere_series"), times, (A = A,))
 
 end
 


### PR DESCRIPTION
Currently we support named tuples for the single-snapshot version of the `writevtk` function. But not for the time series one.
I tried to fix this by overwriting the `writevtk` function so that we can output named tuples of field arrays in time series collections. But my attempt is not working at the moment and needs some more work. Any feedback would be appreciated, thanks.