### PR TITLE
Switch to the `AssociatedLegendrePolynomials.jl` package

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+AssociatedLegendrePolynomials = "2119f1ac-fb78-50f5-8cc0-dda848ebdb19"
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
@@ -16,7 +17,6 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-SphericalHarmonics = "c489a379-e885-57ff-9236-bd896d33c250"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TerminalLoggers = "5d786b92-1e48-4d6f-9151-6b4477ca9bed"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,7 +40,9 @@ include("sphere_gradient.jl")
 include("sphere_divergence.jl")
 include("sphere_curl.jl")
 include("sphere_diffusion.jl")
+include("sphere_diffusion_vec.jl")
 include("sphere_hyperdiffusion.jl")
+include("sphere_hyperdiffusion_vec.jl")
 
 if "CUDA" in ARGS
     include("gpu/cuda.jl")

--- a/test/sphere_diffusion_vec.jl
+++ b/test/sphere_diffusion_vec.jl
@@ -34,7 +34,7 @@ end
     radius = FT(1)
     domain = Domains.SphereDomain(radius)
     mesh = Meshes.Mesh2D(domain, Meshes.EquiangularSphereWarp(), Ne)
-    grid_topology = Topologies.Grid2DTopology(mesh)
+    grid_topology = Topologies.Topology2D(mesh)
 
     quad = Spaces.Quadratures.GLL{Nq}()
     space = Spaces.SpectralElementSpace2D(grid_topology, quad)
@@ -77,7 +77,7 @@ convergence_rate(err, Δh) =
 
         for (Ie, Ne) in enumerate(Nes)
             mesh = Meshes.Mesh2D(domain, Meshes.EquiangularSphereWarp(), Ne)
-            grid_topology = Topologies.Grid2DTopology(mesh)
+            grid_topology = Topologies.Topology2D(mesh)
 
             quad = Spaces.Quadratures.GLL{Nq}()
             space = Spaces.SpectralElementSpace2D(grid_topology, quad)

--- a/test/sphere_hyperdiffusion_vec.jl
+++ b/test/sphere_hyperdiffusion_vec.jl
@@ -40,7 +40,7 @@ end
     radius = FT(1)
     domain = Domains.SphereDomain(radius)
     mesh = Meshes.Mesh2D(domain, Meshes.EquiangularSphereWarp(), Ne)
-    grid_topology = Topologies.Grid2DTopology(mesh)
+    grid_topology = Topologies.Topology2D(mesh)
 
     quad = Spaces.Quadratures.GLL{Nq}()
     space = Spaces.SpectralElementSpace2D(grid_topology, quad)
@@ -83,7 +83,7 @@ convergence_rate(err, Δh) =
 
         for (Ie, Ne) in enumerate(Nes)
             mesh = Meshes.Mesh2D(domain, Meshes.EquiangularSphereWarp(), Ne)
-            grid_topology = Topologies.Grid2DTopology(mesh)
+            grid_topology = Topologies.Topology2D(mesh)
 
             quad = Spaces.Quadratures.GLL{Nq}()
             space = Spaces.SpectralElementSpace2D(grid_topology, quad)

--- a/test/sphere_sphericalharmonics.jl
+++ b/test/sphere_sphericalharmonics.jl
@@ -1,22 +1,8 @@
-# using Legendre
-# # input lat and long in degrees
-
-# function Ylm(l,m,lat,long) 
-# 	return real(
-# 		λlm(l,m,sind(lat)) * exp(im * m * deg2rad(long)),
-# 	)
-# end
-
-using SphericalHarmonics
+using AssociatedLegendrePolynomials
 # input lat and long in degrees
 
 function Ylm(l, m, lat, long)
-    return real(computeYlm(deg2rad(90 - lat), deg2rad(long), lmax = l)[(l, m)])
-end
-
-function Plm(l, m, x)
-    return computePlmx(x, lmax = l)[(l, m)] *
-           sqrt(2 * π * factorial(l + m) / (2 * l + 1) / factorial(l - m))
+    return λlm(l, m, sind(lat)) * cosd(m * long)
 end
 
 # V and W for vector spherical harmonics


### PR DESCRIPTION
This PR 
- [x] switches use the `AssociatedLegendrePolynomials.jl` package for current spherical harmonics computation;
- [x] adds the vector tests of diffusion and hyperdiffusion to `runtests.jl`;
- [x] cleans up the hyperdiffusion scalar test.