### PR TITLE
Add output viz tests for vtk data & test that the generated files can be read by paraview

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -175,6 +175,8 @@ steps:
       - "julia --color=yes --project=examples examples/column/hydrostatic_implicit.jl"
     artifact_paths:
       - "examples/column/output/hydrostatic_implicit/*"
+    soft_fail:
+      - exit_status: 1
     agents:
       config: cpu
       queue: central

--- a/.github/workflows/ClimaCoreMakie.yml
+++ b/.github/workflows/ClimaCoreMakie.yml
@@ -34,6 +34,8 @@ jobs:
           julia --project=monorepo -e 'using Pkg; Pkg.develop(path="$(pwd())"); Pkg.develop(path="$(pwd())/lib/ClimaCoreMakie")'
       - name: Run the tests
         continue-on-error: true
+        env:
+            CI_OUTPUT_DIR: output
         run: >
           DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24' julia --project=monorepo -e 'using Pkg; Pkg.test("ClimaCoreMakie")'
           && echo "TESTS_SUCCESSFUL=true" >> $GITHUB_ENV

--- a/.github/workflows/ClimaCorePlots.yml
+++ b/.github/workflows/ClimaCorePlots.yml
@@ -35,6 +35,7 @@ jobs:
         continue-on-error: true
         env:
           GKSwstype: nul
+          CI_OUTPUT_DIR: output
         run: >
           julia --project=monorepo -e 'using Pkg; Pkg.test("ClimaCorePlots")'
           && echo "TESTS_SUCCESSFUL=true" >> $GITHUB_ENV

--- a/.github/workflows/ClimaCoreVTK.yml
+++ b/.github/workflows/ClimaCoreVTK.yml
@@ -28,6 +28,9 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
+      - name: Install Paraview
+        run: |
+          sudo apt-get update && sudo apt-get -y install paraview python3-paraview
       - name: Install Julia dependencies
         shell: julia --project=monorepo {0}
         run: |
@@ -35,5 +38,23 @@ jobs:
           # dev mono repo versions
           pkg"dev . lib/ClimaCoreVTK"
       - name: Run the tests
-        run: |
+        env:
+          CI_OUTPUT_DIR: output
+        run: >
           julia --project=monorepo -e 'using Pkg; Pkg.test("ClimaCoreVTK")'
+          && echo "TESTS_SUCCESSFUL=true" >> $GITHUB_ENV
+      - name: Render the VTK images
+        run: >
+          for f in lib/ClimaCoreVTK/test/output/*.vtu;
+          do
+            xvfb-run -a pvpython lib/ClimaCoreVTK/paraview/renderimage.py "$f" "$f.png";
+          done
+      - name: Upload test Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: climacore-vtk-output
+          path: |
+            lib/ClimaCoreVTK/test/output/*.png
+      - name: Fail after artifacts if tests failed
+        if: ${{ env.TESTS_SUCCESSFUL != 'true' }}
+        run: exit 1

--- a/lib/ClimaCoreMakie/test/runtests.jl
+++ b/lib/ClimaCoreMakie/test/runtests.jl
@@ -4,12 +4,10 @@ using IntervalSets
 import ClimaCore
 import ClimaCoreMakie: ClimaCoreMakie, Makie
 
-running_CI() = !isempty(get(ENV, "CI", ""))
-
-if running_CI()
+if haskey(ENV, "CI")
     using GLMakie
-    OUTPUT_DIR = mkdir(joinpath(@__DIR__, "output"))
 end
+OUTPUT_DIR = mkpath(get(ENV, "CI_OUTPUT_DIR", tempname()))
 
 @testset "spectral element 2D cubed-sphere" begin
     R = 6.37122e6
@@ -35,9 +33,9 @@ end
     fig = ClimaCoreMakie.viz(u.components.data.:1)
     @test fig !== nothing
 
-    if running_CI()
-        GLMakie.save(joinpath(OUTPUT_DIR, "2D_cubed_sphere.png"), fig)
-    end
+    fig_png = joinpath(OUTPUT_DIR, "2D_cubed_sphere.png")
+    GLMakie.save(fig_png, fig)
+    @test isfile(fig_png)
 end
 
 @testset "spectral element rectangle 2D" begin
@@ -64,7 +62,7 @@ end
     fig = ClimaCoreMakie.viz(sinxy)
     @test fig !== nothing
 
-    if running_CI()
-        GLMakie.save(joinpath(OUTPUT_DIR, "2D_rectangle.png"), fig)
-    end
+    fig_png = joinpath(OUTPUT_DIR, "2D_rectangle.png")
+    GLMakie.save(fig_png, fig)
+    @test isfile(fig_png)
 end

--- a/lib/ClimaCorePlots/test/runtests.jl
+++ b/lib/ClimaCorePlots/test/runtests.jl
@@ -1,3 +1,4 @@
+ENV["GKSwstype"] = "nul"
 using Test
 using IntervalSets
 
@@ -6,12 +7,7 @@ import Plots
 import ClimaCore
 import ClimaCorePlots
 
-running_CI() = !isempty(get(ENV, "CI", ""))
-
-if running_CI()
-    ENV["GKSwstype"] = "nul"
-    OUTPUT_DIR = mkdir(joinpath(@__DIR__, "output"))
-end
+OUTPUT_DIR = mkpath(get(ENV, "CI_OUTPUT_DIR", tempname()))
 
 @testset "spectral element 2D cubed-sphere" begin
     R = 6.37122e6
@@ -37,9 +33,9 @@ end
     field_fig = Plots.plot(u.components.data.:1)
     @test field_fig !== nothing
 
-    if running_CI()
-        Plots.png(field_fig, joinpath(OUTPUT_DIR, "2D_cubed_sphere_field.png"))
-    end
+    fig_png = joinpath(OUTPUT_DIR, "2D_cubed_sphere_field.png")
+    Plots.png(field_fig, fig_png)
+    @test isfile(fig_png)
 end
 
 @testset "spectral element rectangle 2D" begin
@@ -69,10 +65,12 @@ end
     field_fig = Plots.plot(sinxy)
     @test field_fig !== nothing
 
-    if running_CI()
-        Plots.png(space_fig, joinpath(OUTPUT_DIR, "2D_rectangle_space.png"))
-        Plots.png(field_fig, joinpath(OUTPUT_DIR, "2D_rectangle_field.png"))
-    end
+    space_png = joinpath(OUTPUT_DIR, "2D_rectangle_space.png")
+    field_png = joinpath(OUTPUT_DIR, "2D_rectangle_field.png")
+    Plots.png(space_fig, space_png)
+    Plots.png(field_fig, field_png)
+    @test isfile(space_png)
+    @test isfile(field_png)
 end
 
 @testset "hybrid finite difference / spectral element 2D" begin
@@ -115,14 +113,10 @@ end
     zcoords_fig = Plots.plot(coords.z)
     @test zcoords_fig !== nothing
 
-    if running_CI()
-        Plots.png(
-            xcoords_fig,
-            joinpath(OUTPUT_DIR, "hybrid_xcoords_center_field.png"),
-        )
-        Plots.png(
-            zcoords_fig,
-            joinpath(OUTPUT_DIR, "hybrid_zcoords_center_field.png"),
-        )
-    end
+    xcoords_png = joinpath(OUTPUT_DIR, "hybrid_xcoords_center_field.png")
+    zcoords_png = joinpath(OUTPUT_DIR, "hybrid_zcoords_center_field.png")
+    Plots.png(xcoords_fig, xcoords_png)
+    Plots.png(zcoords_fig, zcoords_png)
+    @test isfile(xcoords_png)
+    @test isfile(zcoords_png)
 end

--- a/lib/ClimaCoreVTK/paraview/renderimage.py
+++ b/lib/ClimaCoreVTK/paraview/renderimage.py
@@ -1,0 +1,55 @@
+#> pvpython renderimage.py input.vtk output.png
+
+import sys, os
+
+print(sys.argv)
+if len(sys.argv) != 3:
+    raise Exception('must provide a valid input vtk path and output render png path')
+
+from paraview.simple import *
+
+#open data file
+data = OpenDataFile(sys.argv[1])
+
+# get active view
+view = GetActiveViewOrCreate('RenderView')
+Show(data, view)
+
+# reset view to fit data
+view.ResetCamera()
+view.OrientationAxesVisibility = 0
+
+#position camera
+# XZ view by default
+camera = GetActiveCamera()
+camera.Pitch(90)
+view.CameraViewUp = [0, 0, 1]
+
+# This is computed by reseting the camera to the data
+# bounds = data.GetDataInformation().DataInformation.GetBounds()
+# centerXPos = 0.5 * sum(bounds[0:1])
+# centerYPos = 0.5 * sum(bounds[2:3])
+# centerZPos = 0.5 * sum(bounds[4:5])]
+# view.CameraFocalPoint = [centerXPos, centerYPos, centerZPos]
+# view.CameraPosition = [centerXPos, centerYPos, 0]
+
+# show the grid
+axesGrid = view.AxesGrid
+axesGrid.Visibility = 1
+
+#draw the object
+Show()
+
+#set the background color
+view.Background = [0,0,0]  #black
+#set image size
+view.ViewSize = [600, 600] #[width, height]
+
+#set representation to wireframe
+dp = GetDisplayProperties()
+dp.Representation = "Wireframe"
+
+Render()
+
+#save screenshot
+WriteImage(sys.argv[2])

--- a/lib/ClimaCoreVTK/test/runtests.jl
+++ b/lib/ClimaCoreVTK/test/runtests.jl
@@ -4,8 +4,8 @@ using IntervalSets
 import ClimaCore:
     Geometry, Domains, Meshes, Topologies, Spaces, Fields, Operators
 
-
-dir = mktempdir()
+OUTPUT_DIR = mkpath(get(ENV, "CI_OUTPUT_DIR", tempname()))
+mkpath(joinpath(OUTPUT_DIR, "series"))
 
 @testset "sphere" begin
     R = 6.37122e6
@@ -28,8 +28,12 @@ dir = mktempdir()
         Geometry.UVVector(uu, uv)
     end
 
-    writevtk(joinpath(dir, "sphere"), (coords = coords, u = u); basis = :point)
-    @test isfile(joinpath(dir, "sphere.vtu"))
+    writevtk(
+        joinpath(OUTPUT_DIR, "sphere"),
+        (coords = coords, u = u);
+        basis = :point,
+    )
+    @test isfile(joinpath(OUTPUT_DIR, "sphere.vtu"))
 
     times = 0:10:350
     A = [
@@ -38,8 +42,18 @@ dir = mktempdir()
             (sind(coord.long) * sind(α) + cosd(coord.long) * cosd(α))
         end for α in times
     ]
-    writevtk(joinpath(dir, "sphere_scalar_series"), times, (A = A, B = A))
-    @test isfile(joinpath(dir, "sphere_scalar_series.pvd"))
+    writevtk(
+        joinpath(OUTPUT_DIR, "series", "sphere_scalar_series"),
+        times,
+        (A = A, B = A),
+    )
+    for (i, _) in enumerate(times)
+        istr = lpad(i, 3, "0")
+        @test isfile(
+            joinpath(OUTPUT_DIR, "series", "sphere_scalar_series_$(istr).vtu"),
+        )
+    end
+    @test isfile(joinpath(OUTPUT_DIR, "series", "sphere_scalar_series.pvd"))
 
     U = Array{Fields.Field}(undef, length(times))
     for t in 1:(div(350, 10) + 1)
@@ -55,9 +69,18 @@ dir = mktempdir()
         end
         U[t] = u
     end
-    writevtk(joinpath(dir, "sphere_vector_series"), times, (U = U,))
-    @test isfile(joinpath(dir, "sphere_vector_series.pvd"))
-
+    writevtk(
+        joinpath(OUTPUT_DIR, "series", "sphere_vector_series"),
+        times,
+        (U = U,),
+    )
+    for (i, _) in enumerate(times)
+        istr = lpad(i, 3, "0")
+        @test isfile(
+            joinpath(OUTPUT_DIR, "series", "sphere_vector_series_$(istr).vtu"),
+        )
+    end
+    @test isfile(joinpath(OUTPUT_DIR, "series", "sphere_vector_series.pvd"))
 end
 
 @testset "rectangle" begin
@@ -84,8 +107,8 @@ end
         Geometry.UVVector(-coord.y, coord.x)
     end
 
-    writevtk(joinpath(dir, "plane"), (sinxy = sinxy, u = u))
-    @test isfile(joinpath(dir, "plane.vtu"))
+    writevtk(joinpath(OUTPUT_DIR, "plane"), (sinxy = sinxy, u = u))
+    @test isfile(joinpath(OUTPUT_DIR, "plane.vtu"))
 
 end
 
@@ -111,17 +134,17 @@ end
     fspace = Spaces.ExtrudedFiniteDifferenceSpace(hspace, vspace)
     cspace = Spaces.CenterExtrudedFiniteDifferenceSpace(fspace)
     writevtk(
-        joinpath(dir, "hybrid2d_point"),
+        joinpath(OUTPUT_DIR, "hybrid2d_point"),
         Fields.coordinate_field(fspace);
         basis = :point,
     )
-    @test isfile(joinpath(dir, "hybrid2d_point.vtu"))
+    @test isfile(joinpath(OUTPUT_DIR, "hybrid2d_point.vtu"))
     writevtk(
-        joinpath(dir, "hybrid2d_cell"),
+        joinpath(OUTPUT_DIR, "hybrid2d_cell"),
         Fields.coordinate_field(cspace);
         basis = :cell,
     )
-    @test isfile(joinpath(dir, "hybrid2d_cell.vtu"))
+    @test isfile(joinpath(OUTPUT_DIR, "hybrid2d_cell.vtu"))
 end
 
 @testset "hybrid 3d" begin
@@ -149,15 +172,15 @@ end
     fspace = Spaces.ExtrudedFiniteDifferenceSpace(hspace, vspace)
     cspace = Spaces.CenterExtrudedFiniteDifferenceSpace(fspace)
     writevtk(
-        joinpath(dir, "hybrid3d_point"),
+        joinpath(OUTPUT_DIR, "hybrid3d_point"),
         Fields.coordinate_field(fspace);
         basis = :point,
     )
-    @test isfile(joinpath(dir, "hybrid3d_point.vtu"))
+    @test isfile(joinpath(OUTPUT_DIR, "hybrid3d_point.vtu"))
     writevtk(
-        joinpath(dir, "hybrid3d_cell"),
+        joinpath(OUTPUT_DIR, "hybrid3d_cell"),
         Fields.coordinate_field(cspace);
         basis = :cell,
     )
-    @test isfile(joinpath(dir, "hybrid3d_cell.vtu"))
+    @test isfile(joinpath(OUTPUT_DIR, "hybrid3d_cell.vtu"))
 end


### PR DESCRIPTION
Output is added as a summary of each run (similar to all the other CI assets).  We'll have to play around with the camera to make it reasonable for both 2D and 3D (or have a cli arg) but this should get us started.  Tests that the output files can be read by paraview and the pvpython script is useful for debugging.

https://github.com/CliMA/ClimaCore.jl/actions/runs/1665961301

Ex:
![sphere vtu](https://user-images.githubusercontent.com/1157798/148485992-f0ddff76-66c3-4312-9d10-a5ea4e2adeae.png)

