### PR TITLE
Fix product metric terms

### DIFF
--- a/src/Spaces/hybrid.jl
+++ b/src/Spaces/hybrid.jl
@@ -152,9 +152,9 @@ function blockmat(
         (Geometry.UVWAxis(), Geometry.Covariant123Axis()),
         SMatrix{3, 3}(
             A[1, 1],
-            A[1, 2],
-            zero(FT),
             A[2, 1],
+            zero(FT),
+            A[1, 2],
             A[2, 2],
             zero(FT),
             zero(FT),


### PR DESCRIPTION
The matrix was transposed, which caused strange behavior in the rotation test case.

Co-authored by: Zhaoyi Shen <pkuszy@gmail.com>