### PR TITLE
Explicitly return nothing & splt union method w convert

### DIFF
--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -2073,12 +2073,10 @@ Base.Broadcast._broadcast_getindex_eltype(
 ) = eltype(bc)
 
 # check that inferred output field space is equal to dest field space
-@noinline inferred_stencil_spaces_error(
-    dest_space_type::Type,
-    result_space_type::Type,
-) = error(
-    "dest space `$dest_space_type` is not the same instance as the inferred broadcasted result space `$result_space_type`",
+inferred_stencil_spaces_error(::Type{A}, ::Type{B}) = error(
+    "dest space `$A` is not the same instance as the inferred broadcasted result space `$B`",
 )
+inferred_stencil_spaces_error(::T, ::T) where {T} = nothing
 
 function Base.Broadcast.materialize!(
     ::Base.Broadcast.BroadcastStyle,
@@ -2086,11 +2084,9 @@ function Base.Broadcast.materialize!(
     bc::Base.Broadcast.Broadcasted{Style},
 ) where {Style <: AbstractStencilStyle}
     dest_space, result_space = axes(dest), axes(bc)
-    if result_space !== dest_space
-        # TODO: we pass the types here to avoid stack copying data
-        # but this could lead to a confusing error message (same space type but different instances)
-        inferred_stencil_spaces_error(typeof(dest_space), typeof(result_space))
-    end
+    # TODO: we pass the types here to avoid stack copying data
+    # but this could lead to a confusing error message (same space type but different instances)
+    inferred_stencil_spaces_error(dest_space, result_space)
     # the default Base behavior is to instantiate a Broadcasted object with the same axes as the dest
     return copyto!(
         dest,


### PR DESCRIPTION
I was [Cthulhu-ing](https://github.com/JuliaDebug/Cthulhu.jl) through some TurbulenceConvection code and saw that it wasn't able to infer some ClimaCore methods, in particular:
 - Overloaded `Base.copyto!` for `VF` (and potentially others), which seems to be due to the `Union` definition
 - A edge case bug in `set_struct!` (all explicitly `return nothing` except the "leaf" diagonal case)
 - and `setidx!`, which can't seem to be inferred because the resulting output type is equal to the input type (which currently left generic). There may be a different preferred way to do this, but I figured the proposed fix (returning `nothing`) would be simplest for now since we don't ever use the returned value.