### PR TITLE
Add a cleanup script for deleting unwanted files

### DIFF
--- a/.dev/cleanup.jl
+++ b/.dev/cleanup.jl
@@ -1,0 +1,17 @@
+#=
+A simple script for cleaning up temporary files.
+=#
+
+code_dir = dirname(@__DIR__)
+
+for (root, dirs, files) in Base.Filesystem.walkdir(code_dir)
+    for f in files
+        if endswith(f, ".DS_Store")
+            rm(joinpath(root, f); force = true)
+        end
+        # https://github.com/JuliaLang/Pkg.jl/issues/3014
+        if basename(f) == "LocalPreferences.toml"
+            rm(joinpath(root, f); force = true)
+        end
+    end
+end


### PR DESCRIPTION
I'm finding as many as 6 `.DS_Store` files are generated when running a single example. This PR adds a script to help make deleting them easier. 