### PR TITLE
restrict curl / weak curl to work on only covariant vector field inputs, this enables us to optimize through the hyperdiffusion operation

### DIFF
--- a/docs/tutorials/introduction.jl
+++ b/docs/tutorials/introduction.jl
@@ -511,8 +511,11 @@ function shallow_water_tendency!(dydt, y, _, t)
     ClimaCore.Spaces.weighted_dss!(dydt)
 
     @. dydt.u =
-        -D₄ *
-        (wgrad(sdiv(dydt.u)) - Geometry.Covariant12Vector(wcurl(curl(dydt.u))))
+        -D₄ * (
+            wgrad(sdiv(dydt.u)) - Geometry.Covariant12Vector(
+                wcurl(Geometry.Covariant3Vector(curl(dydt.u))),
+            )
+        )
     @. dydt.ρθ = -D₄ * wdiv(grad(dydt.ρθ))
 
     ## comute rest of tendency

--- a/examples/3dsphere/baroclinic_wave.jl
+++ b/examples/3dsphere/baroclinic_wave.jl
@@ -204,15 +204,20 @@ function rhs!(dY, Y, _, t)
 
     χe = @. dρe = hwdiv(hgrad(cρe / cρ))
     χuₕ = @. duₕ =
-        hwgrad(hdiv(cuₕ)) - Geometry.Covariant12Vector(hwcurl(hcurl(cuₕ)))
+        hwgrad(hdiv(cuₕ)) - Geometry.Covariant12Vector(
+            hwcurl(Geometry.Covariant3Vector(hcurl(cuₕ))),
+        )
 
     Spaces.weighted_dss!(dρe)
     Spaces.weighted_dss!(duₕ)
 
     @. dρe = -κ₄ * hwdiv(cρ * hgrad(χe))
     @. duₕ =
-        -κ₄ *
-        (hwgrad(hdiv(χuₕ)) - Geometry.Covariant12Vector(hwcurl(hcurl(χuₕ))))
+        -κ₄ * (
+            hwgrad(hdiv(χuₕ)) - Geometry.Covariant12Vector(
+                hwcurl(Geometry.Covariant3Vector(hcurl(χuₕ))),
+            )
+        )
 
     # 1) Mass conservation
     If2c = Operators.InterpolateF2C()

--- a/examples/3dsphere/nonhydrostatic_gravity_wave.jl
+++ b/examples/3dsphere/nonhydrostatic_gravity_wave.jl
@@ -141,7 +141,9 @@ function rhs!(dY, Y, _, t)
 
     χe = @. dρe = hwdiv(hgrad(cρe / cρ))
     χuₕ = @. duₕ =
-        hwgrad(hdiv(cuₕ)) - Geometry.Covariant12Vector(hwcurl(hcurl(cuₕ)))
+        hwgrad(hdiv(cuₕ)) - Geometry.Covariant12Vector(
+            hwcurl(Geometry.Covariant3Vector(hcurl(cuₕ))),
+        )
 
     Spaces.weighted_dss!(dρe)
     Spaces.weighted_dss!(duₕ)
@@ -149,8 +151,11 @@ function rhs!(dY, Y, _, t)
     κ₄ = 1.0e17 # m^4/s
     @. dρe = -κ₄ * hwdiv(cρ * hgrad(χe))
     @. duₕ =
-        -κ₄ *
-        (hwgrad(hdiv(χuₕ)) - Geometry.Covariant12Vector(hwcurl(hcurl(χuₕ))))
+        -κ₄ * (
+            hwgrad(hdiv(χuₕ)) - Geometry.Covariant12Vector(
+                hwcurl(Geometry.Covariant3Vector(hcurl(χuₕ))),
+            )
+        )
 
     # 1) Mass conservation
     If2c = Operators.InterpolateF2C()

--- a/examples/bickleyjet/bickleyjet_cg_invariant_hypervisc.jl
+++ b/examples/bickleyjet/bickleyjet_cg_invariant_hypervisc.jl
@@ -88,14 +88,19 @@ function rhs!(dydt, y, _, t)
     wcurl = Operators.WeakCurl()
 
     # compute hyperviscosity first
-    @. dydt.u = wgrad(sdiv(y.u)) - Geometry.Covariant12Vector(wcurl(curl(y.u)))
+    @. dydt.u =
+        wgrad(sdiv(y.u)) -
+        Geometry.Covariant12Vector(wcurl(Geometry.Covariant3Vector(curl(y.u))))
     @. dydt.ρθ = wdiv(grad(y.ρθ))
 
     Spaces.weighted_dss!(dydt)
 
     @. dydt.u =
-        -D₄ *
-        (wgrad(sdiv(dydt.u)) - Geometry.Covariant12Vector(wcurl(curl(dydt.u))))
+        -D₄ * (
+            wgrad(sdiv(dydt.u)) - Geometry.Covariant12Vector(
+                wcurl(Geometry.Covariant3Vector(curl(dydt.u))),
+            )
+        )
     @. dydt.ρθ = -D₄ * wdiv(grad(dydt.ρθ))
 
     # add in pieces

--- a/examples/hybrid/bubble3d_invariant.jl
+++ b/examples/hybrid/bubble3d_invariant.jl
@@ -180,7 +180,9 @@ function rhs_invariant!(dY, Y, _, t)
 
     χθ = @. dρθ = hwdiv(hgrad(cρθ / cρ)) # we store χθ in dρθ
     χuₕ = @. duₕ =
-        hwgrad(hdiv(cuₕ)) - Geometry.Covariant12Vector(hwcurl(hcurl(cuₕ)))
+        hwgrad(hdiv(cuₕ)) - Geometry.Covariant12Vector(
+            hwcurl(Geometry.Covariant3Vector(hcurl(cuₕ))),
+        )
 
     Spaces.weighted_dss!(dρθ)
     Spaces.weighted_dss!(duₕ)
@@ -188,8 +190,11 @@ function rhs_invariant!(dY, Y, _, t)
     κ₄ = 100.0 # m^4/s
     @. dρθ = -κ₄ * hwdiv(cρ * hgrad(χθ))
     @. duₕ =
-        -κ₄ *
-        (hwgrad(hdiv(χuₕ)) - Geometry.Covariant12Vector(hwcurl(hcurl(χuₕ))))
+        -κ₄ * (
+            hwgrad(hdiv(χuₕ)) - Geometry.Covariant12Vector(
+                hwcurl(Geometry.Covariant3Vector(hcurl(χuₕ))),
+            )
+        )
 
     # 1) Mass conservation
     If2c = Operators.InterpolateF2C()

--- a/examples/hybrid/bubble3d_invariant_totalenergy.jl
+++ b/examples/hybrid/bubble3d_invariant_totalenergy.jl
@@ -145,7 +145,9 @@ function rhs_invariant!(dY, Y, _, t)
 
     χe = @. dρe = hwdiv(hgrad(cρe / cρ)) # we store χe in dρe
     χuₕ = @. duₕ =
-        hwgrad(hdiv(cuₕ)) - Geometry.Covariant12Vector(hwcurl(hcurl(cuₕ)))
+        hwgrad(hdiv(cuₕ)) - Geometry.Covariant12Vector(
+            hwcurl(Geometry.Covariant3Vector(hcurl(cuₕ))),
+        )
 
 
     Spaces.weighted_dss!(dρe)
@@ -154,8 +156,11 @@ function rhs_invariant!(dY, Y, _, t)
     κ₄ = 100.0 # m^4/s
     @. dρe = -κ₄ * hwdiv(cρ * hgrad(χe))
     @. duₕ =
-        -κ₄ *
-        (hwgrad(hdiv(χuₕ)) - Geometry.Covariant12Vector(hwcurl(hcurl(χuₕ))))
+        -κ₄ * (
+            hwgrad(hdiv(χuₕ)) - Geometry.Covariant12Vector(
+                hwcurl(Geometry.Covariant3Vector(hcurl(χuₕ))),
+            )
+        )
 
     # 1) Mass conservation
     If2c = Operators.InterpolateF2C()

--- a/examples/sphere/shallow_water.jl
+++ b/examples/sphere/shallow_water.jl
@@ -367,14 +367,19 @@ function rhs!(dydt, y, parameters, t)
 
     # Compute hyperviscosity first
     @. dydt.h = wdiv(grad(y.h))
-    @. dydt.u = wgrad(div(y.u)) - Geometry.Covariant12Vector(wcurl(curl(y.u)))
+    @. dydt.u =
+        wgrad(div(y.u)) -
+        Geometry.Covariant12Vector(wcurl(Geometry.Covariant3Vector(curl(y.u))))
 
     Spaces.weighted_dss!(dydt)
 
     @. dydt.h = -D₄ * wdiv(grad(dydt.h))
     @. dydt.u =
-        -D₄ *
-        (wgrad(div(dydt.u)) - Geometry.Covariant12Vector(wcurl(curl(dydt.u))))
+        -D₄ * (
+            wgrad(div(dydt.u)) - Geometry.Covariant12Vector(
+                wcurl(Geometry.Covariant3Vector(curl(dydt.u))),
+            )
+        )
 
     # Add in pieces
     @. begin

--- a/src/Geometry/conversions.jl
+++ b/src/Geometry/conversions.jl
@@ -318,15 +318,37 @@ end
 The return type when taking the curl along dimensions `I` of a field of eltype `V`, defined on dimensions `L`
 
 Required for statically infering the result type of the curl operation for `AxisVector` subtypes.
+Curl is only defined for `CovariantVector`` field input types.
+
+| Input Vector | Operator direction | Curl output vector |
+| ------------ | ------------------ | -------------- |
+|  Covariant12Vector | (1,2) | Contravariant3Vector |
+|  Covariant3Vector | (1,2) | Contravariant12Vector |
+|  Covariant123Vector | (1,2) | Contravariant123Vector |
+|  Covariant1Vector | (1,) | Contravariant1Vector |
+|  Covariant2Vector | (1,) | Contravariant3Vector |
+|  Covariant3Vector | (1,) | Contravariant2Vector |
+|  Covariant12Vector | (3,) | Contravariant12Vector |
+|  Covariant1Vector | (3,) | Contravariant2Vector |
+|  Covariant2Vector | (3,) | Contravariant1Vector |
+|  Covariant3Vector | (3,) | Contravariant3Vector |
 """
+@inline curl_result_type(
+    ::Val{(1, 2)},
+    ::Type{Covariant3Vector{FT}},
+) where {FT} = Contravariant12Vector{FT}
 @inline curl_result_type(
     ::Val{(1, 2)},
     ::Type{Covariant12Vector{FT}},
 ) where {FT} = Contravariant3Vector{FT}
 @inline curl_result_type(
     ::Val{(1, 2)},
-    ::Type{Covariant3Vector{FT}},
-) where {FT} = Contravariant12Vector{FT}
+    ::Type{Covariant123Vector{FT}},
+) where {FT} = Contravariant123Vector{FT}
+@inline curl_result_type(::Val{(1,)}, ::Type{Covariant1Vector{FT}}) where {FT} =
+    Contravariant1Vector{FT}
+@inline curl_result_type(::Val{(1,)}, ::Type{Covariant2Vector{FT}}) where {FT} =
+    Contravariant3Vector{FT}
 @inline curl_result_type(::Val{(1,)}, ::Type{Covariant3Vector{FT}}) where {FT} =
     Contravariant2Vector{FT}
 @inline curl_result_type(
@@ -337,21 +359,8 @@ Required for statically infering the result type of the curl operation for `Axis
     Contravariant2Vector{FT}
 @inline curl_result_type(::Val{(3,)}, ::Type{Covariant2Vector{FT}}) where {FT} =
     Contravariant1Vector{FT}
-
-# these are only true in 2D
-@inline curl_result_type(
-    ::Val{(1, 2)},
-    ::Type{Contravariant12Vector{FT}},
-) where {FT} = Contravariant3Vector{FT}
-@inline curl_result_type(::Val{(1, 2)}, ::Type{UVVector{FT}}) where {FT} =
+@inline curl_result_type(::Val{(3,)}, ::Type{Covariant3Vector{FT}}) where {FT} =
     Contravariant3Vector{FT}
-@inline curl_result_type(
-    ::Val{(1, 2)},
-    ::Type{Contravariant3Vector{FT}},
-) where {FT} = Contravariant12Vector{FT}
-@inline curl_result_type(::Val{(1, 2)}, ::Type{WVector{FT}}) where {FT} =
-    Contravariant12Vector{FT}
-
 
 _norm_sqr(x, local_geometry::LocalGeometry) =
     sum(x -> _norm_sqr(x, local_geometry), x)

--- a/src/Spaces/dss.jl
+++ b/src/Spaces/dss.jl
@@ -2,30 +2,31 @@ import ..Topologies
 using ..RecursiveApply
 
 
-function dss_transform(arg, local_geometry)
+@inline function dss_transform(arg, local_geometry)
     RecursiveApply.rmap(arg) do x
+        Base.@_inline_meta
         dss_transform(x, local_geometry)
     end
 end
-dss_transform(arg::Number, local_geometry) = arg
-dss_transform(
+@inline dss_transform(arg::Number, local_geometry) = arg
+@inline dss_transform(
     arg::Geometry.AxisTensor{T, N, <:Tuple{Vararg{Geometry.CartesianAxis}}},
     local_geometry::Geometry.LocalGeometry,
 ) where {T, N} = arg
-dss_transform(
+@inline dss_transform(
     arg::Geometry.CartesianVector,
     local_geometry::Geometry.LocalGeometry,
 ) where {T, N} = arg
-dss_transform(
+@inline dss_transform(
     arg::Geometry.AxisTensor{T, N, <:Tuple{Vararg{Geometry.LocalAxis}}},
     local_geometry::Geometry.LocalGeometry,
 ) where {T, N} = arg
-dss_transform(
+@inline dss_transform(
     arg::Geometry.LocalVector,
     local_geometry::Geometry.LocalGeometry,
 ) where {T, N} = arg
 
-function dss_transform(
+@inline function dss_transform(
     arg::Geometry.AxisVector,
     local_geometry::Geometry.LocalGeometry,
 )
@@ -49,18 +50,19 @@ function dss_transform(
     Geometry.transform(ax, arg, local_geometry)
 end
 
-function dss_untransform(refarg, targ, local_geometry)
+@inline function dss_untransform(refarg, targ, local_geometry)
     RecursiveApply.rmap(refarg, targ) do rx, tx
+        Base.@_inline_meta
         dss_untransform(rx, tx, local_geometry)
     end
 end
-dss_untransform(refarg::Number, targ, local_geometry) = targ
-dss_untransform(
+@inline dss_untransform(refarg::Number, targ, local_geometry) = targ
+@inline dss_untransform(
     refarg::T,
     targ::T,
     local_geometry::Geometry.LocalGeometry,
 ) where {T <: Geometry.AxisTensor} = targ
-function dss_untransform(
+@inline function dss_untransform(
     refarg::Geometry.AxisTensor,
     targ::Geometry.AxisTensor,
     local_geometry::Geometry.LocalGeometry,

--- a/src/Spaces/dss.jl
+++ b/src/Spaces/dss.jl
@@ -25,20 +25,21 @@ dss_transform(
     local_geometry::Geometry.LocalGeometry,
 ) where {T, N} = arg
 
-
 function dss_transform(
     arg::Geometry.AxisVector,
     local_geometry::Geometry.LocalGeometry,
 )
     ax = axes(local_geometry.∂x∂ξ, 1)
     axfrom = axes(arg, 1)
-    # TODO: make this consistent
+    # TODO: make this consistent for 2D / 3D
+    # 2D domain axis (1,2) horizontal curl
     if ax isa Geometry.UVAxis && (
         axfrom isa Geometry.Covariant3Axis ||
         axfrom isa Geometry.Contravariant3Axis
     )
         return arg
     end
+    # 2D domain axis (1,3) curl
     if ax isa Geometry.UWAxis && (
         axfrom isa Geometry.Covariant2Axis ||
         axfrom isa Geometry.Contravariant2Axis

--- a/test/spectraloperators.jl
+++ b/test/spectraloperators.jl
@@ -117,7 +117,7 @@ end
             )
 
         curl = Operators.Curl()
-        curlv = curl.(v)
+        curlv = curl.(Geometry.Covariant12Vector.(v))
         Spaces.weighted_dss!(curlv)
         curlv_ref =
             Geometry.Contravariant3Vector.(
@@ -147,7 +147,12 @@ end
             2 .* sin.(coords.x .+ 2 .* coords.y)
 
         curl = Operators.Curl()
-        curlcurlv = curl.(curl.(v))
+        curlcurlv =
+            curl.(
+                Geometry.Covariant3Vector.(
+                    curl.(Geometry.Covariant12Vector.(v)),
+                ),
+            )
         Spaces.weighted_dss!(curlcurlv)
 
         @test Geometry.UVVector.(curlcurlv) ≈
@@ -175,7 +180,13 @@ end
         curl = Operators.Curl()
         wcurl = Operators.WeakCurl()
         curlcurlv =
-            Geometry.UVVector.(wcurl.(Geometry.Covariant3Vector.(curl.(v))),)
+            Geometry.UVVector.(
+                wcurl.(
+                    Geometry.Covariant3Vector.(
+                        curl.(Geometry.Covariant12Vector.(v)),
+                    ),
+                ),
+            )
         Spaces.weighted_dss!(curlcurlv)
 
         @test curlcurlv ≈ Geometry.UVVector.(curlcurlv_ref1, curlcurlv_ref2) rtol =
@@ -192,7 +203,7 @@ end
             )
 
         wcurl = Operators.WeakCurl()
-        curlv = wcurl.(v)
+        curlv = wcurl.(Geometry.Covariant12Vector.(v))
         Spaces.weighted_dss!(curlv)
         curlv_ref =
             .-3 .* sin.(3 .* coords.x .+ 4 .* coords.y) .-
@@ -305,12 +316,22 @@ end
         wgrad = Operators.WeakGradient()
 
         χ = Spaces.weighted_dss!(
-            @. Geometry.UVVector(wgrad(sdiv(y))) -
-               Geometry.UVVector(wcurl(Geometry.Covariant3Vector(curl(y))))
+            @. Geometry.UVVector(wgrad(sdiv(y))) - Geometry.UVVector(
+                wcurl(
+                    Geometry.Covariant3Vector(
+                        curl(Geometry.Covariant12Vector(y)),
+                    ),
+                ),
+            )
         )
         ∇⁴y = Spaces.weighted_dss!(
-            @. Geometry.UVVector(wgrad(sdiv(χ))) -
-               Geometry.UVVector(wcurl(Geometry.Covariant3Vector(curl(χ))))
+            @. Geometry.UVVector(wgrad(sdiv(χ))) - Geometry.UVVector(
+                wcurl(
+                    Geometry.Covariant3Vector(
+                        curl(Geometry.Covariant12Vector(χ)),
+                    ),
+                ),
+            )
         )
 
         @test ∇⁴y_ref ≈ ∇⁴y rtol = 2e-2

--- a/test/sphere_diffusion_vec.jl
+++ b/test/sphere_diffusion_vec.jl
@@ -33,15 +33,15 @@ end
 
     radius = FT(1)
     domain = Domains.SphereDomain(radius)
-    mesh = Meshes.Mesh2D(domain, Meshes.EquiangularSphereWarp(), Ne)
+    mesh = Meshes.EquiangularCubedSphere(domain, Ne)
     grid_topology = Topologies.Topology2D(mesh)
 
     quad = Spaces.Quadratures.GLL{Nq}()
     space = Spaces.SpectralElementSpace2D(grid_topology, quad)
     coords = Fields.coordinate_field(space)
 
-    # compute vector spherical harmonics (VSH) as the gradient of scalar spherical harmonics 
-    # eigenfunction properties of VSH: ∇² VSH(l,m) = -l(l+1) VSH(l,m) 
+    # compute vector spherical harmonics (VSH) as the gradient of scalar spherical harmonics
+    # eigenfunction properties of VSH: ∇² VSH(l,m) = -l(l+1) VSH(l,m)
     VSH_local = map(coords) do coord
         Geometry.UVVector(VSH(l, m, coord.lat, coord.long)...)
     end
@@ -76,7 +76,7 @@ convergence_rate(err, Δh) =
         Δh = Array{FT}(undef, length(Nes))
 
         for (Ie, Ne) in enumerate(Nes)
-            mesh = Meshes.Mesh2D(domain, Meshes.EquiangularSphereWarp(), Ne)
+            mesh = Meshes.EquiangularCubedSphere(domain, Ne)
             grid_topology = Topologies.Topology2D(mesh)
 
             quad = Spaces.Quadratures.GLL{Nq}()

--- a/test/sphere_hyperdiffusion_vec.jl
+++ b/test/sphere_hyperdiffusion_vec.jl
@@ -39,14 +39,14 @@ end
 
     radius = FT(1)
     domain = Domains.SphereDomain(radius)
-    mesh = Meshes.Mesh2D(domain, Meshes.EquiangularSphereWarp(), Ne)
+    mesh = Meshes.EquiangularCubedSphere(domain, Ne)
     grid_topology = Topologies.Topology2D(mesh)
 
     quad = Spaces.Quadratures.GLL{Nq}()
     space = Spaces.SpectralElementSpace2D(grid_topology, quad)
     coords = Fields.coordinate_field(space)
 
-    # compute vector spherical harmonics (VSH) as the gradient of scalar spherical harmonics 
+    # compute vector spherical harmonics (VSH) as the gradient of scalar spherical harmonics
     # eigenfunction properties of VSH: ∇⁴ VSH(l,m) = l²(l+1)² VSH(l,m)
     VSH_local = map(coords) do coord
         Geometry.UVVector(VSH(l, m, coord.lat, coord.long)...)
@@ -82,7 +82,7 @@ convergence_rate(err, Δh) =
         Δh = Array{FT}(undef, length(Nes))
 
         for (Ie, Ne) in enumerate(Nes)
-            mesh = Meshes.Mesh2D(domain, Meshes.EquiangularSphereWarp(), Ne)
+            mesh = Meshes.EquiangularCubedSphere(domain, Ne)
             grid_topology = Topologies.Topology2D(mesh)
 
             quad = Spaces.Quadratures.GLL{Nq}()


### PR DESCRIPTION
Curl on a covariant vector field does not depend on the local metric tensor, this enables the compiler to be able to statically infer the result type and optimize through `curl(curl())` forms found in computing the hyper viscosity terms.

Closes #334 
Closes #264