### PR TITLE
Add Cent types--complement to PlusHalf

### DIFF
--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -6,7 +6,7 @@ import ..Domains
 import ..Topologies
 import ..Spaces: Spaces, AbstractSpace
 import ..Geometry: Geometry, Cartesian12Vector
-import ..Utilities: PlusHalf
+import ..Utilities: PlusHalf, Cent
 
 using ..RecursiveApply
 
@@ -327,5 +327,60 @@ function level(field::FaceExtrudedFiniteDifferenceField, v::PlusHalf)
     data = level(field_values(field), v.i + 1)
     Field(data, hspace)
 end
+
+#=
+Defining `getindex` here is required to differentiate between
+ - `getindex` to get the i-th n-tuple field
+ - `getindex` to get the k-th vertical cell center
+=#
+Base.@propagate_inbounds Base.getindex(
+    field::FiniteDifferenceField,
+    i::Integer,
+) = Base.getproperty(field, i)
+
+Base.@propagate_inbounds Base.getindex(
+    field::CenterFiniteDifferenceField,
+    i::Cent,
+) = Base.getindex(field_values(field), i.i)
+Base.@propagate_inbounds Base.setindex!(
+    field::CenterFiniteDifferenceField,
+    v,
+    i::Cent,
+) = Base.setindex!(field_values(field), v, i.i)
+
+Base.@propagate_inbounds Base.getindex(
+    field::FaceFiniteDifferenceField,
+    i::PlusHalf,
+) = Base.getindex(field_values(field), i.i)
+Base.@propagate_inbounds Base.setindex!(
+    field::FaceFiniteDifferenceField,
+    v,
+    i::PlusHalf,
+) = Base.setindex!(field_values(field), v, i.i)
+
+Base.@propagate_inbounds Base.getindex(
+    field::FaceFiniteDifferenceField,
+    ::Cent,
+) = error("Attempting to getindex with a center index (Cent) into a Face field")
+Base.@propagate_inbounds Base.getindex(
+    field::CenterFiniteDifferenceField,
+    ::PlusHalf,
+) = error(
+    "Attempting to getindex with a face index (PlusHalf) into a Center field",
+)
+
+Base.@propagate_inbounds Base.setindex!(
+    field::FaceFiniteDifferenceField,
+    v,
+    ::Cent,
+) = error("Attempting to setindex with a center index (Cent) into a Face field")
+Base.@propagate_inbounds Base.setindex!(
+    field::CenterFiniteDifferenceField,
+    v,
+    ::PlusHalf,
+) = error(
+    "Attempting to setindex with a face index (PlusHalf) into a Center field",
+)
+
 
 end # module

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -1,5 +1,6 @@
 module Utilities
 
 include("plushalf.jl")
+include("cent.jl")
 
 end # module

--- a/src/Utilities/cent.jl
+++ b/src/Utilities/cent.jl
@@ -1,0 +1,43 @@
+"""
+    Cent(i)
+
+Represents `i`, but stored as internally as an integer value. Used for
+indexing into staggered finite difference meshes: the convention "cent" values
+are indexed at cell centers, whereas [`PlusHalf`](@ref) are indexed at cell faces.
+
+Supports `+`, `-` and inequalities.
+
+This is a complementary struct to [`PlusHalf`](@ref).
+
+This is required to differentiate
+ - `getindex` to get the i-th n-tuple field
+ - `getindex` to get the k-th vertical cell center
+"""
+struct Cent{I <: Integer}
+    i::I
+end
+
+Base.:+(h::Cent) = h
+Base.:-(h::Cent) = Cent(-h.i - one(h.i))
+Base.:+(i::Integer, h::Cent) = Cent(i + h.i)
+Base.:+(h::Cent, i::Integer) = Cent(h.i + i)
+Base.:+(h1::Cent, h2::Cent) = h1.i + h2.i + one(h1.i)
+Base.:-(i::Integer, h::Cent) = Cent(i - h.i - one(h.i))
+Base.:-(h::Cent, i::Integer) = Cent(h.i - i)
+Base.:-(h1::Cent, h2::Cent) = h1.i - h2.i
+
+Base.:<=(h1::Cent, h2::Cent) = h1.i <= h2.i
+Base.:<(h1::Cent, h2::Cent) = h1.i < h2.i
+Base.max(h1::Cent, h2::Cent) = Cent(max(h1.i, h2.i))
+Base.min(h1::Cent, h2::Cent) = Cent(min(h1.i, h2.i))
+
+# Can we do this?
+# # TODO: deprecate, we should not overload getindex/setindex for ordinary arrays.
+# Base.@propagate_inbounds Base.getindex(arr::AbstractArray, i::Cent) = Base.getindex(arr, i.i)
+# Base.@propagate_inbounds Base.setindex!(arr::AbstractArray, v, i::Cent) = Base.setindex!(arr, v, i.i)
+# Base.@propagate_inbounds Base.getindex(arr::AbstractArray, i::CCO.PlusHalf) = Base.getindex(arr, i.i)
+# Base.@propagate_inbounds Base.setindex!(arr::AbstractArray, v, i::CCO.PlusHalf) = Base.setindex!(arr, v, i.i)
+# Base.@propagate_inbounds Base.getindex(arr::AbstractArray, i::Int, j::Cent) = Base.getindex(arr, i, j.i)
+# Base.@propagate_inbounds Base.setindex!(arr::AbstractArray, v, i::Int, j::Cent) = Base.setindex!(arr, v, i, j.i)
+# Base.@propagate_inbounds Base.getindex(arr::AbstractArray, i::Int, j::CCO.PlusHalf) = Base.getindex(arr, i, j.i)
+# Base.@propagate_inbounds Base.setindex!(arr::AbstractArray, v, i::Int, j::CCO.PlusHalf) = Base.setindex!(arr, v, i, j.i)


### PR DESCRIPTION
This PR defines a new type, `Cent`, to support `ntuple` fields, because we must be able to differentiate between
 - `getindex` to get the i-th n-tuple field (using `::Int`)
 - `getindex` to get the k-th vertical cell center (using `::Cent`)

This was pulled out from TC.jl

I still need to add the tests... I'll probably just mirror the tests from `PlusHalf`.