### PR TITLE
enable opt-in operator thread parallelism

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -452,12 +452,13 @@ steps:
   - label: ":computer: baroclinic wave"
     key: "cpu_baroclinic_wave"
     command:
-      - "julia --color=yes --project=examples examples/3dsphere/baroclinic_wave.jl"
+      - "julia --threads=4 --color=yes --project=examples examples/3dsphere/baroclinic_wave.jl"
     artifact_paths:
       - "examples/3dsphere/output/baroclinic_wave/*"
     agents:
       config: cpu
       queue: central
+      slurm_cpus_per_task: 4
       slurm_ntasks: 1
 
   - label: ":computer: baroclinic wave rho etot implicit"

--- a/examples/3dsphere/baroclinic_wave.jl
+++ b/examples/3dsphere/baroclinic_wave.jl
@@ -21,6 +21,10 @@ import Logging
 import TerminalLoggers
 Logging.global_logger(TerminalLoggers.TerminalLogger())
 
+# Enable threading for the baroclinic wave example
+import ClimaCore: enable_threading
+enable_threading() = true
+
 # This experiment tests
 #     1) hydrostatic and geostrophic balance;
 #     2) linear instability.

--- a/src/DataLayouts/DataLayouts.jl
+++ b/src/DataLayouts/DataLayouts.jl
@@ -17,7 +17,7 @@ module DataLayouts
 import Base: Base, @propagate_inbounds
 import StaticArrays: SOneTo, MArray
 
-import ..slab, ..slab_args, ..column, ..column_args, ..level
+import ..enable_threading, ..slab, ..slab_args, ..column, ..column_args, ..level
 export slab, column, IJFH, IJF, IFH, IF, VF, VIJFH, VIFH
 
 include("struct.jl")

--- a/src/Operators/Operators.jl
+++ b/src/Operators/Operators.jl
@@ -4,7 +4,7 @@ import LinearAlgebra
 
 using StaticArrays
 
-import ..slab, ..slab_args, ..column, ..column_args
+import ..enable_threading, ..slab, ..slab_args, ..column, ..column_args
 import ..DataLayouts: DataLayouts, Data2D, DataSlab2D
 import ..Geometry: Geometry, Covariant12Vector, Contravariant12Vector, ⊗
 import ..Spaces: Spaces, Quadratures, AbstractSpace

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -2134,6 +2134,38 @@ function Base.similar(
     return Field(Eltype, sp)
 end
 
+function _serial_copyto!(
+    field_out::Field,
+    bc::Base.Broadcast.Broadcasted{S},
+    Ni::Int,
+    Nj::Int,
+    Nh::Int,
+) where {S <: AbstractStencilStyle}
+    for h in 1:Nh, j in 1:Nj, i in 1:Ni
+        column_field_out = column(field_out, i, j, h)
+        column_bc = column(bc, i, j, h)
+        apply_stencil!(column_field_out, column_bc)
+    end
+    return field_out
+end
+
+function _threaded_copyto!(
+    field_out::Field,
+    bc::Base.Broadcast.Broadcasted{S},
+    Ni::Int,
+    Nj::Int,
+    Nh::Int,
+) where {S <: AbstractStencilStyle}
+    Threads.@threads for h in 1:Nh
+        for j in 1:Nj, i in 1:Ni
+            column_field_out = column(field_out, i, j, h)
+            column_bc = column(bc, i, j, h)
+            apply_stencil!(column_field_out, column_bc)
+        end
+    end
+    return field_out
+end
+
 function Base.copyto!(
     field_out::Field,
     bc::Base.Broadcast.Broadcasted{S},
@@ -2141,12 +2173,10 @@ function Base.copyto!(
     space = axes(bc)
     local_geometry = Spaces.local_geometry_data(space)
     (Ni, Nj, _, _, Nh) = size(local_geometry)
-    for h in 1:Nh, j in 1:Nj, i in 1:Ni
-        column_field_out = column(field_out, i, j, h)
-        column_bc = column(bc, i, j, h)
-        apply_stencil!(column_field_out, column_bc)
+    if enable_threading()
+        return _threaded_copyto!(field_out, bc, Ni, Nj, Nh)
     end
-    return field_out
+    return _serial_copyto!(field_out, bc, Ni, Nj, Nh)
 end
 
 function apply_stencil!(field_out, bc)

--- a/src/Operators/spectralelement.jl
+++ b/src/Operators/spectralelement.jl
@@ -151,21 +151,56 @@ function Base.Broadcast.materialize(sbc::SpectralBroadcasted)
     copy(Base.Broadcast.instantiate(sbc))
 end
 
+Base.@propagate_inbounds function _inner_copyto!(
+    field_out::Field,
+    sbc::SpectralBroadcasted,
+    v::Integer,
+    h::Integer,
+)
+    slab_out = slab(field_out, v, h)
+    out_slab_space = slab(axes(sbc), v, h)
+    in_slab_space = slab(input_space(sbc), v, h)
+    _slab_args = _apply_slab_args(slab_args(sbc.args, v, h), v, h)
+    copy_slab!(
+        slab_out,
+        apply_slab(sbc.op, out_slab_space, in_slab_space, _slab_args...),
+    )
+end
+
+function _serial_copyto!(
+    field_out::Field,
+    sbc::SpectralBroadcasted,
+    Nv::Int,
+    Nh::Int,
+)
+    @inbounds for h in 1:Nh, v in 1:Nv
+        _inner_copyto!(field_out, sbc, v, h)
+    end
+    return field_out
+end
+
+function _threaded_copyto!(
+    field_out::Field,
+    sbc::SpectralBroadcasted,
+    Nv::Int,
+    Nh::Int,
+)
+    Threads.@threads for h in 1:Nh
+        @inbounds for v in 1:Nv
+            _inner_copyto!(field_out, sbc, v, h)
+        end
+    end
+    return field_out
+end
+
 function Base.copyto!(field_out::Field, sbc::SpectralBroadcasted)
     space = axes(field_out)
     Nv = Spaces.nlevels(space)
     Nh = Topologies.nlocalelems(Spaces.topology(space))
-    @inbounds for h in 1:Nh, v in 1:Nv
-        slab_out = slab(field_out, v, h)
-        out_slab_space = slab(axes(sbc), v, h)
-        in_slab_space = slab(input_space(sbc), v, h)
-        _slab_args = _apply_slab_args(slab_args(sbc.args, v, h), v, h)
-        copy_slab!(
-            slab_out,
-            apply_slab(sbc.op, out_slab_space, in_slab_space, _slab_args...),
-        )
+    if enable_threading()
+        return _threaded_copyto!(field_out, sbc, Nv, Nh)
     end
-    return field_out
+    return _serial_copyto!(field_out, sbc, Nv, Nh)
 end
 
 function Base.Broadcast.materialize!(dest, sbc::SpectralBroadcasted)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,6 +1,19 @@
 # Toplevel interface functions for recurisve broadcast expressions
 
 """
+    enable_threading()
+
+By default returns `false` signifying threading is disabled.
+Enable the threading runtime by redefining the method at the toplevel your experiment file:
+
+    import ClimaCore: enable_threading
+    enable_threading() = true
+
+and running julia with `julia --nthreads=N ...`
+"""
+enable_threading() = false
+
+"""
     slab(data::AbstractData, h::Integer)
 
 A "pancake" view into an underlying

--- a/test/Topologies/dtopo4.jl
+++ b/test/Topologies/dtopo4.jl
@@ -36,7 +36,7 @@ function distributed_grid(
         x1boundary = x1periodic ? nothing : (:west, :east),
         x2boundary = x2periodic ? nothing : (:south, :north),
     )
-    mesh = Meshes.EquispacedRectangleMesh(domain, n1, n2)
+    mesh = Meshes.RectilinearMesh(domain, n1, n2)
     return Topologies.DistributedTopology2D(mesh, Context)
 end
 


### PR DESCRIPTION
To address the question we need to do it this way to make our static analysis tests continue to work (the optimizer can const prop and eliminate the branch by default, so everything should still work as before until the method is redefined). 

This is just to get us going and the API will change in the future.

Closes #503 