### PR TITLE
Define fill! for field vectors

### DIFF
--- a/src/Fields/fieldvector.jl
+++ b/src/Fields/fieldvector.jl
@@ -186,6 +186,14 @@ end
     return dest
 end
 
+@inline function Base.fill!(fv::FV, val::Real) where {FV <: FieldVector}
+    for symb in propertynames(fv)
+        fvp = parent(getproperty(fv, symb))
+        fill!(fvp, val)
+    end
+    return fv
+end
+
 # Recursively call transform_bc_args() on broadcast arguments in a way that is statically reducible by the optimizer
 # see Base.Broadcast.preprocess_args
 @inline transform_bc_args(args::Tuple, inds...) = (

--- a/src/Fields/fieldvector.jl
+++ b/src/Fields/fieldvector.jl
@@ -186,11 +186,8 @@ end
     return dest
 end
 
-@inline function Base.fill!(fv::FV, val::Real) where {FV <: FieldVector}
-    for symb in propertynames(fv)
-        fvp = parent(getproperty(fv, symb))
-        fill!(fvp, val)
-    end
+@inline function Base.fill!(fv::FV, val) where {FV <: FieldVector}
+    fv .= val
     return fv
 end
 


### PR DESCRIPTION
The allocation monitoring shows that the fallback implementation to `fill!` is allocating a lot. This PR implements `fill!` for `FieldVector`s similar to `copyto!`.