### PR TITLE
check in Manifest files

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,7 @@
+docs: Manifest.toml
+	julia --project=. make.jl
+
+Manifest.toml:
+	julia --project=. -e 'using Pkg; Pkg.develop([Pkg.PackageSpec(path=".."), Pkg.PackageSpec(path="../lib/ClimaCorePlots"), Pkg.PackageSpec(path="../lib/ClimaCoreVTK"), Pkg.PackageSpec(path="../lib/ClimaCoreMakie")])'
+
+.PHONY: docs

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,6 @@
+instantiate: Manifest.toml
+
+Manifest.toml:
+	julia --project=. -e 'using Pkg; Pkg.develop([Pkg.PackageSpec(path=".."), Pkg.PackageSpec(path="../lib/ClimaCorePlots")])'
+
+.PHONY: instantiate


### PR DESCRIPTION
Since it is a bit annoying to instantiate these directly. 

Alternatively, we could check in Manifest.toml files for these (which may not be a bad idea, as then they should be always reproducible?)
