### PR TITLE
Prep examples for perf analysis

### DIFF
--- a/examples/hybrid/bubble3d_invariant_totalenergy.jl
+++ b/examples/hybrid/bubble3d_invariant_totalenergy.jl
@@ -264,20 +264,26 @@ function rhs_invariant!(dY, Y, _, t)
 end
 
 dYdt = similar(Y);
-rhs_invariant!(dYdt, Y, nothing, 0.0);
+rhs_invariant!(dYdt, Y, parameters, 0.0);
 
 # run!
 using OrdinaryDiffEq
 Δt = 0.050
-prob = ODEProblem(rhs_invariant!, Y, (0.0, 700.0))
-sol_invariant = solve(
+prob = ODEProblem(rhs_invariant!, Y, (0.0, 700.0), parameters)
+integrator = OrdinaryDiffEq.init(
     prob,
     SSPRK33(),
     dt = Δt,
-    saveat = 1.0,
+    saveat = 10.0,
     progress = true,
     progress_message = (dt, u, p, t) -> t,
 );
+
+if haskey(ENV, "CI_PERF_SKIP_RUN") # for performance analysis
+    throw(:exit_profile)
+end
+
+sol_invariant = @timev OrdinaryDiffEq.solve!(integrator)
 
 ENV["GKSwstype"] = "nul"
 import Plots

--- a/perf/allocs.jl
+++ b/perf/allocs.jl
@@ -23,7 +23,6 @@ all_cases = [
     (joinpath(EXAMPLE_DIR, "hybrid", "bubble_3d.jl"), ""),
     (joinpath(EXAMPLE_DIR, "3dsphere", "baroclinic_wave.jl"), "baroclinic_wave"),
     (joinpath(EXAMPLE_DIR, "sphere", "shallow_water.jl"), "barotropic_instability"),
-    (joinpath(EXAMPLE_DIR, "3dsphere", "solid_body_rotation_3d.jl"), ""),
     (joinpath(EXAMPLE_DIR, "3dsphere", "baroclinic_wave_rho_etot.jl"), ""),
 ]
 #! format: on


### PR DESCRIPTION
This PR preallocates some fields, and preps some examples for perf analysis:
 - `examples/hybrid/bubble3d_invariant_totalenergy.jl`
 - `examples/3dsphere/held_suarez_rho_etot.jl`