### PR TITLE
Unify hybrid model tendencies and add rhoe_int

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -309,78 +309,78 @@ steps:
       queue: central
       slurm_ntasks: 1
 
-  - label: ":computer: Rising Bubble 2D hybrid"
-    key: "cpu_rising_bubble_2d_hybrid"
+  - label: ":computer: Rising Bubble 2D hybrid (ρθ)"
+    key: "cpu_rising_bubble_2d_hybrid_rhotheta"
     command:
-      - "julia --color=yes --project=examples examples/hybrid/plane/bubble_2d.jl"
+      - "julia --color=yes --project=examples examples/hybrid/plane/bubble_2d_rhotheta.jl"
     artifact_paths:
-      - "examples/hybrid/plane/output/bubble_2d/*"
+      - "examples/hybrid/plane/output/bubble_2d_rhotheta/*"
     agents:
       config: cpu
       queue: central
       slurm_ntasks: 1
 
-  - label: ":computer: Rising Bubble 3D hybrid"
-    key: "cpu_rising_bubble_3d_hybrid"
+  - label: ":computer: Rising Bubble 3D hybrid (ρθ)"
+    key: "cpu_rising_bubble_3d_hybrid_rhotheta"
     command:
-      - "julia --color=yes --project=examples examples/hybrid/box/bubble_3d.jl"
+      - "julia --color=yes --project=examples examples/hybrid/box/bubble_3d_rhotheta.jl"
     artifact_paths:
-      - "examples/hybrid/box/output/bubble_3d/*"
+      - "examples/hybrid/box/output/bubble_3d_rhotheta/*"
     agents:
       config: cpu
       queue: central
       slurm_ntasks: 1
 
-  - label: ":computer: Rising Bubble hybrid invariant potential temperature"
-    key: "cpu_rising_bubble_hybrid_invariant_rho_theta"
+  - label: ":computer: Rising Bubble 2D hybrid invariant (ρθ)"
+    key: "cpu_rising_bubble_2d_hybrid_invariant_rhotheta"
     command:
-      - "julia --color=yes --project=examples examples/hybrid/plane/bubble_2d_invariant.jl"
+      - "julia --color=yes --project=examples examples/hybrid/plane/bubble_2d_invariant_rhotheta.jl"
     artifact_paths:
-      - "examples/hybrid/plane/output/bubble_2d_invariant/*"
+      - "examples/hybrid/plane/output/bubble_2d_invariant_rhotheta/*"
     agents:
       config: cpu
       queue: central
       slurm_ntasks: 1
 
-  - label: ":computer: Rising Bubble hybrid invariant total energy"
-    key: "cpu_rising_bubble_hybrid_invariant_total_energy"
+  - label: ":computer: Rising Bubble 2D hybrid invariant (ρe)"
+    key: "cpu_rising_bubble_2d_hybrid_invariant_rhoe"
     command:
-      - "julia --color=yes --project=examples examples/hybrid/plane/bubble_2d_invariant_totalenergy.jl"
+      - "julia --color=yes --project=examples examples/hybrid/plane/bubble_2d_invariant_rhoe.jl"
     artifact_paths:
-      - "examples/hybrid/plane/output/bubble_2d_invariant_etot/*"
+      - "examples/hybrid/plane/output/bubble_2d_invariant_rhoe/*"
     agents:
       config: cpu
       queue: central
       slurm_ntasks: 1
 
-  - label: ":computer: Rising Bubble 3D hybrid invariant"
-    key: "cpu_rising_bubble_3d_hybrid_invariant_potential_temperature"
+  - label: ":computer: Rising Bubble 3D hybrid invariant (ρθ)"
+    key: "cpu_rising_bubble_3d_hybrid_invariant_rhotheta"
     command:
-      - "julia --color=yes --project=examples examples/hybrid/box/bubble_3d_invariant.jl"
+      - "julia --color=yes --project=examples examples/hybrid/box/bubble_3d_invariant_rhotheta.jl"
     artifact_paths:
-      - "examples/hybrid/box/output/bubble_3d_invariant/*"
+      - "examples/hybrid/box/output/bubble_3d_invariant_rhotheta/*"
     agents:
       config: cpu
       queue: central
       slurm_ntasks: 1
 
-  - label: ":computer: Rising Bubble 3D hybrid invariant total energy"
-    key: "cpu_rising_bubble_3d_hybrid_invariant_total_energy"
+  - label: ":computer: Rising Bubble 3D hybrid invariant (ρe)"
+    key: "cpu_rising_bubble_3d_hybrid_invariant_rhoe"
     command:
-      - "julia --color=yes --project=examples examples/hybrid/box/bubble_3d_invariant_totalenergy.jl"
+      - "julia --color=yes --project=examples examples/hybrid/box/bubble_3d_invariant_rhoe.jl"
     artifact_paths:
-      - "examples/hybrid/box/output/bubble_3d_invariant_etot/*"
+      - "examples/hybrid/box/output/bubble_3d_invariant_rhoe/*"
     agents:
       config: cpu
       queue: central
       slurm_ntasks: 1
 
-  - label: ":computer: MPI Rising Bubble 3D hybrid invariant total energy"
-    key: "cpu_mpi_rising_bubble_3d_hybrid_invariant_total_energy"
+  - label: ":computer: MPI Rising Bubble 3D hybrid invariant (ρe)"
+    key: "cpu_mpi_rising_bubble_3d_hybrid_invariant_rhoe"
     command:
-      - "mpiexec julia --color=yes --project=examples examples/hybrid/box/bubble_3d_invariant_totalenergy.jl"
+      - "mpiexec julia --color=yes --project=examples examples/hybrid/box/bubble_3d_invariant_rhoe.jl"
     artifact_paths:
-      - "examples/hybrid/box/output/bubble_3d_invariant_etot/*"
+      - "examples/hybrid/box/output/bubble_3d_invariant_rhoe/*"
     env:
       CLIMACORE_DISTRIBUTED: "MPI"
     agents:
@@ -657,6 +657,32 @@ steps:
       - "examples/hybrid/sphere/output/held_suarez_rhotheta/*"
     env:
       TEST_NAME: "sphere/held_suarez_rhotheta"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
+  - label: ":computer: dry held-suarez (ρe_int)"
+    key: "cpu_held_suarez_rho_e_int"
+    command:
+      - "julia --color=yes --project=examples examples/hybrid/driver.jl"
+    artifact_paths:
+      - "examples/hybrid/sphere/output/held_suarez_rhoe_int/*"
+    env:
+      TEST_NAME: "sphere/held_suarez_rhoe_int"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
+  - label: ":computer: inertial gravity wave"
+    key: "cpu_inertial_gravity_wave"
+    command:
+      - "julia --color=yes --project=examples examples/hybrid/driver.jl"
+    artifact_paths:
+      - "examples/hybrid/plane/output/inertial_gravity_wave/*"
+    env:
+      TEST_NAME: "plane/inertial_gravity_wave"
     agents:
       config: cpu
       queue: central

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,6 +1,3 @@
-[compat]
-OrdinaryDiffEq = "5.64.0"
-
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
@@ -18,12 +15,16 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+ProgressLogging = "33c8b6b6-d38a-422a-b730-caa89a2f386c"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TerminalLoggers = "5d786b92-1e48-4d6f-9151-6b4477ca9bed"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
+
+[compat]
+OrdinaryDiffEq = "5.64.0"
 
 [extras]
 CPUSummary = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"

--- a/examples/hybrid/box/bubble_3d_invariant_rhoe.jl
+++ b/examples/hybrid/box/bubble_3d_invariant_rhoe.jl
@@ -340,7 +340,7 @@ ENV["GKSwstype"] = "nul"
 import Plots
 Plots.GRBackend()
 
-dir = "bubble3d_invariant_etot"
+dir = "bubble_3d_invariant_rhoe"
 path = joinpath(@__DIR__, "output", dir)
 mkpath(path)
 

--- a/examples/hybrid/box/bubble_3d_invariant_rhotheta.jl
+++ b/examples/hybrid/box/bubble_3d_invariant_rhotheta.jl
@@ -321,7 +321,7 @@ function linkfig(figpath, alt = "")
     end
 end
 
-dir = "bubble3d_invariant"
+dir = "bubble_3d_invariant_rhotheta"
 path = joinpath(@__DIR__, "output", dir)
 mkpath(path)
 

--- a/examples/hybrid/plane/bubble_2d_invariant_rhotheta.jl
+++ b/examples/hybrid/plane/bubble_2d_invariant_rhotheta.jl
@@ -1,7 +1,5 @@
-push!(LOAD_PATH, joinpath(@__DIR__, "..", ".."))
-
 using Test
-using StaticArrays, IntervalSets, LinearAlgebra, UnPack
+using LinearAlgebra
 
 import ClimaCore:
     ClimaCore,
@@ -14,17 +12,18 @@ import ClimaCore:
     Spaces,
     Fields,
     Operators
+
 using ClimaCore.Geometry
 
-using Logging: global_logger
-using TerminalLoggers: TerminalLogger
-global_logger(TerminalLogger())
-
+import Logging
+import TerminalLoggers
+Logging.global_logger(TerminalLoggers.TerminalLogger())
+# set up function space
 function hvspace_2D(
     xlim = (-π, π),
     zlim = (0, 4π),
-    xelem = 10,
-    zelem = 40,
+    helem = 10,
+    velem = 40,
     npoly = 4,
 )
     FT = Float64
@@ -33,15 +32,15 @@ function hvspace_2D(
         Geometry.ZPoint{FT}(zlim[2]);
         boundary_names = (:bottom, :top),
     )
-    vertmesh = Meshes.IntervalMesh(vertdomain, nelems = zelem)
+    vertmesh = Meshes.IntervalMesh(vertdomain, nelems = velem)
     vert_center_space = Spaces.CenterFiniteDifferenceSpace(vertmesh)
 
     horzdomain = Domains.IntervalDomain(
         Geometry.XPoint{FT}(xlim[1]),
-        Geometry.XPoint{FT}(xlim[2]);
+        Geometry.XPoint{FT}(xlim[2]),
         periodic = true,
     )
-    horzmesh = Meshes.IntervalMesh(horzdomain, nelems = xelem)
+    horzmesh = Meshes.IntervalMesh(horzdomain; nelems = helem)
     horztopology = Topologies.IntervalTopology(horzmesh)
 
     quad = Spaces.Quadratures.GLL{npoly + 1}()
@@ -53,8 +52,9 @@ function hvspace_2D(
     return (hv_center_space, hv_face_space)
 end
 
-# set up 2D domain - doubly periodic box
+# set up rhs!
 hv_center_space, hv_face_space = hvspace_2D((-500, 500), (0, 1000))
+#hv_center_space, hv_face_space = hvspace_2D((-500,500),(0,30000), 5, 30)
 
 const MSLP = 1e5 # mean sea level pressure
 const grav = 9.8 # gravitational constant
@@ -62,12 +62,19 @@ const R_d = 287.058 # R dry (gas constant / mol mass dry air)
 const γ = 1.4 # heat capacity ratio
 const C_p = R_d * γ / (γ - 1) # heat capacity at constant pressure
 const C_v = R_d / (γ - 1) # heat capacity at constant volume
-const T_0 = 273.16 # triple point temperature
+const R_m = R_d # moist R, assumed to be dry
+
+function pressure(ρθ)
+    if ρθ >= 0
+        return MSLP * (R_d * ρθ / MSLP)^γ
+    else
+        return NaN
+    end
+end
 
 Φ(z) = grav * z
 
 # Reference: https://journals.ametsoc.org/view/journals/mwre/140/4/mwr-d-10-05073.1.xml, Section 5a
-# Prognostic thermodynamic variable: Total Energy 
 function init_dry_rising_bubble_2d(x, z)
     x_c = 0.0
     z_c = 350.0
@@ -88,10 +95,9 @@ function init_dry_rising_bubble_2d(x, z)
     T = π_exn * θ # temperature
     p = p_0 * π_exn^(cp_d / R_d) # pressure
     ρ = p / R_d / T # density
-    e = cv_d * (T - T_0) + g * z
-    ρe = ρ * e # total energy
+    ρθ = ρ * θ # potential temperature density
 
-    return (ρ = ρ, ρe = ρe)
+    return (ρ = ρ, ρθ = ρθ)
 end
 
 # initial conditions
@@ -103,21 +109,20 @@ uₕ = map(_ -> Geometry.Covariant1Vector(0.0), coords)
 w = map(_ -> Geometry.Covariant3Vector(0.0), face_coords)
 Y = Fields.FieldVector(Yc = Yc, uₕ = uₕ, w = w)
 
-energy_0 = sum(Y.Yc.ρe)
-mass_0 = sum(Y.Yc.ρ)
-
 function rhs_invariant!(dY, Y, _, t)
 
     cρ = Y.Yc.ρ # scalar on centers
     fw = Y.w # Covariant3Vector on faces
     cuₕ = Y.uₕ # Covariant1Vector on centers
-    cρe = Y.Yc.ρe
+    cρθ = Y.Yc.ρθ
 
     dρ = dY.Yc.ρ
     dw = dY.w
     duₕ = dY.uₕ
-    dρe = dY.Yc.ρe
+    dρθ = dY.Yc.ρθ
+    ρθ = Yc.ρθ
     z = coords.z
+
 
     # 0) update w at the bottom
     # fw = -g^31 cuₕ/ g^33
@@ -128,38 +133,30 @@ function rhs_invariant!(dY, Y, _, t)
     hwgrad = Operators.WeakGradient()
     hcurl = Operators.Curl()
 
+    dρ .= 0 .* cρ
+
+    ### HYPERVISCOSITY
+    # 1) compute hyperviscosity coefficients
+
+    χθ = @. dρθ = hwdiv(hgrad(cρθ / cρ)) # we store χθ in dρθ
+    χuₕ = @. duₕ = hwgrad(hdiv(cuₕ))
+    Spaces.weighted_dss!(dρθ)
+    Spaces.weighted_dss!(duₕ)
+
+    κ₄ = 100.0 # m^4/s
+    @. dρθ = -κ₄ * hwdiv(cρ * hgrad(χθ))
+    @. duₕ = -κ₄ * hwgrad(hdiv(χuₕ))
+
+    # 1) Mass conservation
     If2c = Operators.InterpolateF2C()
     Ic2f = Operators.InterpolateC2F(
         bottom = Operators.Extrapolate(),
         top = Operators.Extrapolate(),
     )
-
-    dρ .= 0 .* cρ
-
     cw = If2c.(fw)
     fuₕ = Ic2f.(cuₕ)
     cuw = Geometry.Covariant13Vector.(cuₕ) .+ Geometry.Covariant13Vector.(cw)
 
-    ce = @. cρe / cρ
-    cI = @. ce - Φ(z) - (norm(cuw)^2) / 2
-    cT = @. cI / C_v + T_0
-    cp = @. cρ * R_d * cT
-
-    h_tot = @. ce + cp / cρ # Total enthalpy at cell centers
-
-    ### HYPERVISCOSITY
-    # 1) compute hyperviscosity coefficients
-    χe = @. dρe = hwdiv(hgrad(h_tot)) # we store χe in dρe
-    χuₕ = @. duₕ = hwgrad(hdiv(cuₕ))
-
-    Spaces.weighted_dss!(dρe)
-    Spaces.weighted_dss!(duₕ)
-
-    κ₄ = 100.0 # m^4/s
-    @. dρe = -κ₄ * hwdiv(cρ * hgrad(χe))
-    @. duₕ = -κ₄ * (hwgrad(hdiv(χuₕ)))
-
-    # 1) Mass conservation
     dw .= fw .* 0
 
     # 1.a) horizontal divergence
@@ -188,19 +185,24 @@ function rhs_invariant!(dY, Y, _, t)
         bottom = Operators.SetCurl(Geometry.Contravariant2Vector(0.0)),
         top = Operators.SetCurl(Geometry.Contravariant2Vector(0.0)),
     )
-
-    fω¹² = hcurl.(fw)
-    fω¹² .+= vcurlc2f.(cuₕ)
+    #cω³ = hcurl.(cu) # zero because we're only in 1D: we can leave this off for the bubble
+    fω¹² = hcurl.(fw) # Contravariant2Vector / Contravariant12Vector
+    fω¹² .+= vcurlc2f.(cuₕ) # Contravariant2Vector / Contravariant12Vector
 
     # cross product
     # convert to contravariant
     # these will need to be modified with topography
     fu¹² =
-        Geometry.Contravariant1Vector.(Geometry.Covariant13Vector.(Ic2f.(cuₕ)),)
+        Geometry.Contravariant1Vector.(Geometry.Covariant13Vector.(Ic2f.(cuₕ))) # Contravariant12Vector in 3D
     fu³ = Geometry.Contravariant3Vector.(Geometry.Covariant13Vector.(fw))
     @. dw -= fω¹² × fu¹² # Covariant3Vector on faces
     @. duₕ -= If2c(fω¹² × fu³)
 
+    # Needed for 3D:
+    #cu¹² = Contravariant12Vector.(cu)
+    #@. du += cω³ × cu¹²
+
+    cp = @. pressure(cρθ)
     @. duₕ -= hgrad(cp) / cρ
     vgradc2f = Operators.GradientC2F(
         bottom = Operators.SetGradient(Geometry.Covariant3Vector(0.0)),
@@ -212,11 +214,11 @@ function rhs_invariant!(dY, Y, _, t)
     @. duₕ -= hgrad(cE)
     @. dw -= vgradc2f(cE)
 
-    # 3) total energy
+    # 3) potential temperature
 
-    @. dρe -= hdiv(cuw * (cρe + cp))
-    @. dρe -= vdivf2c(fw * Ic2f(cρe + cp))
-    @. dρe -= vdivf2c(Ic2f(cuₕ * (cρe + cp)))
+    @. dρθ -= hdiv(cuw * ρθ)
+    @. dρθ -= vdivf2c(fw * Ic2f(cρθ))
+    @. dρθ -= vdivf2c(Ic2f(cuₕ * cρθ))
 
     fcc = Operators.FluxCorrectionC2C(
         bottom = Operators.Extrapolate(),
@@ -227,90 +229,65 @@ function rhs_invariant!(dY, Y, _, t)
         top = Operators.Extrapolate(),
     )
 
-    # Flux correction (Upwind Correction to Central scheme)
-    # @. dρ += fcc(fw, cρ)
-    # @. dρe += fcc(fw, cρe)
+    @. dρ += fcc(fw, cρ)
+    @. dρθ += fcc(fw, cρθ)
+    # dYc.ρuₕ += fcc(w, Yc.ρuₕ)
 
     Spaces.weighted_dss!(dY.Yc)
     Spaces.weighted_dss!(dY.uₕ)
     Spaces.weighted_dss!(dY.w)
 
+
     return dY
 end
+
+
 
 dYdt = similar(Y);
 rhs_invariant!(dYdt, Y, nothing, 0.0);
 
+
+
 # run!
 using OrdinaryDiffEq
-Δt = 0.02
-prob = ODEProblem(rhs_invariant!, Y, (0.0, 500.0))
-integrator = OrdinaryDiffEq.init(
+Δt = 0.025
+prob = ODEProblem(rhs_invariant!, Y, (0.0, 1.0))
+sol_invariant = solve(
     prob,
     SSPRK33(),
     dt = Δt,
-    saveat = 10.0,
+    saveat = 5.0,
     progress = true,
     progress_message = (dt, u, p, t) -> t,
 );
 
-if haskey(ENV, "CI_PERF_SKIP_RUN") # for performance analysis
-    throw(:exit_profile)
-end
-
-sol = @timev OrdinaryDiffEq.solve!(integrator)
-
 ENV["GKSwstype"] = "nul"
-import Plots, ClimaCorePlots
+using ClimaCorePlots, Plots
 Plots.GRBackend()
 
-dir = "bubble2d_invariant_etot"
+dir = "bubble_2d_invariant_rhotheta"
 path = joinpath(@__DIR__, "output", dir)
 mkpath(path)
 
-anim = Plots.@animate for u in sol.u
-    Plots.plot(u.Yc.ρe ./ u.Yc.ρ)
+# post-processing
+anim = Plots.@animate for u in sol_invariant.u
+    Plots.plot(u.Yc.ρθ ./ u.Yc.ρ, clim = (300.0, 300.8))
 end
-Plots.mp4(anim, joinpath(path, "total_energy.mp4"), fps = 20)
+Plots.mp4(anim, joinpath(path, "theta.mp4"), fps = 20)
+
+anim = Plots.@animate for u in sol_invariant.u
+    Plots.plot(u.Yc.ρ)
+end
+Plots.mp4(anim, joinpath(path, "rho.mp4"), fps = 20)
+
 
 If2c = Operators.InterpolateF2C()
-anim = Plots.@animate for u in sol.u
+anim = Plots.@animate for u in sol_invariant.u
     Plots.plot(Geometry.WVector.(Geometry.Covariant13Vector.(If2c.(u.w))))
 end
 Plots.mp4(anim, joinpath(path, "vel_w.mp4"), fps = 20)
 
-anim = Plots.@animate for u in sol.u
+anim = Plots.@animate for u in sol_invariant.u
     Plots.plot(Geometry.UVector.(Geometry.Covariant13Vector.(u.uₕ)))
 end
 Plots.mp4(anim, joinpath(path, "vel_u.mp4"), fps = 20)
-
-# post-processing
-Es = [sum(u.Yc.ρe) for u in sol.u]
-Mass = [sum(u.Yc.ρ) for u in sol.u]
-
-Plots.png(
-    Plots.plot((Es .- energy_0) ./ energy_0),
-    joinpath(path, "energy_cons.png"),
-)
-Plots.png(
-    Plots.plot((Mass .- mass_0) ./ mass_0),
-    joinpath(path, "mass_cons.png"),
-)
-
-function linkfig(figpath, alt = "")
-    # buildkite-agent upload figpath
-    # link figure in logs if we are running on CI
-    if get(ENV, "BUILDKITE", "") == "true"
-        artifact_url = "artifact://$figpath"
-        print("\033]1338;url='$(artifact_url)';alt='$(alt)'\a\n")
-    end
-end
-
-linkfig(
-    relpath(joinpath(path, "energy_cons.png"), joinpath(@__DIR__, "../..")),
-    "Total Energy",
-)
-linkfig(
-    relpath(joinpath(path, "mass_cons.png"), joinpath(@__DIR__, "../..")),
-    "Mass",
-)

--- a/examples/hybrid/plane/bubble_2d_rhotheta.jl
+++ b/examples/hybrid/plane/bubble_2d_rhotheta.jl
@@ -19,43 +19,32 @@ import TerminalLoggers
 Logging.global_logger(TerminalLoggers.TerminalLogger())
 
 # set up function space
-
-function hvspace_3D(
+function hvspace_2D(
     xlim = (-π, π),
-    ylim = (-π, π),
     zlim = (0, 4π),
-    xelem = 4,
-    yelem = 4,
-    zelem = 16,
+    helem = 10,
+    velem = 40,
     npoly = 4,
 )
     FT = Float64
-
-    xdomain = Domains.IntervalDomain(
-        Geometry.XPoint{FT}(xlim[1]),
-        Geometry.XPoint{FT}(xlim[2]),
-        periodic = true,
-    )
-    ydomain = Domains.IntervalDomain(
-        Geometry.YPoint{FT}(ylim[1]),
-        Geometry.YPoint{FT}(ylim[2]),
-        periodic = true,
-    )
-
-    horzdomain = Domains.RectangleDomain(xdomain, ydomain)
-    horzmesh = Meshes.RectilinearMesh(horzdomain, xelem, yelem)
-    horztopology = Topologies.Topology2D(horzmesh)
-
-    zdomain = Domains.IntervalDomain(
+    vertdomain = Domains.IntervalDomain(
         Geometry.ZPoint{FT}(zlim[1]),
         Geometry.ZPoint{FT}(zlim[2]);
         boundary_names = (:bottom, :top),
     )
-    vertmesh = Meshes.IntervalMesh(zdomain, nelems = zelem)
+    vertmesh = Meshes.IntervalMesh(vertdomain, nelems = velem)
     vert_center_space = Spaces.CenterFiniteDifferenceSpace(vertmesh)
 
+    horzdomain = Domains.IntervalDomain(
+        Geometry.XPoint{FT}(xlim[1]),
+        Geometry.XPoint{FT}(xlim[2]),
+        periodic = true,
+    )
+    horzmesh = Meshes.IntervalMesh(horzdomain; nelems = helem)
+    horztopology = Topologies.IntervalTopology(horzmesh)
+
     quad = Spaces.Quadratures.GLL{npoly + 1}()
-    horzspace = Spaces.SpectralElementSpace2D(horztopology, quad)
+    horzspace = Spaces.SpectralElementSpace1D(horztopology, quad)
 
     hv_center_space =
         Spaces.ExtrudedFiniteDifferenceSpace(horzspace, vert_center_space)
@@ -63,8 +52,9 @@ function hvspace_3D(
     return (hv_center_space, hv_face_space)
 end
 
-# set up 3D domain - doubly periodic box
-hv_center_space, hv_face_space = hvspace_3D((-500, 500), (-500, 500), (0, 1000))
+# set up rhs!
+hv_center_space, hv_face_space = hvspace_2D((-500, 500), (0, 1000))
+#hv_center_space, hv_face_space = hvspace_2D((-500,500),(0,30000), 5, 30)
 
 const MSLP = 1e5 # mean sea level pressure
 const grav = 9.8 # gravitational constant
@@ -85,9 +75,8 @@ end
 Φ(z) = grav * z
 
 # Reference: https://journals.ametsoc.org/view/journals/mwre/140/4/mwr-d-10-05073.1.xml, Section 5a
-function init_dry_rising_bubble_3d(x, y, z)
+function init_dry_rising_bubble_2d(x, z)
     x_c = 0.0
-    y_c = 0.0
     z_c = 350.0
     r_c = 250.0
     θ_b = 300.0
@@ -108,8 +97,7 @@ function init_dry_rising_bubble_3d(x, y, z)
     ρ = p / R_d / T # density
     ρθ = ρ * θ # potential temperature density
 
-    # Horizontal momentum defined on cell centers
-    return (ρ = ρ, ρθ = ρθ, ρuₕ = ρ * Geometry.UVVector(0.0, 0.0))
+    return (ρ = ρ, ρθ = ρθ)
 end
 
 # initial conditions
@@ -117,16 +105,19 @@ coords = Fields.coordinate_field(hv_center_space)
 face_coords = Fields.coordinate_field(hv_face_space)
 
 Yc = map(coords) do coord
-    bubble = init_dry_rising_bubble_3d(coord.x, coord.y, coord.z)
+    bubble = init_dry_rising_bubble_2d(coord.x, coord.z)
     bubble
 end
 
-# Vertical momentum defined on cell faces
 ρw = map(face_coords) do coord
     Geometry.WVector(0.0)
 end;
 
-Y = Fields.FieldVector(Yc = Yc, ρw = ρw)
+Y = Fields.FieldVector(
+    Yc = Yc,
+    ρuₕ = Yc.ρ .* Ref(Geometry.UVector(0.0)),
+    ρw = ρw,
+)
 
 function energy(Yc, ρu, z)
     ρ = Yc.ρ
@@ -138,12 +129,12 @@ function energy(Yc, ρu, z)
     return kinetic + potential + internal
 end
 function combine_momentum(ρuₕ, ρw)
-    Geometry.transform(Geometry.UVWAxis(), ρuₕ) +
-    Geometry.transform(Geometry.UVWAxis(), ρw)
+    Geometry.transform(Geometry.UWAxis(), ρuₕ) +
+    Geometry.transform(Geometry.UWAxis(), ρw)
 end
 function center_momentum(Y)
     If2c = Operators.InterpolateF2C()
-    combine_momentum.(Y.Yc.ρuₕ, If2c.(Y.ρw))
+    combine_momentum.(Y.ρuₕ, If2c.(Y.ρw))
 end
 function total_energy(Y)
     ρ = Y.Yc.ρ
@@ -155,18 +146,17 @@ end
 
 energy_0 = total_energy(Y)
 mass_0 = sum(Yc.ρ) # Computes ∫ρ∂Ω such that quadrature weighting is accounted for.
-theta_0 = sum(Yc.ρθ)
 
 function rhs!(dY, Y, _, t)
+    ρuₕ = Y.ρuₕ
     ρw = Y.ρw
     Yc = Y.Yc
     dYc = dY.Yc
+    dρuₕ = dY.ρuₕ
     dρw = dY.ρw
     ρ = Yc.ρ
-    ρuₕ = Yc.ρuₕ
     ρθ = Yc.ρθ
     dρθ = dYc.ρθ
-    dρuₕ = dYc.ρuₕ
     dρ = dYc.ρ
 
     # spectral horizontal operators
@@ -186,11 +176,9 @@ function rhs!(dY, Y, _, t)
     )
     uvdivf2c = Operators.DivergenceF2C(
         bottom = Operators.SetValue(
-            Geometry.WVector(0.0) ⊗ Geometry.UVVector(0.0, 0.0),
+            Geometry.WVector(0.0) ⊗ Geometry.UVector(0.0),
         ),
-        top = Operators.SetValue(
-            Geometry.WVector(0.0) ⊗ Geometry.UVVector(0.0, 0.0),
-        ),
+        top = Operators.SetValue(Geometry.WVector(0.0) ⊗ Geometry.UVector(0.0)),
     )
     If = Operators.InterpolateC2F(
         bottom = Operators.Extrapolate(),
@@ -230,6 +218,7 @@ function rhs!(dY, Y, _, t)
     @. dρuₕ = hdiv(hgrad(uₕ))
     @. dρw = hdiv(hgrad(w))
     Spaces.weighted_dss!(dYc)
+    Spaces.weighted_dss!(dρuₕ)
     Spaces.weighted_dss!(dρw)
 
     κ₄ = 100.0 # m^4/s
@@ -245,14 +234,14 @@ function rhs!(dY, Y, _, t)
     @. dρθ += -(∂(ρw * If(ρθ / ρ)))
     @. dρθ -= hdiv(uₕ * ρθ)
 
-    # Horizontal momentum
-    @. dρuₕ += -uvdivf2c(ρw ⊗ If(uₕ))
+    # horizontal momentum
     Ih = Ref(
         Geometry.Axis2Tensor(
-            (Geometry.UVAxis(), Geometry.UVAxis()),
-            @SMatrix [1.0 0.0; 0.0 1.0]
+            (Geometry.UAxis(), Geometry.UAxis()),
+            @SMatrix [1.0]
         ),
     )
+    @. dρuₕ += -uvdivf2c(ρw ⊗ If(uₕ))
     @. dρuₕ -= hdiv(ρuₕ ⊗ uₕ + p * Ih)
 
     # vertical momentum
@@ -283,14 +272,15 @@ function rhs!(dY, Y, _, t)
     #  1c) horizontal div of horizontal grad of vert momentum
     @. dρw += hdiv(κ₂ * (Yfρ * hgrad(ρw / Yfρ)))
     #  1d) vertical div of vertical grad of vert momentun
-    @. dρw += vvdivc2f(κ₂ * (Yc.ρ * ∂c(ρw / Yfρ)))
+    @. dρw += vvdivc2f(κ₂ * (ρ * ∂c(ρw / Yfρ)))
 
     #  2a) horizontal div of horizontal grad of potential temperature
-    @. dρθ += hdiv(κ₂ * (Yc.ρ * hgrad(ρθ / ρ)))
+    @. dρθ += hdiv(κ₂ * (ρ * hgrad(ρθ / ρ)))
     #  2b) vertical div of vertial grad of potential temperature
     @. dρθ += ∂(κ₂ * (Yfρ * ∂f(ρθ / ρ)))
 
     Spaces.weighted_dss!(dYc)
+    Spaces.weighted_dss!(dρuₕ)
     Spaces.weighted_dss!(dρw)
     return dY
 end
@@ -301,13 +291,14 @@ rhs!(dYdt, Y, nothing, 0.0);
 
 # run!
 using OrdinaryDiffEq
-Δt = 0.05
-prob = ODEProblem(rhs!, Y, (0.0, 1.0))
+Δt = 0.03
+prob = ODEProblem(rhs!, Y, (0.0, 500.0))
+
 integrator = OrdinaryDiffEq.init(
     prob,
     SSPRK33(),
     dt = Δt,
-    saveat = 50.0,
+    saveat = 25.0,
     progress = true,
     progress_message = (dt, u, p, t) -> t,
 );
@@ -319,46 +310,36 @@ end
 sol = @timev OrdinaryDiffEq.solve!(integrator)
 
 ENV["GKSwstype"] = "nul"
-import Plots
+using ClimaCorePlots, Plots
 Plots.GRBackend()
 
-dir = "bubble_3d"
+dir = "bubble_2d_rhotheta"
 path = joinpath(@__DIR__, "output", dir)
 mkpath(path)
 
 # post-processing
+using ClimaCorePlots, Plots
+anim = Plots.@animate for u in sol.u
+    Plots.plot(u.Yc.ρθ ./ u.Yc.ρ, clim = (300.0, 300.8))
+end
+Plots.mp4(anim, joinpath(path, "theta.mp4"), fps = 20)
+
+If2c = Operators.InterpolateF2C()
+anim = Plots.@animate for u in sol.u
+    Plots.plot(If2c.(u.ρw) ./ u.Yc.ρ)
+end
+Plots.mp4(anim, joinpath(path, "vel_w.mp4"), fps = 20)
+
+anim = Plots.@animate for u in sol.u
+    Plots.plot(u.ρuₕ ./ u.Yc.ρ)
+end
+Plots.mp4(anim, joinpath(path, "vel_u.mp4"), fps = 20)
+
 Es = [total_energy(u) for u in sol.u]
 Mass = [sum(u.Yc.ρ) for u in sol.u]
-Theta = [sum(u.Yc.ρθ) for u in sol.u]
 
 Plots.png(
     Plots.plot((Es .- energy_0) ./ energy_0),
     joinpath(path, "energy.png"),
 )
 Plots.png(Plots.plot((Mass .- mass_0) ./ mass_0), joinpath(path, "mass.png"))
-Plots.png(
-    Plots.plot((Theta .- theta_0) ./ theta_0),
-    joinpath(path, "rho_theta.png"),
-)
-
-function linkfig(figpath, alt = "")
-    # buildkite-agent upload figpath
-    # link figure in logs if we are running on CI
-    if get(ENV, "BUILDKITE", "") == "true"
-        artifact_url = "artifact://$figpath"
-        print("\033]1338;url='$(artifact_url)';alt='$(alt)'\a\n")
-    end
-end
-
-linkfig(
-    relpath(joinpath(path, "energy.png"), joinpath(@__DIR__, "../..")),
-    "Total Energy",
-)
-linkfig(
-    relpath(joinpath(path, "rho_theta.png"), joinpath(@__DIR__, "../..")),
-    "Potential Temperature",
-)
-linkfig(
-    relpath(joinpath(path, "mass.png"), joinpath(@__DIR__, "../..")),
-    "Mass",
-)

--- a/examples/hybrid/plane/inertial_gravity_wave.jl
+++ b/examples/hybrid/plane/inertial_gravity_wave.jl
@@ -1,0 +1,368 @@
+using Printf
+using ProgressLogging
+using ClimaCorePlots, Plots
+
+# Reference paper: https://rmets.onlinelibrary.wiley.com/doi/pdf/10.1002/qj.2105
+
+# Constants for switching between different experiment setups
+const is_small_scale = true
+const ᶜ𝔼_name = :ρe
+const is_discrete_hydrostatic_balance = true # `false` causes large oscillations
+
+# Constants required by "staggered_nonhydrostatic_model.jl"
+const FT = Float64
+const p_0 = FT(1.0e5)
+const R_d = FT(287.0)
+const κ = FT(2 / 7)
+const T_tri = FT(273.16)
+const grav = FT(9.80616)
+const f = is_small_scale ? FT(0) : 2 * sin(π / 4) * 2π / FT(86164.09)
+include("../staggered_nonhydrostatic_model.jl")
+
+# Additional constants required for inertial gravity wave initial condition
+const zmax = FT(10e3)
+const xmax = is_small_scale ? FT(300e3) : FT(6000e3)
+const xmid = is_small_scale ? FT(100e3) : FT(3000e3)
+const d = is_small_scale ? FT(5e3) : FT(100e3)
+const u₀ = is_small_scale ? FT(20) : FT(0)
+const v₀ = FT(0)
+const T₀ = FT(250)
+const ΔT = FT(0.01)
+
+# Other convenient constants used in reference paper
+const δ = grav / (R_d * T₀)        # Bretherton height parameter
+const cₛ² = cp_d / cv_d * R_d * T₀ # speed of sound squared
+const ρₛ = p_0 / (R_d * T₀)        # air density at surface
+
+# TODO: Loop over all domain setups used in reference paper
+const Δx = is_small_scale ? FT(1e3) : FT(20e3)
+const Δz = is_small_scale ? Δx / 2 : Δx / 40
+zelem = Int(zmax / Δz)
+npoly, xelem = 1, Int(xmax / Δx) # max small-scale dt = 1.5
+# npoly, xelem = 4, Int(xmax / (Δx * (4 + 1))) # max small-scale dt = 0.8
+
+# Animation-related values
+animation_duration = FT(5)
+fps = 2
+
+# Values required for driver
+space =
+    ExtrudedSpace(; zmax, zelem, hspace = PeriodicLine(; xmax, xelem, npoly))
+t_end = is_small_scale ? FT(60 * 60 * 0.5) : FT(60 * 60 * 8)
+dt = is_small_scale ? FT(1.5) : FT(20)
+dt_save_to_sol = t_end / (animation_duration * fps)
+ode_algorithm = OrdinaryDiffEq.Rosenbrock23
+jacobian_flags = (;
+    ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = ᶜ𝔼_name == :ρe ? :no_∂ᶜp∂ᶜK : :exact,
+    ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact,
+)
+show_progress_bar = true
+
+if is_discrete_hydrostatic_balance
+    # Yₜ.f.w = 0 in implicit tendency                                        ==>
+    # -(ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ) + ᶠgradᵥᶜΦ) = 0                             ==>
+    # ᶠgradᵥ(ᶜp) = -grav * ᶠinterp(ᶜρ)                                       ==>
+    # (p(z + Δz) - p(z)) / Δz = -grav * (ρ(z + Δz) + ρ(z)) / 2               ==>
+    # p(z + Δz) + grav * Δz * ρ(z + Δz) / 2 = p(z) - grav * Δz * ρ(z) / 2    ==>
+    # p(z + Δz) * (1 + δ * Δz / 2) = p(z) * (1 - δ * Δz / 2)                 ==>
+    # p(z + Δz) / p(z) = (1 - δ * Δz / 2) / (1 + δ * Δz / 2)                 ==>
+    # p(z) = p(0) * ((1 - δ * Δz / 2) / (1 + δ * Δz / 2))^(z / Δz)
+    p₀(z) = p_0 * ((1 - δ * Δz / 2) / (1 + δ * Δz / 2))^(z / Δz)
+else
+    p₀(z) = p_0 * exp(-δ * z)
+end
+Tb_init(x, z) = ΔT * exp(-(x - xmid)^2 / d^2) * sin(π * z / zmax)
+T′_init(x, z) = Tb_init(x, z) * exp(δ * z / 2)
+
+function center_initial_condition(local_geometry)
+    (; x, z) = local_geometry.coordinates
+    p = p₀(z)
+    T = T₀ + T′_init(x, z)
+    ρ = p / (R_d * T)
+    uₕ_local = Geometry.UVVector(u₀, v₀)
+    uₕ = Geometry.Covariant12Vector(uₕ_local, local_geometry)
+    if ᶜ𝔼_name == :ρθ
+        ρθ = ρ * T * (p_0 / p)^(R_d / cp_d)
+        return (; ρ, ρθ, uₕ)
+    elseif ᶜ𝔼_name == :ρe
+        ρe = ρ * (cv_d * (T - T_tri) + norm_sqr(uₕ_local) / 2 + grav * z)
+        return (; ρ, ρe, uₕ)
+    elseif ᶜ𝔼_name == :ρe_int
+        ρe_int = ρ * cv_d * (T - T_tri)
+        return (; ρ, ρe_int, uₕ)
+    end
+end
+face_initial_condition(local_geometry) =
+    (; w = Geometry.Covariant3Vector(FT(0)))
+
+function postprocessing(sol, p, output_dir)
+    ᶜlocal_geometry = Fields.local_geometry_field(sol.u[1].c)
+    ᶠlocal_geometry = Fields.local_geometry_field(sol.u[1].f)
+    lin_cache = linear_solution_cache(ᶜlocal_geometry, ᶠlocal_geometry)
+    Y_lin = similar(sol.u[1])
+
+    ρ′ = Y -> @. Y.c.ρ - p₀(ᶜlocal_geometry.coordinates.z) / (R_d * T₀)
+    if ᶜ𝔼_name == :ρθ
+        T′ =
+            Y -> @. Y.c.ρθ / Y.c.ρ * (pressure_ρθ(Y.c.ρθ) / p_0)^(R_d / cp_d) -
+               T₀
+    elseif ᶜ𝔼_name == :ρe
+        T′ =
+            Y -> begin
+                @. p.ᶜK = norm_sqr(C123(Y.c.uₕ) + C123(ᶜinterp(Y.f.w))) / 2
+                @. (Y.c.ρe / Y.c.ρ - p.ᶜK - p.ᶜΦ) / cv_d + T_tri - T₀
+            end
+    elseif ᶜ𝔼_name == :ρe_int
+        T′ = Y -> @. Y.c.ρe_int / Y.c.ρ / cv_d + T_tri - T₀
+    end
+    u′ = Y -> @. Geometry.UVVector(Y.c.uₕ).components.data.:1 - u₀
+    v′ = Y -> @. Geometry.UVVector(Y.c.uₕ).components.data.:2 - v₀
+    w′ = Y -> @. Geometry.WVector(Y.f.w).components.data.:1
+
+    for iframe in (1, length(sol.t))
+        t = sol.t[iframe]
+        Y = sol.u[iframe]
+        linear_solution!(Y_lin, lin_cache, t)
+        println("Error norms at time t = $t:")
+        for (name, f) in ((:ρ′, ρ′), (:T′, T′), (:u′, u′), (:v′, v′), (:w′, w′))
+            var = f(Y)
+            var_lin = f(Y_lin)
+            strings = (
+                norm_strings(var, var_lin, 2)...,
+                norm_strings(var, var_lin, Inf)...,
+            )
+            println("ϕ = $name: ", join(strings, ", "))
+        end
+        println()
+    end
+
+    anim_vars = (
+        (:Tprime, T′, is_small_scale ? 0.014 : 0.014),
+        (:uprime, u′, is_small_scale ? 0.042 : 0.014),
+        (:wprime, w′, is_small_scale ? 0.0042 : 0.0014),
+    )
+    anims = [Animation() for _ in 1:(3 * length(anim_vars))]
+    @progress "Animations" for iframe in 1:length(sol.t)
+        t = sol.t[iframe]
+        Y = sol.u[iframe]
+        linear_solution!(Y_lin, lin_cache, t)
+        for (ivar, (_, f, lim)) in enumerate(anim_vars)
+            var = f(Y)
+            var_lin = f(Y_lin)
+            var_rel_err = @. (var - var_lin) / (abs(var_lin) + eps(FT))
+            # adding eps(FT) to the denominator prevents divisions by 0
+            frame(anims[3 * ivar - 2], plot(var_lin, clim = (-lim, lim)))
+            frame(anims[3 * ivar - 1], plot(var, clim = (-lim, lim)))
+            frame(anims[3 * ivar], plot(var_rel_err, clim = (-10, 10)))
+        end
+    end
+    for (ivar, (name, _, _)) in enumerate(anim_vars)
+        mp4(anims[3 * ivar - 2], joinpath(output_dir, "$(name)_lin.mp4"); fps)
+        mp4(anims[3 * ivar - 1], joinpath(output_dir, "$name.mp4"); fps)
+        mp4(anims[3 * ivar], joinpath(output_dir, "$(name)_rel_err.mp4"); fps)
+    end
+end
+
+function norm_strings(var, var_lin, p)
+    norm_err = norm(var .- var_lin, p; normalize = false)
+    scaled_norm_err = norm_err / norm(var_lin, p; normalize = false)
+    return (
+        @sprintf("‖ϕ‖_%d = %-#9.4g", p, norm(var, p; normalize = false)),
+        @sprintf("‖ϕ - ϕ_lin‖_%d = %-#9.4g", p, norm_err),
+        @sprintf("‖ϕ - ϕ_lin‖_%d/‖ϕ_lin‖_%d = %-#9.4g", p, p, scaled_norm_err),
+    )
+end
+
+# min_λx = 2 * (xmax / xelem) / upsampling_factor # this should include npoly
+# min_λz = 2 * (zmax / zelem) / upsampling_factor
+# min_λx = 2 * π / max_kx = xmax / max_ikx
+# min_λz = 2 * π / max_kz = 2 * zmax / max_ikz
+# max_ikx = xmax / min_λx = upsampling_factor * xelem / 2
+# max_ikz = 2 * zmax / min_λz = upsampling_factor * zelem
+function ρfb_init_coefs(
+    upsampling_factor = 3,
+    max_ikx = upsampling_factor * xelem ÷ 2,
+    max_ikz = upsampling_factor * zelem,
+)
+    # upsampled coordinates (more upsampling gives more accurate coefficients)
+    space = ExtrudedSpace(;
+        zmax,
+        zelem = upsampling_factor * zelem,
+        hspace = PeriodicLine(; xmax, xelem = upsampling_factor * xelem, npoly),
+    )
+    ᶜlocal_geometry, _ = local_geometry_fields(space)
+    ᶜx = ᶜlocal_geometry.coordinates.x
+    ᶜz = ᶜlocal_geometry.coordinates.z
+
+    # Bretherton transform of initial perturbation
+    linearize_density_perturbation = false
+    if linearize_density_perturbation
+        ᶜρb_init = @. -ρₛ * Tb_init(ᶜx, ᶜz) / T₀
+    else
+        ᶜp₀ = @. p₀(ᶜz)
+        ᶜρ₀ = @. ᶜp₀ / (R_d * T₀)
+        ᶜρ′_init = @. ᶜp₀ / (R_d * (T₀ + T′_init(ᶜx, ᶜz))) - ᶜρ₀
+        ᶜbretherton_factor_pρ = @. exp(-δ * ᶜz / 2)
+        ᶜρb_init = @. ᶜρ′_init / ᶜbretherton_factor_pρ
+    end
+
+    # Fourier coefficients of Bretherton transform of initial perturbation
+    ρfb_init_array = Array{Complex{FT}}(undef, 2 * max_ikx + 1, 2 * max_ikz + 1)
+    ᶜfourier_factor = Fields.Field(Complex{FT}, axes(ᶜlocal_geometry))
+    ᶜintegrand = Fields.Field(Complex{FT}, axes(ᶜlocal_geometry))
+    unit_integral = 2 * sum(one.(ᶜρb_init))
+    # Since the coefficients are for a modified domain of height 2 * zmax, the
+    # unit integral over the domain must be multiplied by 2 to ensure correct
+    # normalization. On the other hand, ᶜρb_init is assumed to be 0 outside of
+    # the "true" domain, so the integral of ᶜintegrand should not be modified.
+    @progress "ρfb_init" for ikx in (-max_ikx):max_ikx,
+        ikz in (-max_ikz):max_ikz
+
+        kx = 2 * π / xmax * ikx
+        kz = 2 * π / (2 * zmax) * ikz
+        @. ᶜfourier_factor = exp(im * (kx * ᶜx + kz * ᶜz))
+        @. ᶜintegrand = ᶜρb_init / ᶜfourier_factor
+        ρfb_init_array[ikx + max_ikx + 1, ikz + max_ikz + 1] =
+            sum(ᶜintegrand) / unit_integral
+    end
+    return ρfb_init_array
+end
+
+function linear_solution_cache(ᶜlocal_geometry, ᶠlocal_geometry)
+    ᶜz = ᶜlocal_geometry.coordinates.z
+    ᶠz = ᶠlocal_geometry.coordinates.z
+    ᶜp₀ = @. p₀(ᶜz)
+    return (;
+        # coordinates
+        ᶜx = ᶜlocal_geometry.coordinates.x,
+        ᶠx = ᶠlocal_geometry.coordinates.x,
+        ᶜz,
+        ᶠz,
+
+        # background state
+        ᶜp₀,
+        ᶜρ₀ = (@. ᶜp₀ / (R_d * T₀)),
+        ᶜu₀ = map(_ -> u₀, ᶜlocal_geometry),
+        ᶜv₀ = map(_ -> v₀, ᶜlocal_geometry),
+        ᶠw₀ = map(_ -> FT(0), ᶠlocal_geometry),
+
+        # Bretherton transform factors
+        ᶜbretherton_factor_pρ = (@. exp(-δ * ᶜz / 2)),
+        ᶜbretherton_factor_uvwT = (@. exp(δ * ᶜz / 2)),
+        ᶠbretherton_factor_uvwT = (@. exp(δ * ᶠz / 2)),
+
+        # Fourier coefficients of Bretherton transform of initial perturbation
+        ρfb_init_array = ρfb_init_coefs(),
+
+        # Fourier transform factors
+        ᶜfourier_factor = Fields.Field(Complex{FT}, axes(ᶜlocal_geometry)),
+        ᶠfourier_factor = Fields.Field(Complex{FT}, axes(ᶠlocal_geometry)),
+
+        # Bretherton transform of final perturbation
+        ᶜpb = Fields.Field(FT, axes(ᶜlocal_geometry)),
+        ᶜρb = Fields.Field(FT, axes(ᶜlocal_geometry)),
+        ᶜub = Fields.Field(FT, axes(ᶜlocal_geometry)),
+        ᶜvb = Fields.Field(FT, axes(ᶜlocal_geometry)),
+        ᶠwb = Fields.Field(FT, axes(ᶠlocal_geometry)),
+
+        # final state
+        ᶜp = Fields.Field(FT, axes(ᶜlocal_geometry)),
+        ᶜρ = Fields.Field(FT, axes(ᶜlocal_geometry)),
+        ᶜu = Fields.Field(FT, axes(ᶜlocal_geometry)),
+        ᶜv = Fields.Field(FT, axes(ᶜlocal_geometry)),
+        ᶠw = Fields.Field(FT, axes(ᶠlocal_geometry)),
+
+        # final temperature
+        ᶜT = Fields.Field(FT, axes(ᶜlocal_geometry)),
+    )
+end
+
+function linear_solution!(Y, lin_cache, t)
+    (; ᶜx, ᶠx, ᶜz, ᶠz, ᶜp₀, ᶜρ₀, ᶜu₀, ᶜv₀, ᶠw₀) = lin_cache
+    (; ᶜbretherton_factor_pρ) = lin_cache
+    (; ᶜbretherton_factor_uvwT, ᶠbretherton_factor_uvwT) = lin_cache
+    (; ρfb_init_array, ᶜfourier_factor, ᶠfourier_factor) = lin_cache
+    (; ᶜpb, ᶜρb, ᶜub, ᶜvb, ᶠwb, ᶜp, ᶜρ, ᶜu, ᶜv, ᶠw, ᶜT) = lin_cache
+
+    ᶜpb .= FT(0)
+    ᶜρb .= FT(0)
+    ᶜub .= FT(0)
+    ᶜvb .= FT(0)
+    ᶠwb .= FT(0)
+    max_ikx, max_ikz = (size(ρfb_init_array) .- 1) .÷ 2
+    for ikx in (-max_ikx):max_ikx, ikz in (-max_ikz):max_ikz
+        kx = 2 * π / xmax * ikx
+        kz = 2 * π / (2 * zmax) * ikz
+
+        # Fourier coefficient of ᶜρb_init (for current kx and kz)
+        ρfb_init = ρfb_init_array[ikx + max_ikx + 1, ikz + max_ikz + 1]
+
+        # Fourier factors, shifted by u₀ * t along the x-axis
+        @. ᶜfourier_factor = exp(im * (kx * (ᶜx - u₀ * t) + kz * ᶜz))
+        @. ᶠfourier_factor = exp(im * (kx * (ᶠx - u₀ * t) + kz * ᶠz))
+
+        # roots of a₁(s)
+        p₁ = cₛ² * (kx^2 + kz^2 + δ^2 / 4) + f^2
+        q₁ = grav * kx^2 * (cₛ² * δ - grav) + cₛ² * f^2 * (kz^2 + δ^2 / 4)
+        α² = p₁ / 2 - sqrt(p₁^2 / 4 - q₁)
+        β² = p₁ / 2 + sqrt(p₁^2 / 4 - q₁)
+        α = sqrt(α²)
+        β = sqrt(β²)
+
+        # inverse Laplace transform of s^p/((s^2 + α^2)(s^2 + β^2)) for p ∈ -1:3
+        if α == 0
+            L₋₁ = (β² * t^2 / 2 - 1 + cos(β * t)) / β^4
+            L₀ = (β * t - sin(β * t)) / β^3
+        else
+            L₋₁ =
+                (-cos(α * t) / α² + cos(β * t) / β²) / (β² - α²) + 1 / (α² * β²)
+            L₀ = (sin(α * t) / α - sin(β * t) / β) / (β² - α²)
+        end
+        L₁ = (cos(α * t) - cos(β * t)) / (β² - α²)
+        L₂ = (-sin(α * t) * α + sin(β * t) * β) / (β² - α²)
+        L₃ = (-cos(α * t) * α² + cos(β * t) * β²) / (β² - α²)
+
+        # Fourier coefficients of Bretherton transforms of final perturbations
+        C₁ = grav * (grav - cₛ² * (im * kz + δ / 2))
+        C₂ = grav * (im * kz - δ / 2)
+        pfb = -ρfb_init * (L₁ + L₋₁ * f^2) * C₁
+        ρfb =
+            ρfb_init *
+            (L₃ + L₁ * (p₁ + C₂) + L₋₁ * f^2 * (cₛ² * (kz^2 + δ^2 / 4) + C₂))
+        ufb = ρfb_init * L₀ * im * kx * C₁ / ρₛ
+        vfb = -ρfb_init * L₋₁ * im * kx * f * C₁ / ρₛ
+        wfb = -ρfb_init * (L₂ + L₀ * (f^2 + cₛ² * kx^2)) * grav / ρₛ
+
+        # Bretherton transforms of final perturbations
+        @. ᶜpb += real(pfb * ᶜfourier_factor)
+        @. ᶜρb += real(ρfb * ᶜfourier_factor)
+        @. ᶜub += real(ufb * ᶜfourier_factor)
+        @. ᶜvb += real(vfb * ᶜfourier_factor)
+        @. ᶠwb += real(wfb * ᶠfourier_factor)
+        # The imaginary components should be 0 (or at least very close to 0).
+    end
+
+    # final state
+    @. ᶜp = ᶜp₀ + ᶜpb * ᶜbretherton_factor_pρ
+    @. ᶜρ = ᶜρ₀ + ᶜρb * ᶜbretherton_factor_pρ
+    @. ᶜu = ᶜu₀ + ᶜub * ᶜbretherton_factor_uvwT
+    @. ᶜv = ᶜv₀ + ᶜvb * ᶜbretherton_factor_uvwT
+    @. ᶠw = ᶠw₀ + ᶠwb * ᶠbretherton_factor_uvwT
+    @. ᶜT = ᶜp / (R_d * ᶜρ)
+
+    @. Y.c.ρ = ᶜρ
+    if ᶜ𝔼_name == :ρθ
+        @. Y.c.ρθ = ᶜρ * ᶜT * (p_0 / ᶜp)^(R_d / cp_d)
+    elseif ᶜ𝔼_name == :ρe
+        @. Y.c.ρe =
+            ᶜρ * (
+                cv_d * (ᶜT - T_tri) +
+                (ᶜu^2 + ᶜv^2 + ᶜinterp(ᶠw)^2) / 2 +
+                grav * ᶜz
+            )
+    elseif ᶜ𝔼_name == :ρe_int
+        @. Y.c.ρe_int = ᶜρ * cv_d * (ᶜT - T_tri)
+    end
+    @. Y.c.uₕ = Geometry.Covariant12Vector(Geometry.UVVector(ᶜu, ᶜv))
+    @. Y.f.w = Geometry.Covariant3Vector(Geometry.WVector(ᶠw))
+end

--- a/examples/hybrid/schur_complement_W.jl
+++ b/examples/hybrid/schur_complement_W.jl
@@ -1,4 +1,4 @@
-using LinearAlgebra: Tridiagonal, lu!, ldiv!
+using LinearAlgebra
 
 using ClimaCore: Spaces, Fields, Operators
 using ClimaCore.Utilities: half
@@ -6,7 +6,7 @@ using ClimaCore.Utilities: half
 const compose = Operators.ComposeStencils()
 const apply = Operators.ApplyStencil()
 
-struct SchurComplementW{F, T, J1, J2, J3, S, A}
+struct SchurComplementW{F, FT, J1, J2, J3, S, A}
     # whether this struct is used to compute Wfact_t or Wfact
     transform::Bool
 
@@ -14,13 +14,13 @@ struct SchurComplementW{F, T, J1, J2, J3, S, A}
     flags::F
 
     # reference to dtγ, which is specified by the ODE solver
-    dtγ_ref::T
+    dtγ_ref::FT
 
-    # nonzero blocks of the Jacobian (∂ρₜ/∂𝕄, ∂𝔼ₜ/∂𝕄, ∂𝕄ₜ/∂𝔼, and ∂𝕄ₜ/∂ρ)
-    ∂ρₜ∂𝕄::J1
-    ∂𝔼ₜ∂𝕄::J2
-    ∂𝕄ₜ∂𝔼::J3
-    ∂𝕄ₜ∂ρ::J3
+    # nonzero blocks of the Jacobian
+    ∂ᶜρₜ∂ᶠ𝕄::J1
+    ∂ᶜ𝔼ₜ∂ᶠ𝕄::J2
+    ∂ᶠ𝕄ₜ∂ᶜ𝔼::J3
+    ∂ᶠ𝕄ₜ∂ᶜρ::J3
 
     # cache for the Schur complement linear solve
     S::S
@@ -33,23 +33,23 @@ end
 function SchurComplementW(Y, transform, flags, test = false)
     FT = eltype(Y)
     dtγ_ref = Ref(zero(FT))
-    center_space = axes(Y.Yc.ρ)
-    face_space = axes(Y.w)
+    center_space = axes(Y.c)
+    face_space = axes(Y.f)
 
     # TODO: Automate this.
     J1_eltype = Operators.StencilCoefs{-half, half, NTuple{2, FT}}
     J2_eltype =
-        flags.∂𝔼ₜ∂𝕄_mode == :exact && :ρe in propertynames(Y.Yc) ?
+        flags.∂ᶜ𝔼ₜ∂ᶠ𝕄_mode == :exact && :ρe in propertynames(Y.c) ?
         Operators.StencilCoefs{-(1 + half), 1 + half, NTuple{4, FT}} : J1_eltype
-    ∂ρₜ∂𝕄 = Fields.Field(J1_eltype, center_space)
-    ∂𝔼ₜ∂𝕄 = Fields.Field(J2_eltype, center_space)
-    ∂𝕄ₜ∂𝔼 = Fields.Field(J1_eltype, face_space)
-    ∂𝕄ₜ∂ρ = Fields.Field(J1_eltype, face_space)
+    ∂ᶜρₜ∂ᶠ𝕄 = Fields.Field(J1_eltype, center_space)
+    ∂ᶜ𝔼ₜ∂ᶠ𝕄 = Fields.Field(J2_eltype, center_space)
+    ∂ᶠ𝕄ₜ∂ᶜ𝔼 = Fields.Field(J1_eltype, face_space)
+    ∂ᶠ𝕄ₜ∂ᶜρ = Fields.Field(J1_eltype, face_space)
 
     # TODO: Automate this.
     S_eltype = Operators.StencilCoefs{-1, 1, NTuple{3, FT}}
-    S = similar(Y.w, S_eltype)
-    N = Spaces.nlevels(axes(Y.w))
+    S = Fields.Field(S_eltype, face_space)
+    N = Spaces.nlevels(face_space)
     S_column_array = Tridiagonal(
         Array{FT}(undef, N - 1),
         Array{FT}(undef, N),
@@ -59,19 +59,19 @@ function SchurComplementW(Y, transform, flags, test = false)
     SchurComplementW{
         typeof(flags),
         typeof(dtγ_ref),
-        typeof(∂ρₜ∂𝕄),
-        typeof(∂𝔼ₜ∂𝕄),
-        typeof(∂𝕄ₜ∂ρ),
+        typeof(∂ᶜρₜ∂ᶠ𝕄),
+        typeof(∂ᶜ𝔼ₜ∂ᶠ𝕄),
+        typeof(∂ᶠ𝕄ₜ∂ᶜρ),
         typeof(S),
         typeof(S_column_array),
     }(
         transform,
         flags,
         dtγ_ref,
-        ∂ρₜ∂𝕄,
-        ∂𝔼ₜ∂𝕄,
-        ∂𝕄ₜ∂𝔼,
-        ∂𝕄ₜ∂ρ,
+        ∂ᶜρₜ∂ᶠ𝕄,
+        ∂ᶜ𝔼ₜ∂ᶠ𝕄,
+        ∂ᶠ𝕄ₜ∂ᶜ𝔼,
+        ∂ᶠ𝕄ₜ∂ᶜρ,
         S,
         S_column_array,
         test,
@@ -84,9 +84,9 @@ end
 Base.similar(w::SchurComplementW) = w
 
 #=
-A = [-I         0          dtγ ∂ρₜ∂𝕄;
-     0          -I         dtγ ∂𝔼ₜ∂𝕄;
-     dtγ ∂𝕄ₜ∂ρ  dtγ ∂𝕄ₜ∂𝔼  -I       ]
+A = [-I           0            dtγ ∂ᶜρₜ∂ᶠ𝕄;
+     0            -I           dtγ ∂ᶜ𝔼ₜ∂ᶠ𝕄;
+     dtγ ∂ᶠ𝕄ₜ∂ᶜρ  dtγ ∂ᶠ𝕄ₜ∂ᶜ𝔼  -I         ] =
     [-I   0    A13;
      0    -I   A23;
      A31  A32  -I ]
@@ -106,85 +106,90 @@ Note: The matrix S = -I + A31 A13 + A32 A23 is the "Schur complement" of
 =#
 function linsolve!(::Type{Val{:init}}, f, u0; kwargs...)
     function _linsolve!(x, A, b, update_matrix = false; kwargs...)
-        @unpack dtγ_ref, ∂ρₜ∂𝕄, ∂𝔼ₜ∂𝕄, ∂𝕄ₜ∂𝔼, ∂𝕄ₜ∂ρ, S, S_column_array = A
+        (; dtγ_ref, ∂ᶜρₜ∂ᶠ𝕄, ∂ᶜ𝔼ₜ∂ᶠ𝕄, ∂ᶠ𝕄ₜ∂ᶜ𝔼, ∂ᶠ𝕄ₜ∂ᶜρ, S, S_column_array) = A
         dtγ = dtγ_ref[]
 
-        xρ = x.Yc.ρ
-        bρ = b.Yc.ρ
-        if :ρθ in propertynames(x.Yc)
-            x𝔼 = x.Yc.ρθ
-            b𝔼 = b.Yc.ρθ
-        elseif :ρe in propertynames(x.Yc)
-            x𝔼 = x.Yc.ρe
-            b𝔼 = b.Yc.ρe
+        xᶜρ = x.c.ρ
+        bᶜρ = b.c.ρ
+        if :ρθ in propertynames(x.c)
+            xᶜ𝔼 = x.c.ρθ
+            bᶜ𝔼 = b.c.ρθ
+        elseif :ρe in propertynames(x.c)
+            xᶜ𝔼 = x.c.ρe
+            bᶜ𝔼 = b.c.ρe
+        elseif :ρe_int in propertynames(x.c)
+            xᶜ𝔼 = x.c.ρe_int
+            bᶜ𝔼 = b.c.ρe_int
         end
-        if :ρw in propertynames(x)
-            x𝕄 = x.ρw.components.data.:1
-            b𝕄 = b.ρw.components.data.:1
-        elseif :w in propertynames(x)
-            x𝕄 = x.w.components.data.:1
-            b𝕄 = b.w.components.data.:1
+        if :ρw in propertynames(x.f)
+            xᶠ𝕄 = x.f.ρw.components.data.:1
+            bᶠ𝕄 = b.f.ρw.components.data.:1
+        elseif :w in propertynames(x.f)
+            xᶠ𝕄 = x.f.w.components.data.:1
+            bᶠ𝕄 = b.f.w.components.data.:1
         end
 
         # TODO: Extend LinearAlgebra.I to work with stencil fields.
-        T = eltype(eltype(S))
-        I = Ref(Operators.StencilCoefs{-1, 1}((zero(T), one(T), zero(T))))
-        if Operators.bandwidths(eltype(∂𝔼ₜ∂𝕄)) != (-half, half)
-            str = "The linear solver cannot yet be run with the given ∂𝔼ₜ/∂𝕄 \
-                block, since it has more than 2 diagonals. Setting ∂𝔼ₜ/∂𝕄 = 0 \
-                for the Schur complement computation. Consider changing the \
-                jacobian_mode or the energy variable."
+        FT = eltype(eltype(S))
+        I = Ref(Operators.StencilCoefs{-1, 1}((zero(FT), one(FT), zero(FT))))
+        if Operators.bandwidths(eltype(∂ᶜ𝔼ₜ∂ᶠ𝕄)) != (-half, half)
+            str = "The linear solver cannot yet be run with the given ∂ᶜ𝔼ₜ/∂ᶠ𝕄 \
+                block, since it has more than 2 diagonals. So, ∂ᶜ𝔼ₜ/∂ᶠ𝕄 will \
+                be set to 0 for the Schur complement computation. Consider \
+                changing the ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode or the energy variable."
             @warn str maxlog = 1
-            @. S = -I + dtγ^2 * compose(∂𝕄ₜ∂ρ, ∂ρₜ∂𝕄)
+            @. S = -I + dtγ^2 * compose(∂ᶠ𝕄ₜ∂ᶜρ, ∂ᶜρₜ∂ᶠ𝕄)
         else
-            @. S = -I + dtγ^2 * (compose(∂𝕄ₜ∂ρ, ∂ρₜ∂𝕄) + compose(∂𝕄ₜ∂𝔼, ∂𝔼ₜ∂𝕄))
+            @. S =
+                -I +
+                dtγ^2 * (compose(∂ᶠ𝕄ₜ∂ᶜρ, ∂ᶜρₜ∂ᶠ𝕄) + compose(∂ᶠ𝕄ₜ∂ᶜ𝔼, ∂ᶜ𝔼ₜ∂ᶠ𝕄))
         end
 
-        @. x𝕄 = b𝕄 + dtγ * (apply(∂𝕄ₜ∂ρ, bρ) + apply(∂𝕄ₜ∂𝔼, b𝔼))
+        @. xᶠ𝕄 = bᶠ𝕄 + dtγ * (apply(∂ᶠ𝕄ₜ∂ᶜρ, bᶜρ) + apply(∂ᶠ𝕄ₜ∂ᶜ𝔼, bᶜ𝔼))
 
         # TODO: Do this with stencil_solve!.
-        Ni, Nj, _, _, Nh = size(Spaces.local_geometry_data(axes(xρ)))
+        Ni, Nj, _, _, Nh = size(Spaces.local_geometry_data(axes(xᶜρ)))
         for h in 1:Nh, j in 1:Nj, i in 1:Ni
-            x𝕄_column_view = parent(Spaces.column(x𝕄, i, j, h))
+            xᶠ𝕄_column_view = parent(Spaces.column(xᶠ𝕄, i, j, h))
             S_column = Spaces.column(S, i, j, h)
             @views S_column_array.dl .= parent(S_column.coefs.:1)[2:end]
             S_column_array.d .= parent(S_column.coefs.:2)
             @views S_column_array.du .= parent(S_column.coefs.:3)[1:(end - 1)]
-            ldiv!(lu!(S_column_array), x𝕄_column_view)
+            ldiv!(lu!(S_column_array), xᶠ𝕄_column_view)
         end
 
-        @. xρ = -bρ + dtγ * apply(∂ρₜ∂𝕄, x𝕄)
-        @. x𝔼 = -b𝔼 + dtγ * apply(∂𝔼ₜ∂𝕄, x𝕄)
+        @. xᶜρ = -bᶜρ + dtγ * apply(∂ᶜρₜ∂ᶠ𝕄, xᶠ𝕄)
+        @. xᶜ𝔼 = -bᶜ𝔼 + dtγ * apply(∂ᶜ𝔼ₜ∂ᶠ𝕄, xᶠ𝕄)
 
-        if A.test && Operators.bandwidths(eltype(∂𝔼ₜ∂𝕄)) == (-half, half)
-            Ni, Nj, _, Nv, Nh = size(Spaces.local_geometry_data(axes(xρ)))
-            ∂Yₜ∂Y = Array{Float64}(undef, 3 * Nv + 1, 3 * Nv + 1)
-            ΔY = Array{Float64}(undef, 3 * Nv + 1)
-            ΔΔY = Array{Float64}(undef, 3 * Nv + 1)
+        if A.test && Operators.bandwidths(eltype(∂ᶜ𝔼ₜ∂ᶠ𝕄)) == (-half, half)
+            Ni, Nj, _, Nv, Nh = size(Spaces.local_geometry_data(axes(xᶜρ)))
+            ∂Yₜ∂Y = Array{FT}(undef, 3 * Nv + 1, 3 * Nv + 1)
+            ΔY = Array{FT}(undef, 3 * Nv + 1)
+            ΔΔY = Array{FT}(undef, 3 * Nv + 1)
             for h in 1:Nh, j in 1:Nj, i in 1:Ni
                 ∂Yₜ∂Y .= 0.0
                 ∂Yₜ∂Y[1:Nv, (2 * Nv + 1):(3 * Nv + 1)] .=
-                    column_matrix(∂ρₜ∂𝕄, i, j, h)
+                    column_matrix(∂ᶜρₜ∂ᶠ𝕄, i, j, h)
                 ∂Yₜ∂Y[(Nv + 1):(2 * Nv), (2 * Nv + 1):(3 * Nv + 1)] .=
-                    column_matrix(∂𝔼ₜ∂𝕄, i, j, h)
+                    column_matrix(∂ᶜ𝔼ₜ∂ᶠ𝕄, i, j, h)
                 ∂Yₜ∂Y[(2 * Nv + 1):(3 * Nv + 1), 1:Nv] .=
-                    column_matrix(∂𝕄ₜ∂ρ, i, j, h)
+                    column_matrix(∂ᶠ𝕄ₜ∂ᶜρ, i, j, h)
                 ∂Yₜ∂Y[(2 * Nv + 1):(3 * Nv + 1), (Nv + 1):(2 * Nv)] .=
-                    column_matrix(∂𝕄ₜ∂𝔼, i, j, h)
-                ΔY[1:Nv] .= column_vector(xρ, i, j, h)
-                ΔY[(Nv + 1):(2 * Nv)] .= column_vector(x𝔼, i, j, h)
-                ΔY[(2 * Nv + 1):(3 * Nv + 1)] .= column_vector(x𝕄, i, j, h)
-                ΔΔY[1:Nv] .= column_vector(bρ, i, j, h)
-                ΔΔY[(Nv + 1):(2 * Nv)] .= column_vector(b𝔼, i, j, h)
-                ΔΔY[(2 * Nv + 1):(3 * Nv + 1)] .= column_vector(b𝕄, i, j, h)
+                    column_matrix(∂ᶠ𝕄ₜ∂ᶜ𝔼, i, j, h)
+                ΔY[1:Nv] .= column_vector(xᶜρ, i, j, h)
+                ΔY[(Nv + 1):(2 * Nv)] .= column_vector(xᶜ𝔼, i, j, h)
+                ΔY[(2 * Nv + 1):(3 * Nv + 1)] .= column_vector(xᶠ𝕄, i, j, h)
+                ΔΔY[1:Nv] .= column_vector(bᶜρ, i, j, h)
+                ΔΔY[(Nv + 1):(2 * Nv)] .= column_vector(bᶜ𝔼, i, j, h)
+                ΔΔY[(2 * Nv + 1):(3 * Nv + 1)] .= column_vector(bᶠ𝕄, i, j, h)
                 @assert (-LinearAlgebra.I + dtγ * ∂Yₜ∂Y) * ΔY ≈ ΔΔY
             end
         end
 
-        if :ρuₕ in propertynames(x)
-            @. x.ρuₕ = -b.ρuₕ
-        elseif :uₕ in propertynames(x)
-            @. x.uₕ = -b.uₕ
+        if :ρuₕ in propertynames(x.c)
+            @. x.c.ρuₕ = -b.c.ρuₕ
+        elseif :uₕ in propertynames(x.c)
+            @. x.c.uₕ = -b.c.uₕ
         end
 
         if A.transform

--- a/examples/hybrid/sphere/baroclinic_wave_rhoe.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhoe.jl
@@ -1,5 +1,6 @@
 using ClimaCorePlots, Plots
 
+const FT = Float64
 include("baroclinic_wave_utilities.jl")
 
 const sponge = false
@@ -15,39 +16,27 @@ dt = FT(400)
 dt_save_to_sol = FT(60 * 60 * 24)
 dt_save_to_disk = FT(0) # 0 means don't save to disk
 ode_algorithm = OrdinaryDiffEq.Rosenbrock23
-jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :no_∂P∂K, ∂𝕄ₜ∂ρ_mode = :exact)
+jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :no_∂ᶜp∂ᶜK, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)
 
-initial_condition(local_geometry) =
-    initial_condition_ρe(local_geometry; is_balanced_flow = false)
-initial_condition_velocity(local_geometry) =
-    initial_condition_velocity(local_geometry; is_balanced_flow = false)
-
-remaining_cache_values(Y, dt) = merge(
-    baroclinic_wave_cache_values(Y, dt),
-    final_adjustments_cache_values(Y, dt; use_rayleigh_sponge = sponge),
+additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = merge(
+    hyperdiffusion_cache(ᶜlocal_geometry, ᶠlocal_geometry; κ₄ = FT(2e17)),
+    sponge ? rayleigh_sponge_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) : (;),
 )
-
-function remaining_tendency!(dY, Y, p, t)
-    dY .= zero(eltype(dY))
-    baroclinic_wave_ρe_remaining_tendency!(dY, Y, p, t; κ₄ = 2.0e17)
-    final_adjustments!(
-        dY,
-        Y,
-        p,
-        t;
-        use_flux_correction = false,
-        use_rayleigh_sponge = sponge,
-    )
-    return dY
+function additional_tendency!(Yₜ, Y, p, t)
+    hyperdiffusion_tendency!(Yₜ, Y, p, t)
+    sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
 end
 
+center_initial_condition(local_geometry) =
+    center_initial_condition(local_geometry, Val(:ρe))
+
 function postprocessing(sol, p, output_dir)
-    @info "L₂ norm of ρe at t = $(sol.t[1]): $(norm(sol.u[1].Yc.ρe))"
-    @info "L₂ norm of ρe at t = $(sol.t[end]): $(norm(sol.u[end].Yc.ρe))"
+    @info "L₂ norm of ρe at t = $(sol.t[1]): $(norm(sol.u[1].c.ρe))"
+    @info "L₂ norm of ρe at t = $(sol.t[end]): $(norm(sol.u[end].c.ρe))"
 
     anim = Plots.@animate for Y in sol.u
-        v = Geometry.UVVector.(Y.uₕ).components.data.:2
-        Plots.plot(v, level = 3, clim = (-6, 6))
+        ᶜv = Geometry.UVVector.(Y.c.uₕ).components.data.:2
+        Plots.plot(ᶜv, level = 3, clim = (-6, 6))
     end
     Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
 end

--- a/examples/hybrid/sphere/baroclinic_wave_rhotheta.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhotheta.jl
@@ -1,5 +1,6 @@
 using ClimaCorePlots, Plots
 
+const FT = Float64
 include("baroclinic_wave_utilities.jl")
 
 const sponge = false
@@ -15,38 +16,27 @@ dt = FT(400)
 dt_save_to_sol = FT(60 * 60 * 24)
 dt_save_to_disk = FT(0) # 0 means don't save to disk
 ode_algorithm = OrdinaryDiffEq.Rosenbrock23
-jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :exact, ∂𝕄ₜ∂ρ_mode = :exact)
+jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)
 
-initial_condition(local_geometry) = initial_condition_ρθ(local_geometry)
-initial_condition_velocity(local_geometry) =
-    initial_condition_velocity(local_geometry; is_balanced_flow = false)
-
-remaining_cache_values(Y, dt) = merge(
-    baroclinic_wave_cache_values(Y, dt),
-    final_adjustments_cache_values(Y, dt; use_rayleigh_sponge = sponge),
+additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = merge(
+    hyperdiffusion_cache(ᶜlocal_geometry, ᶠlocal_geometry; κ₄ = FT(2e17)),
+    sponge ? rayleigh_sponge_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) : (;),
 )
-
-function remaining_tendency!(dY, Y, p, t)
-    dY .= zero(eltype(dY))
-    baroclinic_wave_ρθ_remaining_tendency!(dY, Y, p, t; κ₄ = 2.0e17)
-    final_adjustments!(
-        dY,
-        Y,
-        p,
-        t;
-        use_flux_correction = false,
-        use_rayleigh_sponge = sponge,
-    )
-    return dY
+function additional_tendency!(Yₜ, Y, p, t)
+    hyperdiffusion_tendency!(Yₜ, Y, p, t)
+    sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
 end
 
+center_initial_condition(local_geometry) =
+    center_initial_condition(local_geometry, Val(:ρθ))
+
 function postprocessing(sol, p, output_dir)
-    @info "L₂ norm of ρθ at t = $(sol.t[1]): $(norm(sol.u[1].Yc.ρθ))"
-    @info "L₂ norm of ρθ at t = $(sol.t[end]): $(norm(sol.u[end].Yc.ρθ))"
+    @info "L₂ norm of ρθ at t = $(sol.t[1]): $(norm(sol.u[1].c.ρθ))"
+    @info "L₂ norm of ρθ at t = $(sol.t[end]): $(norm(sol.u[end].c.ρθ))"
 
     anim = Plots.@animate for Y in sol.u
-        v = Geometry.UVVector.(Y.uₕ).components.data.:2
-        Plots.plot(v, level = 3, clim = (-6, 6))
+        ᶜv = Geometry.UVVector.(Y.c.uₕ).components.data.:2
+        Plots.plot(ᶜv, level = 3, clim = (-6, 6))
     end
     Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
 end

--- a/examples/hybrid/sphere/held_suarez_rhoe_int.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe_int.jl
@@ -16,7 +16,7 @@ dt = FT(400)
 dt_save_to_sol = FT(60 * 60 * 24)
 dt_save_to_disk = FT(0) # 0 means don't save to disk
 ode_algorithm = OrdinaryDiffEq.Rosenbrock23
-jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :no_∂ᶜp∂ᶜK, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)
+jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)
 
 additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = merge(
     hyperdiffusion_cache(ᶜlocal_geometry, ᶠlocal_geometry; κ₄ = FT(2e17)),
@@ -30,11 +30,11 @@ function additional_tendency!(Yₜ, Y, p, t)
 end
 
 center_initial_condition(local_geometry) =
-    center_initial_condition(local_geometry, Val(:ρe))
+    center_initial_condition(local_geometry, Val(:ρe_int))
 
 function postprocessing(sol, p, output_dir)
-    @info "L₂ norm of ρe at t = $(sol.t[1]): $(norm(sol.u[1].c.ρe))"
-    @info "L₂ norm of ρe at t = $(sol.t[end]): $(norm(sol.u[end].c.ρe))"
+    @info "L₂ norm of ρe_int at t = $(sol.t[1]): $(norm(sol.u[1].c.ρe_int))"
+    @info "L₂ norm of ρe_int at t = $(sol.t[end]): $(norm(sol.u[end].c.ρe_int))"
 
     anim = Plots.@animate for Y in sol.u
         ᶜv = Geometry.UVVector.(Y.c.uₕ).components.data.:2

--- a/examples/hybrid/sphere/held_suarez_rhotheta.jl
+++ b/examples/hybrid/sphere/held_suarez_rhotheta.jl
@@ -1,5 +1,6 @@
 using ClimaCorePlots, Plots
 
+const FT = Float64
 include("baroclinic_wave_utilities.jl")
 
 const sponge = false
@@ -15,40 +16,29 @@ dt = FT(400)
 dt_save_to_sol = FT(60 * 60 * 24)
 dt_save_to_disk = FT(0) # 0 means don't save to disk
 ode_algorithm = OrdinaryDiffEq.Rosenbrock23
-jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :exact, ∂𝕄ₜ∂ρ_mode = :exact)
+jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)
 
-initial_condition(local_geometry) = initial_condition_ρθ(local_geometry)
-initial_condition_velocity(local_geometry) =
-    initial_condition_velocity(local_geometry; is_balanced_flow = false)
-
-remaining_cache_values(Y, dt) = merge(
-    baroclinic_wave_cache_values(Y, dt),
-    held_suarez_cache_values(Y, dt),
-    final_adjustments_cache_values(Y, dt; use_rayleigh_sponge = sponge),
+additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = merge(
+    hyperdiffusion_cache(ᶜlocal_geometry, ᶠlocal_geometry; κ₄ = FT(2e17)),
+    sponge ? rayleigh_sponge_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) : (;),
+    held_suarez_cache(ᶜlocal_geometry),
 )
-
-function remaining_tendency!(dY, Y, p, t)
-    dY .= zero(eltype(dY))
-    baroclinic_wave_ρθ_remaining_tendency!(dY, Y, p, t; κ₄ = 2.0e17)
-    held_suarez_forcing!(dY, Y, p, t)
-    final_adjustments!(
-        dY,
-        Y,
-        p,
-        t;
-        use_flux_correction = false,
-        use_rayleigh_sponge = sponge,
-    )
-    return dY
+function additional_tendency!(Yₜ, Y, p, t)
+    hyperdiffusion_tendency!(Yₜ, Y, p, t)
+    sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
+    held_suarez_tendency!(Yₜ, Y, p, t)
 end
 
+center_initial_condition(local_geometry) =
+    center_initial_condition(local_geometry, Val(:ρθ))
+
 function postprocessing(sol, p, output_dir)
-    @info "L₂ norm of ρθ at t = $(sol.t[1]): $(norm(sol.u[1].Yc.ρθ))"
-    @info "L₂ norm of ρθ at t = $(sol.t[end]): $(norm(sol.u[end].Yc.ρθ))"
+    @info "L₂ norm of ρθ at t = $(sol.t[1]): $(norm(sol.u[1].c.ρθ))"
+    @info "L₂ norm of ρθ at t = $(sol.t[end]): $(norm(sol.u[end].c.ρθ))"
 
     anim = Plots.@animate for Y in sol.u
-        v = Geometry.UVVector.(Y.uₕ).components.data.:2
-        Plots.plot(v, level = 3, clim = (-6, 6))
+        ᶜv = Geometry.UVVector.(Y.c.uₕ).components.data.:2
+        Plots.plot(ᶜv, level = 3, clim = (-6, 6))
     end
     Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
 end

--- a/examples/hybrid/sphere/held_suarez_rhotheta_tempest.jl
+++ b/examples/hybrid/sphere/held_suarez_rhotheta_tempest.jl
@@ -1,5 +1,6 @@
 using ClimaCorePlots, Plots
 
+const FT = Float64
 include("baroclinic_wave_utilities.jl")
 
 const sponge = false
@@ -15,40 +16,34 @@ dt = FT(400)
 dt_save_to_sol = FT(60 * 60 * 24)
 dt_save_to_disk = FT(0) # 0 means don't save to disk
 ode_algorithm = OrdinaryDiffEq.Rosenbrock23
-jacobian_flags = (; ∂𝔼ₜ∂𝕄_mode = :exact, ∂𝕄ₜ∂ρ_mode = :exact)
+jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)
 
-initial_condition(local_geometry) = initial_condition_ρθ(local_geometry)
-initial_condition_velocity(local_geometry) =
-    initial_condition_velocity(local_geometry; is_balanced_flow = false)
-
-remaining_cache_values(Y, dt) = merge(
-    baroclinic_wave_cache_values(Y, dt),
-    held_suarez_cache_values(Y, dt),
-    final_adjustments_cache_values(Y, dt; use_rayleigh_sponge = sponge),
+additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = merge(
+    hyperdiffusion_cache(
+        ᶜlocal_geometry,
+        ᶠlocal_geometry;
+        κ₄ = FT(2e17),
+        use_tempest_mode = true,
+    ),
+    sponge ? rayleigh_sponge_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) : (;),
+    held_suarez_cache(ᶜlocal_geometry),
 )
-
-function remaining_tendency!(dY, Y, p, t)
-    dY .= zero(eltype(dY))
-    held_suarez_ρθ_tempest_remaining_tendency!(dY, Y, p, t; κ₄ = 2.0e17)
-    held_suarez_forcing!(dY, Y, p, t)
-    final_adjustments!(
-        dY,
-        Y,
-        p,
-        t;
-        use_flux_correction = false,
-        use_rayleigh_sponge = sponge,
-    )
-    return dY
+function additional_tendency!(Yₜ, Y, p, t)
+    hyperdiffusion_tendency!(Yₜ, Y, p, t)
+    sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
+    held_suarez_tendency!(Yₜ, Y, p, t)
 end
 
+center_initial_condition(local_geometry) =
+    center_initial_condition(local_geometry, Val(:ρθ))
+
 function postprocessing(sol, p, output_dir)
-    @info "L₂ norm of ρθ at t = $(sol.t[1]): $(norm(sol.u[1].Yc.ρθ))"
-    @info "L₂ norm of ρθ at t = $(sol.t[end]): $(norm(sol.u[end].Yc.ρθ))"
+    @info "L₂ norm of ρθ at t = $(sol.t[1]): $(norm(sol.u[1].c.ρθ))"
+    @info "L₂ norm of ρθ at t = $(sol.t[end]): $(norm(sol.u[end].c.ρθ))"
 
     anim = Plots.@animate for Y in sol.u
-        v = Geometry.UVVector.(Y.uₕ).components.data.:2
-        Plots.plot(v, level = 3, clim = (-6, 6))
+        ᶜv = Geometry.UVVector.(Y.c.uₕ).components.data.:2
+        Plots.plot(ᶜv, level = 3, clim = (-6, 6))
     end
     Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
 end

--- a/perf/allocs.jl
+++ b/perf/allocs.jl
@@ -20,8 +20,8 @@ dirs_to_monitor = [
 #! format: off
 all_cases = [
     (joinpath(EXAMPLE_DIR, "sphere", "shallow_water.jl"), "barotropic_instability", ""),
-    (joinpath(EXAMPLE_DIR, "hybrid", "plane", "bubble_2d.jl"), "", ""),
-    (joinpath(EXAMPLE_DIR, "hybrid", "box", "bubble_3d.jl"), "", ""),
+    (joinpath(EXAMPLE_DIR, "hybrid", "plane", "bubble_2d_rhotheta.jl"), "", ""),
+    (joinpath(EXAMPLE_DIR, "hybrid", "box", "bubble_3d_rhotheta.jl"), "", ""),
     (joinpath(EXAMPLE_DIR, "hybrid", "driver.jl"), "", "sphere/baroclinic_wave_rhoe"),
     (joinpath(EXAMPLE_DIR, "hybrid", "driver.jl"), "", "sphere/baroclinic_wave_rhotheta"),
 ]

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -7,8 +7,7 @@ ENV["CI_PERF_SKIP_RUN"] = true # we only need haskey(ENV, "CI_PERF_SKIP_RUN") ==
 
 import ClimaCore
 
-filename = joinpath(EXAMPLE_DIR, "hybrid", "plane", "bubble_2d.jl")
-# filename = joinpath(EXAMPLE_DIR, "3dsphere", "baroclinic_wave_rho_etot.jl")
+filename = joinpath(EXAMPLE_DIR, "hybrid", "plane", "bubble_2d_rhotheta.jl")
 
 try
     include(filename)

--- a/src/Geometry/conversions.jl
+++ b/src/Geometry/conversions.jl
@@ -161,6 +161,47 @@ Jcontravariant3(u::AxisTensor, local_geometry::LocalGeometry) =
 covariant3(u::Contravariant3Vector, local_geometry::LocalGeometry{(1, 2)}) =
     contravariant3(u, local_geometry)
 
+# workarounds for using a Covariant12Vector/Covariant123Vector in a UW space:
+function LocalVector(
+    vector::CovariantVector{<:Any, (1, 2, 3)},
+    local_geometry::LocalGeometry{(1, 3)},
+)
+    u₁, v, u₃ = components(vector)
+    vector2 = Covariant13Vector(u₁, u₃)
+    u, w = components(transform(LocalAxis{(1, 3)}(), vector2, local_geometry))
+    return UVWVector(u, v, w)
+end
+function contravariant1(
+    vector::CovariantVector{<:Any, (1, 2, 3)},
+    local_geometry::LocalGeometry{(1, 3)},
+)
+    u₁, _, u₃ = components(vector)
+    vector2 = Covariant13Vector(u₁, u₃)
+    return transform(Contravariant13Axis(), vector2, local_geometry).u¹
+end
+function contravariant3(
+    vector::CovariantVector{<:Any, (1, 2)},
+    local_geometry::LocalGeometry{(1, 3)},
+)
+    u₁, _ = components(vector)
+    vector2 = Covariant13Vector(u₁, zero(u₁))
+    return transform(Contravariant13Axis(), vector2, local_geometry).u³
+end
+function ContravariantVector(
+    vector::CovariantVector{<:Any, (1, 2)},
+    local_geometry::LocalGeometry{(1, 3)},
+)
+    u₁, v = components(vector)
+    vector2 = Covariant1Vector(u₁)
+    vector3 = transform(
+        ContravariantAxis{(1, 3)}(),
+        transform(CovariantAxis{(1, 3)}(), vector2),
+        local_geometry,
+    )
+    u¹, u³ = components(vector3)
+    return Contravariant123Vector(u¹, v, u³)
+end
+
 """
     transform(axis, V[, local_geometry])
 

--- a/src/Spaces/dss.jl
+++ b/src/Spaces/dss.jl
@@ -46,6 +46,18 @@ end
     )
         return arg
     end
+    # workaround for using a Covariant12Vector in a UW space
+    if ax isa Geometry.UWAxis && axfrom isa Geometry.Covariant12Axis
+        # return Geometry.transform(Geometry.UVWAxis(), arg, local_geometry)
+        u₁, v = Geometry.components(arg)
+        uw_vector = Geometry.transform(
+            Geometry.UWAxis(),
+            Geometry.Covariant13Vector(u₁, zero(u₁)),
+            local_geometry,
+        )
+        u, w = Geometry.components(uw_vector)
+        return Geometry.UVWVector(u, v, w)
+    end
     Geometry.transform(ax, arg, local_geometry)
 end
 
@@ -67,6 +79,20 @@ end
     local_geometry::Geometry.LocalGeometry,
 )
     ax = axes(refarg, 1)
+    # workaround for using a Covariant12Vector in a UW space
+    if (
+        axes(local_geometry.∂x∂ξ, 1) isa Geometry.UWAxis &&
+        ax isa Geometry.Covariant12Axis
+    )
+        u, u₂, w = Geometry.components(targ)
+        u₁_vector = Geometry.transform(
+            Geometry.Covariant1Axis(),
+            Geometry.UWVector(u, w),
+            local_geometry,
+        )
+        u₁, = Geometry.components(u₁_vector)
+        return Geometry.Covariant12Vector(u₁, u₂)
+    end
     Geometry.transform(ax, targ, local_geometry)
 end
 


### PR DESCRIPTION
This PR moves the explicit tendencies defined in `baroclinic_wave_utilities.jl` into `staggered_nonhydrostatic_model.jl`, unifying them into a single function and generalizing them to work with both 2D and 3D domains. It also separates the default tendencies from the non-default tendencies (e.g., hyperdiffusion and Held-Suarez forcing), so that test case files only need to specify non-default tendencies (if there are any), which can be done by defining methods for `additional_cache()` and `additional_tendency!()`.

In addition, this PR introduces a new naming convention for Fields defined on hybrid domains---Fields on cell centers are prefixed with a superscript "c", and Fields on cell faces are prefixed with a superscript "f". Previously, this was only done for some fields, and with non-superscript "c" and "f", which caused confusion when such fields were used alongside variables whose names start with "c" and "f" (e.g., heat capacity and Coriolis frequency). Similarly, this PR introduces a new data structure convention---Fields on cell centers are stored in `Y.c`, and Fields on cell faces are stored in `Y.f`. Previously, the prognostic state was stored as `Y.Yc.ρ`, `Y.Yc.ρe` (or equivalent), `Y.uₕ`, and `Y.w`, which was arbitrary and inefficient (for example, dss needed to be called on both `Y.Yc` and `Y.uₕ`, whereas it can now be called just once on `Y.c`). These new conventions account for most of the lines changed in this PR, but hopefully they will make the code easier to understand.

This PR also adds support for using internal energy as an prognostic variable, and it adds a new Held-Suarez test case that demonstrates this capability ("held_suarez_rhoe_int.jl"). It also adds the "inertial_gravity_wave.jl" test case to "hybrid/plane"; the analytic solution in this test case is still not working, so it can't be used as a proper integration test, but that can be fixed later.

Finally, this PR fixes a minor buildkite bug I introduced in my previous PR that was causing some artifacts from the rising bubble tests to be missing.