### PR TITLE
change hyperdiffusion in 3d test cases

### DIFF
--- a/examples/3dsphere/baroclinic_wave.jl
+++ b/examples/3dsphere/baroclinic_wave.jl
@@ -90,7 +90,7 @@ if test_name == "baroclinic_wave"
         s1(λ, ϕ) *
         cosd(ϕ_c) *
         sind(λ - λ_c) / sin(r(λ, ϕ) / R) * cond(λ, ϕ)
-    const κ₄ = 1.0e16 # m^4/s
+    const κ₄ = 1.0e17 # m^4/s
 elseif test_name == "balanced_flow"
     δu(λ, ϕ, z) = 0.0
     δv(λ, ϕ, z) = 0.0
@@ -191,11 +191,11 @@ function rhs!(dY, Y, _, t)
     # fw = -g^31 cuₕ/ g^33
 
     hdiv = Operators.Divergence()
-    hwdiv = Operators.Divergence()
+    hwdiv = Operators.WeakDivergence()
     hgrad = Operators.Gradient()
-    hwgrad = Operators.Gradient()
+    hwgrad = Operators.WeakGradient()
     hcurl = Operators.Curl()
-    hwcurl = Operators.Curl()
+    hwcurl = Operators.WeakCurl()
 
     dρ .= 0 .* cρ
 
@@ -204,20 +204,15 @@ function rhs!(dY, Y, _, t)
 
     χe = @. dρe = hwdiv(hgrad(cρe / cρ))
     χuₕ = @. duₕ =
-        hwgrad(hdiv(cuₕ)) - Geometry.Covariant12Vector(
-            hwcurl(Geometry.Covariant3Vector(hcurl(cuₕ))),
-        )
+        hwgrad(hdiv(cuₕ)) - Geometry.Covariant12Vector(hwcurl(hcurl(cuₕ)))
 
     Spaces.weighted_dss!(dρe)
     Spaces.weighted_dss!(duₕ)
 
     @. dρe = -κ₄ * hwdiv(cρ * hgrad(χe))
     @. duₕ =
-        -κ₄ * (
-            hwgrad(hdiv(χuₕ)) - Geometry.Covariant12Vector(
-                hwcurl(Geometry.Covariant3Vector(hcurl(χuₕ))),
-            )
-        )
+        -κ₄ *
+        (hwgrad(hdiv(χuₕ)) - Geometry.Covariant12Vector(hwcurl(hcurl(χuₕ))))
 
     # 1) Mass conservation
     If2c = Operators.InterpolateF2C()

--- a/examples/3dsphere/nonhydrostatic_gravity_wave.jl
+++ b/examples/3dsphere/nonhydrostatic_gravity_wave.jl
@@ -128,11 +128,11 @@ function rhs!(dY, Y, _, t)
     # fw = -g^31 cuₕ/ g^33
 
     hdiv = Operators.Divergence()
-    hwdiv = Operators.Divergence()
+    hwdiv = Operators.WeakDivergence()
     hgrad = Operators.Gradient()
-    hwgrad = Operators.Gradient()
+    hwgrad = Operators.WeakGradient()
     hcurl = Operators.Curl()
-    hwcurl = Operators.Curl()
+    hwcurl = Operators.WeakCurl()
 
     dρ .= 0 .* cρ
 
@@ -141,21 +141,16 @@ function rhs!(dY, Y, _, t)
 
     χe = @. dρe = hwdiv(hgrad(cρe / cρ))
     χuₕ = @. duₕ =
-        hwgrad(hdiv(cuₕ)) - Geometry.Covariant12Vector(
-            hwcurl(Geometry.Covariant3Vector(hcurl(cuₕ))),
-        )
+        hwgrad(hdiv(cuₕ)) - Geometry.Covariant12Vector(hwcurl(hcurl(cuₕ)))
 
     Spaces.weighted_dss!(dρe)
     Spaces.weighted_dss!(duₕ)
 
-    κ₄ = 1.0e16 # m^4/s
+    κ₄ = 1.0e17 # m^4/s
     @. dρe = -κ₄ * hwdiv(cρ * hgrad(χe))
     @. duₕ =
-        -κ₄ * (
-            hwgrad(hdiv(χuₕ)) - Geometry.Covariant12Vector(
-                hwcurl(Geometry.Covariant3Vector(hcurl(χuₕ))),
-            )
-        )
+        -κ₄ *
+        (hwgrad(hdiv(χuₕ)) - Geometry.Covariant12Vector(hwcurl(hcurl(χuₕ))))
 
     # 1) Mass conservation
     If2c = Operators.InterpolateF2C()

--- a/examples/3dsphere/solid_body_rotation_3d.jl
+++ b/examples/3dsphere/solid_body_rotation_3d.jl
@@ -106,11 +106,8 @@ function rhs!(dY, Y, _, t)
     # fw = -g^31 cuₕ/ g^33 ????????
 
     hdiv = Operators.Divergence()
-    hwdiv = Operators.Divergence()
     hgrad = Operators.Gradient()
-    hwgrad = Operators.Gradient()
     hcurl = Operators.Curl()
-    hwcurl = Operators.Curl() # Operator.WeakCurl()
 
     dρ .= 0 .* cρ
     dw .= 0 .* fw

--- a/examples/hybrid/bubble3d_invariant.jl
+++ b/examples/hybrid/bubble3d_invariant.jl
@@ -167,11 +167,11 @@ function rhs_invariant!(dY, Y, _, t)
     # fw = -g^31 cuₕ/ g^33
 
     hdiv = Operators.Divergence()
-    hwdiv = Operators.Divergence()
+    hwdiv = Operators.WeakDivergence()
     hgrad = Operators.Gradient()
-    hwgrad = Operators.Gradient()
+    hwgrad = Operators.WeakGradient()
     hcurl = Operators.Curl()
-    hwcurl = Operators.Curl()
+    hwcurl = Operators.WeakCurl()
 
     dρ .= 0 .* cρ
 
@@ -180,9 +180,7 @@ function rhs_invariant!(dY, Y, _, t)
 
     χθ = @. dρθ = hwdiv(hgrad(cρθ / cρ)) # we store χθ in dρθ
     χuₕ = @. duₕ =
-        hwgrad(hdiv(cuₕ)) - Geometry.Covariant12Vector(
-            hwcurl(Geometry.Covariant3Vector(hcurl(cuₕ))),
-        )
+        hwgrad(hdiv(cuₕ)) - Geometry.Covariant12Vector(hwcurl(hcurl(cuₕ)))
 
     Spaces.weighted_dss!(dρθ)
     Spaces.weighted_dss!(duₕ)
@@ -190,11 +188,8 @@ function rhs_invariant!(dY, Y, _, t)
     κ₄ = 100.0 # m^4/s
     @. dρθ = -κ₄ * hwdiv(cρ * hgrad(χθ))
     @. duₕ =
-        -κ₄ * (
-            hwgrad(hdiv(χuₕ)) - Geometry.Covariant12Vector(
-                hwcurl(Geometry.Covariant3Vector(hcurl(χuₕ))),
-            )
-        )
+        -κ₄ *
+        (hwgrad(hdiv(χuₕ)) - Geometry.Covariant12Vector(hwcurl(hcurl(χuₕ))))
 
     # 1) Mass conservation
     If2c = Operators.InterpolateF2C()

--- a/examples/hybrid/bubble3d_invariant_totalenergy.jl
+++ b/examples/hybrid/bubble3d_invariant_totalenergy.jl
@@ -132,11 +132,11 @@ function rhs_invariant!(dY, Y, _, t)
     # fw = -g^31 cuₕ/ g^33
 
     hdiv = Operators.Divergence()
-    hwdiv = Operators.Divergence()
+    hwdiv = Operators.WeakDivergence()
     hgrad = Operators.Gradient()
-    hwgrad = Operators.Gradient()
+    hwgrad = Operators.WeakGradient()
     hcurl = Operators.Curl()
-    hwcurl = Operators.Curl()
+    hwcurl = Operators.WeakCurl()
 
     dρ .= 0 .* cρ
 
@@ -145,9 +145,7 @@ function rhs_invariant!(dY, Y, _, t)
 
     χe = @. dρe = hwdiv(hgrad(cρe / cρ)) # we store χe in dρe
     χuₕ = @. duₕ =
-        hwgrad(hdiv(cuₕ)) - Geometry.Covariant12Vector(
-            hwcurl(Geometry.Covariant3Vector(hcurl(cuₕ))),
-        )
+        hwgrad(hdiv(cuₕ)) - Geometry.Covariant12Vector(hwcurl(hcurl(cuₕ)))
 
 
     Spaces.weighted_dss!(dρe)
@@ -156,11 +154,8 @@ function rhs_invariant!(dY, Y, _, t)
     κ₄ = 100.0 # m^4/s
     @. dρe = -κ₄ * hwdiv(cρ * hgrad(χe))
     @. duₕ =
-        -κ₄ * (
-            hwgrad(hdiv(χuₕ)) - Geometry.Covariant12Vector(
-                hwcurl(Geometry.Covariant3Vector(hcurl(χuₕ))),
-            )
-        )
+        -κ₄ *
+        (hwgrad(hdiv(χuₕ)) - Geometry.Covariant12Vector(hwcurl(hcurl(χuₕ))))
 
     # 1) Mass conservation
     If2c = Operators.InterpolateF2C()

--- a/examples/hybrid/bubble_invariant.jl
+++ b/examples/hybrid/bubble_invariant.jl
@@ -132,7 +132,6 @@ function rhs_invariant!(dY, Y, _, t)
     hgrad = Operators.Gradient()
     hwgrad = Operators.Gradient()
     hcurl = Operators.Curl()
-    hwcurl = Operators.Curl()
 
     dρ .= 0 .* cρ
 


### PR DESCRIPTION
Use weak operators on the outside in the hyperdiffusion. cc @simonbyrne 