### PR TITLE
Add missing existing Interpolation operators to docs

### DIFF
--- a/docs/src/operators.md
+++ b/docs/src/operators.md
@@ -34,9 +34,13 @@ Spaces.weighted_dss!
 ```@docs
 InterpolateC2F
 InterpolateF2C
+WeightedInterpolateC2F
+WeightedInterpolateF2C
 UpwindBiasedProductC2F
 LeftBiasedC2F
 RightBiasedC2F
+LeftBiasedF2C
+RightBiasedF2C
 ```
 
 ### Derivative operators


### PR DESCRIPTION
This adds the docstrings of LeftBiasedF2C, RightBiasedF2C, WeightedInterpolateC2F & WeightedInterpolateF2C interfaces to the docs