### PR TITLE
Update driver for distributed runs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -638,6 +638,7 @@ steps:
     artifact_paths:
       - "examples/hybrid/sphere/output/baroclinic_wave_rhoe/*"
     env:
+      TEST_NAME: "sphere/baroclinic_wave_rhoe"
       CLIMACORE_DISTRIBUTED: "MPI"
     agents:
       config: cpu
@@ -757,18 +758,18 @@ steps:
       queue: central
       slurm_ntasks: 1
 
-#  - label: ":computer: inertial gravity wave"
-#    key: "cpu_inertial_gravity_wave"
-#    command:
-#      - "julia --color=yes --project=examples examples/hybrid/driver.jl"
-#    artifact_paths:
-#      - "examples/hybrid/plane/output/inertial_gravity_wave/*"
-#    env:
-#      TEST_NAME: "plane/inertial_gravity_wave"
-#    agents:
-#      config: cpu
-#      queue: central
-#      slurm_ntasks: 1
+  - label: ":computer: inertial gravity wave"
+    key: "cpu_inertial_gravity_wave"
+    command:
+      - "julia --color=yes --project=examples examples/hybrid/driver.jl"
+    artifact_paths:
+      - "examples/hybrid/plane/output/inertial_gravity_wave/*"
+    env:
+      TEST_NAME: "plane/inertial_gravity_wave"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
 
   - label: ":rocket::computer: Allocations analysis"
     key: "cpu_allocations"

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -1,24 +1,50 @@
-usempi = get(ENV, "CLIMACORE_DISTRIBUTED", "") == "MPI"
+# Test-specific definitions (may be overwritten in each test case file)
+# TODO: Allow some of these to be enironment variables or command line arguments
+horizontal_mesh = nothing # must be object of type AbstractMesh
+npoly = 0
+z_max = 0
+z_elem = 0
+t_end = 0
+dt = 0
+dt_save_to_sol = 0 # 0 means don't save to sol
+dt_save_to_disk = 0 # 0 means don't save to disk
+ode_algorithm = nothing # must be object of type OrdinaryDiffEqAlgorithm
+jacobian_flags = (;) # only required by implicit ODE algorithms
+max_newton_iters = 10 # only required by ODE algorithms that use Newton's method
+show_progress_bar = false
+additional_callbacks = () # e.g., printing diagnostic information
+additional_solver_kwargs = (;) # e.g., abstol and reltol
+test_implicit_solver = false # makes solver extremely slow when set to `true`
+additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = (;)
+additional_tendency!(Yₜ, Y, p, t) = nothing
+center_initial_condition(local_geometry) = (;)
+face_initial_condition(local_geometry) = (;)
+postprocessing(sol, output_dir) = nothing
+
+################################################################################
+
+is_distributed = haskey(ENV, "CLIMACORE_DISTRIBUTED")
 
 using Logging
-if usempi
+if is_distributed
     using ClimaComms
-    using ClimaCommsMPI
-    const Context = ClimaCommsMPI.MPICommsContext
+    if ENV["CLIMACORE_DISTRIBUTED"] == "MPI"
+        using ClimaCommsMPI
+        const Context = ClimaCommsMPI.MPICommsContext
+    else
+        error("ENV[\"CLIMACORE_DISTRIBUTED\"] only supports the \"MPI\" option")
+    end
     const pid, nprocs = ClimaComms.init(Context)
-    if pid == 1
-        println("parallel run with $nprocs processes")
-    end
     logger_stream = ClimaComms.iamroot(Context) ? stderr : devnull
-
     prev_logger = global_logger(ConsoleLogger(logger_stream, Logging.Info))
-    atexit() do
-        global_logger(prev_logger)
-    end
+    @info "Setting up distributed run on $nprocs \
+        processor$(nprocs == 1 ? "" : "s")"
 else
-    using Logging: global_logger
     using TerminalLoggers: TerminalLogger
-    global_logger(TerminalLogger())
+    prev_logger = global_logger(TerminalLogger())
+end
+atexit() do
+    global_logger(prev_logger)
 end
 
 import ClimaCore: enable_threading
@@ -28,56 +54,77 @@ using OrdinaryDiffEq
 using DiffEqCallbacks
 using JLD2
 
-default_test_name = "sphere/baroclinic_wave_rhoe"
-
-test_implicit_solver = false # makes solver extremely slow when set to `true`
-
-# Definitions that are specific to each test:
-space = nothing
-t_end = 0
-dt = 0
-dt_save_to_sol = 0 # 0 means don't save to sol
-dt_save_to_disk = 0 # 0 means don't save to disk
-ode_algorithm = OrdinaryDiffEq.SSPRK33
-jacobian_flags = (;) # only required by implicit ODE algorithms
-max_newton_iters = 10 # only required by ODE algorithms that use Newton's method
-show_progress_bar = false
-additional_callbacks = () # e.g., printing diagnostic information
-additional_solver_kwargs = (;) # e.g., abstol and reltol
-center_initial_condition(local_geometry) = (;)
-face_initial_condition(local_geometry) = (;)
-postprocessing(sol, p, output_dir) = nothing
-################################################################################
-
 const FT = get(ENV, "FLOAT_TYPE", "Float64") == "Float32" ? Float32 : Float64
 
+include("../implicit_solver_debugging_tools.jl")
+include("../ordinary_diff_eq_bug_fixes.jl")
+include("../common_spaces.jl")
+
 if haskey(ENV, "TEST_NAME")
-    test_name = ENV["TEST_NAME"]
+    test_dir, test_file_name = split(ENV["TEST_NAME"], '/')
 else
-    test_name = default_test_name
+    error("ENV[\"TEST_NAME\"] required (e.g., \"sphere/baroclinic_wave_rhoe\")")
 end
-test_dir, test_file_name = split(test_name, '/')
 include(joinpath(test_dir, "$test_file_name.jl"))
 
+# TODO: When is_distributed is true, automatically compute the maximum number of
+# bytes required to store an element from Y.c or Y.f (or, really, from any Field
+# on which gather() or weighted_dss!() will get called). One option is to make a
+# non-distributed space, extract the local_geometry type, and find the sizes of
+# the output types of center_initial_condition() and face_initial_condition()
+# for that local_geometry type. This is rather inefficient, though, so for now
+# we will just hardcode the value of 4.
+max_field_element_size = 4 # ρ = 1 byte, 𝔼 = 1 byte, uₕ = 2 bytes
+
 if haskey(ENV, "RESTART_FILE")
-    restart_data = jldopen(ENV["RESTART_FILE"])
+    restart_file_name = ENV["RESTART_FILE"]
+    if is_distributed
+        restart_file_name =
+            split(restart_file_name, ".jld2")[1] * "_pid$pid.jld2"
+    end
+    restart_data = jldopen(restart_file_name)
     t_start = restart_data["t"]
     Y = restart_data["Y"]
     close(restart_data)
     ᶜlocal_geometry = Fields.local_geometry_field(Y.c)
     ᶠlocal_geometry = Fields.local_geometry_field(Y.f)
+    if is_distributed
+        comms_ctx = Spaces.setup_comms(
+            Context,
+            axes(Y.c).horizontal_space.topology,
+            Spaces.Quadratures.GLL{npoly + 1}(),
+            z_elem + 1,
+            max_field_element_size,
+        )
+    else
+        comms_ctx = nothing
+    end
 else
     t_start = FT(0)
-    ᶜlocal_geometry, ᶠlocal_geometry =
-        Fields.local_geometry_field(hv_center_space),
-        Fields.local_geometry_field(hv_face_space)
-
+    if is_distributed
+        h_space, comms_ctx = make_distributed_horizontal_space(
+            horizontal_mesh,
+            npoly,
+            Context,
+            z_elem + 1,
+            max_field_element_size,
+        )
+    else
+        h_space = make_horizontal_space(horizontal_mesh, npoly)
+        comms_ctx = nothing
+    end
+    center_space, face_space = make_hybrid_spaces(h_space, z_max, z_elem)
+    ᶜlocal_geometry = Fields.local_geometry_field(center_space)
+    ᶠlocal_geometry = Fields.local_geometry_field(face_space)
     Y = Fields.FieldVector(
-        c = map(center_initial_condition, ᶜlocal_geometry),
-        f = map(face_initial_condition, ᶠlocal_geometry),
+        c = center_initial_condition.(ᶜlocal_geometry),
+        f = face_initial_condition.(ᶠlocal_geometry),
     )
+    # apply dss in case the initial conditions are discontinuous across elements
+    Spaces.weighted_dss!(Y.c, comms_ctx)
+    Spaces.weighted_dss!(Y.f, comms_ctx)
 end
-p = get_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt)
+p = get_cache(ᶜlocal_geometry, ᶠlocal_geometry, comms_ctx, dt)
 
 if ode_algorithm <: Union{
     OrdinaryDiffEq.OrdinaryDiffEqImplicitAlgorithm,
@@ -108,11 +155,12 @@ else
 end
 mkpath(output_dir)
 
-function make_save_to_disk(output_dir, test_file_name)
+function make_save_to_disk(output_dir, test_file_name, is_distributed)
     function save_to_disk(integrator)
         day = floor(Int, integrator.t / (60 * 60 * 24))
         @info "Saving prognostic variables to JLD2 file on day $day"
-        output_file = joinpath(output_dir, "$(test_file_name)_day$day.jld2")
+        suffix = is_distributed ? "_pid$pid.jld2" : ".jld2"
+        output_file = joinpath(output_dir, "$(test_file_name)_day$day$suffix")
         jldsave(output_file; t = integrator.t, Y = integrator.u)
         return nothing
     end
@@ -122,12 +170,13 @@ if dt_save_to_disk == 0
     saving_callback = nothing
 else
     saving_callback = PeriodicCallback(
-        make_save_to_disk(output_dir, test_file_name),
+        make_save_to_disk(output_dir, test_file_name, is_distributed),
         dt_save_to_disk;
         initial_affect = true,
     )
 end
 callback = CallbackSet(saving_callback, additional_callbacks...)
+
 problem = SplitODEProblem(
     ODEFunction(
         implicit_tendency!;
@@ -155,12 +204,45 @@ if haskey(ENV, "CI_PERF_SKIP_RUN") # for performance analysis
     throw(:exit_profile)
 end
 
-@info "Running `$test_name`"
+@info "Running `$test_dir/$test_file_name` test case"
 sol = @timev OrdinaryDiffEq.solve!(integrator)
 
-#@show typeof(sol.u)
-#@show typeof(sol.u[1])
-#@show typeof(sol.u[1].c)
-#@show typeof(sol.u[1].f)
-ENV["GKSwstype"] = "nul" # avoid displaying plots
-postprocessing(sol, p, output_dir, usempi)
+if is_distributed # replace sol.u on the root processor with the global sol.u
+    if ClimaComms.iamroot(Context)
+        global_h_space = make_horizontal_space(horizontal_mesh, npoly)
+        global_center_space, global_face_space =
+            make_hybrid_spaces(global_h_space, z_max, z_elem)
+        global_Y_c_type = Fields.Field{
+            typeof(Fields.field_values(Y.c)),
+            typeof(global_center_space),
+        }
+        global_Y_f_type = Fields.Field{
+            typeof(Fields.field_values(Y.f)),
+            typeof(global_face_space),
+        }
+        global_Y_type = Fields.FieldVector{
+            FT,
+            NamedTuple{(:c, :f), Tuple{global_Y_c_type, global_Y_f_type}},
+        }
+        global_sol_u = similar(sol.u, global_Y_type)
+    end
+    for i in 1:length(sol.u)
+        global_Y_c =
+            DataLayouts.gather(comms_ctx, Fields.field_values(sol.u[i].c))
+        global_Y_f =
+            DataLayouts.gather(comms_ctx, Fields.field_values(sol.u[i].f))
+        if ClimaComms.iamroot(Context)
+            global_sol_u[i] = Fields.FieldVector(
+                c = Fields.Field(global_Y_c, global_center_space),
+                f = Fields.Field(global_Y_f, global_face_space),
+            )
+        end
+    end
+    if ClimaComms.iamroot(Context)
+        sol = DiffEqBase.sensitivity_solution(sol, global_sol_u, sol.t)
+    end
+end
+if !is_distributed || (is_distributed && ClimaComms.iamroot(Context))
+    ENV["GKSwstype"] = "nul" # avoid displaying plots
+    postprocessing(sol, output_dir)
+end

--- a/examples/hybrid/hyperdiffusion.jl
+++ b/examples/hybrid/hyperdiffusion.jl
@@ -19,7 +19,7 @@ function hyperdiffusion_tendency!(Yₜ, Y, p, t, comms_ctx = nothing)
     ᶜρ = Y.c.ρ
     ᶜuₕ = Y.c.uₕ
     (; ᶜp, ᶜχ, ᶜχuₕ) = p # assume that ᶜp has been updated
-    (; κ₄, divergence_damping_factor, use_tempest_mode) = p
+    (; comms_ctx, κ₄, divergence_damping_factor, use_tempest_mode) = p
     point_type = eltype(Fields.local_geometry_field(axes(Y.c)).coordinates)
 
     if use_tempest_mode

--- a/examples/hybrid/sphere/balanced_flow_rhoe.jl
+++ b/examples/hybrid/sphere/balanced_flow_rhoe.jl
@@ -7,46 +7,10 @@ include("baroclinic_wave_utilities.jl")
 const sponge = false
 
 # Variables required for driver.jl (modify as needed)
-helems, zelems, npoly = 4, 10, 4
-
-horzdomain = Domains.SphereDomain(R)
-vertdomain = Domains.IntervalDomain(
-    Geometry.ZPoint{FT}(FT(0)),
-    Geometry.ZPoint{FT}(FT(30e3));
-    boundary_tags = (:bottom, :top),
-)
-horzmesh = Meshes.EquiangularCubedSphere(horzdomain, helems)
-vertmesh = Meshes.IntervalMesh(vertdomain, nelems = zelems)
-quad = Spaces.Quadratures.GLL{npoly + 1}()
-
-Nv = Meshes.nelements(vertmesh)
-Nf_center, Nf_face = 4, 1
-vert_center_space = Spaces.CenterFiniteDifferenceSpace(vertmesh)
-
-if usempi
-    horztopology = Topologies.DistributedTopology2D(horzmesh, Context)
-    comms_ctx =
-        Spaces.setup_comms(Context, horztopology, quad, Nv + 1, Nf_center)
-    global_topology = Topologies.Topology2D(horzmesh)
-    global_horz_space = Spaces.SpectralElementSpace2D(global_topology, quad)
-    global_center_space = Spaces.ExtrudedFiniteDifferenceSpace(
-        global_horz_space,
-        vert_center_space,
-    )
-    global_face_space =
-        Spaces.FaceExtrudedFiniteDifferenceSpace(global_center_space)
-
-else
-    horztopology = Topologies.Topology2D(horzmesh)
-    comms_ctx = nothing
-end
-
-horzspace = Spaces.SpectralElementSpace2D(horztopology, quad, comms_ctx)
-
-hv_center_space =
-    Spaces.ExtrudedFiniteDifferenceSpace(horzspace, vert_center_space)
-hv_face_space = Spaces.FaceExtrudedFiniteDifferenceSpace(hv_center_space)
-
+horizontal_mesh = cubed_sphere_mesh(; radius = R, h_elem = 4)
+npoly = 4
+z_max = FT(30e3)
+z_elem = 10
 t_end = FT(60 * 60)
 dt = FT(5)
 dt_save_to_sol = FT(50)
@@ -57,66 +21,34 @@ additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = merge(
     hyperdiffusion_cache(ᶜlocal_geometry, ᶠlocal_geometry; κ₄ = FT(2e17)),
     sponge ? rayleigh_sponge_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) : (;),
 )
-function additional_tendency!(Yₜ, Y, p, t, comms_ctx = nothing)
-    hyperdiffusion_tendency!(Yₜ, Y, p, t, comms_ctx)
+function additional_tendency!(Yₜ, Y, p, t)
+    hyperdiffusion_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
 end
 
 center_initial_condition(local_geometry) =
     center_initial_condition(local_geometry, Val(:ρe); is_balanced_flow = true)
 
-function postprocessing(sol, p, output_dir, usempi = false)
-    sol_global = []
-    if usempi
-        for sol_step in sol.u
-            sol_step_values_center_global =
-                DataLayouts.gather(comms_ctx, Fields.field_values(sol_step.c))
-            sol_step_values_face_global =
-                DataLayouts.gather(comms_ctx, Fields.field_values(sol_step.f))
-            if ClimaComms.iamroot(Context)
-                sol_step_global = Fields.FieldVector(
-                    c = Fields.Field(
-                        sol_step_values_center_global,
-                        global_center_space,
-                    ),
-                    f = Fields.Field(
-                        sol_step_values_face_global,
-                        global_face_space,
-                    ),
-                )
-                push!(sol_global, sol_step_global)
-            end
-        end
-        if ClimaComms.iamroot(Context)
-        end
-    else
-        sol_global = sol.u
-    end
+function postprocessing(sol, output_dir)
+    @info "L₂ norm of ρe at t = $(sol.t[1]): $(norm(sol.u[1].c.ρe))"
+    @info "L₂ norm of ρe at t = $(sol.t[end]): $(norm(sol.u[end].c.ρe))"
 
-    if !usempi || (usempi && ClimaComms.iamroot(Context))
-        @info "L₂ norm of ρe at t = $(sol.t[1]): $(norm(sol_global[1].c.ρe))"
-        @info "L₂ norm of ρe at t = $(sol.t[end]): $(norm(sol_global[end].c.ρe))"
+    ᶜu_end = Geometry.UVVector.(sol.u[end].c.uₕ).components.data.:1
+    Plots.png(Plots.plot(ᶜu_end, level = 3), joinpath(output_dir, "u_end.png"))
 
-        ᶜu_end = Geometry.UVVector.(sol_global[end].c.uₕ).components.data.:1
-        Plots.png(
-            Plots.plot(ᶜu_end, level = 3),
-            joinpath(output_dir, "u_end.png"),
-        )
+    ᶜw_end = Geometry.WVector.(sol.u[end].f.w).components.data.:1
+    Plots.png(
+        Plots.plot(ᶜw_end, level = 3 + half, clim = (-4, 4)),
+        joinpath(output_dir, "w_end.png"),
+    )
 
-        ᶜw_end = Geometry.WVector.(sol_global[end].f.w).components.data.:1
-        Plots.png(
-            Plots.plot(ᶜw_end, level = 3 + half, clim = (-4, 4)),
-            joinpath(output_dir, "w_end.png"),
-        )
+    ᶜu_start = Geometry.UVVector.(sol.u[1].c.uₕ).components.data.:1
+    Plots.png(
+        Plots.plot(ᶜu_end .- ᶜu_start, level = 3, clim = (-1, 1)),
+        joinpath(output_dir, "Δu_end.png"),
+    )
 
-        ᶜu_start = Geometry.UVVector.(sol_global[1].c.uₕ).components.data.:1
-        Plots.png(
-            Plots.plot(ᶜu_end .- ᶜu_start, level = 3, clim = (-1, 1)),
-            joinpath(output_dir, "Δu_end.png"),
-        )
-
-        @test sol_global[end].c.ρ ≈ sol_global[1].c.ρ rtol = 5e-2
-        @test sol_global[end].c.ρe ≈ sol_global[1].c.ρe rtol = 5e-2
-        @test sol_global[end].c.uₕ ≈ sol_global[1].c.uₕ rtol = 5e-2
-    end
+    @test sol.u[end].c.ρ ≈ sol.u[1].c.ρ rtol = 5e-2
+    @test sol.u[end].c.ρe ≈ sol.u[1].c.ρe rtol = 5e-2
+    @test sol.u[end].c.uₕ ≈ sol.u[1].c.uₕ rtol = 5e-2
 end

--- a/examples/hybrid/sphere/balanced_flow_rhotheta.jl
+++ b/examples/hybrid/sphere/balanced_flow_rhotheta.jl
@@ -6,46 +6,10 @@ include("baroclinic_wave_utilities.jl")
 const sponge = false
 
 # Variables required for driver.jl (modify as needed)
-helems, zelems, npoly = 4, 10, 4
-
-horzdomain = Domains.SphereDomain(R)
-vertdomain = Domains.IntervalDomain(
-    Geometry.ZPoint{FT}(FT(0)),
-    Geometry.ZPoint{FT}(FT(30e3));
-    boundary_tags = (:bottom, :top),
-)
-horzmesh = Meshes.EquiangularCubedSphere(horzdomain, helems)
-vertmesh = Meshes.IntervalMesh(vertdomain, nelems = zelems)
-quad = Spaces.Quadratures.GLL{npoly + 1}()
-
-Nv = Meshes.nelements(vertmesh)
-Nf_center, Nf_face = 4, 1
-vert_center_space = Spaces.CenterFiniteDifferenceSpace(vertmesh)
-
-if usempi
-    horztopology = Topologies.DistributedTopology2D(horzmesh, Context)
-    comms_ctx =
-        Spaces.setup_comms(Context, horztopology, quad, Nv + 1, Nf_center)
-    global_topology = Topologies.Topology2D(horzmesh)
-    global_horz_space = Spaces.SpectralElementSpace2D(global_topology, quad)
-    global_center_space = Spaces.ExtrudedFiniteDifferenceSpace(
-        global_horz_space,
-        vert_center_space,
-    )
-    global_face_space =
-        Spaces.FaceExtrudedFiniteDifferenceSpace(global_center_space)
-
-else
-    horztopology = Topologies.Topology2D(horzmesh)
-    comms_ctx = nothing
-end
-
-horzspace = Spaces.SpectralElementSpace2D(horztopology, quad, comms_ctx)
-
-hv_center_space =
-    Spaces.ExtrudedFiniteDifferenceSpace(horzspace, vert_center_space)
-hv_face_space = Spaces.FaceExtrudedFiniteDifferenceSpace(hv_center_space)
-
+horizontal_mesh = cubed_sphere_mesh(; radius = R, h_elem = 4)
+npoly = 4
+z_max = FT(30e3)
+z_elem = 10
 t_end = FT(60 * 60 * 24 * 10)
 dt = FT(400)
 dt_save_to_sol = FT(60 * 60 * 24)
@@ -57,61 +21,32 @@ additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = merge(
     hyperdiffusion_cache(ᶜlocal_geometry, ᶠlocal_geometry; κ₄ = FT(2e17)),
     sponge ? rayleigh_sponge_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) : (;),
 )
-function additional_tendency!(Yₜ, Y, p, t, comms_ctx = nothing)
-    hyperdiffusion_tendency!(Yₜ, Y, p, t, comms_ctx)
+function additional_tendency!(Yₜ, Y, p, t)
+    hyperdiffusion_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
 end
 
 center_initial_condition(local_geometry) =
     center_initial_condition(local_geometry, Val(:ρθ); is_balanced_flow = true)
 
-function postprocessing(sol, p, output_dir, usempi = false)
-    sol_global = []
-    if usempi
-        for sol_step in sol.u
-            sol_step_values_center_global =
-                DataLayouts.gather(comms_ctx, Fields.field_values(sol_step.c))
-            sol_step_values_face_global =
-                DataLayouts.gather(comms_ctx, Fields.field_values(sol_step.f))
-            if ClimaComms.iamroot(Context)
-                sol_step_global = Fields.FieldVector(
-                    c = Fields.Field(
-                        sol_step_values_center_global,
-                        global_center_space,
-                    ),
-                    f = Fields.Field(
-                        sol_step_values_face_global,
-                        global_face_space,
-                    ),
-                )
-                push!(sol_global, sol_step_global)
-            end
-        end
-        if ClimaComms.iamroot(Context)
-        end
-    else
-        sol_global = sol.u
+function postprocessing(sol, output_dir)
+    @info "L₂ norm of ρθ at t = $(sol.t[1]): $(norm(sol.u[1].c.ρθ))"
+    @info "L₂ norm of ρθ at t = $(sol.t[end]): $(norm(sol.u[end].c.ρθ))"
+
+    anim = Plots.@animate for Y in sol.u
+        ᶜu = Geometry.UVVector.(Y.c.uₕ).components.data.:1
+        Plots.plot(ᶜu, level = 3, clim = (-25, 25))
     end
+    Plots.mp4(anim, joinpath(output_dir, "u.mp4"), fps = 5)
 
-    if !usempi || (usempi && ClimaComms.iamroot(Context))
-        @info "L₂ norm of ρθ at t = $(sol.t[1]): $(norm(sol_global[1].c.ρθ))"
-        @info "L₂ norm of ρθ at t = $(sol.t[end]): $(norm(sol_global[end].c.ρθ))"
-
-        anim = Plots.@animate for Y in sol_global
-            ᶜu = Geometry.UVVector.(Y.c.uₕ).components.data.:1
-            Plots.plot(ᶜu, level = 3, clim = (-25, 25))
-        end
-        Plots.mp4(anim, joinpath(output_dir, "u.mp4"), fps = 5)
-
-        anim = Plots.@animate for Y in sol_global
-            ᶜv = Geometry.UVVector.(Y.c.uₕ).components.data.:2
-            Plots.plot(ᶜv, level = 3, clim = (-3, 3))
-        end
-        Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
-
-        anim = Plots.@animate for Y in sol_global
-            Plots.plot(Y.c.ρθ ./ Y.c.ρ, level = 3, clim = (225, 255))
-        end
-        Plots.mp4(anim, joinpath(output_dir, "theta.mp4"), fps = 5)
+    anim = Plots.@animate for Y in sol.u
+        ᶜv = Geometry.UVVector.(Y.c.uₕ).components.data.:2
+        Plots.plot(ᶜv, level = 3, clim = (-3, 3))
     end
+    Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
+
+    anim = Plots.@animate for Y in sol.u
+        Plots.plot(Y.c.ρθ ./ Y.c.ρ, level = 3, clim = (225, 255))
+    end
+    Plots.mp4(anim, joinpath(output_dir, "theta.mp4"), fps = 5)
 end

--- a/examples/hybrid/sphere/baroclinic_wave_rhoe.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhoe.jl
@@ -6,46 +6,10 @@ include("baroclinic_wave_utilities.jl")
 const sponge = false
 
 # Variables required for driver.jl (modify as needed)
-helems, zelems, npoly = 4, 10, 4
-
-horzdomain = Domains.SphereDomain(R)
-vertdomain = Domains.IntervalDomain(
-    Geometry.ZPoint{FT}(FT(0)),
-    Geometry.ZPoint{FT}(FT(30e3));
-    boundary_tags = (:bottom, :top),
-)
-horzmesh = Meshes.EquiangularCubedSphere(horzdomain, helems)
-vertmesh = Meshes.IntervalMesh(vertdomain, nelems = zelems)
-quad = Spaces.Quadratures.GLL{npoly + 1}()
-
-Nv = Meshes.nelements(vertmesh)
-Nf_center, Nf_face = 4, 1
-vert_center_space = Spaces.CenterFiniteDifferenceSpace(vertmesh)
-
-if usempi
-    horztopology = Topologies.DistributedTopology2D(horzmesh, Context)
-    comms_ctx =
-        Spaces.setup_comms(Context, horztopology, quad, Nv + 1, Nf_center)
-    global_topology = Topologies.Topology2D(horzmesh)
-    global_horz_space = Spaces.SpectralElementSpace2D(global_topology, quad)
-    global_center_space = Spaces.ExtrudedFiniteDifferenceSpace(
-        global_horz_space,
-        vert_center_space,
-    )
-    global_face_space =
-        Spaces.FaceExtrudedFiniteDifferenceSpace(global_center_space)
-
-else
-    horztopology = Topologies.Topology2D(horzmesh)
-    comms_ctx = nothing
-end
-
-horzspace = Spaces.SpectralElementSpace2D(horztopology, quad, comms_ctx)
-
-hv_center_space =
-    Spaces.ExtrudedFiniteDifferenceSpace(horzspace, vert_center_space)
-hv_face_space = Spaces.FaceExtrudedFiniteDifferenceSpace(hv_center_space)
-
+horizontal_mesh = cubed_sphere_mesh(; radius = R, h_elem = 4)
+npoly = 4
+z_max = FT(30e3)
+z_elem = 10
 t_end = FT(60 * 60 * 24 * 10)
 dt = FT(400)
 dt_save_to_sol = FT(60 * 60 * 24)
@@ -57,49 +21,20 @@ additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = merge(
     hyperdiffusion_cache(ᶜlocal_geometry, ᶠlocal_geometry; κ₄ = FT(2e17)),
     sponge ? rayleigh_sponge_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) : (;),
 )
-function additional_tendency!(Yₜ, Y, p, t, comms_ctx = nothing)
-    hyperdiffusion_tendency!(Yₜ, Y, p, t, comms_ctx)
+function additional_tendency!(Yₜ, Y, p, t)
+    hyperdiffusion_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
 end
 
 center_initial_condition(local_geometry) =
     center_initial_condition(local_geometry, Val(:ρe))
-function postprocessing(sol, p, output_dir, usempi = false)
-    sol_global = []
-    if usempi
-        for sol_step in sol.u
-            sol_step_values_center_global =
-                DataLayouts.gather(comms_ctx, Fields.field_values(sol_step.c))
-            sol_step_values_face_global =
-                DataLayouts.gather(comms_ctx, Fields.field_values(sol_step.f))
-            if ClimaComms.iamroot(Context)
-                sol_step_global = Fields.FieldVector(
-                    c = Fields.Field(
-                        sol_step_values_center_global,
-                        global_center_space,
-                    ),
-                    f = Fields.Field(
-                        sol_step_values_face_global,
-                        global_face_space,
-                    ),
-                )
-                push!(sol_global, sol_step_global)
-            end
-        end
-        if ClimaComms.iamroot(Context)
-        end
-    else
-        sol_global = sol.u
-    end
+function postprocessing(sol, output_dir)
+    @info "L₂ norm of ρe at t = $(sol.t[1]): $(norm(sol.u[1].c.ρe))"
+    @info "L₂ norm of ρe at t = $(sol.t[end]): $(norm(sol.u[end].c.ρe))"
 
-    if !usempi || (usempi && ClimaComms.iamroot(Context))
-        @info "L₂ norm of ρe at t = $(sol.t[1]): $(norm(sol_global[1].c.ρe))"
-        @info "L₂ norm of ρe at t = $(sol.t[end]): $(norm(sol_global[end].c.ρe))"
-
-        anim = Plots.@animate for Y in sol_global
-            ᶜv = Geometry.UVVector.(Y.c.uₕ).components.data.:2
-            Plots.plot(ᶜv, level = 3, clim = (-6, 6))
-        end
-        Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
+    anim = Plots.@animate for Y in sol.u
+        ᶜv = Geometry.UVVector.(Y.c.uₕ).components.data.:2
+        Plots.plot(ᶜv, level = 3, clim = (-6, 6))
     end
+    Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
 end

--- a/examples/hybrid/sphere/baroclinic_wave_rhotheta.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhotheta.jl
@@ -6,46 +6,10 @@ include("baroclinic_wave_utilities.jl")
 const sponge = false
 
 # Variables required for driver.jl (modify as needed)
-helems, zelems, npoly = 4, 10, 4
-
-horzdomain = Domains.SphereDomain(R)
-vertdomain = Domains.IntervalDomain(
-    Geometry.ZPoint{FT}(FT(0)),
-    Geometry.ZPoint{FT}(FT(30e3));
-    boundary_tags = (:bottom, :top),
-)
-horzmesh = Meshes.EquiangularCubedSphere(horzdomain, helems)
-vertmesh = Meshes.IntervalMesh(vertdomain, nelems = zelems)
-quad = Spaces.Quadratures.GLL{npoly + 1}()
-
-Nv = Meshes.nelements(vertmesh)
-Nf_center, Nf_face = 4, 1
-vert_center_space = Spaces.CenterFiniteDifferenceSpace(vertmesh)
-
-if usempi
-    horztopology = Topologies.DistributedTopology2D(horzmesh, Context)
-    comms_ctx =
-        Spaces.setup_comms(Context, horztopology, quad, Nv + 1, Nf_center)
-    global_topology = Topologies.Topology2D(horzmesh)
-    global_horz_space = Spaces.SpectralElementSpace2D(global_topology, quad)
-    global_center_space = Spaces.ExtrudedFiniteDifferenceSpace(
-        global_horz_space,
-        vert_center_space,
-    )
-    global_face_space =
-        Spaces.FaceExtrudedFiniteDifferenceSpace(global_center_space)
-
-else
-    horztopology = Topologies.Topology2D(horzmesh)
-    comms_ctx = nothing
-end
-
-horzspace = Spaces.SpectralElementSpace2D(horztopology, quad, comms_ctx)
-
-hv_center_space =
-    Spaces.ExtrudedFiniteDifferenceSpace(horzspace, vert_center_space)
-hv_face_space = Spaces.FaceExtrudedFiniteDifferenceSpace(hv_center_space)
-
+horizontal_mesh = cubed_sphere_mesh(; radius = R, h_elem = 4)
+npoly = 4
+z_max = FT(30e3)
+z_elem = 10
 t_end = FT(60 * 60 * 24 * 10)
 dt = FT(400)
 dt_save_to_sol = FT(60 * 60 * 24)
@@ -57,53 +21,15 @@ additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = merge(
     hyperdiffusion_cache(ᶜlocal_geometry, ᶠlocal_geometry; κ₄ = FT(2e17)),
     sponge ? rayleigh_sponge_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) : (;),
 )
-function additional_tendency!(Yₜ, Y, p, t, comms_ctx = nothing)
-    hyperdiffusion_tendency!(Yₜ, Y, p, t, comms_ctx)
+function additional_tendency!(Yₜ, Y, p, t)
+    hyperdiffusion_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
 end
 
 center_initial_condition(local_geometry) =
     center_initial_condition(local_geometry, Val(:ρθ))
 
-function postprocessing(sol, p, output_dir, usempi = false)
-    sol_global = []
-    if usempi
-        for sol_step in sol.u
-            sol_step_values_center_global =
-                DataLayouts.gather(comms_ctx, Fields.field_values(sol_step.c))
-            sol_step_values_face_global =
-                DataLayouts.gather(comms_ctx, Fields.field_values(sol_step.f))
-            if ClimaComms.iamroot(Context)
-                sol_step_global = Fields.FieldVector(
-                    c = Fields.Field(
-                        sol_step_values_center_global,
-                        global_center_space,
-                    ),
-                    f = Fields.Field(
-                        sol_step_values_face_global,
-                        global_face_space,
-                    ),
-                )
-                push!(sol_global, sol_step_global)
-            end
-        end
-        if ClimaComms.iamroot(Context)
-        end
-    else
-        sol_global = sol.u
-    end
-
-    if !usempi || (usempi && ClimaComms.iamroot(Context))
-        @info "L₂ norm of ρθ at t = $(sol.t[1]): $(norm(sol_global[1].c.ρθ))"
-        @info "L₂ norm of ρθ at t = $(sol.t[end]): $(norm(sol_global[end].c.ρθ))"
-
-        anim = Plots.@animate for Y in sol_global
-            ᶜv = Geometry.UVVector.(Y.c.uₕ).components.data.:2
-            Plots.plot(ᶜv, level = 3, clim = (-6, 6))
-        end
-        Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
-    end
-    #=
+function postprocessing(sol, output_dir)
     @info "L₂ norm of ρθ at t = $(sol.t[1]): $(norm(sol.u[1].c.ρθ))"
     @info "L₂ norm of ρθ at t = $(sol.t[end]): $(norm(sol.u[end].c.ρθ))"
 
@@ -112,5 +38,4 @@ function postprocessing(sol, p, output_dir, usempi = false)
         Plots.plot(ᶜv, level = 3, clim = (-6, 6))
     end
     Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
-    =#
 end

--- a/examples/hybrid/sphere/held_suarez_rhoe.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe.jl
@@ -6,46 +6,10 @@ include("baroclinic_wave_utilities.jl")
 const sponge = false
 
 # Variables required for driver.jl (modify as needed)
-helems, zelems, npoly = 4, 10, 4
-
-horzdomain = Domains.SphereDomain(R)
-vertdomain = Domains.IntervalDomain(
-    Geometry.ZPoint{FT}(FT(0)),
-    Geometry.ZPoint{FT}(FT(30e3));
-    boundary_tags = (:bottom, :top),
-)
-horzmesh = Meshes.EquiangularCubedSphere(horzdomain, helems)
-vertmesh = Meshes.IntervalMesh(vertdomain, nelems = zelems)
-quad = Spaces.Quadratures.GLL{npoly + 1}()
-
-Nv = Meshes.nelements(vertmesh)
-Nf_center, Nf_face = 4, 1
-vert_center_space = Spaces.CenterFiniteDifferenceSpace(vertmesh)
-
-if usempi
-    horztopology = Topologies.DistributedTopology2D(horzmesh, Context)
-    comms_ctx =
-        Spaces.setup_comms(Context, horztopology, quad, Nv + 1, Nf_center)
-    global_topology = Topologies.Topology2D(horzmesh)
-    global_horz_space = Spaces.SpectralElementSpace2D(global_topology, quad)
-    global_center_space = Spaces.ExtrudedFiniteDifferenceSpace(
-        global_horz_space,
-        vert_center_space,
-    )
-    global_face_space =
-        Spaces.FaceExtrudedFiniteDifferenceSpace(global_center_space)
-
-else
-    horztopology = Topologies.Topology2D(horzmesh)
-    comms_ctx = nothing
-end
-
-horzspace = Spaces.SpectralElementSpace2D(horztopology, quad, comms_ctx)
-
-hv_center_space =
-    Spaces.ExtrudedFiniteDifferenceSpace(horzspace, vert_center_space)
-hv_face_space = Spaces.FaceExtrudedFiniteDifferenceSpace(hv_center_space)
-
+horizontal_mesh = cubed_sphere_mesh(; radius = R, h_elem = 4)
+npoly = 4
+z_max = FT(30e3)
+z_elem = 10
 t_end = FT(60 * 60 * 24 * 10)
 dt = FT(400)
 dt_save_to_sol = FT(60 * 60 * 24)
@@ -58,8 +22,8 @@ additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = merge(
     sponge ? rayleigh_sponge_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) : (;),
     held_suarez_cache(ᶜlocal_geometry),
 )
-function additional_tendency!(Yₜ, Y, p, t, comms_ctx = nothing)
-    hyperdiffusion_tendency!(Yₜ, Y, p, t, comms_ctx)
+function additional_tendency!(Yₜ, Y, p, t)
+    hyperdiffusion_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
     held_suarez_tendency!(Yₜ, Y, p, t)
 end
@@ -67,42 +31,13 @@ end
 center_initial_condition(local_geometry) =
     center_initial_condition(local_geometry, Val(:ρe))
 
-function postprocessing(sol, p, output_dir, usempi = false)
-    sol_global = []
-    if usempi
-        for sol_step in sol.u
-            sol_step_values_center_global =
-                DataLayouts.gather(comms_ctx, Fields.field_values(sol_step.c))
-            sol_step_values_face_global =
-                DataLayouts.gather(comms_ctx, Fields.field_values(sol_step.f))
-            if ClimaComms.iamroot(Context)
-                sol_step_global = Fields.FieldVector(
-                    c = Fields.Field(
-                        sol_step_values_center_global,
-                        global_center_space,
-                    ),
-                    f = Fields.Field(
-                        sol_step_values_face_global,
-                        global_face_space,
-                    ),
-                )
-                push!(sol_global, sol_step_global)
-            end
-        end
-        if ClimaComms.iamroot(Context)
-        end
-    else
-        sol_global = sol.u
-    end
+function postprocessing(sol, output_dir)
+    @info "L₂ norm of ρe at t = $(sol.t[1]): $(norm(sol.u[1].c.ρe))"
+    @info "L₂ norm of ρe at t = $(sol.t[end]): $(norm(sol.u[end].c.ρe))"
 
-    if !usempi || (usempi && ClimaComms.iamroot(Context))
-        @info "L₂ norm of ρe at t = $(sol.t[1]): $(norm(sol_global[1].c.ρe))"
-        @info "L₂ norm of ρe at t = $(sol.t[end]): $(norm(sol_global[end].c.ρe))"
-
-        anim = Plots.@animate for Y in sol_global
-            ᶜv = Geometry.UVVector.(Y.c.uₕ).components.data.:2
-            Plots.plot(ᶜv, level = 3, clim = (-6, 6))
-        end
-        Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
+    anim = Plots.@animate for Y in sol.u
+        ᶜv = Geometry.UVVector.(Y.c.uₕ).components.data.:2
+        Plots.plot(ᶜv, level = 3, clim = (-6, 6))
     end
+    Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
 end

--- a/examples/hybrid/sphere/held_suarez_rhoe_int.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe_int.jl
@@ -6,46 +6,10 @@ include("baroclinic_wave_utilities.jl")
 const sponge = false
 
 # Variables required for driver.jl (modify as needed)
-helems, zelems, npoly = 4, 10, 4
-
-horzdomain = Domains.SphereDomain(R)
-vertdomain = Domains.IntervalDomain(
-    Geometry.ZPoint{FT}(FT(0)),
-    Geometry.ZPoint{FT}(FT(30e3));
-    boundary_tags = (:bottom, :top),
-)
-horzmesh = Meshes.EquiangularCubedSphere(horzdomain, helems)
-vertmesh = Meshes.IntervalMesh(vertdomain, nelems = zelems)
-quad = Spaces.Quadratures.GLL{npoly + 1}()
-
-Nv = Meshes.nelements(vertmesh)
-Nf_center, Nf_face = 4, 1
-vert_center_space = Spaces.CenterFiniteDifferenceSpace(vertmesh)
-
-if usempi
-    horztopology = Topologies.DistributedTopology2D(horzmesh, Context)
-    comms_ctx =
-        Spaces.setup_comms(Context, horztopology, quad, Nv + 1, Nf_center)
-    global_topology = Topologies.Topology2D(horzmesh)
-    global_horz_space = Spaces.SpectralElementSpace2D(global_topology, quad)
-    global_center_space = Spaces.ExtrudedFiniteDifferenceSpace(
-        global_horz_space,
-        vert_center_space,
-    )
-    global_face_space =
-        Spaces.FaceExtrudedFiniteDifferenceSpace(global_center_space)
-
-else
-    horztopology = Topologies.Topology2D(horzmesh)
-    comms_ctx = nothing
-end
-
-horzspace = Spaces.SpectralElementSpace2D(horztopology, quad, comms_ctx)
-
-hv_center_space =
-    Spaces.ExtrudedFiniteDifferenceSpace(horzspace, vert_center_space)
-hv_face_space = Spaces.FaceExtrudedFiniteDifferenceSpace(hv_center_space)
-
+horizontal_mesh = cubed_sphere_mesh(; radius = R, h_elem = 4)
+npoly = 4
+z_max = FT(30e3)
+z_elem = 10
 t_end = FT(60 * 60 * 24 * 10)
 dt = FT(400)
 dt_save_to_sol = FT(60 * 60 * 24)
@@ -58,8 +22,8 @@ additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = merge(
     sponge ? rayleigh_sponge_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) : (;),
     held_suarez_cache(ᶜlocal_geometry),
 )
-function additional_tendency!(Yₜ, Y, p, t, comms_ctx = nothing)
-    hyperdiffusion_tendency!(Yₜ, Y, p, t, comms_ctx)
+function additional_tendency!(Yₜ, Y, p, t)
+    hyperdiffusion_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
     held_suarez_tendency!(Yₜ, Y, p, t)
 end
@@ -67,42 +31,13 @@ end
 center_initial_condition(local_geometry) =
     center_initial_condition(local_geometry, Val(:ρe_int))
 
-function postprocessing(sol, p, output_dir, usempi = false)
-    sol_global = []
-    if usempi
-        for sol_step in sol.u
-            sol_step_values_center_global =
-                DataLayouts.gather(comms_ctx, Fields.field_values(sol_step.c))
-            sol_step_values_face_global =
-                DataLayouts.gather(comms_ctx, Fields.field_values(sol_step.f))
-            if ClimaComms.iamroot(Context)
-                sol_step_global = Fields.FieldVector(
-                    c = Fields.Field(
-                        sol_step_values_center_global,
-                        global_center_space,
-                    ),
-                    f = Fields.Field(
-                        sol_step_values_face_global,
-                        global_face_space,
-                    ),
-                )
-                push!(sol_global, sol_step_global)
-            end
-        end
-        if ClimaComms.iamroot(Context)
-        end
-    else
-        sol_global = sol.u
-    end
+function postprocessing(sol, output_dir)
+    @info "L₂ norm of ρe_int at t = $(sol.t[1]): $(norm(sol.u[1].c.ρe_int))"
+    @info "L₂ norm of ρe_int at t = $(sol.t[end]): $(norm(sol.u[end].c.ρe_int))"
 
-    if !usempi || (usempi && ClimaComms.iamroot(Context))
-        @info "L₂ norm of ρe_int at t = $(sol.t[1]): $(norm(sol_global[1].c.ρe_int))"
-        @info "L₂ norm of ρe_int at t = $(sol.t[end]): $(norm(sol_global[end].c.ρe_int))"
-
-        anim = Plots.@animate for Y in sol_global
-            ᶜv = Geometry.UVVector.(Y.c.uₕ).components.data.:2
-            Plots.plot(ᶜv, level = 3, clim = (-6, 6))
-        end
-        Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
+    anim = Plots.@animate for Y in sol.u
+        ᶜv = Geometry.UVVector.(Y.c.uₕ).components.data.:2
+        Plots.plot(ᶜv, level = 3, clim = (-6, 6))
     end
+    Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
 end

--- a/examples/hybrid/sphere/held_suarez_rhotheta.jl
+++ b/examples/hybrid/sphere/held_suarez_rhotheta.jl
@@ -6,46 +6,10 @@ include("baroclinic_wave_utilities.jl")
 const sponge = false
 
 # Variables required for driver.jl (modify as needed)
-helems, zelems, npoly = 4, 10, 4
-
-horzdomain = Domains.SphereDomain(R)
-vertdomain = Domains.IntervalDomain(
-    Geometry.ZPoint{FT}(FT(0)),
-    Geometry.ZPoint{FT}(FT(30e3));
-    boundary_tags = (:bottom, :top),
-)
-horzmesh = Meshes.EquiangularCubedSphere(horzdomain, helems)
-vertmesh = Meshes.IntervalMesh(vertdomain, nelems = zelems)
-quad = Spaces.Quadratures.GLL{npoly + 1}()
-
-Nv = Meshes.nelements(vertmesh)
-Nf_center, Nf_face = 4, 1
-vert_center_space = Spaces.CenterFiniteDifferenceSpace(vertmesh)
-
-if usempi
-    horztopology = Topologies.DistributedTopology2D(horzmesh, Context)
-    comms_ctx =
-        Spaces.setup_comms(Context, horztopology, quad, Nv + 1, Nf_center)
-    global_topology = Topologies.Topology2D(horzmesh)
-    global_horz_space = Spaces.SpectralElementSpace2D(global_topology, quad)
-    global_center_space = Spaces.ExtrudedFiniteDifferenceSpace(
-        global_horz_space,
-        vert_center_space,
-    )
-    global_face_space =
-        Spaces.FaceExtrudedFiniteDifferenceSpace(global_center_space)
-
-else
-    horztopology = Topologies.Topology2D(horzmesh)
-    comms_ctx = nothing
-end
-
-horzspace = Spaces.SpectralElementSpace2D(horztopology, quad, comms_ctx)
-
-hv_center_space =
-    Spaces.ExtrudedFiniteDifferenceSpace(horzspace, vert_center_space)
-hv_face_space = Spaces.FaceExtrudedFiniteDifferenceSpace(hv_center_space)
-
+horizontal_mesh = cubed_sphere_mesh(; radius = R, h_elem = 4)
+npoly = 4
+z_max = FT(30e3)
+z_elem = 10
 t_end = FT(60 * 60 * 24 * 10)
 dt = FT(400)
 dt_save_to_sol = FT(60 * 60 * 24)
@@ -58,8 +22,8 @@ additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = merge(
     sponge ? rayleigh_sponge_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) : (;),
     held_suarez_cache(ᶜlocal_geometry),
 )
-function additional_tendency!(Yₜ, Y, p, t, comms_ctx = nothing)
-    hyperdiffusion_tendency!(Yₜ, Y, p, t, comms_ctx)
+function additional_tendency!(Yₜ, Y, p, t)
+    hyperdiffusion_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
     held_suarez_tendency!(Yₜ, Y, p, t)
 end
@@ -67,42 +31,13 @@ end
 center_initial_condition(local_geometry) =
     center_initial_condition(local_geometry, Val(:ρθ))
 
-function postprocessing(sol, p, output_dir, usempi = false)
-    sol_global = []
-    if usempi
-        for sol_step in sol.u
-            sol_step_values_center_global =
-                DataLayouts.gather(comms_ctx, Fields.field_values(sol_step.c))
-            sol_step_values_face_global =
-                DataLayouts.gather(comms_ctx, Fields.field_values(sol_step.f))
-            if ClimaComms.iamroot(Context)
-                sol_step_global = Fields.FieldVector(
-                    c = Fields.Field(
-                        sol_step_values_center_global,
-                        global_center_space,
-                    ),
-                    f = Fields.Field(
-                        sol_step_values_face_global,
-                        global_face_space,
-                    ),
-                )
-                push!(sol_global, sol_step_global)
-            end
-        end
-        if ClimaComms.iamroot(Context)
-        end
-    else
-        sol_global = sol.u
-    end
+function postprocessing(sol, output_dir)
+    @info "L₂ norm of ρθ at t = $(sol.t[1]): $(norm(sol.u[1].c.ρθ))"
+    @info "L₂ norm of ρθ at t = $(sol.t[end]): $(norm(sol.u[end].c.ρθ))"
 
-    if !usempi || (usempi && ClimaComms.iamroot(Context))
-        @info "L₂ norm of ρθ at t = $(sol.t[1]): $(norm(sol_global[1].c.ρθ))"
-        @info "L₂ norm of ρθ at t = $(sol.t[end]): $(norm(sol_global[end].c.ρθ))"
-
-        anim = Plots.@animate for Y in sol_global
-            ᶜv = Geometry.UVVector.(Y.c.uₕ).components.data.:2
-            Plots.plot(ᶜv, level = 3, clim = (-6, 6))
-        end
-        Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
+    anim = Plots.@animate for Y in sol.u
+        ᶜv = Geometry.UVVector.(Y.c.uₕ).components.data.:2
+        Plots.plot(ᶜv, level = 3, clim = (-6, 6))
     end
+    Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
 end

--- a/examples/hybrid/sphere/held_suarez_rhotheta_tempest.jl
+++ b/examples/hybrid/sphere/held_suarez_rhotheta_tempest.jl
@@ -6,46 +6,10 @@ include("baroclinic_wave_utilities.jl")
 const sponge = false
 
 # Variables required for driver.jl (modify as needed)
-helems, zelems, npoly = 4, 10, 4
-
-horzdomain = Domains.SphereDomain(R)
-vertdomain = Domains.IntervalDomain(
-    Geometry.ZPoint{FT}(FT(0)),
-    Geometry.ZPoint{FT}(FT(30e3));
-    boundary_tags = (:bottom, :top),
-)
-horzmesh = Meshes.EquiangularCubedSphere(horzdomain, helems)
-vertmesh = Meshes.IntervalMesh(vertdomain, nelems = zelems)
-quad = Spaces.Quadratures.GLL{npoly + 1}()
-
-Nv = Meshes.nelements(vertmesh)
-Nf_center, Nf_face = 4, 1
-vert_center_space = Spaces.CenterFiniteDifferenceSpace(vertmesh)
-
-if usempi
-    horztopology = Topologies.DistributedTopology2D(horzmesh, Context)
-    comms_ctx =
-        Spaces.setup_comms(Context, horztopology, quad, Nv + 1, Nf_center)
-    global_topology = Topologies.Topology2D(horzmesh)
-    global_horz_space = Spaces.SpectralElementSpace2D(global_topology, quad)
-    global_center_space = Spaces.ExtrudedFiniteDifferenceSpace(
-        global_horz_space,
-        vert_center_space,
-    )
-    global_face_space =
-        Spaces.FaceExtrudedFiniteDifferenceSpace(global_center_space)
-
-else
-    horztopology = Topologies.Topology2D(horzmesh)
-    comms_ctx = nothing
-end
-
-horzspace = Spaces.SpectralElementSpace2D(horztopology, quad, comms_ctx)
-
-hv_center_space =
-    Spaces.ExtrudedFiniteDifferenceSpace(horzspace, vert_center_space)
-hv_face_space = Spaces.FaceExtrudedFiniteDifferenceSpace(hv_center_space)
-
+horizontal_mesh = cubed_sphere_mesh(; radius = R, h_elem = 4)
+npoly = 4
+z_max = FT(30e3)
+z_elem = 10
 t_end = FT(60 * 60 * 24 * 10)
 dt = FT(400)
 dt_save_to_sol = FT(60 * 60 * 24)
@@ -63,8 +27,8 @@ additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = merge(
     sponge ? rayleigh_sponge_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) : (;),
     held_suarez_cache(ᶜlocal_geometry),
 )
-function additional_tendency!(Yₜ, Y, p, t, comms_ctx = nothing)
-    hyperdiffusion_tendency!(Yₜ, Y, p, t, comms_ctx)
+function additional_tendency!(Yₜ, Y, p, t)
+    hyperdiffusion_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
     held_suarez_tendency!(Yₜ, Y, p, t)
 end
@@ -72,42 +36,13 @@ end
 center_initial_condition(local_geometry) =
     center_initial_condition(local_geometry, Val(:ρθ))
 
-function postprocessing(sol, p, output_dir, usempi = false)
-    sol_global = []
-    if usempi
-        for sol_step in sol.u
-            sol_step_values_center_global =
-                DataLayouts.gather(comms_ctx, Fields.field_values(sol_step.c))
-            sol_step_values_face_global =
-                DataLayouts.gather(comms_ctx, Fields.field_values(sol_step.f))
-            if ClimaComms.iamroot(Context)
-                sol_step_global = Fields.FieldVector(
-                    c = Fields.Field(
-                        sol_step_values_center_global,
-                        global_center_space,
-                    ),
-                    f = Fields.Field(
-                        sol_step_values_face_global,
-                        global_face_space,
-                    ),
-                )
-                push!(sol_global, sol_step_global)
-            end
-        end
-        if ClimaComms.iamroot(Context)
-        end
-    else
-        sol_global = sol.u
-    end
+function postprocessing(sol, output_dir)
+    @info "L₂ norm of ρθ at t = $(sol.t[1]): $(norm(sol.u[1].c.ρθ))"
+    @info "L₂ norm of ρθ at t = $(sol.t[end]): $(norm(sol.u[end].c.ρθ))"
 
-    if !usempi || (usempi && ClimaComms.iamroot(Context))
-        @info "L₂ norm of ρθ at t = $(sol.t[1]): $(norm(sol_global[1].c.ρθ))"
-        @info "L₂ norm of ρθ at t = $(sol.t[end]): $(norm(sol_global[end].c.ρθ))"
-
-        anim = Plots.@animate for Y in sol_global
-            ᶜv = Geometry.UVVector.(Y.c.uₕ).components.data.:2
-            Plots.plot(ᶜv, level = 3, clim = (-6, 6))
-        end
-        Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
+    anim = Plots.@animate for Y in sol.u
+        ᶜv = Geometry.UVVector.(Y.c.uₕ).components.data.:2
+        Plots.plot(ᶜv, level = 3, clim = (-6, 6))
     end
+    Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
 end

--- a/perf/benchmark.jl
+++ b/perf/benchmark.jl
@@ -8,6 +8,7 @@ ENV["CI_PERF_SKIP_RUN"] = true # we only need haskey(ENV, "CI_PERF_SKIP_RUN") ==
 import ClimaCore
 
 filename = joinpath(EXAMPLE_DIR, "hybrid", "driver.jl")
+ENV["TEST_NAME"] = "sphere/baroclinic_wave_rhoe"
 
 try
     include(filename)


### PR DESCRIPTION
This PR reverts all the hybrid examples that use `driver.jl` to how they looked before #613; that is, it isolates all distributed computations to `driver.jl`. The interface for using `driver.jl` is unchanged, except now one must specify `horizontal_mesh_description`, `npoly`, `zmax`, and `zelem` instead of specifying `space` (this is to allow the driver to construct a distributed horizontal topology before constructing the entire hybrid space). Since the inertial gravity wave test case works with `driver.jl` again, I've added it back to the Buildkite pipeline.

In addition, this PR allows restart files to work in distributed mode (any restart file that needs to get read by or written to from multiple processors gets `_pid$pid` appended to its name). Also, while testing this PR, I found it useful to modify `t_end` and `dt_save_to_disk` from the run script (by setting `ENV[T_END]` and `ENV[DT_SAVE_TO_DISK]`), instead of repeatedly modifying the test case files. I've left this change in the PR, in case others also find it helpful.