### PR TITLE
Increase 2d bubble timestep, reduce io

### DIFF
--- a/examples/hybrid/bubble_2d.jl
+++ b/examples/hybrid/bubble_2d.jl
@@ -292,7 +292,7 @@ rhs!(dYdt, Y, nothing, 0.0);
 
 # run!
 using OrdinaryDiffEq
-Δt = 0.025
+Δt = 0.03
 prob = ODEProblem(rhs!, Y, (0.0, 500.0))
 
 haskey(ENV, "CI_PERF_SKIP_RUN") && exit() # for performance analysis
@@ -301,7 +301,7 @@ sol = @timev solve(
     prob,
     SSPRK33(),
     dt = Δt,
-    saveat = 5.0,
+    saveat = 25.0,
     progress = true,
     progress_message = (dt, u, p, t) -> t,
 );


### PR DESCRIPTION
There aren't many inference failures left in the 2D bubble, most of the time spent is in runtime. Comparing with the 3D bubble driver, we run for 500x longer, and with 10x the output frequency. This PR increases the timestep, and decreases the output frequency.