### PR TITLE
Use integrator interface, add flame script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,6 @@ docs/src/tutorials/
 
 
 *.gif
+*.gz
 *.mp4
 *.png

--- a/examples/3dsphere/baroclinic_wave.jl
+++ b/examples/3dsphere/baroclinic_wave.jl
@@ -316,11 +316,7 @@ end
 dt = 5
 prob = ODEProblem(rhs!, Y, (0.0, time_end))
 
-if haskey(ENV, "CI_PERF_SKIP_RUN") # for performance analysis
-    throw(:exit_profile)
-end
-
-sol = @timev solve(
+integrator = OrdinaryDiffEq.init(
     prob,
     SSPRK33(),
     dt = dt,
@@ -329,6 +325,12 @@ sol = @timev solve(
     adaptive = false,
     progress_message = (dt, u, p, t) -> t,
 )
+
+if haskey(ENV, "CI_PERF_SKIP_RUN") # for performance analysis
+    throw(:exit_profile)
+end
+
+sol = @timev OrdinaryDiffEq.solve!(integrator)
 
 # visualization artifacts
 if test_name == "baroclinic_wave"

--- a/examples/3dsphere/solid_body_rotation_3d.jl
+++ b/examples/3dsphere/solid_body_rotation_3d.jl
@@ -264,12 +264,7 @@ T = 3600
 dt = 5
 prob = ODEProblem(rhs!, Y, (0.0, T))
 
-if haskey(ENV, "CI_PERF_SKIP_RUN") # for performance analysis
-    throw(:exit_profile)
-end
-
-# solve ode
-sol = solve(
+integrator = OrdinaryDiffEq.init(
     prob,
     SSPRK33(),
     dt = dt,
@@ -278,6 +273,13 @@ sol = solve(
     adaptive = false,
     progress_message = (dt, u, p, t) -> t,
 )
+
+if haskey(ENV, "CI_PERF_SKIP_RUN") # for performance analysis
+    throw(:exit_profile)
+end
+
+# solve ode
+sol = @timev OrdinaryDiffEq.solve!(integrator)
 
 uₕ_phy = Geometry.transform.(Ref(Geometry.UVAxis()), sol.u[end].uₕ)
 w_phy = Geometry.transform.(Ref(Geometry.WAxis()), sol.u[end].w)

--- a/examples/hybrid/bubble_2d.jl
+++ b/examples/hybrid/bubble_2d.jl
@@ -295,11 +295,7 @@ using OrdinaryDiffEq
 Δt = 0.03
 prob = ODEProblem(rhs!, Y, (0.0, 500.0))
 
-if haskey(ENV, "CI_PERF_SKIP_RUN") # for performance analysis
-    throw(:exit_profile)
-end
-
-sol = @timev solve(
+integrator = OrdinaryDiffEq.init(
     prob,
     SSPRK33(),
     dt = Δt,
@@ -307,6 +303,12 @@ sol = @timev solve(
     progress = true,
     progress_message = (dt, u, p, t) -> t,
 );
+
+if haskey(ENV, "CI_PERF_SKIP_RUN") # for performance analysis
+    throw(:exit_profile)
+end
+
+sol = @timev OrdinaryDiffEq.solve!(integrator)
 
 ENV["GKSwstype"] = "nul"
 using ClimaCorePlots, Plots

--- a/examples/hybrid/bubble_3d.jl
+++ b/examples/hybrid/bubble_3d.jl
@@ -303,12 +303,7 @@ rhs!(dYdt, Y, nothing, 0.0);
 using OrdinaryDiffEq
 Δt = 0.05
 prob = ODEProblem(rhs!, Y, (0.0, 1.0))
-
-if haskey(ENV, "CI_PERF_SKIP_RUN") # for performance analysis
-    throw(:exit_profile)
-end
-
-sol = @timev solve(
+integrator = OrdinaryDiffEq.init(
     prob,
     SSPRK33(),
     dt = Δt,
@@ -316,6 +311,12 @@ sol = @timev solve(
     progress = true,
     progress_message = (dt, u, p, t) -> t,
 );
+
+if haskey(ENV, "CI_PERF_SKIP_RUN") # for performance analysis
+    throw(:exit_profile)
+end
+
+sol = @timev OrdinaryDiffEq.solve!(integrator)
 
 ENV["GKSwstype"] = "nul"
 import Plots

--- a/perf/allocs_per_case.jl
+++ b/perf/allocs_per_case.jl
@@ -14,24 +14,6 @@ catch err
     end
 end
 
-if @isdefined integrator
-    OrdinaryDiffEq.step!(integrator) # compile first
-    Profile.clear_malloc_data()
-    OrdinaryDiffEq.step!(integrator)
-else
-    if @isdefined parameters
-        rhs!(dYdt, Y, parameters, 0.0) # compile first
-        Profile.clear_malloc_data()
-        rhs!(dYdt, Y, parameters, 0.0)
-    else
-        rhs!(dYdt, Y, nothing, 0.0) # compile first
-        Profile.clear_malloc_data()
-        rhs!(dYdt, Y, nothing, 0.0)
-    end
-end
-
-# Quit julia (which generates .mem files), then call
-#=
-import Coverage
-allocs = Coverage.analyze_malloc("src")
-=#
+OrdinaryDiffEq.step!(integrator) # compile first
+Profile.clear_malloc_data()
+OrdinaryDiffEq.step!(integrator)

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -1,0 +1,33 @@
+import Pkg
+Pkg.develop(path = ".")
+
+mod_dir(x) = dirname(dirname(pathof(x)))
+import Profile
+
+ENV["CI_PERF_SKIP_RUN"] = true # we only need haskey(ENV, "CI_PERF_SKIP_RUN") == true
+
+import ClimaCore
+pkg_dir = mod_dir(ClimaCore)
+
+filename = joinpath(pkg_dir, "examples", "hybrid", "bubble_2d.jl")
+# filename = joinpath(pkg_dir, "examples", "3dsphere", "baroclinic_wave_rho_etot.jl")
+
+try
+    include(filename)
+catch err
+    if err.error !== :exit_profile
+        rethrow(err.error)
+    end
+end
+
+OrdinaryDiffEq.step!(integrator) # compile first
+Profile.clear_malloc_data()
+prof = Profile.@profile begin
+    for _ in 1:5
+        OrdinaryDiffEq.step!(integrator)
+    end
+end
+
+import PProf
+PProf.pprof()
+# http://localhost:57599/ui/flamegraph?tf


### PR DESCRIPTION
This PR adds a flame script to the repo, and changes the monitored drivers to use OrdinaryDiffEq.jl's integrator interface. This should help make the analysis a bit more streamlined.