### PR TITLE
Hybrid 3D box limiters advection example

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -326,6 +326,39 @@ steps:
       queue: central
       slurm_ntasks: 1
 
+  - label: ":computer: 3D Box limiters advection cosine bells"
+    key: "cpu_box_advection_limiter_cosine_bells"
+    command:
+      - "julia --color=yes --project=examples examples/hybrid/box/limiters_advection.jl"
+    artifact_paths:
+      - "examples/hybrid/box/output/box_advection_limiter_cosine_bells_D0/*"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
+  - label: ":computer: 3D Box limiters advection Gaussian bells"
+    key: "cpu_box_advection_limiter_gaussian_bells"
+    command:
+      - "julia --color=yes --project=examples examples/hybrid/box/limiters_advection.jl gaussian_bells"
+    artifact_paths:
+      - "examples/hybrid/box/output/box_advection_limiter_gaussian_bells_D0/*"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
+  - label: ":computer: 3D Box limiters advection slotted spheres"
+    key: "cpu_box_advection_limiter_slotted_spheres"
+    command:
+      - "julia --color=yes --project=examples examples/hybrid/box/limiters_advection.jl slotted_spheres"
+    artifact_paths:
+      - "examples/hybrid/box/output/box_advection_limiter_slotted_spheres_D0/*"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
   - label: ":computer: Rising Bubble 2D hybrid (ρθ)"
     key: "cpu_rising_bubble_2d_hybrid_rhotheta"
     command:
@@ -402,7 +435,7 @@ steps:
       config: cpu
       queue: central
       slurm_ntasks: 1
-  
+
   - label: ":computer: Density current 2D hybrid invariant total energy (topography mesh interface)"
     key: "cpu_density_current_2d_hybrid_invariant_total_energy_no-warp_topography"
     command:

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -34,8 +34,18 @@ withenv("GKSwstype" => "nul") do
     bib =
         DocumenterCitations.CitationBibliography(joinpath(@__DIR__, "refs.bib"))
 
+    mathengine = Documenter.MathJax(
+        Dict(
+            :TeX => Dict(
+                :equationNumbers => Dict(:autoNumber => "AMS"),
+                :Macros => Dict(),
+            ),
+        ),
+    )
+
     format = Documenter.HTML(
         prettyurls = !isempty(get(ENV, "CI", "")),
+        mathengine = mathengine,
         collapselevel = 1,
     )
 
@@ -64,6 +74,7 @@ withenv("GKSwstype" => "nul") do
                 joinpath("tutorials", tutorial * ".md") for
                 tutorial in TUTORIALS
             ],
+            "Examples" => "examples.md",
             "Libraries" => [
                 joinpath("lib", "ClimaCoreVTK.md"),
                 joinpath("lib", "ClimaCoreTempestRemap.md"),

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -1,0 +1,115 @@
+# Examples
+
+## 1D Column examples
+
+## 2D Cartesian examples
+
+## 3D Cartesian examples
+
+### Flux Limiters advection
+
+The 3D Cartesian advection/transport example in [`examples/hybrid/box/limiters_advection.jl`](https://github.com/CliMA/ClimaCore.jl/tree/main/examples/hybrid/box/limiters_advection.jl) demonstrates the application of flux limiters, namely [`quasimonotone_limiter!`](@ref), in a hybrid Cartesian domain. It also demonstrates the usage of the high-order upwinding scheme in the vertical direction, called [`Upwind3rdOrderBiasedProductC2F`](@ref).
+
+#### Equations and discretizations
+
+#### Mass
+
+Follows the continuity equation
+```math
+\begin{equation}
+  \frac{\partial}{\partial t} \rho = - \nabla \cdot(\rho \boldsymbol{u}) .
+\label{eq:continuity}
+\end{equation}
+```
+
+This is discretized using the following
+```math
+\begin{equation}
+  \frac{\partial}{\partial t} \rho \approx - D_h[ \rho (\boldsymbol{u}_h + I^c(\boldsymbol{u}_v))] - D^c_v[I^f(\rho \boldsymbol{u}_h)) + I^f(\rho) \boldsymbol{u}_v)] .
+\label{eq:discrete-continuity}
+\end{equation}
+```
+
+#### Tracers
+
+For the tracer concentration per unit mass ``q``, the tracer density (scalar) ``\rho q`` follows the advection/transport equation
+
+```math
+\begin{equation}
+  \frac{\partial}{\partial t} \rho q = - \nabla \cdot(\rho q \boldsymbol{u})  + g(\rho, q).
+\label{eq:tracers}
+\end{equation}
+```
+
+This is discretized using the following
+```math
+\begin{equation}
+\frac{\partial}{\partial t} \rho q \approx
+- D_h[ \rho q (\boldsymbol{u}_h + I^c(\boldsymbol{u}_v))]
+- D^c_v\left[I^f(\rho) U^f\left(I^f(\boldsymbol{u}_h) + \boldsymbol{u}_v, \frac{\rho q}{\rho} \right) \right] + g(\rho, q),
+\label{eq:discrete-tracers}
+\end{equation}
+```
+where ``g(\rho, q) = - \nu_4 [\nabla^4_h (\rho q)]`` represents the horizontal hyperdiffusion operator, with ``\nu_4`` (measured in m^4/s) the hyperviscosity constant coefficient.
+
+Currently tracers are only treated explicitly in the time discretization.
+
+
+#### Prognostic variables
+
+* ``\rho``: _density_ measured in kg/m³. This is discretized at cell centers.
+* ``\boldsymbol{u}`` _velocity_, a vector measured in m/s. This is discretized via ``\boldsymbol{u} = \boldsymbol{u}_h + \boldsymbol{u}_v`` where
+  - ``\boldsymbol{u}_h = u_1 \boldsymbol{e}^1 + u_2 \boldsymbol{e}^2`` is the projection onto horizontal covariant components (covariance here means with respect to the reference element), stored at cell centers.
+  - ``\boldsymbol{u}_v = u_3 \boldsymbol{e}^3`` is the projection onto the vertical covariant components, stored at cell faces.
+* ``\rho q``: the tracer density scalar, where ``q`` is the tracer concentration per unit mass, is stored at cell centers.
+
+#### Operators
+
+We make use of the following operators
+
+#### Reconstructions
+
+* ``I^c`` is the [face-to-center reconstruction operator](https://clima.github.io/ClimaCore.jl/stable/operators/#ClimaCore.Operators.InterpolateF2C), called `first_order_If2c` in the example code.
+* ``I^f`` is the [center-to-face reconstruction operator](https://clima.github.io/ClimaCore.jl/stable/operators/#ClimaCore.Operators.InterpolateC2F), called `first_order_Ic2f` in the example code.
+  - Currently this is just the arithmetic mean, but we will need to use a weighted version with stretched vertical grids.
+* ``U^f`` is the [center-to-face upwind product operator](https://clima.github.io/ClimaCore.jl/stable/operators/#ClimaCore.Operators.Upwind3rdOrderBiasedProductC2F), called `third_order_upwind_c2f` in the example code
+  - This operator is of third-order of accuracy (when used with a constant vertical velocity and some reduced, but still high-order for non constant vertical velocity).
+
+
+#### Differentiation operators
+
+- ``D_h`` is the [discrete horizontal weak spectral divergence](https://clima.github.io/ClimaCore.jl/stable/operators/#ClimaCore.Operators.WeakDivergence), called `hwdiv` in the example code.
+- ``D^c_v`` is the [face-to-center vertical divergence](https://clima.github.io/ClimaCore.jl/stable/operators/#ClimaCore.Operators.DivergenceF2C), called `vdivf2c` in the example code.
+  - This example uses advective fluxes equal to zero at the top and bottom boundaries.
+- ``G_h`` is the [discrete horizontal spectral gradient](https://clima.github.io/ClimaCore.jl/stable/operators/#ClimaCore.Operators.Gradient), called `hgrad` in the example code.
+
+To discretize the hyperdiffusion operator, ``g(\rho, q) = - \nu_4 [\nabla^4 (\rho q)]``, in the horizontal direction, we compose the horizontal weak divergence, ``D_h``, and the horizontal gradient operator, ``G_h``, twice, with an intermediate call to [`weighted_dss!`](@ref) between the two compositions, as in ``[g_2(\rho, g) \circ DSS(\rho, q) \circ g_1(\rho, q)]``, with:
+- ``g_1(\rho, q) = D_h(G_h(q))``
+- ``DSS(\rho, q) = DSS(g_1(\rho q))``
+- ``g_2(\rho, q) = -\nu_4 D_h(\rho G_h(\rho q))``
+    - with ``\nu_4`` the hyperviscosity coefficient.
+
+#### Problem flow and set-up
+
+This test case is set up in a Cartesian (box) domain `` [-2 \pi, 2 \pi]^2 \times [0, 4 \pi] ~\textrm{m}^3``, doubly periodic in the horizontal direction, but not in the vertical direction.
+
+The flow was chosen to be a spiral, i.e., so to have a horizontal uniform rotation, and a vertical velocity ``\boldsymbol{u}_v \equiv w = 0`` at the top and bottom boundaries, and ``\boldsymbol{u}_v \equiv w = 1`` in the center of the domain. Moreover, the flow is reversed in all directions halfway through the period so that the tracer blobs go back to its initial configuration (using the same speed scaling constant which was derived to account for the distance travelled in all directions in a half period).
+
+```math
+\begin{align}
+    u &= -u_0 (y - c_y) \cos(\pi t / T_f) \nonumber \\
+    v &= u_0 (x - c_x) \cos(\pi t / T_f) \nonumber \\
+    w &= u_0 \sin(\pi z / z_m) \cos(\pi t / T_f) \nonumber
+\label{eq:flow}
+\end{align}
+```
+where ``u_0 = \pi / 2`` is the speed scaling factor to have the flow reversed halfway through the period, ``\boldsymbol{c} = (c_x, c_y)`` is the center of the rotational flow, which coincides with the center of the domain,  ``z_m = 4 \pi`` is the maximum height of the domain, and `` T_f = 2 \pi`` is the final simulation time, which coincides with the temporal period to have a full rotation in the horizontal direction.
+
+This example is set up to run with three possible initial conditions:
+- `cosine_bells`
+- `gaussian_bells`
+- `slotted_spheres`: a slight modification of the 2D slotted cylinder test case available in the literature (cfr: [GubaOpt2014](@cite)).
+
+## 2D Sphere examples
+
+## 3D Sphere examples

--- a/examples/Manifest.toml
+++ b/examples/Manifest.toml
@@ -96,9 +96,9 @@ version = "0.1.1"
 
 [[deps.CPUSummary]]
 deps = ["CpuId", "IfElse", "Static"]
-git-tree-sha1 = "913b28a04929053e4310d0a4915f1efe195c0ce6"
+git-tree-sha1 = "80f3d536df634cabed8b98ad3f0cea3a715fd254"
 uuid = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"
-version = "0.1.19"
+version = "0.1.20"
 
 [[deps.CUDA]]
 deps = ["AbstractFFTs", "Adapt", "BFloat16s", "CEnum", "CompilerSupportLibraries_jll", "ExprTools", "GPUArrays", "GPUCompiler", "LLVM", "LazyArtifacts", "Libdl", "LinearAlgebra", "Logging", "Printf", "Random", "Random123", "RandomNumbers", "Reexport", "Requires", "SparseArrays", "SpecialFunctions", "TimerOutputs"]
@@ -173,9 +173,9 @@ version = "0.7.1"
 
 [[deps.ClimaTimeSteppers]]
 deps = ["CUDA", "DiffEqBase", "DiffEqCallbacks", "KernelAbstractions", "LinearAlgebra", "MPI", "SciMLBase", "StaticArrays"]
-git-tree-sha1 = "bcd531eff2eea0e29e35d255bfa8450bb696748b"
+git-tree-sha1 = "c37396ad5e74f42da86d9baba166987933e8fadd"
 uuid = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
-version = "0.2.0"
+version = "0.2.1"
 
 [[deps.CloseOpenIntervals]]
 deps = ["ArrayInterface", "Static"]

--- a/examples/hybrid/box/limiters_advection.jl
+++ b/examples/hybrid/box/limiters_advection.jl
@@ -1,0 +1,476 @@
+using LinearAlgebra
+
+import ClimaCore:
+    Domains,
+    Fields,
+    Geometry,
+    Meshes,
+    Operators,
+    Spaces,
+    Topologies,
+    Limiters,
+    slab
+import ClimaCore.Geometry: ⊗
+using OrdinaryDiffEq: ODEProblem, solve
+using DiffEqBase
+using ClimaTimeSteppers
+
+import Logging
+import TerminalLoggers
+Logging.global_logger(TerminalLoggers.TerminalLogger())
+
+"""
+    convergence_rate(err, Δh)
+
+Estimate convergence rate given vectors `err` and `Δh`
+
+    err = C Δh^p + H.O.T
+    err_k ≈ C Δh_k^p
+    err_k/err_m ≈ Δh_k^p/Δh_m^p
+    log(err_k/err_m) ≈ log((Δh_k/Δh_m)^p)
+    log(err_k/err_m) ≈ p*log(Δh_k/Δh_m)
+    log(err_k/err_m)/log(Δh_k/Δh_m) ≈ p
+
+"""
+convergence_rate(err, Δh) =
+    [log(err[i] / err[i - 1]) / log(Δh[i] / Δh[i - 1]) for i in 2:length(Δh)]
+
+# Function space setup
+function hvspace_3D(
+    FT = Float64;
+    xlim = (-2π, 2π),
+    ylim = (-2π, 2π),
+    zlim = (0, 4π),
+    xelems = 16,
+    yelems = 16,
+    zelems = 16,
+    Nij = 2,
+)
+
+    xdomain = Domains.IntervalDomain(
+        Geometry.XPoint{FT}(xlim[1]),
+        Geometry.XPoint{FT}(xlim[2]),
+        periodic = true,
+    )
+    ydomain = Domains.IntervalDomain(
+        Geometry.YPoint{FT}(ylim[1]),
+        Geometry.YPoint{FT}(ylim[2]),
+        periodic = true,
+    )
+
+    horzdomain = Domains.RectangleDomain(xdomain, ydomain)
+    horzmesh = Meshes.RectilinearMesh(horzdomain, xelems, yelems)
+    horztopology = Topologies.Topology2D(horzmesh)
+
+    zdomain = Domains.IntervalDomain(
+        Geometry.ZPoint{FT}(zlim[1]),
+        Geometry.ZPoint{FT}(zlim[2]);
+        boundary_names = (:bottom, :top),
+    )
+    vertmesh = Meshes.IntervalMesh(zdomain, nelems = zelems)
+    vert_center_space = Spaces.CenterFiniteDifferenceSpace(vertmesh)
+
+    quad = Spaces.Quadratures.GLL{Nij}()
+    horzspace = Spaces.SpectralElementSpace2D(horztopology, quad)
+
+    hv_center_space =
+        Spaces.ExtrudedFiniteDifferenceSpace(horzspace, vert_center_space)
+    hv_face_space = Spaces.FaceExtrudedFiniteDifferenceSpace(hv_center_space)
+    return (horzspace, hv_center_space, hv_face_space)
+end
+
+# Advection problem on a 3D Cartesian domain with bounds-preserving quasimonotone horizontal limiter.
+# The initial condition can be set via a command line argument.
+# Possible test cases are: cosine_bells (default), gaussian_bells, and cylinders
+
+FT = Float64
+
+# Set up physical parameters
+const xmin = -2π              # domain x lower bound
+const xmax = 2π               # domain x upper bound
+const ymin = -2π              # domain y lower bound
+const ymax = 2π               # domain y upper bound
+const zmin = 0                # domain z lower bound
+const zmax = 4π               # domain z upper bound
+const ρ₀ = 1.0                # air density
+const D₄ = 0.0                # hyperdiffusion coefficient
+const u0 = π / 2              # angular velocity
+const r0 = (xmax - xmin) / 6  # bells radius
+const end_time = 2π           # simulation period in seconds
+const dt = end_time / 800
+const n_steps = Int(round(end_time / dt))
+const flow_center = Geometry.XYZPoint(
+    xmin + (xmax - xmin) / 2,
+    ymin + (ymax - ymin) / 2,
+    zmin + (zmax - zmin) / 2,
+)
+const bell_centers = [
+    Geometry.XYZPoint(
+        xmin + (xmax - xmin) / 4,
+        ymin + (ymax - ymin) / 2,
+        zmin + (zmax - zmin) / 2,
+    ),
+    Geometry.XYZPoint(
+        xmin + 3 * (xmax - xmin) / 4,
+        ymin + (ymax - ymin) / 2,
+        zmin + (zmax - zmin) / 2,
+    ),
+]
+const zelems = 8
+
+# Set up test parameters
+const test_name = get(ARGS, 1, "cosine_bells") # default test case to run
+const cosine_test_name = "cosine_bells"
+const gaussian_test_name = "gaussian_bells"
+const cylinder_test_name = "slotted_spheres"
+const lim_flag = true
+const limiter_tol = 5e-14
+
+# Plot variables and auxiliary function
+ENV["GKSwstype"] = "nul"
+using ClimaCorePlots, Plots
+Plots.GRBackend()
+dirname = "box_advection_limiter_$(test_name)"
+
+if lim_flag == false
+    dirname = "$(dirname)_no_lim"
+end
+if D₄ == 0
+    dirname = "$(dirname)_D0"
+end
+
+path = joinpath(@__DIR__, "output", dirname)
+mkpath(path)
+
+function linkfig(figpath, alt = "")
+    # buildkite-agent upload figpath
+    # link figure in logs if we are running on CI
+    if get(ENV, "BUILDKITE", "") == "true"
+        artifact_url = "artifact://$figpath"
+        print("\033]1338;url='$(artifact_url)';alt='$(alt)'\a\n")
+    end
+end
+
+# Set up spatial discretization
+horz_ne_seq = 2 .^ (2, 3, 4, 5)
+Δh = zeros(FT, length(horz_ne_seq))
+L1err, L2err, Linferr = zeros(FT, length(horz_ne_seq)),
+zeros(FT, length(horz_ne_seq)),
+zeros(FT, length(horz_ne_seq))
+Nij = 3
+
+# h-refinement study loop
+for (k, horz_ne) in enumerate(horz_ne_seq)
+    # Set up 3D spatial domain - doubly periodic box
+    horzspace, hv_center_space, hv_face_space = hvspace_3D(
+        FT,
+        Nij = Nij,
+        xelems = horz_ne,
+        yelems = horz_ne,
+        zelems = zelems,
+    )
+
+    # Initialize variables needed for limiters
+    horz_n_elems = Topologies.nlocalelems(horzspace.topology)
+    min_q = zeros(horz_n_elems, zelems)
+    max_q = zeros(horz_n_elems, zelems)
+
+    center_coords = Fields.coordinate_field(hv_center_space)
+    face_coords = Fields.coordinate_field(hv_face_space)
+    Δh[k] = (xmax - xmin) / horz_ne
+
+    # Initialize state
+    y0 = map(center_coords) do coord
+        x, y, z = coord.x, coord.y, coord.z
+
+        rd = Vector{Float64}(undef, 2)
+        for i in 1:2
+            rd[i] = Geometry.euclidean_distance(coord, bell_centers[i])
+        end
+
+        # Initialize specific tracer concentration
+        if test_name == cylinder_test_name
+            if rd[1] <= r0 && abs(x - bell_centers[1].x) >= r0 / 6
+                q = 1.0
+            elseif rd[2] <= r0 && abs(x - bell_centers[2].x) >= r0 / 6
+                q = 1.0
+            elseif rd[1] <= r0 &&
+                   abs(x - bell_centers[1].x) < r0 / 6 &&
+                   (y - bell_centers[1].y) < -5 * r0 / 12
+                q = 1.0
+            elseif rd[2] <= r0 &&
+                   abs(x - bell_centers[2].x) < r0 / 6 &&
+                   (y - bell_centers[2].y) > 5 * r0 / 12
+                q = 1.0
+            else
+                q = 0.1
+            end
+        elseif test_name == gaussian_test_name
+            q = 0.95 * (exp(-5.0 * (rd[1] / r0)^2) + exp(-5.0 * (rd[2] / r0)^2))
+        else # default test case, cosine bells
+            if rd[1] < r0
+                q = 0.1 + 0.9 * (1 / 2) * (1 + cospi(rd[1] / r0))
+            elseif rd[2] < r0
+                q = 0.1 + 0.9 * (1 / 2) * (1 + cospi(rd[2] / r0))
+            else
+                q = 0.1
+            end
+        end
+
+        # Initialize air density
+        ρ = ρ₀
+
+        # Tracer density
+        Q = ρ * q
+        return (ρ = ρ, ρq = Q)
+    end
+
+    y0 = Fields.FieldVector(ρ = y0.ρ, ρq = y0.ρq)
+
+    function f!(dy, y, parameters, t, alpha, beta)
+
+        end_time = parameters.end_time
+        center_coords = parameters.center_coords
+        face_coords = parameters.face_coords
+        zf = face_coords.z
+        xc, yc = center_coords.x, center_coords.y
+
+        # Define the flow
+        uu = @. -u0 * (yc - flow_center.y) * cospi(t / end_time)
+        uv = @. u0 * (xc - flow_center.x) * cospi(t / end_time)
+        uw = @. u0 * sinpi(zf / zmax) * cospi(t / end_time)
+
+        uₕ = Geometry.Covariant12Vector.(Geometry.UVVector.(uu, uv))
+        w = Geometry.Covariant3Vector.(Geometry.WVector.(uw))
+
+        # Set up operators
+        # Spectral horizontal operators
+        hgrad = Operators.Gradient()
+        hwdiv = Operators.WeakDivergence()
+        # Vertical staggered FD operators
+        first_order_Ic2f = Operators.InterpolateC2F(
+            bottom = Operators.Extrapolate(),
+            top = Operators.Extrapolate(),
+        )
+        first_order_If2c = Operators.InterpolateF2C()
+        vdivf2c = Operators.DivergenceF2C(
+            top = Operators.SetValue(Geometry.Contravariant3Vector(FT(0.0))),
+            bottom = Operators.SetValue(Geometry.Contravariant3Vector(FT(0.0))),
+        )
+        third_order_upwind_c2f = Operators.Upwind3rdOrderBiasedProductC2F(
+            bottom = Operators.ThirdOrderOneSided(),
+            top = Operators.ThirdOrderOneSided(),
+        )
+
+        vert_flux_wρ = vdivf2c.(w .* first_order_Ic2f.(y.ρ))
+        vert_flux_wρq =
+            vdivf2c.(
+                first_order_Ic2f.(y.ρ) .*
+                third_order_upwind_c2f.(w, y.ρq ./ y.ρ),
+            )
+
+        # Compute min_q[] and max_q[] that will be needed later in the stage limiter
+        horzspace = parameters.horzspace
+        horz_n_elems = Topologies.nlocalelems(horzspace)
+        topology = horzspace.topology
+
+        horz_neigh_elems_q_min = Array{FT}(undef, 8, zelems)
+        horz_neigh_elems_q_max = Array{FT}(undef, 8, zelems)
+        horz_q_e = Array{Fields.Field}(undef, zelems)
+        horz_q_e_min = Array{FT}(undef, zelems)
+        horz_q_e_max = Array{FT}(undef, zelems)
+
+        for v in 1:zelems
+            for he in 1:horz_n_elems
+                horz_q_e[v] =
+                    Fields.slab(y.ρq, v, he) ./ Fields.slab(y.ρ, v, he)
+
+                horz_q_e_min[v] = minimum(horz_q_e[v])
+                horz_q_e_max[v] = maximum(horz_q_e[v])
+                horz_neigh_elems = Topologies.neighboring_elements(topology, he)
+                for i in 1:length(horz_neigh_elems)
+                    if horz_neigh_elems[i] == 0
+                        horz_neigh_elems_q_min[i] = +Inf
+                        horz_neigh_elems_q_max[i] = -Inf
+                    else
+                        horz_neigh_elems_q_min[i] = Fields.minimum(
+                            Fields.slab(y.ρq, v, horz_neigh_elems[i]) ./
+                            Fields.slab(y.ρ, v, horz_neigh_elems[i]),
+                        )
+                        horz_neigh_elems_q_max[i] = Fields.maximum(
+                            Fields.slab(y.ρq, v, horz_neigh_elems[i]) ./
+                            Fields.slab(y.ρ, v, horz_neigh_elems[i]),
+                        )
+                    end
+                end
+                parameters.min_q[he, v] =
+                    min(minimum(horz_neigh_elems_q_min), horz_q_e_min[v])
+                parameters.max_q[he, v] =
+                    max(maximum(horz_neigh_elems_q_max), horz_q_e_max[v])
+            end
+        end
+
+        # Compute hyperviscosity for the tracer equation by splitting it in two diffusion calls
+        ystar = similar(y)
+        @. ystar.ρq = hwdiv(hgrad(y.ρq / y.ρ))
+        Spaces.weighted_dss!(ystar.ρq)
+        @. ystar.ρq = -D₄ * hwdiv(y.ρ * hgrad(ystar.ρq))
+
+        # Compute vertical velocity by interpolating faces to centers
+        cw = first_order_If2c.(w)        # Covariant3Vector on faces, interpolated to centers
+        cuvw =
+            Geometry.Covariant123Vector.(uₕ) .+ Geometry.Covariant123Vector.(cw)
+
+        # 1) Contintuity equation:
+        # 1.1) Horizontal advective flux with horizontal/vertical velocity
+        @. dy.ρ = beta * dy.ρ - alpha * hwdiv(y.ρ * cuvw)
+
+        # 1.2) Horizontal advective flux with vertical velocity
+        # already accounted for in 1.1)
+
+        # 1.3) Vertical advective flux with horizontal velocity
+        @. dy.ρ -= alpha * vdivf2c.(first_order_Ic2f.(y.ρ .* uₕ))
+
+        # 1.4) Vertical advective flux with vertical velocity
+        @. dy.ρ -= alpha * vert_flux_wρ
+
+        # 2) Advection of tracers equation:
+        # 2.1) Horizontal advective flux with horizontal/vertical velocity
+        @. dy.ρq = beta * dy.ρq - alpha * hwdiv(y.ρq * cuvw) + alpha * ystar.ρq
+
+        # 2.2) Horizontal advective flux with vertical velocity
+        # already accounted for in 2.1)
+
+        # 2.3) Vertical advective flux with horizontal velocity
+        @. dy.ρq -= alpha * vdivf2c.(first_order_Ic2f.(y.ρq .* uₕ))
+
+        # 2.4) Vertical advective flux with vertical velocity
+        @. dy.ρq -= alpha * vert_flux_wρq
+
+        min_q = parameters.min_q
+        max_q = parameters.max_q
+
+        if lim_flag
+            # Call quasimonotone limiter, to find optimal ρq (where ρq gets updated in place)
+            Limiters.quasimonotone_limiter!(
+                dy.ρq,
+                dy.ρ,
+                min_q,
+                max_q,
+                rtol = limiter_tol,
+            )
+        end
+        Spaces.weighted_dss!(dy.ρ)
+        Spaces.weighted_dss!(dy.ρq)
+    end
+
+    # Set up RHS function
+    ystar = copy(y0)
+    parameters = (
+        horzspace = horzspace,
+        min_q = min_q,
+        max_q = max_q,
+        end_time = end_time,
+        center_coords = center_coords,
+        face_coords = face_coords,
+    )
+    f!(ystar, y0, parameters, 0.0, dt, 1)
+
+    # Solve the ODE
+    prob = ODEProblem(
+        IncrementingODEFunction(f!),
+        copy(y0),
+        (0.0, end_time),
+        parameters,
+    )
+    sol = solve(
+        prob,
+        SSPRK33ShuOsher(),
+        dt = dt,
+        saveat = 0.99 * 80 * dt,
+        progress = true,
+        adaptive = false,
+        progress_message = (dt, u, p, t) -> t,
+    )
+    L1err[k] = norm(
+        (sol.u[end].ρq ./ sol.u[end].ρ .- y0.ρq ./ y0.ρ) ./ (y0.ρq ./ y0.ρ),
+        1,
+    )
+    L2err[k] = norm(
+        (sol.u[end].ρq ./ sol.u[end].ρ .- y0.ρq ./ y0.ρ) ./ (y0.ρq ./ y0.ρ),
+    )
+    Linferr[k] = norm(
+        (sol.u[end].ρq ./ sol.u[end].ρ .- y0.ρq ./ y0.ρ) ./ (y0.ρq ./ y0.ρ),
+        Inf,
+    )
+
+    @info "Test case: $(test_name)"
+    @info "With limiter: $(lim_flag)"
+    @info "Hyperdiffusion coefficient: D₄ = $(D₄)"
+    @info "Number of elements in XYZ domain: $(horz_ne) x $(horz_ne) x $(zelems)"
+    @info "Number of quadrature points per horizontal element: $(Nij) x $(Nij) (p = $(Nij-1))"
+    @info "Time step dt = $(dt) (s)"
+    @info "Tracer concentration norm at t = 0 (s): ", norm(y0.ρq ./ y0.ρ)
+    @info "Tracer concentration norm at $(n_steps) time steps, t = $(end_time) (s): ",
+    norm(sol.u[end].ρq ./ sol.u[end].ρ)
+    @info "L₁ error at $(n_steps) time steps, t = $(end_time) (s): ", L1err[k]
+    @info "L₂ error at $(n_steps) time steps, t = $(end_time) (s): ", L2err[k]
+    @info "L∞ error at $(n_steps) time steps, t = $(end_time) (s): ", Linferr[k]
+end
+
+# Print convergence rate info
+conv = convergence_rate(L2err, Δh)
+@info "Converge rates for this test case are: ", conv
+
+# Plot the errors
+# L₁ error Vs number of elements
+Plots.png(
+    Plots.plot(
+        collect(horz_ne_seq),
+        L1err,
+        yscale = :log10,
+        xlabel = "Nₑ",
+        ylabel = "log₁₀(L₁ err)",
+        label = "",
+    ),
+    joinpath(path, "L1error.png"),
+)
+linkfig(
+    relpath(joinpath(path, "L1error.png"), joinpath(@__DIR__, "../..")),
+    "L₁ error Vs Nₑ",
+)
+
+
+# L₂ error Vs number of elements
+Plots.png(
+    Plots.plot(
+        collect(horz_ne_seq),
+        L2err,
+        yscale = :log10,
+        xlabel = "Nₑ",
+        ylabel = "log₁₀(L₂ err)",
+        label = "",
+    ),
+    joinpath(path, "L2error.png"),
+)
+linkfig(
+    relpath(joinpath(path, "L2error.png"), joinpath(@__DIR__, "../..")),
+    "L₂ error Vs Nₑ",
+)
+
+# L∞ error Vs number of elements
+Plots.png(
+    Plots.plot(
+        collect(horz_ne_seq),
+        Linferr,
+        yscale = :log10,
+        xlabel = "Nₑ",
+        ylabel = "log₁₀(L∞ err)",
+        label = "",
+    ),
+    joinpath(path, "Linferror.png"),
+)
+linkfig(
+    relpath(joinpath(path, "Linferror.png"), joinpath(@__DIR__, "../..")),
+    "L∞ error Vs Nₑ",
+)


### PR DESCRIPTION
This PR adds a test case for 3D limiters in a Cartesian (box) domain. 
The flow is ~non-uniform~ constant in the vertical, rotational in the horizontal and reversed halfway the period.

This is the first example/integration test case in ClimaCore.jl that showcases the usage of `ClimaTimeSteppers`, and that also demonstrates the usage of a third-order upwinding `Upwind3rdOrderBiasedProductC2F` FD operator in the vertical. 

Dependencies for this PR: PR #620, #643, and #683.

Sub-tasks:

- [x] Modify the ODE solve to work separately in the horizontal and in the vertical  (i.e., remove the stage callback mechanism we had when using the `OrdinaryDiffEq` package). Adapted, based in what was done in 2D in #620.
- [x] use third-order upwinding `Upwind3rdOrderBiasedProductC2F` FD operator in the vertical
- [x] Use slotted spheres IC: a slight modification of the 2D slotted cylinders IC  
- [x] Added this example to buildkite's pipeline and check artifacts
- [x] Added documentation 

All done. 

This will close #575 

cc: @simonbyrne 