### PR TITLE
Use better recursion pattern for instantiate, avoid getindex

### DIFF
--- a/examples/3dsphere/implicit_3d_sphere_utils.jl
+++ b/examples/3dsphere/implicit_3d_sphere_utils.jl
@@ -456,30 +456,6 @@ function sphere_3D(
     return (hv_center_space, hv_face_space)
 end
 
-
-
-# temporary FieldVector broadcast and fill patches that speeds up solves by 2-3x
-import Base: copyto!, fill!
-using Base.Broadcast: Broadcasted, broadcasted, BroadcastStyle
-transform_broadcasted(bc::Broadcasted{Fields.FieldVectorStyle}, symb, axes) =
-    Broadcasted(
-        bc.f,
-        map(arg -> transform_broadcasted(arg, symb, axes), bc.args),
-        axes,
-    )
-transform_broadcasted(fv::Fields.FieldVector, symb, axes) =
-    parent(getproperty(fv, symb))
-transform_broadcasted(x, symb, axes) = x
-@inline function Base.copyto!(
-    dest::Fields.FieldVector,
-    bc::Broadcasted{Fields.FieldVectorStyle},
-)
-    for symb in propertynames(dest)
-        p = parent(getproperty(dest, symb))
-        copyto!(p, transform_broadcasted(bc, symb, axes(p)))
-    end
-    return dest
-end
 function Base.fill!(a::Fields.FieldVector, x)
     for symb in propertynames(a)
         fill!(parent(getproperty(a, symb)), x)

--- a/src/Fields/fieldvector.jl
+++ b/src/Fields/fieldvector.jl
@@ -101,6 +101,8 @@ function Base.getindex(fv::FieldVector, bidx::BlockArrays.BlockIndex{1})
     X = fv[BlockArrays.block(bidx)]
     X[bidx.α...]
 end
+
+# TODO: drop support for this
 Base.getindex(fv::FieldVector, i::Integer) =
     getindex(fv, BlockArrays.findblockindex(axes(fv, 1), i))
 
@@ -108,9 +110,9 @@ function Base.setindex!(fv::FieldVector, val, bidx::BlockArrays.BlockIndex{1})
     X = fv[BlockArrays.block(bidx)]
     X[bidx.α...] = val
 end
+# TODO: drop support for this
 Base.setindex!(fv::FieldVector, val, i::Integer) =
     setindex!(fv, val, BlockArrays.findblockindex(axes(fv, 1), i))
-
 
 Base.similar(fv::FieldVector{T}) where {T} =
     FieldVector{T}(map(similar, _values(fv)))
@@ -167,14 +169,46 @@ function Base.similar(
     error("Cannot construct FieldVector")
 end
 
-@inline function Base.copyto!(
-    dest::FV,
-    src::FV,
-) where {FV <: Fields.FieldVector}
+@inline function Base.copyto!(dest::FV, src::FV) where {FV <: FieldVector}
     for symb in propertynames(dest)
         pd = parent(getproperty(dest, symb))
         ps = parent(getproperty(src, symb))
         copyto!(pd, ps)
+    end
+    return dest
+end
+
+# Recursively call transform_bc_args() on broadcast arguments in a way that is statically reducible by the optimizer
+# see Base.Broadcast.preprocess_args
+@inline transform_bc_args(args::Tuple, inds...) = (
+    transform_broadcasted(args[1], inds...),
+    transform_bc_args(Base.tail(args), inds...)...,
+)
+@inline transform_bc_args(args::Tuple{Any}, inds...) =
+    (transform_broadcasted(args[1], inds...),)
+@inline transform_bc_args(args::Tuple{}, inds...) = ()
+
+function transform_broadcasted(
+    bc::Base.Broadcast.Broadcasted{FieldVectorStyle},
+    symb,
+    axes,
+)
+    Base.Broadcast.Broadcasted(
+        bc.f,
+        transform_bc_args(bc.args, symb, axes),
+        axes,
+    )
+end
+transform_broadcasted(fv::FieldVector, symb, axes) =
+    parent(getfield(_values(fv), symb))
+transform_broadcasted(x, symb, axes) = x
+Base.@propagate_inbounds function Base.copyto!(
+    dest::FieldVector,
+    bc::Base.Broadcast.Broadcasted{FieldVectorStyle},
+)
+    for symb in propertynames(dest)
+        p = parent(getfield(_values(dest), symb))
+        copyto!(p, transform_broadcasted(bc, symb, axes(p)))
     end
     return dest
 end


### PR DESCRIPTION
After looking at more flame graphs, I saw a call chain of `fast_materialize!` -> `materialize!` -> bad stuff with allocs and `getindex`. I took a look at our `materialize!` and that basically just calls `copyto!` and `instantiate`. Since we recently fixed issues with `copyto!`, I took a look at `instantiate` and recognized that we were using the same old, recursion pattern as before. This PR changes this recursion pattern to follow `column_args` and alike.

This will only affect the spectral code, since the call to `initialize` in FD's `materialize!` isn't recursive.

This PR also moves @dennisYatunin's `copyto!(::FieldVector,::Base.Broadcast.Broadcasted{FieldVectorStyle})` into `src/` with some minor adjustments (using a better recursion pattern, and supporting `VectorField`s with scalars.). This change seems to account for most of the performance benefit, as it elides calling `getindex` (which was the main culprit in the flame graph).