### PR TITLE
fix return values to align with setindex! behavior

### DIFF
--- a/src/DataLayouts/struct.jl
+++ b/src/DataLayouts/struct.jl
@@ -206,7 +206,7 @@ function set_struct!(array::AbstractArray{T}, val::S, offset) where {T, S}
                 )),
             )
         end
-        push!(ex.args, :(return nothing))
+        push!(ex.args, :(return val))
         return ex
     else
         Base.@_propagate_inbounds_meta
@@ -217,7 +217,7 @@ function set_struct!(array::AbstractArray{T}, val::S, offset) where {T, S}
                 offset + fieldtypeoffset(T, S, i),
             )
         end
-        return nothing
+        return val
     end
 end
 
@@ -227,6 +227,7 @@ end
     offset,
 ) where {S}
     array[offset + 1] = val
+    val
 end
 
 @inline function set_struct!(array, val)

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -2037,14 +2037,14 @@ function getidx(bc::Base.Broadcast.Broadcasted, loc::Location, idx)
 end
 
 # setidx! methods for copyto!
-function setidx!(bc::Fields.CenterFiniteDifferenceField, idx::Integer, val)
-    field_data = Fields.field_values(bc)
+function setidx!(field::Fields.CenterFiniteDifferenceField, idx::Integer, val)
+    field_data = Fields.field_values(field)
     field_data[idx] = val
     val
 end
 
-function setidx!(bc::Fields.FaceFiniteDifferenceField, idx::PlusHalf, val)
-    field_data = Fields.field_values(bc)
+function setidx!(field::Fields.FaceFiniteDifferenceField, idx::PlusHalf, val)
+    field_data = Fields.field_values(field)
     field_data[idx.i + 1] = val
     val
 end

--- a/test/DataLayouts/data1d.jl
+++ b/test/DataLayouts/data1d.jl
@@ -48,7 +48,10 @@ end
     array = zeros(Float64, Nv, 2)
     data = VF{typeof(SA)}(array)
 
-    data[1] = SA
+    ret = begin
+        data[1] = SA
+    end
+    @test ret === SA
     @test data[1] isa typeof(SA)
     @test_throws MethodError data[1] = SB
 end

--- a/test/DataLayouts/data2d.jl
+++ b/test/DataLayouts/data2d.jl
@@ -93,7 +93,10 @@ end
     array = zeros(Float64, Nij, Nij, 2, Nh)
     data = IJFH{typeof(SA), Nij}(array)
     data_slab = slab(data, 1)
-    data_slab[1, 1] = SA
+    ret = begin
+        data_slab[1, 1] = SA
+    end
+    @test ret === SA
     @test data_slab[1, 1] isa typeof(SA)
     @test_throws MethodError data_slab[1, 1] = SB
 end


### PR DESCRIPTION
spotted by @charleskawczynski.  Adds some tests for the two cases we can call setindex on data layouts directly