### PR TITLE
fix coordinates.jl for the 3d sphere mesh

### DIFF
--- a/src/Geometry/coordinates.jl
+++ b/src/Geometry/coordinates.jl
@@ -67,12 +67,16 @@ Cartesian123Point(pt::Cartesian13Point{FT}) where {FT} =
     Cartesian123Point(pt.x1, zero(FT), pt.x3)
 
 @pointtype LatLongPoint lat long
+@pointtype LatLongZPoint lat long z
 
 product_coordinates(xp::XPoint, yp::YPoint) = XYPoint(promote(xp.x, yp.y)...)
 product_coordinates(xp::XPoint, zp::ZPoint) = XZPoint(promote(xp.x, zp.z)...)
 
 product_coordinates(xyp::XYPoint, zp::ZPoint) =
     XYZPoint(promote(xyp.x, xyp.y, zp.z)...)
+
+product_coordinates(latlongp::LatLongPoint, zp::ZPoint) =
+    LatLongZPoint(promote(latlongp.lat, latlongp.long, zp.z)...)
 
 component(p::AbstractPoint{FT}, i::Symbol) where {FT} = getfield(p, i)::FT
 component(p::AbstractPoint{FT}, i::Integer) where {FT} = getfield(p, i)::FT

--- a/test/sphere_metric_terms.jl
+++ b/test/sphere_metric_terms.jl
@@ -1,5 +1,5 @@
 using LinearAlgebra, IntervalSets, UnPack
-import ClimaCore: Domains, Topologies, Meshes, Spaces
+import ClimaCore: Domains, Topologies, Meshes, Spaces, Geometry
 import ClimaCore.Meshes: EquiangularSphereWarp, Mesh2D
 
 using Test
@@ -9,7 +9,6 @@ using Test
     radius = FT(3)
     ne = 4
     Nq = 4
-    Nqh = 7
     domain = Domains.SphereDomain(radius)
     mesh = Mesh2D(domain, EquiangularSphereWarp(), ne)
     grid_topology = Topologies.Grid2DTopology(mesh)
@@ -17,4 +16,34 @@ using Test
     space = Spaces.SpectralElementSpace2D(grid_topology, quad)
 
     @test sum(ones(space)) ≈ 4pi * radius^2 rtol = 1e-3
+end
+
+@testset "Volume of a sphere" begin
+    FT = Float64
+    radius = FT(128)
+    zlim = (0, 1)
+    helem = 4
+    zelem = 10
+    Nq = 4
+
+    vertdomain = Domains.IntervalDomain(
+        Geometry.ZPoint{FT}(zlim[1]),
+        Geometry.ZPoint{FT}(zlim[2]);
+        boundary_tags = (:bottom, :top),
+    )
+    vertmesh = Meshes.IntervalMesh(vertdomain, nelems = zelem)
+    vert_center_space = Spaces.CenterFiniteDifferenceSpace(vertmesh)
+
+    horzdomain = Domains.SphereDomain(radius)
+    horzmesh = Meshes.Mesh2D(horzdomain, Meshes.EquiangularSphereWarp(), helem)
+    horztopology = Topologies.Grid2DTopology(horzmesh)
+    quad = Spaces.Quadratures.GLL{Nq}()
+    horzspace = Spaces.SpectralElementSpace2D(horztopology, quad)
+
+    hv_center_space =
+        Spaces.ExtrudedFiniteDifferenceSpace(horzspace, vert_center_space)
+
+    # "shallow atmosphere" spherical shell: volume = surface area * height
+    @test sum(ones(hv_center_space)) ≈ 4pi * radius^2 * (zlim[2] - zlim[1]) rtol =
+        1e-3
 end


### PR DESCRIPTION
co-authored-by: @simonbyrne 

This PR fixes coordinates.jl for the 3d sphere mesh. It also adds a simple test for the sphere metric terms.
Will squash and rebase once it is approved.