### PR TITLE
Update ClimaCoreMakie.yml

### DIFF
--- a/.github/workflows/ClimaCoreMakie.yml
+++ b/.github/workflows/ClimaCoreMakie.yml
@@ -31,7 +31,7 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y xorg-dev mesa-utils xvfb libgl1 freeglut3-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev
       - name: Install Julia dependencies
         run: >
-          DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24' julia --project=monorepo -e 'using Pkg; Pkg.develop(path="$(pwd())"); Pkg.develop(path="$(pwd())/lib/ClimaCoreMakie")'
+          julia --project=monorepo -e 'using Pkg; Pkg.develop(path="$(pwd())"); Pkg.develop(path="$(pwd())/lib/ClimaCoreMakie")'
       - name: Run the tests
         continue-on-error: true
         run: >


### PR DESCRIPTION
we don't need to run with an mock x frame buffer during installation.

running xvfb multiple times causes can hang the process when outputting to the same display.  A workaround is to use `xvfb-run -a` to generate automatically an open display but we shouldn't need it here during installation.