### PR TITLE
promote wrapped datastyles for field broadcasts

### DIFF
--- a/src/Fields/broadcast.jl
+++ b/src/Fields/broadcast.jl
@@ -14,13 +14,18 @@ struct FieldStyle{DS <: DataStyle} <: AbstractFieldStyle end
 
 FieldStyle(::DS) where {DS <: DataStyle} = FieldStyle{DS}()
 
-Base.Broadcast.BroadcastStyle(::Type{Field{V, M}}) where {V, M} =
+Base.Broadcast.BroadcastStyle(::Type{Field{V, S}}) where {V, S} =
     FieldStyle(DataStyle(V))
 
 Base.Broadcast.BroadcastStyle(
     ::Base.Broadcast.AbstractArrayStyle{0},
     fs::AbstractFieldStyle,
 ) = fs
+
+Base.Broadcast.BroadcastStyle(
+    ::FieldStyle{DS1},
+    ::FieldStyle{DS2},
+) where {DS1, DS2} = FieldStyle(Base.Broadcast.BroadcastStyle(DS1(), DS2()))
 
 Base.Broadcast.broadcastable(field::Field) = field
 

--- a/test/Fields/field.jl
+++ b/test/Fields/field.jl
@@ -59,6 +59,18 @@ end
     res = field.re .+ 1
     @test parent(Fields.field_values(res)) ==
           Float64[2 for i in 1:Nij, j in 1:Nij, f in 1:1, h in 1:(n1 * n2)]
+
+    # test field slab broadcasting
+    f1 = ones(space)
+    f2 = ones(space)
+
+    for h in 1:(n1 * n2)
+        f1_slab = Fields.slab(f1, h)
+        f2_slab = Fields.slab(f2, h)
+        q = f1_slab .+ f2_slab
+        f1_slab .= q .+ f2_slab
+    end
+    @test all(parent(f1) .== 3)
 end
 
 @testset "Broadcasting interception for tuple-valued fields" begin


### PR DESCRIPTION
Fixes a bug where we couldn't properly promote to the underlying data layout style (for Field slab / columns).