### PR TITLE
Limiters advection test case in 2D spectral space

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -276,6 +276,39 @@ steps:
       queue: central
       slurm_ntasks: 1
 
+  - label: ":computer: Advection CG plane limiter cosine bells"
+    key: "cpu_advection_cg_plane_limiter_cosine_bells"
+    command:
+      - "julia --color=yes --project=examples examples/plane/limiters_advection.jl"
+    artifact_paths:
+      - "examples/plane/output/plane_advection_limiter_cosine_bells_D0/*"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
+  - label: ":computer: Advection CG plane limiter Gaussian bells"
+    key: "cpu_advection_cg_plane_limiter_gaussian_bells"
+    command:
+      - "julia --color=yes --project=examples examples/plane/limiters_advection.jl gaussian_bells"
+    artifact_paths:
+      - "examples/plane/output/plane_advection_limiter_gaussian_bells_D0/*"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
+  - label: ":computer: Advection CG plane limiter cylinders"
+    key: "cpu_advection_cg_plane_limiter_cylinders"
+    command:
+      - "julia --color=yes --project=examples examples/plane/limiters_advection.jl cylinders"
+    artifact_paths:
+      - "examples/plane/output/plane_advection_limiter_cylinders_D0/*"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
   - label: ":computer: Rising Bubble 2D hybrid"
     key: "cpu_rising_bubble_2d_hybrid"
     command:

--- a/examples/plane/limiters_advection.jl
+++ b/examples/plane/limiters_advection.jl
@@ -3,7 +3,7 @@ using LinearAlgebra
 import ClimaCore:
     Domains, Fields, Geometry, Meshes, Operators, Spaces, Topologies, Limiters
 
-using OrdinaryDiffEq
+using OrdinaryDiffEq: ODEProblem, solve, SSPRK33
 
 import Logging
 import TerminalLoggers
@@ -25,22 +25,31 @@ Estimate convergence rate given vectors `err` and `Δh`
 convergence_rate(err, Δh) =
     [log(err[i] / err[i - 1]) / log(Δh[i] / Δh[i - 1]) for i in 2:length(Δh)]
 
-# Advection problem on a sphere with bounds-preserving quasimonotone limiter.
+# Advection problem on a 2D Cartesian domain with bounds-preserving quasimonotone limiter.
 # The initial condition can be set via a command line argument.
 # Possible test cases are: cosine_bells (default), gaussian_bells, and cylinders
 
-const R = 6.37122e6  # sphere radius
-const r0 = R / 2     # bells radius
-const ρ₀ = 1.0       # air density
-const D₄ = 6.6e14    # hyperdiffusion coefficient
-const u0 = 2 * pi * R / (86400 * 12)
-const T = 86400 * 12 # simulation period in seconds (12 days)
-const n_steps = 1200
-const dt = T / n_steps
-const centers = [
-    Geometry.LatLongPoint(0.0, rad2deg(5 * pi / 6) - 180.0),
-    Geometry.LatLongPoint(0.0, rad2deg(7 * pi / 6) - 180.0),
-] # center of bells
+FT = Float64
+
+# Set up physical parameters
+const xmin = -2π              # domain x lower bound
+const xmax = 2π               # domain x upper bound
+const ymin = -2π              # domain y lower bound
+const ymax = 2π               # domain y upper bound
+const ρ₀ = 1.0                # air density
+const D₄ = 0.0                # hyperdiffusion coefficient
+const r0 = (xmax - xmin) / 6  # bells radius
+const end_time = 2 * pi       # simulation period in seconds
+const dt = 1e-3
+const n_steps = Int(div(end_time, dt))
+const flow_center =
+    Geometry.XYPoint(xmin + (xmax - xmin) / 2, ymin + (ymax - ymin) / 2)
+const bell_centers = [
+    Geometry.XYPoint(xmin + (xmax - xmin) / 4, ymin + (ymax - ymin) / 2),
+    Geometry.XYPoint(xmin + 3 * (xmax - xmin) / 4, ymin + (ymax - ymin) / 2),
+]
+
+# Set up test parameters
 const test_name = get(ARGS, 1, "cosine_bells") # default test case to run
 const cosine_test_name = "cosine_bells"
 const gaussian_test_name = "gaussian_bells"
@@ -52,7 +61,7 @@ const limiter_tol = 5e-14
 ENV["GKSwstype"] = "nul"
 import ClimaCorePlots, Plots
 Plots.GRBackend()
-dirname = "cg_sphere_solidbody_limiter_$(test_name)"
+dirname = "plane_advection_limiter_$(test_name)"
 
 if lim_flag == false
     dirname = "$(dirname)_no_lim"
@@ -73,20 +82,31 @@ function linkfig(figpath, alt = "")
     end
 end
 
+# Set up spatial domain
+domain = Domains.RectangleDomain(
+    Domains.IntervalDomain(
+        Geometry.XPoint(xmin),
+        Geometry.XPoint(xmax),
+        periodic = true,
+    ),
+    Domains.IntervalDomain(
+        Geometry.YPoint(ymin),
+        Geometry.YPoint(ymax),
+        periodic = true,
+    ),
+)
+
 # Set up spatial discretization
-FT = Float64
-ne_seq = (5, 10, 20)
+ne_seq = 2 .^ (2, 3, 4, 5)
 Δh = zeros(FT, length(ne_seq))
 L1err, L2err, Linferr = zeros(FT, length(ne_seq)),
 zeros(FT, length(ne_seq)),
 zeros(FT, length(ne_seq))
 Nq = 4
 
-# h-refinement study
+# h-refinement study loop
 for (k, ne) in enumerate(ne_seq)
-    # Set up space
-    domain = Domains.SphereDomain(R)
-    mesh = Meshes.EquiangularCubedSphere(domain, ne)
+    mesh = Meshes.RectilinearMesh(domain, ne, ne)
     grid_topology = Topologies.Topology2D(mesh)
     quad = Spaces.Quadratures.GLL{Nq}()
     space = Spaces.SpectralElementSpace2D(grid_topology, quad)
@@ -97,40 +117,46 @@ for (k, ne) in enumerate(ne_seq)
     max_Q = zeros(n_elems)
 
     coords = Fields.coordinate_field(space)
-    Δh[k] = 2 * R / ne
-    global_geom = space.global_geometry
+    Δh[k] = (xmax - xmin) / ne
+
+    # Initialize simple uniform rotational flow
+    u = map(coords) do coord
+        x, y = coord.x, coord.y
+
+        u₁ = -(y - flow_center.y)
+        u₂ = (x - flow_center.x)
+
+        Geometry.UVVector(u₁, u₂)
+    end
 
     # Initialize state
     y0 = map(coords) do coord
+        x, y = coord.x, coord.y
 
-        ϕ = coord.lat
-        λ = coord.long
         rd = Vector{Float64}(undef, 2)
-
         for i in 1:2
-            rd[i] = Geometry.great_circle_distance(coord, centers[i], global_geom)
+            rd[i] = Geometry.euclidean_distance(coord, bell_centers[i])
         end
 
         # Initialize specific tracer concentration
         if test_name == cylinder_test_name
-            if rd[1] <= r0 && abs(λ - centers[1].long) * R >= rad2deg(r0 / 6)
+            if rd[1] <= r0 && abs(x - bell_centers[1].x) >= r0 / 6
                 q = 1.0
-            elseif rd[2] <= r0 &&
-                   abs(λ - centers[2].long) * R >= rad2deg(r0 / 6)
+            elseif rd[2] <= r0 && abs(x - bell_centers[2].x) >= r0 / 6
                 q = 1.0
             elseif rd[1] <= r0 &&
-                   abs(λ - centers[1].long) * R < rad2deg(r0 / 6) &&
-                   (ϕ - centers[1].lat) * R < rad2deg(-5 * r0 / 12)
+                   abs(x - bell_centers[1].x) < r0 / 6 &&
+                   (y - bell_centers[1].y) < -5 * r0 / 12
                 q = 1.0
             elseif rd[2] <= r0 &&
-                   abs(λ - centers[2].long) * R < rad2deg(r0 / 6) &&
-                   (ϕ - centers[2].lat) * R > rad2deg(5 * r0 / 12)
+                   abs(x - bell_centers[2].x) < r0 / 6 &&
+                   (y - bell_centers[2].y) > 5 * r0 / 12
                 q = 1.0
             else
                 q = 0.1
             end
         elseif test_name == gaussian_test_name
-            q = 0.95 * (exp(-(rd[1] / r0)^2) + exp(-(rd[2] / r0)^2))
+            q = 0.95 * (exp(-5.0 * (rd[1] / r0)^2) + exp(-5.0 * (rd[2] / r0)^2))
         else # default test case, cosine bells
             if rd[1] < r0
                 q = 0.1 + 0.9 * (1 / 2) * (1 + cospi(rd[1] / r0))
@@ -151,21 +177,9 @@ for (k, ne) in enumerate(ne_seq)
 
     function f!(ystar, y, parameters, t)
 
+        # Set up operators
         grad = Operators.Gradient()
         wdiv = Operators.WeakDivergence()
-        T = parameters.T
-
-        coords = Fields.coordinate_field(axes(y.ρq))
-        u = map(coords) do coord
-            ϕ = coord.lat
-            λ = coord.long
-
-            uu =
-                u0 * sind(λ)^2 * sind(2 * ϕ) * cospi(t / T) +
-                360.0 * cosd(ϕ) / T
-            uv = u0 * sind(2 * λ) * cosd(ϕ) * cospi(t / T)
-            Geometry.UVVector(uu, uv)
-        end
 
         # Compute min_Q[] and max_Q[] that will be needed later in the stage limiter
         space = parameters.space
@@ -210,7 +224,6 @@ for (k, ne) in enumerate(ne_seq)
         space = parameters.space
         min_Q = parameters.min_Q
         max_Q = parameters.max_Q
-        T = parameters.T
 
         if lim_flag
             # Call quasimonotone limiter, to find optimal ρq (where ρq gets updated in place)
@@ -227,29 +240,29 @@ for (k, ne) in enumerate(ne_seq)
 
     # Set up RHS function
     ystar = similar(y0)
-    parameters =
-        (quad = quad, space = space, min_Q = min_Q, max_Q = max_Q, T = T)
+    parameters = (quad = quad, space = space, min_Q = min_Q, max_Q = max_Q)
     f!(ystar, y0, parameters, 0.0)
 
     # Solve the ODE
-    end_time = T
     prob = ODEProblem(f!, y0, (0.0, end_time), parameters)
     sol = solve(
         prob,
         SSPRK33(stage_callback!),
         dt = dt,
-        saveat = 5 * dt,
+        saveat = dt,
         progress = true,
         adaptive = false,
         progress_message = (dt, u, p, t) -> t,
     )
-    L1err[k] = norm(
-        (sol.u[end].ρq ./ sol.u[end].ρ .- y0.ρq ./ y0.ρ) ./ (y0.ρq ./ y0.ρ),
-        1,
-    )
-    L2err[k] = norm(
-        (sol.u[end].ρq ./ sol.u[end].ρ .- y0.ρq ./ y0.ρ) ./ (y0.ρq ./ y0.ρ),
-    )
+    L1err[k] =
+        norm(
+            (sol.u[end].ρq ./ sol.u[end].ρ .- y0.ρq ./ y0.ρ) ./ (y0.ρq ./ y0.ρ),
+            1,
+        ) / norm(ones(space), 1)
+    L2err[k] =
+        norm(
+            (sol.u[end].ρq ./ sol.u[end].ρ .- y0.ρq ./ y0.ρ) ./ (y0.ρq ./ y0.ρ),
+        ) / norm(ones(space))
     Linferr[k] = norm(
         (sol.u[end].ρq ./ sol.u[end].ρ .- y0.ρq ./ y0.ρ) ./ (y0.ρq ./ y0.ρ),
         Inf,
@@ -258,7 +271,7 @@ for (k, ne) in enumerate(ne_seq)
     @info "Test case: $(test_name)"
     @info "With limiter: $(lim_flag)"
     @info "Hyperdiffusion coefficient: D₄ = $(D₄)"
-    @info "Number of elements per cube panel: $(ne) x $(ne)"
+    @info "Number of elements in domain: $(ne) x $(ne)"
     @info "Number of quadrature points per element: $(Nq) x $(Nq) (p = $(Nq-1))"
     @info "Time step dt = $(dt) (s)"
     @info "Tracer concentration norm at t = 0 (s): ", norm(y0.ρq ./ y0.ρ)
@@ -273,6 +286,7 @@ for (k, ne) in enumerate(ne_seq)
         joinpath(path, "final_q.png"),
     )
 end
+
 
 # Print convergence rate info
 conv = convergence_rate(L2err, Δh)


### PR DESCRIPTION
This PR adds a simple Cartesian 2D CG passive tracer advection test case on a doubly periodic plane (with or without hyperdiffusion, with or without limiters).

It is a good baseline before expanding to 2D and 3D hybrid spaces. 
This will close #513 

PS:
I decided to call this `limiters_advection.jl`. I had left a [comment](https://github.com/CliMA/ClimaCore.jl/issues/513#issuecomment-1033179937) on the linked issue. If people agree, we could rename the others to make them consistent in a separate PR. 

