### PR TITLE
Fix allocations and other implicit solver improvements

### DIFF
--- a/examples/3dsphere/balanced_flow_ρe.jl
+++ b/examples/3dsphere/balanced_flow_ρe.jl
@@ -11,7 +11,7 @@ driver_values(FT) = (;
     tmax = FT(60 * 60),
     dt = FT(5.0),
     ode_algorithm = OrdinaryDiffEq.SSPRK33,
-    jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :constant_P, ∂𝕄ₜ∂ρ_mode = :exact),
+    jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :no_∂P∂K, ∂𝕄ₜ∂ρ_mode = :exact),
     max_newton_iters = 2,
     save_every_n_steps = 10,
     additional_solver_kwargs = (;), # e.g., reltol, abstol, etc.

--- a/examples/3dsphere/baroclinic_wave_ρe.jl
+++ b/examples/3dsphere/baroclinic_wave_ρe.jl
@@ -10,7 +10,7 @@ driver_values(FT) = (;
     tmax = FT(60 * 60 * 24 * 10),
     dt = FT(500.0),
     ode_algorithm = OrdinaryDiffEq.Rosenbrock23,
-    jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :constant_P, ∂𝕄ₜ∂ρ_mode = :exact),
+    jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :no_∂P∂K, ∂𝕄ₜ∂ρ_mode = :exact),
     max_newton_iters = 2,
     save_every_n_steps = 10,
     additional_solver_kwargs = (;), # e.g., reltol, abstol, etc.

--- a/examples/3dsphere/held_suarez_ρe.jl
+++ b/examples/3dsphere/held_suarez_ρe.jl
@@ -10,7 +10,7 @@ driver_values(FT) = (;
     tmax = FT(60 * 60 * 24 * 10),
     dt = FT(500.0),
     ode_algorithm = OrdinaryDiffEq.Rosenbrock23,
-    jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :constant_P, ∂𝕄ₜ∂ρ_mode = :exact),
+    jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :no_∂P∂K, ∂𝕄ₜ∂ρ_mode = :exact),
     max_newton_iters = 2,
     save_every_n_steps = 10,
     additional_solver_kwargs = (;), # e.g., reltol, abstol, etc.

--- a/examples/3dsphere/utilities.jl
+++ b/examples/3dsphere/utilities.jl
@@ -110,8 +110,10 @@ function Wfact!(W, Y, p, dtγ, t)
 
     dtγ_ref[] = dtγ
 
+    # w = w_data * w_unit; w_data = w.components.data.:1 and w_unit = one(w)
+
     # ρₜ = -∇◦ᵥᶜ(Iᶠ(ρ) * w)
-    # ∂ρₜ/∂w = -∇◦ᵥᶜ_stencil(Iᶠ(ρ) * one(w))
+    # ∂ρₜ/∂(w_data) = -∇◦ᵥᶜ_stencil(Iᶠ(ρ) * w_unit)
     @. ∂ρₜ∂𝕄 = -∇◦ᵥᶜ_stencil(Iᶠ(ρ) * one(w))
 
     if :ρθ in propertynames(Y.Yc)
@@ -123,92 +125,116 @@ function Wfact!(W, Y, p, dtγ, t)
         end
 
         # ρθₜ = -∇◦ᵥᶜ(Iᶠ(ρθ) * w)
-        # ∂ρθₜ/∂w = -∇◦ᵥᶜ_stencil(Iᶠ(ρθ) * one(w))
+        # ∂ρθₜ/∂(w_data) = -∇◦ᵥᶜ_stencil(Iᶠ(ρθ) * w_unit)
         @. ∂𝔼ₜ∂𝕄 = -∇◦ᵥᶜ_stencil(Iᶠ(ρθ) * one(w))
     elseif :ρe in propertynames(Y.Yc)
         ρe = Y.Yc.ρe
         V = Geometry.Covariant123Vector
         @. P = pressure(ρ, ρe / ρ, norm_sqr(V(uₕ) + V(Iᶜ(w))) / 2, Φ)
 
+        # P = ρ * R_d * ((ρe / ρ - K - Φ) / cv_d + T_tri)
+
+        # Iᶜ(w) = Iᶜ(w)_data * Iᶜ(w)_unit = Iᶜ(w_data) * Iᶜ(w)_unit
+        # norm_sqr(Iᶜ(w)) = norm_sqr(Iᶜ(w_data) * Iᶜ(w)_unit) =
+        #     Iᶜ(w_data)^2 * norm(Iᶜ(w)_unit)^2
+        # K = norm_sqr(V(uₕ) + V(Iᶜ(w))) / 2 =
+        #     norm_sqr(uₕ) / 2 + norm_sqr(Iᶜ(w)) / 2 =
+        #     norm_sqr(uₕ) / 2 + Iᶜ(w_data)^2 * norm(Iᶜ(w)_unit)^2 / 2
+
         if flags.∂𝔼ₜ∂𝕄_mode == :exact
             # ρeₜ = -∇◦ᵥᶜ(Iᶠ(ρe + P) * w)
-            # ∂ρeₜ/∂w = -∇◦ᵥᶜ_stencil(Iᶠ(ρe + P) * one(w))
-            # ∂ρeₜ/∂(Iᶠ(ρe + P)) = -∇◦ᵥᶜ_stencil(w)
-            # ∂(Iᶠ(ρe + P))/∂P = Iᶠ_stencil(one(P))
-            # ∂P/∂(norm_sqr(V(uₕ) + V(Iᶜ(w)))) = -ρ * R_d / cv_d
-            # ∂(norm_sqr(V(uₕ) + V(Iᶜ(w)))/∂(Iᶜ(w)) =
-            #     ∂_norm_w_∂_w_data^2 * Iᶜ(w_data)
-            # ∂(Iᶜ(w))/∂w = Iᶜ_stencil(one(w_data))
+            # ∂ρeₜ/∂(w_data) = -∇◦ᵥᶜ_stencil(Iᶠ(ρe + P) * w_unit) +
+            #     -∇◦ᵥᶜ_stencil(w) * ∂(Iᶠ(ρe + P))/∂(w_data)
+            # ∂(Iᶠ(ρe + P))/∂(w_data) = ∂(Iᶠ(ρe + P))/∂P * ∂P/∂(w_data)
+            # ∂(Iᶠ(ρe + P))/∂P = Iᶠ_stencil(1)
+            # ∂P/∂(w_data) = ∂P/∂K * ∂K/∂(w_data)
+            # ∂P/∂K = -ρ * R_d / cv_d
+            # ∂K/∂(w_data) = ∂K/∂(Iᶜ(w_data)) * ∂(Iᶜ(w_data))/∂(w_data)
+            # ∂K/∂(Iᶜ(w_data)) = Iᶜ(w_data) * norm(Iᶜ(w)_unit)^2
+            # ∂(Iᶜ(w_data))/∂(w_data) = Iᶜ_stencil(1)
             w_data = w.components.data.:1
             if eltype(w) <: Geometry.Covariant3Vector
-                ∂_norm_w_∂_w_data =
+                norm_Iᶜ_w_unit =
                     Fields.local_geometry_field(axes(P)).∂ξ∂x.components.data.:9
             elseif eltype(w) <: Geometry.WVector
-                ∂_norm_w_∂_w_data = 1
+                norm_Iᶜ_w_unit = 1
             end
             @. ∂𝔼ₜ∂𝕄 =
                 -∇◦ᵥᶜ_stencil(Iᶠ(ρe + P) * one(w)) + compose(
-                    compose(-∇◦ᵥᶜ_stencil(w), Iᶠ_stencil(one(P))),
-                    -ρ * R_d / cv_d *
-                    ∂_norm_w_∂_w_data^2 *
-                    Iᶜ(w_data) *
-                    Iᶜ_stencil(one(w_data)),
+                    -∇◦ᵥᶜ_stencil(w),
+                    compose(
+                        Iᶠ_stencil(one(P)),
+                        -ρ * R_d / cv_d *
+                        Iᶜ(w_data) *
+                        norm_Iᶜ_w_unit^2 *
+                        Iᶜ_stencil(one(w_data)),
+                    ),
                 )
-        elseif flags.∂𝔼ₜ∂𝕄_mode == :constant_P
-            # ρeₜ = -∇◦ᵥᶜ(Iᶠ(ρe + P′) * w); ∂P′/∂ρ = 0
+        elseif flags.∂𝔼ₜ∂𝕄_mode == :no_∂P∂K
+            # ρeₜ = -∇◦ᵥᶜ(Iᶠ(ρe + P) * w), but we approximate ∂P/∂K = 0
             @. ∂𝔼ₜ∂𝕄 = -∇◦ᵥᶜ_stencil(Iᶠ(ρe + P) * one(w))
         else
-            error("∂𝔼ₜ∂𝕄_mode must be :exact or :constant_P when using ρe")
+            error("∂𝔼ₜ∂𝕄_mode must be :exact or :no_∂P∂K when using ρe")
         end
     end
 
-    # To get scalar stencils, we must extract each Covariant3Vector's value.
+    # To convert ∂wₜ/∂𝔼 to ∂(w_data)ₜ/∂𝔼, we must extract the third component of
+    # each vector-valued stencil coefficient.
     to_scalar_coefs(vector_coefs) =
         map(vector_coef -> vector_coef.u₃, vector_coefs)
 
     if :ρθ in propertynames(Y.Yc)
         # wₜ = -∇ᵥᶠ(P) / Iᶠ(ρ) - ∇ᵥΦ
+        # ∂wₜ/∂ρθ = ∂wₜ/∂(∇ᵥᶠ(P)) * ∂(∇ᵥᶠ(P))/∂ρθ
         # ∂wₜ/∂(∇ᵥᶠ(P)) = -1 / Iᶠ(ρ)
-        # ∂(∇ᵥᶠ(P))/∂(ρθ) = ∇ᵥᶠ_stencil(γ * R_d * (ρθ * R_d / p_0)^(γ - 1))
+        # ∂(∇ᵥᶠ(P))/∂ρθ = ∇ᵥᶠ_stencil(γ * R_d * (ρθ * R_d / p_0)^(γ - 1))
         @. ∂𝕄ₜ∂𝔼 = to_scalar_coefs(
             -1 / Iᶠ(ρ) * ∇ᵥᶠ_stencil(γ * R_d * (ρθ * R_d / p_0)^(γ - 1)),
         )
         if flags.∂𝕄ₜ∂ρ_mode == :exact
             # wₜ = -∇ᵥᶠ(P) / Iᶠ(ρ) - ∇ᵥΦ
+            # ∂wₜ/∂ρ = ∂wₜ/∂(Iᶠ(ρ)) * ∂(Iᶠ(ρ))/∂ρ
             # ∂wₜ/∂(Iᶠ(ρ)) = ∇ᵥᶠ(P) / Iᶠ(ρ)^2
-            # ∂(Iᶠ(ρ))/∂ρ = Iᶠ_stencil(one(ρ))
+            # ∂(Iᶠ(ρ))/∂ρ = Iᶠ_stencil(1)
             @. ∂𝕄ₜ∂ρ = to_scalar_coefs(∇ᵥᶠ(P) / Iᶠ(ρ)^2 * Iᶠ_stencil(one(ρ)))
         elseif flags.∂𝕄ₜ∂ρ_mode == :∇Φ_shenanigans
-            # wₜ = -∇ᵥᶠ(P) / Iᶠ(ρ′) - ∇ᵥΦ / Iᶠ(ρ′) * Iᶠ(ρ); ∂ρ′/∂ρ = 0
-            @. ∂𝕄ₜ∂ρ = to_scalar_coefs(∇ᵥΦ / Iᶠ(ρ) * Iᶠ_stencil(one(ρ)))
+            # wₜ = -∇ᵥᶠ(P) / Iᶠ(ρ′) - ∇ᵥΦ / Iᶠ(ρ′) * Iᶠ(ρ), where ρ′ = ρ but we
+            #     approximate ∂ρ′/∂ρ = 0
+            # TODO: if we use this often, optimize it to cached_stencil / Iᶠ(ρ)
+            @. ∂𝕄ₜ∂ρ = to_scalar_coefs(-∇ᵥΦ / Iᶠ(ρ) * Iᶠ_stencil(one(ρ)))
         else
-            error("∂𝕄ₜ∂ρ_mode must be :exact or :∇Φ_shenanigans when using ρθ")
+            error("∂𝕄ₜ∂ρ_mode must be :exact or :∇Φ_shenanigans")
         end
     elseif :ρe in propertynames(Y.Yc)
         # wₜ = -∇ᵥᶠ(P) / Iᶠ(ρ) - ∇ᵥΦ
+        # ∂wₜ/∂ρe = ∂wₜ/∂(∇ᵥᶠ(P)) * ∂(∇ᵥᶠ(P))/∂ρe
         # ∂wₜ/∂(∇ᵥᶠ(P)) = -1 / Iᶠ(ρ)
-        # ∂(∇ᵥᶠ(P))/∂(ρe) = ∇ᵥᶠ_stencil(R_d / cv_d * one(ρe))
+        # ∂(∇ᵥᶠ(P))/∂ρe = ∇ᵥᶠ_stencil(R_d / cv_d)
         @. ∂𝕄ₜ∂𝔼 =
             to_scalar_coefs(-1 / Iᶠ(ρ) * ∇ᵥᶠ_stencil(R_d / cv_d * one(ρe)))
         if flags.∂𝕄ₜ∂ρ_mode == :exact
             # wₜ = -∇ᵥᶠ(P) / Iᶠ(ρ) - ∇ᵥΦ
-            # ∂(∇ᵥᶠ(P))/∂ρ = ∇ᵥᶠ_stencil(
-            #     R_d * (-(Φ + norm_sqr(V(uₕ) + V(Iᶜ(w))) / 2) / cv_d + T_tri)
-            # )
+            # ∂wₜ/∂ρ = ∂wₜ/∂(∇ᵥᶠ(P)) * ∂(∇ᵥᶠ(P))/∂ρ + ∂wₜ/∂(Iᶠ(ρ)) * ∂(Iᶠ(ρ))/∂ρ
+            # ∂wₜ/∂(∇ᵥᶠ(P)) = -1 / Iᶠ(ρ)
+            # ∂(∇ᵥᶠ(P))/∂ρ = ∇ᵥᶠ_stencil(R_d * ((-K - Φ) / cv_d + T_tri))
             # ∂wₜ/∂(Iᶠ(ρ)) = ∇ᵥᶠ(P) / Iᶠ(ρ)^2
-            # ∂(Iᶠ(ρ))/∂ρ = Iᶠ_stencil(one(ρ))
+            # ∂(Iᶠ(ρ))/∂ρ = Iᶠ_stencil(1)
             @. ∂𝕄ₜ∂ρ = to_scalar_coefs(
                 -1 / Iᶠ(ρ) * ∇ᵥᶠ_stencil(
                     R_d *
-                    (-(Φ + norm_sqr(V(uₕ) + V(Iᶜ(w))) / 2) / cv_d + T_tri),
+                    ((-norm_sqr(V(uₕ) + V(Iᶜ(w))) / 2 - Φ) / cv_d + T_tri),
                 ) + ∇ᵥᶠ(P) / Iᶠ(ρ)^2 * Iᶠ_stencil(one(ρ)),
             )
-        elseif flags.∂𝕄ₜ∂ρ_mode == :constant_P
-            # wₜ = -∇ᵥᶠ(P′) / Iᶠ(ρ) - ∇ᵥΦ; ∂P′/∂ρ = 0
-            @. ∂𝕄ₜ∂ρ = to_scalar_coefs(∇ᵥᶠ(P) / Iᶠ(ρ)^2 * Iᶠ_stencil(one(ρ)))
         elseif flags.∂𝕄ₜ∂ρ_mode == :∇Φ_shenanigans
-            # wₜ = -∇ᵥᶠ(P′) / Iᶠ(ρ′) - ∇ᵥΦ / Iᶠ(ρ′) * Iᶠ(ρ); ∂P′/∂ρ = ∂ρ′/∂ρ = 0
-            @. ∂𝕄ₜ∂ρ = to_scalar_coefs(∇ᵥΦ / Iᶠ(ρ) * Iᶠ_stencil(one(ρ)))
+            # wₜ = -∇ᵥᶠ(P′) / Iᶠ(ρ′) - ∇ᵥΦ / Iᶠ(ρ′) * Iᶠ(ρ), where ρ′ = ρ but we
+            #     approximate ∂ρ′/∂ρ = 0, and where P′ = P but with K = 0
+            # TODO: if we use this often, optimize it to cached_stencil / Iᶠ(ρ)
+            @. ∂𝕄ₜ∂ρ = to_scalar_coefs(
+                -1 / Iᶠ(ρ) * ∇ᵥᶠ_stencil(R_d * (-Φ / cv_d + T_tri)) -
+                ∇ᵥΦ / Iᶠ(ρ) * Iᶠ_stencil(one(ρ)),
+            )
+        else
+            error("∂𝕄ₜ∂ρ_mode must be :exact or :∇Φ_shenanigans")
         end
     end
 
@@ -221,24 +247,26 @@ function Wfact!(W, Y, p, dtγ, t)
             𝔼_name = :ρe
         end
         args = (implicit_tendency!, Y, p, t, i, j, h)
-        @assert column_matrix(∂ρₜ∂𝕄, i, j, h) ≈
-                exact_column_jacobian(args..., (:w,), (:Yc, :ρ))
+        @assert column_matrix(∂ρₜ∂𝕄, i, j, h) ==
+                exact_column_jacobian_block(args..., (:Yc, :ρ), (:w,))
         @assert column_matrix(∂𝕄ₜ∂𝔼, i, j, h) ≈
-                exact_column_jacobian(args..., (:Yc, 𝔼_name), (:w,))
+                exact_column_jacobian_block(args..., (:w,), (:Yc, 𝔼_name))
         ∂𝔼ₜ∂𝕄_approx = column_matrix(∂𝔼ₜ∂𝕄, i, j, h)
-        ∂𝔼ₜ∂𝕄_exact = exact_column_jacobian(args..., (:w,), (:Yc, 𝔼_name))
-        if flags.∂𝔼ₜ∂𝕄_mode == :exact
+        ∂𝔼ₜ∂𝕄_exact = exact_column_jacobian_block(args..., (:Yc, 𝔼_name), (:w,))
+        if flags.∂𝕄ₜ∂ρ_mode == :exact
             @assert ∂𝔼ₜ∂𝕄_approx ≈ ∂𝔼ₜ∂𝕄_exact
         else
-            @assert norm((∂𝔼ₜ∂𝕄_approx .- ∂𝔼ₜ∂𝕄_exact)) / norm(∂𝔼ₜ∂𝕄_exact) <
-                    1e-5 # highest seen so far
+            @assert norm(∂𝔼ₜ∂𝕄_approx .- ∂𝔼ₜ∂𝕄_exact) / norm(∂𝔼ₜ∂𝕄_exact) < 1e-6
+            # Note: the highest value seen so far is ~3e-7 (only applies to ρe)
         end
         ∂𝕄ₜ∂ρ_approx = column_matrix(∂𝕄ₜ∂ρ, i, j, h)
-        ∂𝕄ₜ∂ρ_exact = exact_column_jacobian(args..., (:Yc, :ρ), (:w,))
+        ∂𝕄ₜ∂ρ_exact = exact_column_jacobian_block(args..., (:w,), (:Yc, :ρ))
         if flags.∂𝕄ₜ∂ρ_mode == :exact
             @assert ∂𝕄ₜ∂ρ_approx ≈ ∂𝕄ₜ∂ρ_exact
         else
-            @assert norm((∂𝕄ₜ∂ρ_approx .- ∂𝕄ₜ∂ρ_exact)) / norm(∂𝕄ₜ∂ρ_exact) < 3 # highest seen so far
+            @assert norm(∂𝕄ₜ∂ρ_approx .- ∂𝕄ₜ∂ρ_exact) / norm(∂𝕄ₜ∂ρ_exact) < 0.03
+            # Note: the highest value seen so far for ρe is ~0.01, and the
+            # highest value seen so far for ρθ is ~0.02
         end
     end
 end

--- a/examples/implicit_solver_debugging_tools.jl
+++ b/examples/implicit_solver_debugging_tools.jl
@@ -5,7 +5,17 @@ using ClimaCore: Spaces, Operators
 
 get_var(obj, ::Tuple{}) = obj
 get_var(obj, tup::Tuple) = get_var(getproperty(obj, tup[1]), Base.tail(tup))
-function exact_column_jacobian(rhs_implicit!, Y, p, t, i, j, h, Y_name, Yₜ_name)
+function exact_column_jacobian_block(
+    implicit_tendency!,
+    Y,
+    p,
+    t,
+    i,
+    j,
+    h,
+    Yₜ_name,
+    Y_name,
+)
     T = eltype(Y)
     Y_var = get_var(Y, Y_name)
     Y_var_vert_space = Spaces.column(axes(Y_var), i, j, h)
@@ -19,7 +29,7 @@ function exact_column_jacobian(rhs_implicit!, Y, p, t, i, j, h, Y_name, Yₜ_nam
         parent(Spaces.level(Yᴰ_var, level)) .+= ith_ε(level - bot_level + 1)
     foreach(set_level_εs!, bot_level:top_level)
     Yₜᴰ = similar(Yᴰ)
-    rhs_implicit!(Yₜᴰ, Yᴰ, p, t)
+    implicit_tendency!(Yₜᴰ, Yᴰ, p, t)
     col = Spaces.column(get_var(Yₜᴰ, Yₜ_name), i, j, h)
     return vcat(map(dual -> [dual.partials.values...]', parent(col))...)
 end

--- a/examples/schur_complement_W.jl
+++ b/examples/schur_complement_W.jl
@@ -160,10 +160,10 @@ function linsolve!(::Type{Val{:init}}, f, u0; kwargs...)
 
         if A.test && Operators.bandwidths(eltype(∂𝔼ₜ∂𝕄)) == (-half, half)
             Ni, Nj, _, Nv, Nh = size(Spaces.local_geometry_data(axes(xρ)))
+            ∂Yₜ∂Y = Array{Float64}(undef, 3 * Nv + 1, 3 * Nv + 1)
+            ΔY = Array{Float64}(undef, 3 * Nv + 1)
+            ΔΔY = Array{Float64}(undef, 3 * Nv + 1)
             for h in 1:Nh, j in 1:Nj, i in 1:Ni
-                ∂Yₜ∂Y = Array{Float64}(undef, 3 * Nv + 1, 3 * Nv + 1)
-                ΔΔY = Array{Float64}(undef, 3 * Nv + 1)
-                ΔY = Array{Float64}(undef, 3 * Nv + 1)
                 ∂Yₜ∂Y .= 0.0
                 ∂Yₜ∂Y[1:Nv, (2 * Nv + 1):(3 * Nv + 1)] .=
                     column_matrix(∂ρₜ∂𝕄, i, j, h)
@@ -173,13 +173,13 @@ function linsolve!(::Type{Val{:init}}, f, u0; kwargs...)
                     column_matrix(∂𝕄ₜ∂ρ, i, j, h)
                 ∂Yₜ∂Y[(2 * Nv + 1):(3 * Nv + 1), (Nv + 1):(2 * Nv)] .=
                     column_matrix(∂𝕄ₜ∂𝔼, i, j, h)
-                ΔΔY[1:Nv] .= column_vector(bρ, i, j, h)
-                ΔΔY[(Nv + 1):(2 * Nv)] .= column_vector(b𝔼, i, j, h)
-                ΔΔY[(2 * Nv + 1):(3 * Nv + 1)] .= column_vector(b𝕄, i, j, h)
                 ΔY[1:Nv] .= column_vector(xρ, i, j, h)
                 ΔY[(Nv + 1):(2 * Nv)] .= column_vector(x𝔼, i, j, h)
                 ΔY[(2 * Nv + 1):(3 * Nv + 1)] .= column_vector(x𝕄, i, j, h)
-                @assert (-LinearAlgebra.I + dtγ * ∂Yₜ∂Y) \ ΔΔY ≈ ΔY
+                ΔΔY[1:Nv] .= column_vector(bρ, i, j, h)
+                ΔΔY[(Nv + 1):(2 * Nv)] .= column_vector(b𝔼, i, j, h)
+                ΔΔY[(2 * Nv + 1):(3 * Nv + 1)] .= column_vector(b𝕄, i, j, h)
+                @assert (-LinearAlgebra.I + dtγ * ∂Yₜ∂Y) * ΔY ≈ ΔΔY
             end
         end
 

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -184,6 +184,9 @@ end
 
 Base.copy(field::Field) = Field(copy(field_values(field)), axes(field))
 
+Base.deepcopy_internal(field::Field, stackdict::IdDict) =
+    Field(Base.deepcopy_internal(field_values(field), stackdict), axes(field))
+
 function Base.copyto!(dest::Field{V, M}, src::Field{V, M}) where {V, M}
     @assert axes(dest) == axes(src)
     copyto!(field_values(dest), field_values(src))

--- a/src/Fields/mapreduce.jl
+++ b/src/Fields/mapreduce.jl
@@ -135,3 +135,6 @@ function Base.isapprox(
     d = norm(x .- y)
     return isfinite(d) && d <= max(atol, rtol * max(norm(x), norm(y)))
 end
+
+Base.:(==)(field1::Field, field2::Field) =
+    axes(field1) === axes(field2) && parent(field1) == parent(field2)


### PR DESCRIPTION
This PR removes the primary source of allocations when using the implicit solver by adding the two methods
```
@inline function Base.copyto!(
    dest::FieldVector,
    bc::Base.Broadcast.Broadcasted{<:Base.Broadcast.AbstractArrayStyle{0}},
)
    for symb in propertynames(dest)
        p = parent(getfield(_values(dest), symb))
        copyto!(p, bc)
    end
    return dest
end

Base.fill!(dest::FieldVector, value) = dest .= value
```
Here is the allocations table for the `baroclinic_wave_ρe` test before the fix:
```
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬─────────────┬───────────────┐
│ <file>:<line number>                                                                                                  │ Allocations │ Allocations % │
│                                                                                                                       │   (bytes)   │    (xᵢ/∑x)    │
├───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼─────────────┼───────────────┤
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/examples/3dsphere/baroclinic_wave_ρe.jl:30                             │  358387200  │      58       │
│ ClimaCore.jl//Users/dennisyatunin/.julia/packages/OrdinaryDiffEq/WD8cC/src/perform_step/rosenbrock_perform_step.jl:43 │  119474112  │      19       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/examples/3dsphere/driver.jl:54                                         │  119462400  │      19       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/src/Operators/pointwisestencil.jl:379                                  │   6604800   │       1       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/src/Operators/pointwisestencil.jl:503                                  │   5990400   │       1       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/src/Operators/finitedifference.jl:2061                                 │   3302400   │       1       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/src/Operators/finitedifference.jl:2055                                 │   3148800   │       1       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/src/Operators/pointwisestencil.jl:502                                  │   2764800   │       0       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/src/Operators/finitedifference.jl:1903                                 │   2150400   │       0       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/src/Operators/pointwisestencil.jl:378                                  │   1075200   │       0       │
│ ClimaCore.jl//Users/dennisyatunin/.julia/packages/DiffEqBase/1V2xg/src/init.jl:19                                     │   308032    │       0       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/src/Operators/finitedifference.jl:1962                                 │    60208    │       0       │
│ ClimaCore.jl//Users/dennisyatunin/.julia/packages/SciMLBase/L7Nun/src/scimlfunctions.jl:363                           │    26352    │       0       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/src/Operators/spectralelement.jl:201                                   │    12144    │       0       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/examples/3dsphere/baroclinic_wave_utilities.jl:331                     │    9792     │       0       │
│ ClimaCore.jl//Users/dennisyatunin/.julia/packages/OrdinaryDiffEq/WD8cC/src/perform_step/rosenbrock_perform_step.jl:69 │    8784     │       0       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/examples/3dsphere/baroclinic_wave_utilities.jl:296                     │    8160     │       0       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/examples/3dsphere/utilities.jl:90                                      │    7488     │       0       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/examples/3dsphere/utilities.jl:76                                      │    6048     │       0       │
│ ClimaCore.jl//Users/dennisyatunin/.julia/packages/OrdinaryDiffEq/WD8cC/src/perform_step/rosenbrock_perform_step.jl:65 │    5856     │       0       │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴─────────────┴───────────────┘
```
And here is the table after the fix:
```
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬─────────────┬───────────────┐
│ <file>:<line number>                                                                                                  │ Allocations │ Allocations % │
│                                                                                                                       │   (bytes)   │    (xᵢ/∑x)    │
├───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼─────────────┼───────────────┤
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/src/Operators/pointwisestencil.jl:366                                  │   6604800   │      21       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/src/Operators/pointwisestencil.jl:379                                  │   6604128   │      21       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/src/Operators/pointwisestencil.jl:503                                  │   5990400   │      19       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/src/Operators/finitedifference.jl:2061                                 │   3302016   │      10       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/src/Operators/finitedifference.jl:2055                                 │   3148800   │      10       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/src/Operators/pointwisestencil.jl:502                                  │   2764800   │       9       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/src/Operators/finitedifference.jl:1903                                 │   2150400   │       7       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/src/Operators/pointwisestencil.jl:378                                  │   1075200   │       3       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/src/Operators/finitedifference.jl:1962                                 │    60208    │       0       │
│ ClimaCore.jl//Users/dennisyatunin/.julia/packages/SciMLBase/L7Nun/src/scimlfunctions.jl:363                           │    26352    │       0       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/src/Operators/spectralelement.jl:201                                   │    12144    │       0       │
│ ClimaCore.jl//Users/dennisyatunin/.julia/packages/OrdinaryDiffEq/WD8cC/src/perform_step/rosenbrock_perform_step.jl:43 │    11712    │       0       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/examples/3dsphere/baroclinic_wave_utilities.jl:331                     │    9792     │       0       │
│ ClimaCore.jl//Users/dennisyatunin/.julia/packages/OrdinaryDiffEq/WD8cC/src/perform_step/rosenbrock_perform_step.jl:69 │    8784     │       0       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/examples/3dsphere/baroclinic_wave_utilities.jl:296                     │    8160     │       0       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/examples/3dsphere/utilities.jl:90                                      │    7488     │       0       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/examples/3dsphere/utilities.jl:76                                      │    6048     │       0       │
│ ClimaCore.jl//Users/dennisyatunin/.julia/packages/OrdinaryDiffEq/WD8cC/src/perform_step/rosenbrock_perform_step.jl:65 │    5856     │       0       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/examples/3dsphere/baroclinic_wave_utilities.jl:313                     │    5424     │       0       │
│ ClimaCore.jl//Users/dennisyatunin/ClimaCore.jl/examples/3dsphere/baroclinic_wave_utilities.jl:330                     │    4176     │       0       │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴─────────────┴───────────────┘
```
The 3 primary sources of allocations before the fix were all of the form `field_vector .= scalar` or `fill!(field_vector, scalar)`, and they are eliminated by the fix.

It should be noted, though, that there is still a large amount of memory being allocated unnecessarily when running the implicit solver due to my current implementation of pointwise stencil operations. Specifically, pointwise stencils are sets of banded matrices that are stored in `Field`s. Each matrix corresponds to a column of the `Field`, and each row of the matrix is an element of the `Field`. The number of values ("stencil coefficients") stored for each row is the same throughout the domain (it is determined by the type of the `Field`), but this means that the rows stored at the top and bottom of a `Field` column may contain values that lie outside of the matrix and must be ignored. The number of these extraneous values is not known at compile-time; it is only determined when the pointwise stencil is applied to a `Field` (a matrix-vector product for each `Field` column), or when it is composed with another pointwise stencil (a matrix-matrix product for each column). This causes some parts of my code to be type unstable because the compiler is unable to determine the lengths of certain tuples until runtime. I can't think of a good way to fix this with my current setup, so we may have to live with this allocation issue until we develop a more robust matrix storage format for `ClimaCore`.

In addition to fixing the aforementioned allocation issue, this PR also clarifies the derivation of the Jacobian and addresses a concern from Oswald regarding his Jacobian approximations. In addition, it defines `==` for `Field`s (two `Field`s are equal if they share the same axes and their parent arrays are equal). Also, it moves the definition of `deepcopy_internal(field::Field, stackdict::IdDict)` from `fieldvector.jl` to `Fields.jl`, and it removes the unnecessary definition of `deepcopy_internal(x::FieldVector, stackdict::IdDict)` (this definition was needed before `deepcopy_internal` was defined for `Field`s).