### PR TITLE
Add neighboring_elements

### DIFF
--- a/src/Topologies/Topologies.jl
+++ b/src/Topologies/Topologies.jl
@@ -16,6 +16,7 @@ mesh in the horizontal domain.
 - [`vertex_coordinates`](@ref)
 - [`interior_faces`](@ref)
 - [`vertices`](@ref)
+- [`neighboring_elements`](@ref)
 - [`boundary_tags`](@ref)
 - [`boundary_tag`](@ref)
 - [`boundary_faces`](@ref)
@@ -109,6 +110,13 @@ end
 struct InteriorFaceIterator{T <: AbstractTopology}
     topology::T
 end
+
+"""
+    neighboring_elements(topology, elem)
+
+The list of neighboring elements of element `elem` in `topology`.
+"""
+function neighboring_elements end
 
 """
     boundary_tags(topology)

--- a/src/Topologies/interval.jl
+++ b/src/Topologies/interval.jl
@@ -35,7 +35,7 @@ function opposing_face(topology::IntervalTopology, elem, face)
     n = length(topology.mesh.faces) - 1
     if face == 1
         if elem == 1
-            if isempty(mesh.boundaries) # periodic
+            if isempty(topology.mesh.boundaries) # periodic
                 opelem = n
             else
                 return (0, 1, false)
@@ -46,7 +46,7 @@ function opposing_face(topology::IntervalTopology, elem, face)
         opface = 2
     else
         if elem == n
-            if isempty(mesh.boundaries) # periodic
+            if isempty(topology.mesh.boundaries) # periodic
                 opelem = 1
             else
                 return (0, 2, false)
@@ -77,4 +77,10 @@ function Base.iterate(fiter::InteriorFaceIterator{<:IntervalTopology}, i = 1)
     else
         return nothing
     end
+end
+
+function neighboring_elements(topology::IntervalTopology, elem)
+    (opelem_1, _, _) = opposing_face(topology, elem, 1)
+    (opelem_2, _, _) = opposing_face(topology, elem, 2)
+    return (opelem_1, opelem_2)
 end

--- a/test/Topologies/cubedsphere.jl
+++ b/test/Topologies/cubedsphere.jl
@@ -2,7 +2,35 @@ using ClimaCore: Geometry, Domains, Meshes, Topologies
 using Test
 
 
-
+@testset "neighboring element tests" begin
+    @testset "1 element across each panel" begin
+        topology = Topologies.Topology2D(
+            Meshes.EquiangularCubedSphere(Domains.SphereDomain(5.0), 1),
+        )
+        @test Topologies.neighboring_elements(topology, 1) ==
+              [6, 2, 3, 5, 0, 0, 0, 0]
+    end
+    @testset "2 elements across each panel" begin
+        topology = Topologies.Topology2D(
+            Meshes.EquiangularCubedSphere(Domains.SphereDomain(5.0), 2),
+        )
+        @test Topologies.neighboring_elements(topology, 1) ==
+              [23, 2, 3, 20, 24, 4, 19, 0]
+        @test Topologies.neighboring_elements(topology, 2) ==
+              [24, 5, 4, 1, 0, 7, 3, 23]
+        @test Topologies.neighboring_elements(topology, 3) ==
+              [1, 4, 11, 19, 2, 9, 0, 20]
+        @test Topologies.neighboring_elements(topology, 4) ==
+              [2, 7, 9, 3, 5, 0, 11, 1]
+    end
+    @testset "3 elements across each panel" begin
+        topology = Topologies.Topology2D(
+            Meshes.EquiangularCubedSphere(Domains.SphereDomain(5.0), 3),
+        )
+        @test Topologies.neighboring_elements(topology, 5) ==
+              [2, 6, 8, 4, 3, 9, 7, 1]
+    end
+end
 
 @testset "interior faces iterator" begin
     @testset "1 element across each panel" begin
@@ -19,7 +47,6 @@ using Test
     end
 end
 
-
 @testset "boundaries" begin
     @testset "1 element across each panel" begin
         topology = Topologies.Topology2D(
@@ -34,7 +61,6 @@ end
         @test isempty(Topologies.boundary_tags(topology))
     end
 end
-
 
 @testset "boundaries" begin
     @testset "1 element across each panel" begin

--- a/test/Topologies/rectangle.jl
+++ b/test/Topologies/rectangle.jl
@@ -77,6 +77,45 @@ end
     end
 end
 
+@testset "neighboring element tests" begin
+
+    @testset "1×1 element quad mesh with 1 periodic boundary" begin
+        topology = rectangular_grid(1, 1, true, false)
+        @test Topologies.neighboring_elements(topology, 1) ==
+              [0, 1, 0, 1, 0, 0, 0, 0]
+    end
+
+    @testset "1×1 element quad mesh with non-periodic boundaries" begin
+        topology = rectangular_grid(1, 1, false, false)
+        @test Topologies.neighboring_elements(topology, 1) ==
+              [0, 0, 0, 0, 0, 0, 0, 0]
+    end
+
+    @testset "2×2 element quad mesh with periodic boundaries" begin
+        topology = rectangular_grid(2, 2, true, true)
+        @test Topologies.neighboring_elements(topology, 1) ==
+              [3, 2, 3, 2, 4, 4, 4, 4]
+        @test Topologies.neighboring_elements(topology, 2) ==
+              [4, 1, 4, 1, 3, 3, 3, 3]
+        @test Topologies.neighboring_elements(topology, 3) ==
+              [1, 4, 1, 4, 2, 2, 2, 2]
+        @test Topologies.neighboring_elements(topology, 4) ==
+              [2, 3, 2, 3, 1, 1, 1, 1]
+    end
+
+    @testset "2×2 element quad mesh with non-periodic boundaries" begin
+        topology = rectangular_grid(2, 2, false, false)
+        @test Topologies.neighboring_elements(topology, 1) ==
+              [0, 2, 3, 0, 0, 4, 0, 0]
+        @test Topologies.neighboring_elements(topology, 2) ==
+              [0, 0, 4, 1, 0, 0, 3, 0]
+        @test Topologies.neighboring_elements(topology, 3) ==
+              [1, 4, 0, 0, 2, 0, 0, 0]
+        @test Topologies.neighboring_elements(topology, 4) ==
+              [2, 0, 0, 3, 0, 0, 0, 1]
+    end
+end
+
 @testset "simple rectangular mesh interior faces iterator" begin
 
     @testset "1×1 element quad mesh with all periodic boundries" begin


### PR DESCRIPTION
This PR adds a function that given an element returns its neighboring elements (in a 2D topology). 
This is needed in #426.
While at it, I fixed a bug in `IntervalTopology`'s `opposing_face` (and realized that we do not have any tests for `IntervalTopology`!!)

Will close #445 .

