### PR TITLE
Update limiter function to work on both 2D and 2D x 1D extruded spaces

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -64,7 +64,7 @@ steps:
       JULIA_NUM_PRECOMPILE_TASKS: 8
 
   - wait
- 
+
   - label: ":computer: unit tests"
     key: "cpu_unittests"
     command:
@@ -277,7 +277,7 @@ steps:
       slurm_ntasks: 1
 
   - label: ":computer: Advection CG plane limiter cosine bells"
-    key: "cpu_advection_cg_plane_limiter_cosine_bells"
+    key: "cpu_cg_plane_advection_limiter_cosine_bells"
     command:
       - "julia --color=yes --project=examples examples/plane/limiters_advection.jl"
     artifact_paths:
@@ -288,7 +288,7 @@ steps:
       slurm_ntasks: 1
 
   - label: ":computer: Advection CG plane limiter Gaussian bells"
-    key: "cpu_advection_cg_plane_limiter_gaussian_bells"
+    key: "cpu_cg_plane_advection_limiter_gaussian_bells"
     command:
       - "julia --color=yes --project=examples examples/plane/limiters_advection.jl gaussian_bells"
     artifact_paths:
@@ -299,7 +299,7 @@ steps:
       slurm_ntasks: 1
 
   - label: ":computer: Advection CG plane limiter cylinders"
-    key: "cpu_advection_cg_plane_limiter_cylinders"
+    key: "cpu_cg_plane_advection_limiter_cylinders"
     command:
       - "julia --color=yes --project=examples examples/plane/limiters_advection.jl cylinders"
     artifact_paths:
@@ -341,7 +341,7 @@ steps:
       config: cpu
       queue: central
       slurm_ntasks: 1
-  
+
   - label: ":computer: Rising Bubble hybrid invariant total energy"
     key: "cpu_rising_bubble_hybrid_invariant_total_energy"
     command:
@@ -363,7 +363,7 @@ steps:
       config: cpu
       queue: central
       slurm_ntasks: 1
-  
+
   - label: ":computer: Rising Bubble 3D hybrid invariant total energy"
     key: "cpu_rising_bubble_3d_hybrid_invariant_total_energy"
     command:
@@ -432,34 +432,34 @@ steps:
       queue: central
       slurm_ntasks: 1
 
-  - label: ":computer: Solid body CG sphere limiter cosine bells"
-    key: "cpu_solidbody_cg_sphere_limiter_cosine_bells"
+  - label: ":computer: Advection CG sphere limiter cosine bells"
+    key: "cpu_cg_sphere_advection_limiter_cosine_bells"
     command:
-      - "julia --color=yes --project=examples examples/sphere/opt_limiters_solidbody.jl"
+      - "julia --color=yes --project=examples examples/sphere/limiters_advection.jl"
     artifact_paths:
-      - "examples/sphere/output/cg_sphere_solidbody_limiter_cosine_bells/*"
+      - "examples/sphere/output/cg_sphere_advection_limiter_cosine_bells/*"
     agents:
       config: cpu
       queue: central
       slurm_ntasks: 1
 
-  - label: ":computer: Solid body CG sphere limiter Gaussian bells"
-    key: "cpu_solidbody_cg_sphere_limiter_gaussian_bells"
+  - label: ":computer: Advection CG sphere limiter Gaussian bells"
+    key: "cpu_cg_advection_limiter_gaussian_bells"
     command:
-      - "julia --color=yes --project=examples examples/sphere/opt_limiters_solidbody.jl gaussian_bells"
+      - "julia --color=yes --project=examples examples/sphere/limiters_advection.jl gaussian_bells"
     artifact_paths:
-      - "examples/sphere/output/cg_sphere_solidbody_limiter_gaussian_bells/*"
+      - "examples/sphere/output/cg_sphere_advection_limiter_gaussian_bells/*"
     agents:
       config: cpu
       queue: central
       slurm_ntasks: 1
 
-  - label: ":computer: Solid body CG sphere limiter cylinders"
-    key: "cpu_solidbody_cg_sphere_limiter_cylinders"
+  - label: ":computer: Advection CG sphere limiter cylinders"
+    key: "cpu_cg_advection_limiter_cylinders"
     command:
-      - "julia --color=yes --project=examples examples/sphere/opt_limiters_solidbody.jl cylinders"
+      - "julia --color=yes --project=examples examples/sphere/limiters_advection.jl cylinders"
     artifact_paths:
-      - "examples/sphere/output/cg_sphere_solidbody_limiter_cylinders/*"
+      - "examples/sphere/output/cg_sphere_advection_limiter_cylinders/*"
     agents:
       config: cpu
       queue: central
@@ -622,7 +622,7 @@ steps:
       config: cpu
       queue: central
       slurm_ntasks: 1
-  
+
   - label: ":computer: hydrostatically and geostrophically balanced flow (ρθ)"
     key: "cpu_balanced_flow_rho_theta"
     command:

--- a/examples/plane/limiters_advection.jl
+++ b/examples/plane/limiters_advection.jl
@@ -240,7 +240,7 @@ for (k, ne) in enumerate(ne_seq)
 
     # Set up RHS function
     ystar = similar(y0)
-    parameters = (quad = quad, space = space, min_Q = min_Q, max_Q = max_Q)
+    parameters = (space = space, min_Q = min_Q, max_Q = max_Q)
     f!(ystar, y0, parameters, 0.0)
 
     # Solve the ODE

--- a/examples/sphere/limiters_advection.jl
+++ b/examples/sphere/limiters_advection.jl
@@ -52,7 +52,7 @@ const limiter_tol = 5e-14
 ENV["GKSwstype"] = "nul"
 import ClimaCorePlots, Plots
 Plots.GRBackend()
-dirname = "cg_sphere_solidbody_limiter_$(test_name)"
+dirname = "cg_sphere_advection_limiter_$(test_name)"
 
 if lim_flag == false
     dirname = "$(dirname)_no_lim"
@@ -227,8 +227,7 @@ for (k, ne) in enumerate(ne_seq)
 
     # Set up RHS function
     ystar = similar(y0)
-    parameters =
-        (quad = quad, space = space, min_Q = min_Q, max_Q = max_Q, T = T)
+    parameters = (space = space, min_Q = min_Q, max_Q = max_Q, T = T)
     f!(ystar, y0, parameters, 0.0)
 
     # Solve the ODE

--- a/test/Limiters/limiter.jl
+++ b/test/Limiters/limiter.jl
@@ -1,6 +1,7 @@
 using ClimaCore: Fields, Domains, Geometry, Topologies, Meshes, Spaces, Limiters
 using Test
 
+# 2D mesh setup
 function rectangular_mesh(
     n1,
     n2,
@@ -30,7 +31,51 @@ function rectangular_mesh(
     return Meshes.RectilinearMesh(domain, n1, n2)
 end
 
-@testset "Optimization-based limiter on a 1×1 2D domain space" begin
+# 2D x 1D hybrid function space setup
+function hvspace_3D(
+    FT = Float64;
+    xlim = (-2π, 2π),
+    ylim = (-2π, 2π),
+    zlim = (0, 4π),
+    xelems = 4,
+    yelems = 8,
+    zelems = 16,
+    Nij = 4,
+)
+
+    xdomain = Domains.IntervalDomain(
+        Geometry.XPoint{FT}(xlim[1]),
+        Geometry.XPoint{FT}(xlim[2]),
+        periodic = true,
+    )
+    ydomain = Domains.IntervalDomain(
+        Geometry.YPoint{FT}(ylim[1]),
+        Geometry.YPoint{FT}(ylim[2]),
+        periodic = true,
+    )
+
+    horzdomain = Domains.RectangleDomain(xdomain, ydomain)
+    horzmesh = Meshes.RectilinearMesh(horzdomain, xelems, yelems)
+    horztopology = Topologies.Topology2D(horzmesh)
+
+    zdomain = Domains.IntervalDomain(
+        Geometry.ZPoint{FT}(zlim[1]),
+        Geometry.ZPoint{FT}(zlim[2]);
+        boundary_names = (:bottom, :top),
+    )
+    vertmesh = Meshes.IntervalMesh(zdomain, nelems = zelems)
+    vert_center_space = Spaces.CenterFiniteDifferenceSpace(vertmesh)
+
+    quad = Spaces.Quadratures.GLL{Nij}()
+    horzspace = Spaces.SpectralElementSpace2D(horztopology, quad)
+
+    hv_center_space =
+        Spaces.ExtrudedFiniteDifferenceSpace(horzspace, vert_center_space)
+    hv_face_space = Spaces.FaceExtrudedFiniteDifferenceSpace(hv_center_space)
+    return (horzspace, hv_center_space, hv_face_space)
+end
+
+@testset "Optimization-based limiter on a 1×1 elem 2D domain space" begin
     FT = Float64
     lim_tol = 5e-14
     Nij = 2
@@ -60,7 +105,7 @@ end
     @test sum(ρq) ≈ initial_Q_mass rtol = 10eps()
 end
 
-@testset "Optimization-based limiter on a 3×3 2D domain space" begin
+@testset "Optimization-based limiter on a 3×3 elem 2D domain space" begin
     FT = Float64
     lim_tol = 5e-14
     Nij = 2
@@ -86,11 +131,86 @@ end
     max_ρq = ones(n_elems)
     max_ρq[2] = 0.5
 
+    Limiters.quasimonotone_limiter!(ρq, ρ, min_ρq, max_ρq, rtol = lim_tol)
+    # Check elem 1 values, with min_ρq = 0, max_ρq = 1
+    @test parent(ρq)[:, :, 1, 1] ≈ [0.0 0.0; 0.950005 0.950005] rtol = 10eps()
+    # Check elem 2 values, with min_ρq = 0, max_ρq = 0.5
+    @test parent(ρq)[:, :, 1, 2] ≈ [0.45 0.45001; 0.5 0.5] rtol = 10eps()
+    # Check elem 3, vertex 1 value that was between min_ρq = 0, max_ρq = 1 bounds
+    @test parent(ρq)[9] ≈ 1 rtol = 10eps()
+    # Check mass conservation after application of limiter
+    @test sum(ρq) ≈ initial_Q_mass rtol = 10eps()
+end
+
+@testset "Optimization-based limiter on a doubly-periodic 1x1×1 elem 2D x 1D hybrid domain space" begin
+    FT = Float64
+    lim_tol = 5e-14
+    Nij = 2
+    n1 = n2 = n3 = 1
+
+    horzspace, hv_center_space, hv_face_space =
+        hvspace_3D(FT, Nij = Nij, xelems = n1, yelems = n2, zelems = n3)
+
+    # Initialize fields
+    ρ = ones(hv_center_space)
+    q = ones(hv_center_space)
+    parent(q)[1, :, :, 1, 1] = [-0.2 0.00001; 1.1 1]
+
+    ρq = ρ .* q
+    initial_Q_mass = sum(ρq)
+
+    # Initialize variables needed for limiters
+    horz_n_elems = Topologies.nlocalelems(horzspace.topology)
+    min_ρq = zeros(horz_n_elems, n3)
+    max_ρq = ones(horz_n_elems, n3)
 
     Limiters.quasimonotone_limiter!(ρq, ρ, min_ρq, max_ρq, rtol = lim_tol)
-    @test parent(ρq)[:, :, 1, 1] ≈ [0.0 0.0; 0.950005 0.950005] rtol = 10eps()
-    @test parent(ρq)[:, :, 1, 2] ≈ [0.45 0.45001; 0.5 0.5] rtol = 10eps()
-    @test parent(ρq)[9] ≈ 1 rtol = 10eps()
+    @test parent(ρq)[1, :, :, 1, 1] ≈ [0.0 0.0; 0.950005 0.950005] rtol =
+        10eps()
+
+    # Check mass conservation after application of limiter
+    @test sum(ρq) ≈ initial_Q_mass rtol = 10eps()
+end
+
+@testset "Optimization-based limiter on a doubly-periodic 3x3×3 elem 2D x 1D hybrid domain space" begin
+    FT = Float64
+    lim_tol = 5e-14
+    Nij = 2
+    n1 = n2 = 3
+    n3 = 3
+
+    horzspace, hv_center_space, hv_face_space =
+        hvspace_3D(FT, Nij = Nij, xelems = n1, yelems = n2, zelems = n3)
+
+    # Initialize fields
+    ρ = ones(hv_center_space)
+    q = ones(hv_center_space)
+    parent(q)[1, :, :, 1, 1] = [-0.2 0.00001; 1.1 1]
+    parent(q)[1, :, :, 1, 2] = [-0.2 0.00001; 1.1 1]
+    parent(q)[2, :, :, 1, 5] = [-0.2 0.00001; 1.1 1]
+    parent(q)[3, :, :, 1, 7] = [1 1; 1 1]
+
+    ρq = ρ .* q
+    initial_Q_mass = sum(ρq)
+
+    # Initialize variables needed for limiters
+    horz_n_elems = Topologies.nlocalelems(horzspace.topology)
+    min_ρq = zeros(horz_n_elems, n3)
+    max_ρq = ones(horz_n_elems, n3)
+    # Change max only for level 1, elem 2
+    max_ρq[2, 1] = 0.5
+
+    Limiters.quasimonotone_limiter!(ρq, ρ, min_ρq, max_ρq, rtol = lim_tol)
+    # Check level 1, elem 1 values, with min_ρq = 0, max_ρq = 1
+    @test parent(ρq)[1, :, :, 1, 1] ≈ [0.0 0.0; 0.950005 0.950005] rtol =
+        10eps()
+    # Check level 1, elem 2 values, with min_ρq = 0, max_ρq = 0.5
+    @test parent(ρq)[1, :, :, 1, 2] ≈ [0.45 0.45001; 0.5 0.5] rtol = 10eps()
+    # Check level 2, elem 5 values, with min_ρq = 0, max_ρq = 1
+    @test parent(ρq)[2, :, :, 1, 5] ≈ [0.0 0.0; 0.950005 0.950005] rtol =
+        10eps()
+    # Check level 3, elem 7 values, with unvaried entries
+    @test parent(ρq)[3, :, :, 1, 7] ≈ [1 1; 1 1] rtol = 10eps()
     # Check mass conservation after application of limiter
     @test sum(ρq) ≈ initial_Q_mass rtol = 10eps()
 end


### PR DESCRIPTION
This PR updates the limiter function to work on both 2D and 2D x 1D extruded spaces. 

For now the 1D x 1D extruded space support was not deemed a priority and can be added in a following PR with related tests/examples. 

This will close #584  

PS: I also took the occasion to rename `examples/sphere/opt_limiters_solidbody.jl` -> `examples/sphere/limiters_advection.jl` for consistency with the plane and following examples I am working on to address #575 .