### PR TITLE
Update implict solver unit test

### DIFF
--- a/examples/hybrid/schur_complement_W.jl
+++ b/examples/hybrid/schur_complement_W.jl
@@ -174,21 +174,23 @@ function linsolve!(::Type{Val{:init}}, f, u0; kwargs...)
             ΔY = Array{FT}(undef, 3 * Nv + 1)
             ΔΔY = Array{FT}(undef, 3 * Nv + 1)
             for h in 1:Nh, j in 1:Nj, i in 1:Ni
-                ∂Yₜ∂Y .= 0.0
+                ∂Yₜ∂Y .= zero(FT)
                 ∂Yₜ∂Y[1:Nv, (2 * Nv + 1):(3 * Nv + 1)] .=
-                    column_matrix(∂ᶜρₜ∂ᶠ𝕄, i, j, h)
+                    matrix_column(∂ᶜρₜ∂ᶠ𝕄, axes(x.f), i, j, h)
                 ∂Yₜ∂Y[(Nv + 1):(2 * Nv), (2 * Nv + 1):(3 * Nv + 1)] .=
-                    column_matrix(∂ᶜ𝔼ₜ∂ᶠ𝕄, i, j, h)
+                    matrix_column(∂ᶜ𝔼ₜ∂ᶠ𝕄, axes(x.f), i, j, h)
                 ∂Yₜ∂Y[(2 * Nv + 1):(3 * Nv + 1), 1:Nv] .=
-                    column_matrix(∂ᶠ𝕄ₜ∂ᶜρ, i, j, h)
+                    matrix_column(∂ᶠ𝕄ₜ∂ᶜρ, axes(x.c), i, j, h)
                 ∂Yₜ∂Y[(2 * Nv + 1):(3 * Nv + 1), (Nv + 1):(2 * Nv)] .=
-                    column_matrix(∂ᶠ𝕄ₜ∂ᶜ𝔼, i, j, h)
-                ΔY[1:Nv] .= column_vector(xᶜρ, i, j, h)
-                ΔY[(Nv + 1):(2 * Nv)] .= column_vector(xᶜ𝔼, i, j, h)
-                ΔY[(2 * Nv + 1):(3 * Nv + 1)] .= column_vector(xᶠ𝕄, i, j, h)
-                ΔΔY[1:Nv] .= column_vector(bᶜρ, i, j, h)
-                ΔΔY[(Nv + 1):(2 * Nv)] .= column_vector(bᶜ𝔼, i, j, h)
-                ΔΔY[(2 * Nv + 1):(3 * Nv + 1)] .= column_vector(bᶠ𝕄, i, j, h)
+                    matrix_column(∂ᶠ𝕄ₜ∂ᶜ𝔼, axes(x.c), i, j, h)
+                ∂Yₜ∂Y[(2 * Nv + 1):(3 * Nv + 1), (2 * Nv + 1):(3 * Nv + 1)] .=
+                    matrix_column(∂ᶠ𝕄ₜ∂ᶠ𝕄, axes(x.f), i, j, h)
+                ΔY[1:Nv] .= vector_column(xᶜρ, i, j, h)
+                ΔY[(Nv + 1):(2 * Nv)] .= vector_column(xᶜ𝔼, i, j, h)
+                ΔY[(2 * Nv + 1):(3 * Nv + 1)] .= vector_column(xᶠ𝕄, i, j, h)
+                ΔΔY[1:Nv] .= vector_column(bᶜρ, i, j, h)
+                ΔΔY[(Nv + 1):(2 * Nv)] .= vector_column(bᶜ𝔼, i, j, h)
+                ΔΔY[(2 * Nv + 1):(3 * Nv + 1)] .= vector_column(bᶠ𝕄, i, j, h)
                 @assert (-LinearAlgebra.I + dtγ * ∂Yₜ∂Y) * ΔY ≈ ΔΔY
             end
         end

--- a/examples/hybrid/staggered_nonhydrostatic_model.jl
+++ b/examples/hybrid/staggered_nonhydrostatic_model.jl
@@ -107,7 +107,7 @@ function implicit_tendency!(Yₜ, Y, p, t)
     # allocation because the cache is stored separately from Y, which means that
     # similar(Y, <:Dual) doesn't allocate an appropriate cache for computing Yₜ.
     if eltype(Y) <: Dual
-        ᶜK = similar(ᶜK)
+        ᶜK = similar(ᶜρ)
         ᶜp = similar(ᶜρ)
     end
 
@@ -485,21 +485,23 @@ function Wfact!(W, Y, p, dtγ, t)
             ᶜ𝔼_name = :ρe_int
         end
         args = (implicit_tendency!, Y, p, t, i, j, h)
-        @assert column_matrix(∂ᶜρₜ∂ᶠ𝕄, i, j, h) ==
+        @assert matrix_column(∂ᶜρₜ∂ᶠ𝕄, axes(Y.f), i, j, h) ==
                 exact_column_jacobian_block(args..., (:c, :ρ), (:f, :w))
-        @assert column_matrix(∂ᶠ𝕄ₜ∂ᶜ𝔼, i, j, h) ≈
+        @assert matrix_column(∂ᶠ𝕄ₜ∂ᶜ𝔼, axes(Y.c), i, j, h) ≈
                 exact_column_jacobian_block(args..., (:f, :w), (:c, ᶜ𝔼_name))
-        ∂ᶜ𝔼ₜ∂ᶠ𝕄_approx = column_matrix(∂ᶜ𝔼ₜ∂ᶠ𝕄, i, j, h)
+        @assert matrix_column(∂ᶠ𝕄ₜ∂ᶠ𝕄, axes(Y.f), i, j, h) ≈
+                exact_column_jacobian_block(args..., (:f, :w), (:f, :w))
+        ∂ᶜ𝔼ₜ∂ᶠ𝕄_approx = matrix_column(∂ᶜ𝔼ₜ∂ᶠ𝕄, axes(Y.f), i, j, h)
         ∂ᶜ𝔼ₜ∂ᶠ𝕄_exact =
             exact_column_jacobian_block(args..., (:c, ᶜ𝔼_name), (:f, :w))
-        if flags.∂ᶠ𝕄ₜ∂ᶜρ_mode == :exact
+        if flags.∂ᶜ𝔼ₜ∂ᶠ𝕄_mode == :exact
             @assert ∂ᶜ𝔼ₜ∂ᶠ𝕄_approx ≈ ∂ᶜ𝔼ₜ∂ᶠ𝕄_exact
         else
             err = norm(∂ᶜ𝔼ₜ∂ᶠ𝕄_approx .- ∂ᶜ𝔼ₜ∂ᶠ𝕄_exact) / norm(∂ᶜ𝔼ₜ∂ᶠ𝕄_exact)
             @assert err < 1e-6
             # Note: the highest value seen so far is ~3e-7 (only applies to ρe)
         end
-        ∂ᶠ𝕄ₜ∂ᶜρ_approx = column_matrix(∂ᶠ𝕄ₜ∂ᶜρ, i, j, h)
+        ∂ᶠ𝕄ₜ∂ᶜρ_approx = matrix_column(∂ᶠ𝕄ₜ∂ᶜρ, axes(Y.c), i, j, h)
         ∂ᶠ𝕄ₜ∂ᶜρ_exact = exact_column_jacobian_block(args..., (:f, :w), (:c, :ρ))
         if flags.∂ᶠ𝕄ₜ∂ᶜρ_mode == :exact
             @assert ∂ᶠ𝕄ₜ∂ᶜρ_approx ≈ ∂ᶠ𝕄ₜ∂ᶜρ_exact

--- a/examples/implicit_solver_debugging_tools.jl
+++ b/examples/implicit_solver_debugging_tools.jl
@@ -34,42 +34,23 @@ function exact_column_jacobian_block(
     return vcat(map(dual -> [dual.partials.values...]', parent(col))...)
 end
 
-# TODO: This only works for scalar stencils.
-function column_matrix(stencil, i, j, h)
-    column_stencil = Spaces.column(stencil, i, j, h)
-
-    space = axes(column_stencil)
-    n_rows = Spaces.nlevels(space)
-
-    lbw, ubw = Operators.bandwidths(eltype(column_stencil))
-    n_diags = ubw - lbw + 1
-
-    # We can only infer the the argument space's axes from NaNs in the stencil.
-    loc = Operators.Interior()
-    isnt_left_boundary_row(i_row) =
-        !isnan(Operators.getidx(column_stencil, loc, i_row)[1])
-    isnt_right_boundary_row(i_row) =
-        !isnan(Operators.getidx(column_stencil, loc, i_row)[n_diags])
-    indices = Operators.left_idx(space):Operators.right_idx(space)
-    i_first_interior_row = findfirst(isnt_left_boundary_row, indices)
-    i_last_interior_row = findlast(isnt_right_boundary_row, indices)
-
-    n_cols = i_last_interior_row - i_first_interior_row + n_diags
-
-    function diag_key_value(i_diag)
-        start_index = max(i_first_interior_row - (i_diag - 1), 1)
-        end_index = min(i_last_interior_row + (n_diags - i_diag), n_rows)
-        array = parent(getproperty(column_stencil.coefs, i_diag))
-        @assert length(array) == size(array, 1)
-        return (i_diag - i_first_interior_row) =>
-            view(array, start_index:end_index)
-    end
-
-    return spdiagm(n_rows, n_cols, ntuple(diag_key_value, n_diags)...)
-end
-
-function column_vector(arg, i, j, h)
-    array = parent(Spaces.column(arg, i, j, h))
-    @assert length(array) == size(array, 1)
-    return array
+# Note: These only work for scalar stencils.
+vector_column(arg, i, j, h) = parent(Spaces.column(arg, i, j, h))
+function matrix_column(stencil, stencil_input_space, i, j, h)
+    lbw, ubw = Operators.bandwidths(eltype(stencil))
+    coefs_column = Spaces.column(stencil, i, j, h).coefs
+    row_space = axes(coefs_column)
+    lrow = Operators.left_idx(row_space)
+    rrow = Operators.right_idx(row_space)
+    num_rows = rrow - lrow + 1
+    col_space = Spaces.column(stencil_input_space, i, j, h)
+    lcol = Operators.left_idx(col_space)
+    rcol = Operators.right_idx(col_space)
+    num_cols = rcol - lcol + 1
+    diag_key_value(diag) =
+        (diag + lrow - lcol) => view(
+            parent(getproperty(coefs_column, diag - lbw + 1)),
+            (max(lrow, lcol - diag):min(rrow, rcol - diag)) .- (lrow - 1),
+        )
+    return spdiagm(num_rows, num_cols, map(diag_key_value, lbw:ubw)...)
 end

--- a/src/Operators/operator2stencil.jl
+++ b/src/Operators/operator2stencil.jl
@@ -107,7 +107,7 @@ function stencil_left_boundary(
     arg,
 )
     T = eltype(arg)
-    return StencilCoefs{-half, half}((nan(T), zero(T)))
+    return StencilCoefs{-half, half}((zero(T), zero(T)))
 end
 function stencil_right_boundary(
     ::Operator2Stencil{<:InterpolateC2F},
@@ -117,7 +117,7 @@ function stencil_right_boundary(
     arg,
 )
     T = eltype(arg)
-    return StencilCoefs{-half, half}((zero(T), nan(T)))
+    return StencilCoefs{-half, half}((zero(T), zero(T)))
 end
 function stencil_left_boundary(
     ::Operator2Stencil{<:InterpolateC2F},
@@ -127,7 +127,7 @@ function stencil_left_boundary(
     arg,
 )
     val⁺ = getidx(arg, loc, idx + half)
-    return StencilCoefs{-half, half}((nan(val⁺), val⁺))
+    return StencilCoefs{-half, half}((zero(val⁺), val⁺))
 end
 function stencil_right_boundary(
     ::Operator2Stencil{<:InterpolateC2F},
@@ -137,7 +137,7 @@ function stencil_right_boundary(
     arg,
 )
     val⁻ = getidx(arg, loc, idx - half)
-    return StencilCoefs{-half, half}((val⁻, nan(val⁻)))
+    return StencilCoefs{-half, half}((val⁻, zero(val⁻)))
 end
 
 
@@ -151,19 +151,12 @@ function stencil_interior(
     return StencilCoefs{-half, -half}((val⁻,))
 end
 stencil_left_boundary(
-    ::Operator2Stencil{<:LeftBiasedF2C},
+    ::Operator2Stencil{<:Union{LeftBiasedF2C, LeftBiasedC2F}},
     bc::SetValue,
     loc,
     idx,
     arg,
 ) = StencilCoefs{-half, -half}((zero(eltype(arg)),))
-stencil_left_boundary(
-    ::Operator2Stencil{<:LeftBiasedC2F},
-    bc::SetValue,
-    loc,
-    idx,
-    arg,
-) = StencilCoefs{-half, -half}((nan(eltype(arg)),))
 
 
 function stencil_interior(
@@ -176,19 +169,12 @@ function stencil_interior(
     return StencilCoefs{half, half}((val⁺,))
 end
 stencil_right_boundary(
-    ::Operator2Stencil{<:RightBiasedF2C},
+    ::Operator2Stencil{<:Union{RightBiasedF2C, RightBiasedC2F}},
     bc::SetValue,
     loc,
     idx,
     arg,
 ) = StencilCoefs{half, half}((zero(eltype(arg)),))
-stencil_right_boundary(
-    ::Operator2Stencil{<:RightBiasedC2F},
-    bc::SetValue,
-    loc,
-    idx,
-    arg,
-) = StencilCoefs{half, half}((nan(eltype(arg)),))
 
 
 function stencil_interior(
@@ -414,7 +400,7 @@ function stencil_left_boundary(
     arg,
 )
     val⁺ = Geometry.Covariant3Vector(2) ⊗ getidx(arg, loc, idx + half)
-    return StencilCoefs{-half, half}((nan(val⁺), val⁺))
+    return StencilCoefs{-half, half}((zero(val⁺), val⁺))
 end
 function stencil_right_boundary(
     ::Operator2Stencil{<:GradientC2F},
@@ -434,7 +420,7 @@ function stencil_left_boundary(
     arg,
 )
     T = Geometry.gradient_result_type(Val((3,)), eltype(arg))
-    return StencilCoefs{-half, half}((nan(T), zero(T)))
+    return StencilCoefs{-half, half}((zero(T), zero(T)))
 end
 function stencil_right_boundary(
     ::Operator2Stencil{<:GradientC2F},
@@ -444,7 +430,7 @@ function stencil_right_boundary(
     arg,
 )
     T = Geometry.gradient_result_type(Val((3,)), eltype(arg))
-    return StencilCoefs{-half, half}((zero(T), nan(T)))
+    return StencilCoefs{-half, half}((zero(T), zero(T)))
 end
 
 
@@ -528,7 +514,7 @@ function stencil_left_boundary(
     )
     J = Geometry.LocalGeometry(space, idx).J
     val⁺ = RecursiveApply.rdiv(Ju³⁺, J / 2)
-    return StencilCoefs{-half, half}((nan(val⁺), val⁺))
+    return StencilCoefs{-half, half}((zero(val⁺), val⁺))
 end
 function stencil_right_boundary(
     ::Operator2Stencil{<:DivergenceC2F},
@@ -544,7 +530,7 @@ function stencil_right_boundary(
     )
     J = Geometry.LocalGeometry(space, idx).J
     val⁻ = ⊟(RecursiveApply.rdiv(Ju³⁻, J / 2))
-    return StencilCoefs{-half, half}((val⁻, nan(val⁻)))
+    return StencilCoefs{-half, half}((val⁻, zero(val⁻)))
 end
 function stencil_left_boundary(
     ::Operator2Stencil{<:DivergenceC2F},
@@ -554,7 +540,7 @@ function stencil_left_boundary(
     arg,
 )
     T = Geometry.divergence_result_type(eltype(arg))
-    return StencilCoefs{-half, half}((nan(T), zero(T)))
+    return StencilCoefs{-half, half}((zero(T), zero(T)))
 end
 function stencil_right_boundary(
     ::Operator2Stencil{<:DivergenceC2F},
@@ -564,7 +550,7 @@ function stencil_right_boundary(
     arg,
 )
     T = Geometry.divergence_result_type(eltype(arg))
-    return StencilCoefs{-half, half}((zero(T), nan(T)))
+    return StencilCoefs{-half, half}((zero(T), zero(T)))
 end
 
 # Evaluate fd3_curl(u, zero(u), J).
@@ -597,7 +583,7 @@ function stencil_left_boundary(
     u₊ = getidx(arg, loc, idx + half)
     J = Geometry.LocalGeometry(space, idx).J
     val⁺ = fd3_curl⁺(u₊, J / 2)
-    return StencilCoefs{-half, half}((nan(val⁺), val⁺))
+    return StencilCoefs{-half, half}((zero(val⁺), val⁺))
 end
 function stencil_right_boundary(
     ::Operator2Stencil{<:CurlC2F},
@@ -610,7 +596,7 @@ function stencil_right_boundary(
     u₋ = getidx(arg, loc, idx - half)
     J = Geometry.LocalGeometry(space, idx).J
     val⁻ = ⊟(fd3_curl⁺(u₋, J))
-    return StencilCoefs{-half, half}((val⁻, nan(val⁻)))
+    return StencilCoefs{-half, half}((val⁻, zero(val⁻)))
 end
 function stencil_left_boundary(
     ::Operator2Stencil{<:CurlC2F},
@@ -620,7 +606,7 @@ function stencil_left_boundary(
     arg,
 )
     T = Geometry.curl_result_type(Val((3,)), eltype(arg))
-    return StencilCoefs{-half, half}((nan(T), zero(T)))
+    return StencilCoefs{-half, half}((zero(T), zero(T)))
 end
 function stencil_right_boundary(
     ::Operator2Stencil{<:CurlC2F},
@@ -630,5 +616,5 @@ function stencil_right_boundary(
     arg,
 )
     T = Geometry.curl_result_type(Val((3,)), eltype(arg))
-    return StencilCoefs{-half, half}((zero(T), nan(T)))
+    return StencilCoefs{-half, half}((zero(T), zero(T)))
 end

--- a/src/Operators/pointwisestencil.jl
+++ b/src/Operators/pointwisestencil.jl
@@ -412,7 +412,7 @@ end
 
 function get_i_vals_tuple(i_vals_at_j, stencil1, stencil2)
     lbw, ubw = composed_bandwidths(stencil1, stencil2)
-    return ntuple(j -> i_vals_at_j(j), (ubw - lbw + 1))
+    return ntuple(j -> i_vals_at_j(j), ubw - lbw + 1)
 end
 
 # TODO: Optimize this so that the generated version is unnecessary. This is
@@ -426,9 +426,9 @@ function compose_stencils_at_idx(i_vals_tuple, stencil1, stencil2, loc, idx)
     function j_func(j)
         i_vals = i_vals_tuple[j]
         return length(i_vals) == 0 ? zero(eltype(eltype(stencil1))) :
-               return mapreduce(i_func_at_j(j), ⊞, i_vals)
+               mapreduce(i_func_at_j(j), ⊞, i_vals)
     end
-    return StencilCoefs{lbw, ubw}(ntuple(j -> j_func(j), (ubw - lbw + 1)))
+    return StencilCoefs{lbw, ubw}(ntuple(j -> j_func(j), ubw - lbw + 1))
 end
 
 function compose_stencils_at_idx_expr(i_vals_tuple, stencil1_T, stencil2_T)
@@ -446,7 +446,7 @@ function compose_stencils_at_idx_expr(i_vals_tuple, stencil1_T, stencil2_T)
                :($(mapreduce(i_func_at_j(j), ⊞, i_vals)))
     end
     result_expr =
-        :(StencilCoefs{$lbw, $ubw}($(ntuple(j -> j_func(j), (ubw - lbw + 1)))))
+        :(StencilCoefs{$lbw, $ubw}($(ntuple(j -> j_func(j), ubw - lbw + 1))))
     return :($coefs_expr; return $result_expr)
 end
 

--- a/src/Operators/stencilcoefs.jl
+++ b/src/Operators/stencilcoefs.jl
@@ -3,8 +3,8 @@
 # The bandwidths are stored as type parameters to avoid allocating unnecessary
 # memory and to ensure that all the StencilCoefs in a Field have identical
 # bandwidths.
-# By convention, coefficients outside the matrix represented by a Field of
-# StencilCoefs should be set to NaN (or, rather, nan(T) for coefficient type T).
+# For simplicity, coefficients outside the matrix represented by a Field of
+# StencilCoefs can be set to 0 (or, rather, zero(T) for coefficient type T).
 struct StencilCoefs{lbw, ubw, C <: Tuple}
     coefs::C
 end
@@ -101,15 +101,3 @@ for op in (:+, :-, :*, :/, :÷, :\, :^, :%)
         ($op)(a, b::StencilCoefs) = map(c -> ($op)(a, c), b)
     end
 end
-
-##
-## Utilities
-##
-
-# Computes the equivalent of NaN for the type T. Similar to zero(T).
-nan(::T) where {T} = nan(T)
-nan(::Type{T}) where {T <: Number} = T(NaN)
-nan(::Type{T}) where {S, T′, N, L, T <: SArray{S, T′, N, L}} =
-    T(ntuple(_ -> nan(T′), Val(L)))
-nan(::Type{T}) where {T′, N, A, S, T <: Geometry.AxisTensor{T′, N, A, S}} =
-    T(axes(T), nan(S))


### PR DESCRIPTION
This PR updates the implicit solver unit test to account for the new Jacobian block `d w_t/d w`. In the process of making this update, I caught some minor bugs, and this PR fixes them. Note that these bugs only affected the unit test, not the actual simulations.