### PR TITLE
Interpolate before computing products

### DIFF
--- a/examples/3dsphere/baroclinic_wave_utilities.jl
+++ b/examples/3dsphere/baroclinic_wave_utilities.jl
@@ -223,7 +223,7 @@ function baroclinic_wave_ρθ_remaining_tendency!(dY, Y, p, t; κ₄)
         Geometry.Covariant123Vector(cuₕ) + Geometry.Covariant123Vector(If2c(fw))
 
     @. dY.Yc.ρ -= hdiv(cρ * cuvw)
-    @. dY.Yc.ρ -= vdivf2c(Ic2f(cρ * cuₕ))
+    @. dY.Yc.ρ -= vdivf2c(Ic2f(cρ) * Ic2f(cuₕ))
 
     # Momentum conservation
 
@@ -258,7 +258,7 @@ function baroclinic_wave_ρθ_remaining_tendency!(dY, Y, p, t; κ₄)
     # Energy conservation
 
     @. dY.Yc.ρθ -= hdiv(cuvw * cρθ)
-    @. dY.Yc.ρθ -= vdivf2c(Ic2f(cuₕ * cρθ))
+    @. dY.Yc.ρθ -= vdivf2c(Ic2f(cuₕ) * Ic2f(cρθ))
 end
 
 function held_suarez_ρθ_tempest_remaining_tendency!(dY, Y, p, t; κ₄)


### PR DESCRIPTION
This PR makes the BCs for `cuₕ` consistent, with
```julia
@. fu¹² =
        Geometry.Contravariant12Vector(Geometry.Covariant123Vector(Ic2f(cuₕ)))
```
, by interpolating before computing products with other variables inside vertical divergence operators. @jiahe23, could you try running held suarez with this PR?