### PR TITLE
Fix allocation monitoring

### DIFF
--- a/examples/3dsphere/baroclinic_wave.jl
+++ b/examples/3dsphere/baroclinic_wave.jl
@@ -316,7 +316,9 @@ end
 dt = 5
 prob = ODEProblem(rhs!, Y, (0.0, time_end))
 
-haskey(ENV, "CI_PERF_SKIP_RUN") && exit() # for performance analysis
+if haskey(ENV, "CI_PERF_SKIP_RUN") # for performance analysis
+    throw(:exit_profile)
+end
 
 sol = @timev solve(
     prob,

--- a/examples/3dsphere/baroclinic_wave_rho_etot.jl
+++ b/examples/3dsphere/baroclinic_wave_rho_etot.jl
@@ -51,7 +51,7 @@ Test_Type = "Implicit" # "Implicit" #"Seim-Explicit"  #"Implicit-Explicit"    # 
 P = map(c -> 0.0, c_coords.z)
 Φ = @. gravitational_potential(c_coords.z)
 ∇Φ = vgradc2f.(Φ)
-p = (; P, Φ, ∇Φ)
+parameters = (; P, Φ, ∇Φ)
 
 if Test_Type == "Explicit"
     T = 3600
@@ -93,7 +93,7 @@ elseif Test_Type == "Implicit"
     use_transform = !(ode_algorithm in (Rosenbrock23, Rosenbrock32))
     # TODO
     𝕄 = map(c -> Geometry.WVector(0.0), f_coords)
-    p = (; ρw = similar(𝕄), p...)
+    parameters = (; ρw = similar(𝕄), parameters...)
 
     jac_prototype = CustomWRepresentation(
         velem,
@@ -119,10 +119,13 @@ elseif Test_Type == "Implicit"
         ),
         Y,
         (0.0, T),
-        p,
+        parameters,
     )
 
-    haskey(ENV, "CI_PERF_SKIP_RUN") && exit() # for performance analysis
+    if haskey(ENV, "CI_PERF_SKIP_RUN") # for performance analysis
+        throw(:exit_profile)
+    end
+
 
     sol = solve(
         prob,

--- a/examples/3dsphere/solid_body_rotation_3d.jl
+++ b/examples/3dsphere/solid_body_rotation_3d.jl
@@ -264,7 +264,9 @@ T = 3600
 dt = 5
 prob = ODEProblem(rhs!, Y, (0.0, T))
 
-haskey(ENV, "CI_PERF_SKIP_RUN") && exit() # for performance analysis
+if haskey(ENV, "CI_PERF_SKIP_RUN") # for performance analysis
+    throw(:exit_profile)
+end
 
 # solve ode
 sol = solve(

--- a/examples/hybrid/bubble_2d.jl
+++ b/examples/hybrid/bubble_2d.jl
@@ -295,7 +295,9 @@ using OrdinaryDiffEq
 Δt = 0.03
 prob = ODEProblem(rhs!, Y, (0.0, 500.0))
 
-haskey(ENV, "CI_PERF_SKIP_RUN") && exit() # for performance analysis
+if haskey(ENV, "CI_PERF_SKIP_RUN") # for performance analysis
+    throw(:exit_profile)
+end
 
 sol = @timev solve(
     prob,

--- a/examples/hybrid/bubble_3d.jl
+++ b/examples/hybrid/bubble_3d.jl
@@ -304,7 +304,9 @@ using OrdinaryDiffEq
 Δt = 0.05
 prob = ODEProblem(rhs!, Y, (0.0, 1.0))
 
-haskey(ENV, "CI_PERF_SKIP_RUN") && exit() # for performance analysis
+if haskey(ENV, "CI_PERF_SKIP_RUN") # for performance analysis
+    throw(:exit_profile)
+end
 
 sol = @timev solve(
     prob,

--- a/perf/allocs_per_case.jl
+++ b/perf/allocs_per_case.jl
@@ -6,11 +6,23 @@ import Profile
 
 case_name = ENV["ALLOCATION_CASE_NAME"]
 ENV["CI_PERF_SKIP_RUN"] = true # we only need haskey(ENV, "CI_PERF_SKIP_RUN") == true
-include(case_name)
+try
+    include(case_name)
+catch err
+    if err.error !== :exit_profile
+        rethrow(err.error)
+    end
+end
 
-rhs!(dYdt, Y, nothing, 0.0) # compile first
-Profile.clear_malloc_data()
-rhs!(dYdt, Y, nothing, 0.0)
+if @isdefined parameters
+    rhs!(dYdt, Y, parameters, 0.0) # compile first
+    Profile.clear_malloc_data()
+    rhs!(dYdt, Y, parameters, 0.0)
+else
+    rhs!(dYdt, Y, nothing, 0.0) # compile first
+    Profile.clear_malloc_data()
+    rhs!(dYdt, Y, nothing, 0.0)
+end
 
 # Quit julia (which generates .mem files), then call
 #=


### PR DESCRIPTION
This explains why things were working when I thought #455 would fix the missing parameter sent into `rhs!`-- we are currently exiting the julia session, so we only run this script to the noted line

```julia
# Launch with `julia --project --track-allocation=user`
import Pkg
Pkg.develop(path = ".")

import Profile

case_name = ENV["ALLOCATION_CASE_NAME"]
ENV["CI_PERF_SKIP_RUN"] = true # we only need haskey(ENV, "CI_PERF_SKIP_RUN") == true


include(case_name)      #  <------------------- We exit in here and accidentally skip the rest of the script


rhs!(dYdt, Y, nothing, 0.0) # compile first
Profile.clear_malloc_data()
rhs!(dYdt, Y, nothing, 0.0)

# Quit julia (which generates .mem files), then call
#=
import Coverage
allocs = Coverage.analyze_malloc("src")
=#
```

This PR should reveal the true allocations occurring in the ClimaCore `rhs!` functions.

@jakebolewski / @simonbyrne, is it alright to use `try` / `catch` here like this? I was hoping to keep these performance parts as minimally invasive as possible