### PR TITLE
Reorganize driver

### DIFF
--- a/examples/common_spaces.jl
+++ b/examples/common_spaces.jl
@@ -1,0 +1,87 @@
+using ClimaCore: Geometry, Domains, Meshes, Topologies, Spaces
+
+abstract type Space{FT} end
+
+Base.@kwdef struct PeriodicLine{FT} <: Space{FT}
+    xmax::FT
+    xelem::Int
+    npoly::Int
+end
+
+Base.@kwdef struct PeriodicRectangle{FT} <: Space{FT}
+    xmax::FT
+    ymax::FT
+    xelem::Int
+    yelem::Int
+    npoly::Int
+end
+
+Base.@kwdef struct CubedSphere{FT} <: Space{FT}
+    radius::FT
+    helem::Int # number of elements along side of each panel (6 panels in total)
+    npoly::Int
+end
+
+Base.@kwdef struct ExtrudedSpace{FT, S <: Space{FT}} <: Space{FT}
+    zmax::FT
+    zelem::Int
+    hspace::S
+end
+
+function make_space((; xmax, xelem, npoly)::PeriodicLine)
+    domain = Domains.IntervalDomain(
+        Geometry.XPoint(zero(xmax)),
+        Geometry.XPoint(xmax);
+        periodic = true,
+    )
+    mesh = Meshes.IntervalMesh(domain; nelems = xelem)
+    topology = Topologies.IntervalTopology(mesh)
+    quad = Spaces.Quadratures.GLL{npoly + 1}()
+    return Spaces.SpectralElementSpace1D(topology, quad)
+end
+
+function make_space((; xmax, ymax, xelem, yelem, npoly)::PeriodicRectangle)
+    xdomain = Domains.IntervalDomain(
+        Geometry.XPoint(zero(xmax)),
+        Geometry.XPoint(xmax);
+        periodic = true,
+    )
+    ydomain = Domains.IntervalDomain(
+        Geometry.YPoint(zero(ymax)),
+        Geometry.YPoint(ymax);
+        periodic = true,
+    )
+    domain = Domains.RectangleDomain(xdomain, ydomain)
+    mesh = Meshes.RectilinearMesh(domain, xelem, yelem)
+    topology = Topologies.Topology2D(mesh)
+    quad = Spaces.Quadratures.GLL{npoly + 1}()
+    return Spaces.SpectralElementSpace2D(topology, quad)
+end
+
+function make_space((; radius, helem, npoly)::CubedSphere)
+    domain = Domains.SphereDomain(radius)
+    mesh = Meshes.EquiangularCubedSphere(domain, helem)
+    topology = Topologies.Topology2D(mesh)
+    quad = Spaces.Quadratures.GLL{npoly + 1}()
+    return Spaces.SpectralElementSpace2D(topology, quad)
+end
+
+function make_space((; zmax, zelem, hspace)::ExtrudedSpace)
+    vdomain = Domains.IntervalDomain(
+        Geometry.ZPoint(zero(zmax)),
+        Geometry.ZPoint(zmax);
+        boundary_tags = (:bottom, :top),
+    )
+    vmesh = Meshes.IntervalMesh(vdomain, nelems = zelem)
+    vspace = Spaces.CenterFiniteDifferenceSpace(vmesh)
+    return Spaces.ExtrudedFiniteDifferenceSpace(make_space(hspace), vspace)
+end
+
+function local_geometry_fields(space::ExtrudedSpace)
+    center_space = make_space(space)
+    face_space = Spaces.FaceExtrudedFiniteDifferenceSpace(center_space)
+    return (
+        Fields.local_geometry_field(center_space),
+        Fields.local_geometry_field(face_space),
+    )
+end

--- a/examples/hybrid/schur_complement_W.jl
+++ b/examples/hybrid/schur_complement_W.jl
@@ -3,8 +3,6 @@ using LinearAlgebra: Tridiagonal, lu!, ldiv!
 using ClimaCore: Spaces, Fields, Operators
 using ClimaCore.Utilities: half
 
-include("../implicit_solver_debugging_tools.jl")
-
 const compose = Operators.ComposeStencils()
 const apply = Operators.ApplyStencil()
 

--- a/examples/hybrid/sphere/balanced_flow_rhoe.jl
+++ b/examples/hybrid/sphere/balanced_flow_rhoe.jl
@@ -1,25 +1,21 @@
 using Test
 using ClimaCorePlots, Plots
-using DiffEqCallbacks
-using JLD2
 
 include("baroclinic_wave_utilities.jl")
 
-jld2_callback = PeriodicCallback(output_writer, 864000; initial_affect = true)
+const sponge = false
 
-driver_values(FT) = (;
-    zmax = FT(30.0e3),
-    velem = 10,
-    helem = 4,
-    npoly = 4,
-    tmax = FT(60 * 60),
-    dt = FT(5.0),
-    ode_algorithm = OrdinaryDiffEq.SSPRK33,
-    jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :no_∂P∂K, ∂𝕄ₜ∂ρ_mode = :exact),
-    max_newton_iters = 2,
-    save_every_n_steps = 10,
-    additional_solver_kwargs = (;), # callback = jld2_callback), 
+# Variables required for driver.jl (modify as needed)
+space = ExtrudedSpace(;
+    zmax = FT(30e3),
+    zelem = 10,
+    hspace = CubedSphere(; radius = R, helem = 4, npoly = 4),
 )
+t_end = FT(60 * 60)
+dt = FT(5)
+dt_save_to_sol = FT(50)
+dt_save_to_disk = FT(0) # 0 means don't save to disk
+ode_algorithm = OrdinaryDiffEq.SSPRK33
 
 initial_condition(local_geometry) =
     initial_condition_ρe(local_geometry; is_balanced_flow = true)
@@ -28,7 +24,7 @@ initial_condition_velocity(local_geometry) =
 
 remaining_cache_values(Y, dt) = merge(
     baroclinic_wave_cache_values(Y, dt),
-    final_adjustments_cache_values(Y, dt; use_rayleigh_sponge = false),
+    final_adjustments_cache_values(Y, dt; use_rayleigh_sponge = sponge),
 )
 
 function remaining_tendency!(dY, Y, p, t)
@@ -40,28 +36,28 @@ function remaining_tendency!(dY, Y, p, t)
         p,
         t;
         use_flux_correction = false,
-        use_rayleigh_sponge = false,
+        use_rayleigh_sponge = sponge,
     )
     return dY
 end
 
-function postprocessing(sol, path)
+function postprocessing(sol, p, output_dir)
     @info "L₂ norm of ρe at t = $(sol.t[1]): $(norm(sol.u[1].Yc.ρe))"
     @info "L₂ norm of ρe at t = $(sol.t[end]): $(norm(sol.u[end].Yc.ρe))"
 
     u_end = Geometry.UVVector.(sol.u[end].uₕ).components.data.:1
-    Plots.png(Plots.plot(u_end, level = 3), joinpath(path, "u_end.png"))
+    Plots.png(Plots.plot(u_end, level = 3), joinpath(output_dir, "u_end.png"))
 
     w_end = Geometry.WVector.(sol.u[end].w).components.data.:1
     Plots.png(
         Plots.plot(w_end, level = 3 + half, clim = (-4, 4)),
-        joinpath(path, "w_end.png"),
+        joinpath(output_dir, "w_end.png"),
     )
 
     Δu_end = Geometry.UVVector.(sol.u[end].uₕ .- sol.u[1].uₕ).components.data.:1
     Plots.png(
         Plots.plot(Δu_end, level = 3, clim = (-1, 1)),
-        joinpath(path, "Δu_end.png"),
+        joinpath(output_dir, "Δu_end.png"),
     )
 
     @test sol.u[end].Yc.ρ ≈ sol.u[1].Yc.ρ rtol = 5e-2

--- a/examples/hybrid/sphere/balanced_flow_rhotheta.jl
+++ b/examples/hybrid/sphere/balanced_flow_rhotheta.jl
@@ -1,24 +1,21 @@
-using Test
 using ClimaCorePlots, Plots
-using DiffEqCallbacks
 
 include("baroclinic_wave_utilities.jl")
 
-jld2_callback = PeriodicCallback(output_writer, 864000; initial_affect = true)
+const sponge = false
 
-driver_values(FT) = (;
-    zmax = FT(30.0e3),
-    velem = 10,
-    helem = 4,
-    npoly = 4,
-    tmax = FT(60 * 60 * 24 * 10),
-    dt = FT(400.0),
-    ode_algorithm = OrdinaryDiffEq.Rosenbrock23,
-    jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :exact, ∂𝕄ₜ∂ρ_mode = :exact),
-    max_newton_iters = 2,
-    save_every_n_steps = 216,
-    additional_solver_kwargs = (;),# callback = jld2_callback),
+# Variables required for driver.jl (modify as needed)
+space = ExtrudedSpace(;
+    zmax = FT(30e3),
+    zelem = 10,
+    hspace = CubedSphere(; radius = R, helem = 4, npoly = 4),
 )
+t_end = FT(60 * 60 * 24 * 10)
+dt = FT(400)
+dt_save_to_sol = FT(60 * 60 * 24)
+dt_save_to_disk = FT(0) # 0 means don't save to disk
+ode_algorithm = OrdinaryDiffEq.Rosenbrock23
+jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :exact, ∂𝕄ₜ∂ρ_mode = :exact)
 
 initial_condition(local_geometry) = initial_condition_ρθ(local_geometry)
 initial_condition_velocity(local_geometry) =
@@ -26,7 +23,7 @@ initial_condition_velocity(local_geometry) =
 
 remaining_cache_values(Y, dt) = merge(
     baroclinic_wave_cache_values(Y, dt),
-    final_adjustments_cache_values(Y, dt; use_rayleigh_sponge = false),
+    final_adjustments_cache_values(Y, dt; use_rayleigh_sponge = sponge),
 )
 
 function remaining_tendency!(dY, Y, p, t)
@@ -38,12 +35,12 @@ function remaining_tendency!(dY, Y, p, t)
         p,
         t;
         use_flux_correction = false,
-        use_rayleigh_sponge = false,
+        use_rayleigh_sponge = sponge,
     )
     return dY
 end
 
-function postprocessing(sol, path)
+function postprocessing(sol, p, output_dir)
     @info "L₂ norm of ρe at t = $(sol.t[1]): $(norm(sol.u[1].Yc.ρθ))"
     @info "L₂ norm of ρe at t = $(sol.t[end]): $(norm(sol.u[end].Yc.ρθ))"
 
@@ -51,13 +48,13 @@ function postprocessing(sol, path)
         v = Geometry.UVVector.(Y.uₕ).components.data.:2
         Plots.plot(v, level = 3, clim = (-3, 3))
     end
-    Plots.mp4(anim, joinpath(path, "v.mp4"), fps = 5)
+    Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
 
     anim = Plots.@animate for Y in sol.u
         v = Geometry.UVVector.(Y.uₕ).components.data.:1
         Plots.plot(v, level = 3, clim = (-25, 25))
     end
-    Plots.mp4(anim, joinpath(path, "u.mp4"), fps = 5)
+    Plots.mp4(anim, joinpath(output_dir, "u.mp4"), fps = 5)
 
     anim = Plots.@animate for Y in sol.u
 
@@ -66,5 +63,5 @@ function postprocessing(sol, path)
 
         Plots.plot(θ, level = 3, clim = (225, 255))
     end
-    Plots.mp4(anim, joinpath(path, "theta.mp4"), fps = 5)
+    Plots.mp4(anim, joinpath(output_dir, "theta.mp4"), fps = 5)
 end

--- a/examples/hybrid/sphere/baroclinic_wave_rhoe.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhoe.jl
@@ -1,24 +1,21 @@
 using ClimaCorePlots, Plots
-using DiffEqCallbacks
-using JLD2
 
 include("baroclinic_wave_utilities.jl")
 
-jld2_callback = PeriodicCallback(output_writer, 864000; initial_affect = true)
+const sponge = false
 
-driver_values(FT) = (;
-    zmax = FT(30.0e3),
-    velem = 10,
-    helem = 4,
-    npoly = 4,
-    tmax = FT(60 * 60 * 24 * 10),
-    dt = FT(400.0),
-    ode_algorithm = OrdinaryDiffEq.Rosenbrock23,
-    jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :no_∂P∂K, ∂𝕄ₜ∂ρ_mode = :exact),
-    max_newton_iters = 2,
-    save_every_n_steps = 216,
-    additional_solver_kwargs = (;), # callback = jld2_callback), 
+# Variables required for driver.jl (modify as needed)
+space = ExtrudedSpace(;
+    zmax = FT(30e3),
+    zelem = 10,
+    hspace = CubedSphere(; radius = R, helem = 4, npoly = 4),
 )
+t_end = FT(60 * 60 * 24 * 10)
+dt = FT(400)
+dt_save_to_sol = FT(60 * 60 * 24)
+dt_save_to_disk = FT(0) # 0 means don't save to disk
+ode_algorithm = OrdinaryDiffEq.Rosenbrock23
+jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :no_∂P∂K, ∂𝕄ₜ∂ρ_mode = :exact)
 
 initial_condition(local_geometry) =
     initial_condition_ρe(local_geometry; is_balanced_flow = false)
@@ -27,7 +24,7 @@ initial_condition_velocity(local_geometry) =
 
 remaining_cache_values(Y, dt) = merge(
     baroclinic_wave_cache_values(Y, dt),
-    final_adjustments_cache_values(Y, dt; use_rayleigh_sponge = false),
+    final_adjustments_cache_values(Y, dt; use_rayleigh_sponge = sponge),
 )
 
 function remaining_tendency!(dY, Y, p, t)
@@ -39,12 +36,12 @@ function remaining_tendency!(dY, Y, p, t)
         p,
         t;
         use_flux_correction = false,
-        use_rayleigh_sponge = false,
+        use_rayleigh_sponge = sponge,
     )
     return dY
 end
 
-function postprocessing(sol, path)
+function postprocessing(sol, p, output_dir)
     @info "L₂ norm of ρe at t = $(sol.t[1]): $(norm(sol.u[1].Yc.ρe))"
     @info "L₂ norm of ρe at t = $(sol.t[end]): $(norm(sol.u[end].Yc.ρe))"
 
@@ -52,5 +49,5 @@ function postprocessing(sol, path)
         v = Geometry.UVVector.(Y.uₕ).components.data.:2
         Plots.plot(v, level = 3, clim = (-6, 6))
     end
-    Plots.mp4(anim, joinpath(path, "v.mp4"), fps = 5)
+    Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
 end

--- a/examples/hybrid/sphere/baroclinic_wave_rhotheta.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhotheta.jl
@@ -1,24 +1,21 @@
 using ClimaCorePlots, Plots
-using DiffEqCallbacks
-using JLD2
 
 include("baroclinic_wave_utilities.jl")
 
-jld2_callback = PeriodicCallback(output_writer, 864000; initial_affect = true)
+const sponge = false
 
-driver_values(FT) = (;
-    zmax = FT(30.0e3),
-    velem = 10,
-    helem = 4,
-    npoly = 4,
-    tmax = FT(60 * 60 * 24 * 10),
-    dt = FT(400.0),
-    ode_algorithm = OrdinaryDiffEq.Rosenbrock23,
-    jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :exact, ∂𝕄ₜ∂ρ_mode = :exact),
-    max_newton_iters = 2,
-    save_every_n_steps = 216,
-    additional_solver_kwargs = (;), # callback = jld2_callback), 
+# Variables required for driver.jl (modify as needed)
+space = ExtrudedSpace(;
+    zmax = FT(30e3),
+    zelem = 10,
+    hspace = CubedSphere(; radius = R, helem = 4, npoly = 4),
 )
+t_end = FT(60 * 60 * 24 * 10)
+dt = FT(400)
+dt_save_to_sol = FT(60 * 60 * 24)
+dt_save_to_disk = FT(0) # 0 means don't save to disk
+ode_algorithm = OrdinaryDiffEq.Rosenbrock23
+jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :exact, ∂𝕄ₜ∂ρ_mode = :exact)
 
 initial_condition(local_geometry) = initial_condition_ρθ(local_geometry)
 initial_condition_velocity(local_geometry) =
@@ -26,7 +23,7 @@ initial_condition_velocity(local_geometry) =
 
 remaining_cache_values(Y, dt) = merge(
     baroclinic_wave_cache_values(Y, dt),
-    final_adjustments_cache_values(Y, dt; use_rayleigh_sponge = false),
+    final_adjustments_cache_values(Y, dt; use_rayleigh_sponge = sponge),
 )
 
 function remaining_tendency!(dY, Y, p, t)
@@ -38,12 +35,12 @@ function remaining_tendency!(dY, Y, p, t)
         p,
         t;
         use_flux_correction = false,
-        use_rayleigh_sponge = false,
+        use_rayleigh_sponge = sponge,
     )
     return dY
 end
 
-function postprocessing(sol, path)
+function postprocessing(sol, p, output_dir)
     @info "L₂ norm of ρθ at t = $(sol.t[1]): $(norm(sol.u[1].Yc.ρθ))"
     @info "L₂ norm of ρθ at t = $(sol.t[end]): $(norm(sol.u[end].Yc.ρθ))"
 
@@ -51,5 +48,5 @@ function postprocessing(sol, path)
         v = Geometry.UVVector.(Y.uₕ).components.data.:2
         Plots.plot(v, level = 3, clim = (-6, 6))
     end
-    Plots.mp4(anim, joinpath(path, "v.mp4"), fps = 5)
+    Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
 end

--- a/examples/hybrid/sphere/baroclinic_wave_utilities.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_utilities.jl
@@ -1,5 +1,4 @@
 using LinearAlgebra: ×, norm
-using JLD2
 
 # General parameters
 const k = 3
@@ -467,18 +466,4 @@ function final_adjustments!(
     Spaces.weighted_dss!(dY.Yc)
     Spaces.weighted_dss!(dY.uₕ)
     Spaces.weighted_dss!(dY.w)
-end
-
-# Periodic Callback for output
-function output_writer(integrator)
-    day = floor(Int, (integrator.t + tend) / 3600 / 24)
-    @info "Saving JLD2 with prognostic vars at Day $day"
-    JLD2.jldsave(
-        joinpath(output_dir, "$(test_file_name)_day$day.jld2"),
-        uend = integrator.u,
-        tend = integrator.t + tend,
-        clg = center_local_geometry,
-        flg = face_local_geometry,
-    )
-    return nothing
 end

--- a/examples/hybrid/sphere/held_suarez_rhoe.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe.jl
@@ -1,24 +1,21 @@
 using ClimaCorePlots, Plots
-using DiffEqCallbacks
-using JLD2
 
 include("baroclinic_wave_utilities.jl")
 
-jld2_callback = PeriodicCallback(output_writer, 864000; initial_affect = true)
+const sponge = false
 
-driver_values(FT) = (;
-    zmax = FT(30.0e3),
-    velem = 10,
-    helem = 4,
-    npoly = 4,
-    tmax = FT(60 * 60 * 24 * 10),
-    dt = FT(400.0),
-    ode_algorithm = OrdinaryDiffEq.Rosenbrock23,
-    jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :no_∂P∂K, ∂𝕄ₜ∂ρ_mode = :exact),
-    max_newton_iters = 2,
-    save_every_n_steps = 216,
-    additional_solver_kwargs = (;), # callback = jld2_callback),
+# Variables required for driver.jl (modify as needed)
+space = ExtrudedSpace(;
+    zmax = FT(30e3),
+    zelem = 10,
+    hspace = CubedSphere(; radius = R, helem = 4, npoly = 4),
 )
+t_end = FT(60 * 60 * 24 * 10)
+dt = FT(400)
+dt_save_to_sol = FT(60 * 60 * 24)
+dt_save_to_disk = FT(0) # 0 means don't save to disk
+ode_algorithm = OrdinaryDiffEq.Rosenbrock23
+jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :no_∂P∂K, ∂𝕄ₜ∂ρ_mode = :exact)
 
 initial_condition(local_geometry) =
     initial_condition_ρe(local_geometry; is_balanced_flow = false)
@@ -28,7 +25,7 @@ initial_condition_velocity(local_geometry) =
 remaining_cache_values(Y, dt) = merge(
     baroclinic_wave_cache_values(Y, dt),
     held_suarez_cache_values(Y, dt),
-    final_adjustments_cache_values(Y, dt; use_rayleigh_sponge = false),
+    final_adjustments_cache_values(Y, dt; use_rayleigh_sponge = sponge),
 )
 
 function remaining_tendency!(dY, Y, p, t)
@@ -41,12 +38,12 @@ function remaining_tendency!(dY, Y, p, t)
         p,
         t;
         use_flux_correction = false,
-        use_rayleigh_sponge = false,
+        use_rayleigh_sponge = sponge,
     )
     return dY
 end
 
-function postprocessing(sol, path)
+function postprocessing(sol, p, output_dir)
     @info "L₂ norm of ρe at t = $(sol.t[1]): $(norm(sol.u[1].Yc.ρe))"
     @info "L₂ norm of ρe at t = $(sol.t[end]): $(norm(sol.u[end].Yc.ρe))"
 
@@ -54,5 +51,5 @@ function postprocessing(sol, path)
         v = Geometry.UVVector.(Y.uₕ).components.data.:2
         Plots.plot(v, level = 3, clim = (-6, 6))
     end
-    Plots.mp4(anim, joinpath(path, "v.mp4"), fps = 5)
+    Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
 end

--- a/examples/hybrid/sphere/held_suarez_rhotheta.jl
+++ b/examples/hybrid/sphere/held_suarez_rhotheta.jl
@@ -1,24 +1,21 @@
 using ClimaCorePlots, Plots
-using DiffEqCallbacks
-using JLD2
 
 include("baroclinic_wave_utilities.jl")
 
-jld2_callback = PeriodicCallback(output_writer, 864000; initial_affect = true)
+const sponge = false
 
-driver_values(FT) = (;
-    zmax = FT(30.0e3),
-    velem = 10,
-    helem = 4,
-    npoly = 4,
-    tmax = FT(60 * 60 * 24 * 10),
-    dt = FT(400.0),
-    ode_algorithm = OrdinaryDiffEq.Rosenbrock23,
-    jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :exact, ∂𝕄ₜ∂ρ_mode = :exact),
-    max_newton_iters = 2,
-    save_every_n_steps = 216,
-    additional_solver_kwargs = (;), # callback = jld2_callback), 
+# Variables required for driver.jl (modify as needed)
+space = ExtrudedSpace(;
+    zmax = FT(30e3),
+    zelem = 10,
+    hspace = CubedSphere(; radius = R, helem = 4, npoly = 4),
 )
+t_end = FT(60 * 60 * 24 * 10)
+dt = FT(400)
+dt_save_to_sol = FT(60 * 60 * 24)
+dt_save_to_disk = FT(0) # 0 means don't save to disk
+ode_algorithm = OrdinaryDiffEq.Rosenbrock23
+jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :exact, ∂𝕄ₜ∂ρ_mode = :exact)
 
 initial_condition(local_geometry) = initial_condition_ρθ(local_geometry)
 initial_condition_velocity(local_geometry) =
@@ -27,7 +24,7 @@ initial_condition_velocity(local_geometry) =
 remaining_cache_values(Y, dt) = merge(
     baroclinic_wave_cache_values(Y, dt),
     held_suarez_cache_values(Y, dt),
-    final_adjustments_cache_values(Y, dt; use_rayleigh_sponge = false),
+    final_adjustments_cache_values(Y, dt; use_rayleigh_sponge = sponge),
 )
 
 function remaining_tendency!(dY, Y, p, t)
@@ -40,12 +37,12 @@ function remaining_tendency!(dY, Y, p, t)
         p,
         t;
         use_flux_correction = false,
-        use_rayleigh_sponge = false,
+        use_rayleigh_sponge = sponge,
     )
     return dY
 end
 
-function postprocessing(sol, path)
+function postprocessing(sol, p, output_dir)
     @info "L₂ norm of ρθ at t = $(sol.t[1]): $(norm(sol.u[1].Yc.ρθ))"
     @info "L₂ norm of ρθ at t = $(sol.t[end]): $(norm(sol.u[end].Yc.ρθ))"
 
@@ -53,5 +50,5 @@ function postprocessing(sol, path)
         v = Geometry.UVVector.(Y.uₕ).components.data.:2
         Plots.plot(v, level = 3, clim = (-6, 6))
     end
-    Plots.mp4(anim, joinpath(path, "v.mp4"), fps = 5)
+    Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
 end

--- a/examples/hybrid/sphere/held_suarez_rhotheta_tempest.jl
+++ b/examples/hybrid/sphere/held_suarez_rhotheta_tempest.jl
@@ -1,24 +1,21 @@
 using ClimaCorePlots, Plots
-using DiffEqCallbacks
-using JLD2
 
 include("baroclinic_wave_utilities.jl")
 
-jld2_callback = PeriodicCallback(output_writer, 864000; initial_affect = true)
+const sponge = false
 
-driver_values(FT) = (;
-    zmax = FT(30.0e3),
-    velem = 10,
-    helem = 4,
-    npoly = 4,
-    tmax = FT(60 * 60 * 24 * 10),
-    dt = FT(400.0),
-    ode_algorithm = OrdinaryDiffEq.Rosenbrock23,
-    jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :exact, ∂𝕄ₜ∂ρ_mode = :exact),
-    max_newton_iters = 2,
-    save_every_n_steps = 216,
-    additional_solver_kwargs = (;), # callback = jld2_callback), 
+# Variables required for driver.jl (modify as needed)
+space = ExtrudedSpace(;
+    zmax = FT(30e3),
+    zelem = 10,
+    hspace = CubedSphere(; radius = R, helem = 4, npoly = 4),
 )
+t_end = FT(60 * 60 * 24 * 10)
+dt = FT(400)
+dt_save_to_sol = FT(60 * 60 * 24)
+dt_save_to_disk = FT(0) # 0 means don't save to disk
+ode_algorithm = OrdinaryDiffEq.Rosenbrock23
+jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :exact, ∂𝕄ₜ∂ρ_mode = :exact)
 
 initial_condition(local_geometry) = initial_condition_ρθ(local_geometry)
 initial_condition_velocity(local_geometry) =
@@ -27,7 +24,7 @@ initial_condition_velocity(local_geometry) =
 remaining_cache_values(Y, dt) = merge(
     baroclinic_wave_cache_values(Y, dt),
     held_suarez_cache_values(Y, dt),
-    final_adjustments_cache_values(Y, dt; use_rayleigh_sponge = false),
+    final_adjustments_cache_values(Y, dt; use_rayleigh_sponge = sponge),
 )
 
 function remaining_tendency!(dY, Y, p, t)
@@ -40,12 +37,12 @@ function remaining_tendency!(dY, Y, p, t)
         p,
         t;
         use_flux_correction = false,
-        use_rayleigh_sponge = false,
+        use_rayleigh_sponge = sponge,
     )
     return dY
 end
 
-function postprocessing(sol, path)
+function postprocessing(sol, p, output_dir)
     @info "L₂ norm of ρθ at t = $(sol.t[1]): $(norm(sol.u[1].Yc.ρθ))"
     @info "L₂ norm of ρθ at t = $(sol.t[end]): $(norm(sol.u[end].Yc.ρθ))"
 
@@ -53,5 +50,5 @@ function postprocessing(sol, path)
         v = Geometry.UVVector.(Y.uₕ).components.data.:2
         Plots.plot(v, level = 3, clim = (-6, 6))
     end
-    Plots.mp4(anim, joinpath(path, "v.mp4"), fps = 5)
+    Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
 end


### PR DESCRIPTION
This PR moves everything related to restart files into `driver.jl`. It also cleans up some variable names and clarifies exactly what needs to be defined in each test case file for `driver.jl` to work.