### PR TITLE
Advection & Divergence convergence unit tests

### DIFF
--- a/test/Operators/finitedifference/column.jl
+++ b/test/Operators/finitedifference/column.jl
@@ -644,3 +644,49 @@ end
     cy_ref = [i == length(cyp) ? FT(10) : fyp[i + 1] for i in 1:length(cyp)]
     @test all(cy_ref .== cyp)
 end
+
+@testset "Center -> Center Advection" begin
+
+    function advection(c, f, cs)
+        adv = zeros(eltype(f), cs)
+        A = Operators.AdvectionC2C(
+            bottom = Operators.SetValue(0.0),
+            top = Operators.Extrapolate(),
+        )
+        return @. adv = A(c, f)
+    end
+
+    FT = Float64
+    n_elems_seq = 2 .^ (5, 6, 7, 8)
+    err = zeros(FT, length(n_elems_seq))
+    Δh = zeros(FT, length(n_elems_seq))
+
+    for (k, n) in enumerate(n_elems_seq)
+        domain = Domains.IntervalDomain(
+            Geometry.ZPoint{FT}(0.0),
+            Geometry.ZPoint{FT}(4π);
+            boundary_tags = (:bottom, :top),
+        )
+        mesh = Meshes.IntervalMesh(domain; nelems = n)
+
+        cs = Spaces.CenterFiniteDifferenceSpace(mesh)
+        fs = Spaces.FaceFiniteDifferenceSpace(cs)
+
+        # advective velocity
+        c = Geometry.WVector.(ones(Float64, fs),)
+        # scalar-valued field to be advected
+        f = sin.(Fields.coordinate_field(cs).z)
+
+        # Call the advection operator
+        adv = advection(c, f, cs)
+
+        Δh[k] = cs.face_local_geometry.J[1]
+        err[k] = norm(adv .- cos.(Fields.coordinate_field(cs).z))
+    end
+    # AdvectionC2C convergence rate
+    conv_adv_c2c = convergence_rate(err, Δh)
+    @test err[3] ≤ err[2] ≤ err[1] ≤ 0.1
+    @test conv_adv_c2c[1] ≈ 2 atol = 0.1
+    @test conv_adv_c2c[2] ≈ 2 atol = 0.1
+    @test conv_adv_c2c[3] ≈ 2 atol = 0.1
+end

--- a/test/Operators/hybrid/2d.jl
+++ b/test/Operators/hybrid/2d.jl
@@ -16,6 +16,9 @@ import ClimaCore:
 import ClimaCore.Domains.Geometry: ⊗
 import ClimaCore.Utilities: half
 
+convergence_rate(err, Δh) =
+    [log(err[i] / err[i - 1]) / log(Δh[i] / Δh[i - 1]) for i in 2:length(Δh)]
+
 function hvspace_2D(;
     xlim = (-π, π),
     zlim = (0, 4π),
@@ -107,13 +110,7 @@ end
 
 @testset "1D SE, 1D FD Extruded Domain vertical advection operator" begin
 
-    # Advection Operator
-    # c ∂_z f
-    # for this test, we use f(z) = sin(z) and c = 1, a WVector
-    # => c ∂_z f = cos(z)
-    hv_center_space, hv_face_space = hvspace_2D()
-
-    function advection(c, f)
+    function advection(c, f, hv_center_space)
         adv = zeros(eltype(f), hv_center_space)
         A = Operators.AdvectionC2C(
             bottom = Operators.SetValue(0.0),
@@ -122,15 +119,34 @@ end
         return @. adv = A(c, f)
     end
 
-    # advective velocity
-    c = Geometry.WVector.(ones(Float64, hv_face_space),)
-    # scalar-valued field to be advected
-    f = sin.(Fields.coordinate_field(hv_center_space).z)
+    n_elems_seq = 2 .^ (5, 6, 7, 8)
+    err, Δh = zeros(length(n_elems_seq)), zeros(length(n_elems_seq))
 
-    # Call the advection operator
-    adv = advection(c, f)
+    for (k, n) in enumerate(n_elems_seq)
+        # Advection Operator
+        # c ∂_z f
+        # for this test, we use f(z) = sin(z) and c = 1, a WVector
+        # => c ∂_z f = cos(z)
+        hv_center_space, hv_face_space = hvspace_2D(helem = n, velem = n)
 
-    @test norm(adv .- cos.(Fields.coordinate_field(hv_center_space).z)) ≤ 5e-2
+        Δh[k] = 1.0 / n
+
+        # advective velocity
+        c = Geometry.WVector.(ones(Float64, hv_face_space),)
+        # scalar-valued field to be advected
+        f = sin.(Fields.coordinate_field(hv_center_space).z)
+
+        # Call the advection operator
+        adv = advection(c, f, hv_center_space)
+
+        err[k] = norm(adv .- cos.(Fields.coordinate_field(hv_center_space).z))
+    end
+    # AdvectionC2C convergence rate
+    conv_adv_c2c = convergence_rate(err, Δh)
+    @test err[3] ≤ err[2] ≤ err[1] ≤ 0.1
+    @test conv_adv_c2c[1] ≈ 2 atol = 0.1
+    @test conv_adv_c2c[2] ≈ 2 atol = 0.1
+    @test conv_adv_c2c[3] ≈ 2 atol = 0.1
 end
 
 @testset "1D SE, 1D FD Extruded Domain horizontal divergence operator" begin
@@ -163,7 +179,7 @@ end
     ) ≤ 5e-5
 end
 
-@testset "1D SE, 1D FD Extruded Domain horz & vert divergence operator" begin
+@testset "1D SE, 1D FD Extruded Domain horz & vert divergence operator, with Extrapolate BCs" begin
 
     # Divergence operator in 2D Cartesian domain with
     # Cₕ = (cₕ, 0), Cᵥ = (0, cᵥ)
@@ -172,9 +188,7 @@ end
 
     # NOTE: the equation setup is only correct for Cartesian domains!
 
-    hv_center_space, hv_face_space = hvspace_2D(xlim = (-1, 1), zlim = (-1, 1))
-
-    function divergence(f)
+    function divergence(f, hv_center_space)
 
         divuf = Fields.FieldVector(h = zeros(eltype(f), hv_center_space))
         h = f.h
@@ -200,8 +214,7 @@ end
 
     # A horizontal Gaussian blob, centered at (-x_0, -z_0),
     # with `a` the height of the blob and σ the standard deviation
-    function h_blob(x_0, z_0, a = 1.0, σ = 0.2)
-        coords = Fields.coordinate_field(hv_center_space)
+    function h_blob(coords, x_0, z_0, a = 1.0, σ = 0.2)
         f = map(coords) do coord
             a * exp(-((coord.x + x_0)^2 + (coord.z + z_0)^2) / (2 * σ^2))
         end
@@ -211,8 +224,7 @@ end
 
     # Spatial derivative of a horizontal Gaussian blob, centered at (-x_0, -z_0),
     # with `a` the height of the blob and σ the standard deviation
-    function div_h_blob(x_0, z_0, a = 1.0, σ = 0.2)
-        coords = Fields.coordinate_field(hv_center_space)
+    function div_h_blob(coords, x_0, z_0, a = 1.0, σ = 0.2)
         div_uf = map(coords) do coord
             -a * (exp(-((coord.x + x_0)^2 + (coord.z + z_0)^2) / (2 * σ^2))) /
             (σ^2) * ((coord.x + x_0) + (coord.z + z_0))
@@ -221,14 +233,109 @@ end
         return div_uf
     end
 
-    f = Fields.FieldVector(h = h_blob(0.5, 0.5))
+    n_elems_seq = 2 .^ (6, 7, 8, 9)
+    err, Δh = zeros(length(n_elems_seq)), zeros(length(n_elems_seq))
 
-    divuf = divergence(f)
-    exact_divuf = div_h_blob(0.5, 0.5)
+    for (k, n) in enumerate(n_elems_seq)
+        hv_center_space, hv_face_space =
+            hvspace_2D(xlim = (-1, 1), zlim = (-1, 1), helem = n, velem = n)
 
-    @test norm(exact_divuf .- divuf.h) ≤ 5e-2
+        Δh[k] = 1.0 / n
+
+        coords = Fields.coordinate_field(hv_center_space)
+        f = Fields.FieldVector(h = h_blob(coords, 0.5, 0.5))
+
+        divuf = divergence(f, hv_center_space)
+        exact_divuf = div_h_blob(coords, 0.5, 0.5)
+
+        err[k] = norm(exact_divuf .- divuf.h)
+    end
+    # Divergence convergence rate
+    conv_comp_div = convergence_rate(err, Δh)
+    @test err[3] ≤ err[2] ≤ err[1] ≤ 0.1
+    @test conv_comp_div[1] ≈ 0.5 atol = 0.1
+    @test conv_comp_div[2] ≈ 0.5 atol = 0.1
+    @test conv_comp_div[3] ≈ 0.5 atol = 0.1
 end
 
+@testset "1D SE, 1D FD Extruded Domain horz & vert divergence operator, with Dirichelet BCs" begin
+
+    # Divergence operator in 2D Cartesian domain with
+    # Cₕ = (cₕ, 0), Cᵥ = (0, cᵥ)
+    # ∇ₕ⋅(Cₕ * f) + ∇ᵥ⋅(Cᵥ * f)
+    # here cₕ == cᵥ == 1
+
+    # NOTE: the equation setup is only correct for Cartesian domains!
+
+    function divergence(f, hv_center_space)
+
+        divuf = Fields.FieldVector(h = zeros(eltype(f), hv_center_space))
+        h = f.h
+        dh = divuf.h
+
+        # vertical advection no inflow at bottom
+        # and outflow at top
+        Ic2f = Operators.InterpolateC2F(
+            top = Operators.SetValue(0.0),
+            bottom = Operators.SetValue(0.0),
+        )
+        divf2c = Operators.DivergenceF2C()
+        # only upward component of divergence
+        @. dh = divf2c(Ic2f(h) * Geometry.WVector(1.0))
+
+        # only horizontal component of divergence
+        hdiv = Operators.Divergence()
+        @. dh += hdiv(h * Geometry.UVector(1.0)) # add the two components for full divergence +=
+        Spaces.weighted_dss!(dh)
+
+        return divuf
+    end
+
+    # A horizontal Gaussian blob, centered at (-x_0, -z_0),
+    # with `a` the height of the blob and σ the standard deviation
+    function h_blob(coords, x_0, z_0, a = 1.0, σ = 0.2)
+        f = map(coords) do coord
+            a * exp(-((coord.x + x_0)^2 + (coord.z + z_0)^2) / (2 * σ^2))
+        end
+
+        return f
+    end
+
+    # Spatial derivative of a horizontal Gaussian blob, centered at (-x_0, -z_0),
+    # with `a` the height of the blob and σ the standard deviation
+    function div_h_blob(coords, x_0, z_0, a = 1.0, σ = 0.2)
+        div_uf = map(coords) do coord
+            -a * (exp(-((coord.x + x_0)^2 + (coord.z + z_0)^2) / (2 * σ^2))) /
+            (σ^2) * ((coord.x + x_0) + (coord.z + z_0))
+        end
+
+        return div_uf
+    end
+
+    n_elems_seq = 2 .^ (6, 7, 8, 9)
+    err, Δh = zeros(length(n_elems_seq)), zeros(length(n_elems_seq))
+
+    for (k, n) in enumerate(n_elems_seq)
+        hv_center_space, hv_face_space =
+            hvspace_2D(xlim = (-1, 1), zlim = (-1, 1), helem = n, velem = n)
+
+        Δh[k] = 1.0 / n
+
+        coords = Fields.coordinate_field(hv_center_space)
+        f = Fields.FieldVector(h = h_blob(coords, 0.0, 0.0))
+
+        divuf = divergence(f, hv_center_space)
+        exact_divuf = div_h_blob(coords, 0.0, 0.0)
+
+        err[k] = norm(exact_divuf .- divuf.h)
+    end
+    # Divergence convergence rate
+    conv_comp_div = convergence_rate(err, Δh)
+    @test err[3] ≤ err[2] ≤ err[1] ≤ 0.1
+    @test conv_comp_div[1] ≈ 2 atol = 0.1
+    @test conv_comp_div[2] ≈ 2 atol = 0.1
+    @test conv_comp_div[3] ≈ 2 atol = 0.1
+end
 
 @testset "1D SE, 1D FD Extruded Domain vertical vector advection" begin
 


### PR DESCRIPTION
Since I was confused about the order of convergence of our current `AdvectionC2C` operator from its docs and stencil formula, I added unit tests that check this, both in a 1D FD space and 2d hybrid, i.e., 1D SE x 1D FD. 

I also wanted to add the same for `AdvectionF2F`, but I need some clarifications about this operator as well