### PR TITLE
Diffusion of total enthalpy in tendency terms

### DIFF
--- a/examples/3dsphere/baroclinic_wave_utilities.jl
+++ b/examples/3dsphere/baroclinic_wave_utilities.jl
@@ -266,12 +266,22 @@ function baroclinic_wave_ρe_remaining_tendency!(dY, Y, p, t; κ₄)
     cuₕ = Y.uₕ # Covariant12Vector on centers
     fw = Y.w # Covariant3Vector on faces
 
+    @. cuvw =
+        Geometry.Covariant123Vector(cuₕ) + Geometry.Covariant123Vector(If2c(fw))
+
+    @. cK = norm_sqr(cuvw) / 2
+    @. cp = pressure(cρ, cρe / cρ, cK, cΦ)
+
     # Update w at the bottom
     # fw = -g^31 cuₕ/ g^33 ????????
 
     # Hyperdiffusion
+    ce = @. cρe / cρ
+    ch_tot = @. ce + cp / cρ
 
-    @. cχe = hwdiv(hgrad(cρe / cρ))
+    # Total enthalpy
+
+    @. cχe = hwdiv(hgrad(ch_tot))
     @. cχuₕ =
         hwgrad(hdiv(cuₕ)) - Geometry.Covariant12Vector(
             hwcurl(Geometry.Covariant3Vector(hcurl(cuₕ))),
@@ -288,9 +298,6 @@ function baroclinic_wave_ρe_remaining_tendency!(dY, Y, p, t; κ₄)
         )
 
     # Mass conservation
-
-    @. cuvw =
-        Geometry.Covariant123Vector(cuₕ) + Geometry.Covariant123Vector(If2c(fw))
 
     @. dY.Yc.ρ -= hdiv(cρ * cuvw)
     @. dY.Yc.ρ -= vdivf2c(Ic2f(cρ * cuₕ))
@@ -316,8 +323,6 @@ function baroclinic_wave_ρe_remaining_tendency!(dY, Y, p, t; κ₄)
         (cf + cω³) ×
         Geometry.Contravariant12Vector(Geometry.Covariant123Vector(cuₕ))
 
-    @. cK = norm_sqr(cuvw) / 2
-    @. cp = pressure(cρ, cρe / cρ, cK, cΦ)
 
     @. dY.uₕ -= hgrad(cp) / cρ
     @. dY.uₕ -= hgrad(cK + cΦ)

--- a/examples/3dsphere/held_suarez_rhoe.jl
+++ b/examples/3dsphere/held_suarez_rhoe.jl
@@ -8,7 +8,7 @@ driver_values(FT) = (;
     helem = 4,
     npoly = 4,
     tmax = FT(60 * 60 * 24 * 10),
-    dt = FT(500.0),
+    dt = FT(400.0),
     ode_algorithm = OrdinaryDiffEq.Rosenbrock23,
     jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :no_∂P∂K, ∂𝕄ₜ∂ρ_mode = :exact),
     max_newton_iters = 2,

--- a/examples/hybrid/bubble3d_invariant_totalenergy.jl
+++ b/examples/hybrid/bubble3d_invariant_totalenergy.jl
@@ -176,10 +176,24 @@ function rhs_invariant!(dY, Y, _, t)
 
     dρ .= 0 .* cρ
 
+    If2c = Operators.InterpolateF2C()
+    Ic2f = Operators.InterpolateC2F(
+        bottom = Operators.Extrapolate(),
+        top = Operators.Extrapolate(),
+    )
+    cw = If2c.(fw)
+    fuₕ = Ic2f.(cuₕ)
+    cuvw = Geometry.Covariant123Vector.(cuₕ) .+ Geometry.Covariant123Vector.(cw)
+
+    ce = @. cρe / cρ
+    cI = @. ce - Φ(z) - (norm(cuvw)^2) / 2
+    cT = @. cI / C_v + T_0
+    cp = @. cρ * R_d * cT
+
     ### HYPERVISCOSITY
     # 1) compute hyperviscosity coefficients
-
-    χe = @. dρe = hwdiv(hgrad(cρe / cρ)) # we store χe in dρe
+    ch_tot = @. ce + cp / cρ
+    χe = @. dρe = hwdiv(hgrad(ch_tot)) # we store χe in dρe
     χuₕ = @. duₕ =
         hwgrad(hdiv(cuₕ)) - Geometry.Covariant12Vector(
             hwcurl(Geometry.Covariant3Vector(hcurl(cuₕ))),
@@ -197,14 +211,6 @@ function rhs_invariant!(dY, Y, _, t)
         )
 
     # 1) Mass conservation
-    If2c = Operators.InterpolateF2C()
-    Ic2f = Operators.InterpolateC2F(
-        bottom = Operators.Extrapolate(),
-        top = Operators.Extrapolate(),
-    )
-    cw = If2c.(fw)
-    fuₕ = Ic2f.(cuₕ)
-    cuvw = Geometry.Covariant123Vector.(cuₕ) .+ Geometry.Covariant123Vector.(cw)
 
     dw .= fw .* 0
 
@@ -253,11 +259,6 @@ function rhs_invariant!(dY, Y, _, t)
     @. duₕ -=
         cω³ × Geometry.Contravariant12Vector(Geometry.Covariant123Vector(cuₕ))
 
-    ce = @. cρe / cρ
-    #cp = @. pressure(cρ, ce, cuvw, z) #TODO: the pressure function doesn't work (broadcast error)
-    cI = @. ce - Φ(z) - (norm(cuvw)^2) / 2
-    cT = @. cI / C_v + T_0
-    cp = @. cρ * R_d * cT
 
     @. duₕ -= hgrad(cp) / cρ
     vgradc2f = Operators.GradientC2F(


### PR DESCRIPTION
Modifies examples to include total enthalpy hyperdiffusion in the tendency terms for 
\rhoe_tot. Resolves issue #552