### PR TITLE
Time some solves, make `tuplemap` call `map`

### DIFF
--- a/examples/3dsphere/baroclinic_wave.jl
+++ b/examples/3dsphere/baroclinic_wave.jl
@@ -317,7 +317,7 @@ prob = ODEProblem(rhs!, Y, (0.0, time_end))
 
 haskey(ENV, "CI_PERF_SKIP_RUN") && exit() # for performance analysis
 
-sol = solve(
+sol = @timev solve(
     prob,
     SSPRK33(),
     dt = dt,

--- a/examples/hybrid/bubble_2d.jl
+++ b/examples/hybrid/bubble_2d.jl
@@ -294,7 +294,7 @@ prob = ODEProblem(rhs!, Y, (0.0, 500.0))
 
 haskey(ENV, "CI_PERF_SKIP_RUN") && exit() # for performance analysis
 
-sol = solve(
+sol = @timev solve(
     prob,
     SSPRK33(),
     dt = Δt,

--- a/examples/hybrid/bubble_3d.jl
+++ b/examples/hybrid/bubble_3d.jl
@@ -273,7 +273,7 @@ prob = ODEProblem(rhs!, Y, (0.0, 1.0))
 
 haskey(ENV, "CI_PERF_SKIP_RUN") && exit() # for performance analysis
 
-sol = solve(
+sol = @timev solve(
     prob,
     SSPRK33(),
     dt = Δt,

--- a/examples/sphere/shallow_water.jl
+++ b/examples/sphere/shallow_water.jl
@@ -398,7 +398,7 @@ prob = ODEProblem(rhs!, y0, (0.0, T), (f = f, h_s = h_s))
 
 haskey(ENV, "CI_PERF_SKIP_RUN") && exit() # for performance analysis
 
-sol = solve(
+sol = @timev solve(
     prob,
     SSPRK33(),
     dt = dt,

--- a/src/RecursiveApply/RecursiveApply.jl
+++ b/src/RecursiveApply/RecursiveApply.jl
@@ -15,12 +15,7 @@ export ⊞, ⊠, ⊟, tuplemap
 A simpler `map` impl for mapping function `fn` a tuple argument `tup`
 """
 @inline function tuplemap(fn::F, tup::Tuple) where {F}
-    N = length(tup)
-    ntuple(Val(N)) do I
-        Base.@_inline_meta
-        @inbounds elem = tup[I]
-        fn(elem)
-    end
+    map(fn, tup)
 end
 
 """


### PR DESCRIPTION
This PR
 - adds some `@timev`s to some of the examples that we're monitoring for performance.
 - Changes `tuplemap` to just call `map`, which seems to fix some inference / allocation issues.