### PR TITLE
Enable multi-setup driver

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -1,25 +1,55 @@
-# Test-specific definitions (may be overwritten in each test case file)
-# TODO: Allow some of these to be enironment variables or command line arguments
-horizontal_mesh = nothing # must be object of type AbstractMesh
-npoly = 0
-z_max = 0
-z_elem = 0
-t_end = 0
-dt = 0
-dt_save_to_sol = 0 # 0 means don't save to sol
-dt_save_to_disk = 0 # 0 means don't save to disk
-ode_algorithm = nothing # must be object of type OrdinaryDiffEqAlgorithm
-jacobian_flags = (;) # only required by implicit ODE algorithms
-max_newton_iters = 10 # only required by ODE algorithms that use Newton's method
-show_progress_bar = false
-additional_callbacks = () # e.g., printing diagnostic information
-additional_solver_kwargs = (;) # e.g., abstol and reltol
+# Test-specific definitions; these can be redefined in every test file
+setups = [] # should be a collection of `HybridDriverSetup`s (see below)
+postprocessing(sols, output_dir) = nothing # processes the results of `setups`
 test_implicit_solver = false # makes solver extremely slow when set to `true`
-additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = (;)
-additional_tendency!(Yₜ, Y, p, t) = nothing
-center_initial_condition(local_geometry) = (;)
-face_initial_condition(local_geometry) = (;)
-postprocessing(sol, output_dir) = nothing
+
+################################################################################
+
+if !haskey(ENV, "FLOAT_TYPE") || ENV["FLOAT_TYPE"] == "Float32"
+    const FT = Float32
+elseif ENV["FLOAT_TYPE"] == "Float64"
+    const FT = Float64
+else
+    error("ENV[\"FLOAT_TYPE\"] can only be set to \"Float32\" or \"Float64\"")
+end
+
+################################################################################
+
+using ClimaCore: Meshes
+using OrdinaryDiffEq
+
+default_additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = (;)
+default_additional_tendency!(Yₜ, Y, p, t) = nothing
+default_center_initial_condition(local_geometry) = (;)
+default_face_initial_condition(local_geometry) = (;)
+
+# TODO: Add parameter specification to HybridDriverSetup, and get default
+# parameter values using ClimaParameters.
+Base.@kwdef struct HybridDriverSetup{AC, AT, CIC, FIC, HM, OA, JF, ACB, ASK}
+    # Model specification
+    additional_cache::AC = default_additional_cache
+    additional_tendency!::AT = default_additional_tendency!
+
+    # Initial condition specification
+    center_initial_condition::CIC = default_center_initial_condition
+    face_initial_condition::FIC = default_face_initial_condition
+    horizontal_mesh::HM = nothing # no good default value
+    npoly::Int = 1
+    z_max::FT = FT(0)
+    z_elem::Int = 1
+    restart_file_name::String = "" # empty string means don't use restart file
+
+    # Timestepping specification
+    t_end::FT = FT(0)
+    dt::FT = FT(0)
+    dt_save_to_sol::FT = FT(0) # 0 means don't save to sol
+    dt_save_to_disk::FT = FT(0) # 0 means don't save to disk
+    ode_algorithm::OA = SSPRK33 # good general-purpose explicit ODE algorithm
+    jacobian_flags::JF = (;) # only for implicit algs
+    max_newton_iters::Int = 10 # default in OrdinaryDiffEq; only for Newton algs
+    additional_callbacks::ACB = () # e.g., for printing diagnostic information
+    additional_solver_kwargs::ASK = (;) # e.g., for setting abstol and reltol
+end
 
 ################################################################################
 
@@ -32,12 +62,12 @@ if is_distributed
         using ClimaCommsMPI
         const Context = ClimaCommsMPI.MPICommsContext
     else
-        error("ENV[\"CLIMACORE_DISTRIBUTED\"] only supports the \"MPI\" option")
+        error("ENV[\"CLIMACORE_DISTRIBUTED\"] can only be set to \"MPI\"")
     end
     const pid, nprocs = ClimaComms.init(Context)
     logger_stream = ClimaComms.iamroot(Context) ? stderr : devnull
     prev_logger = global_logger(ConsoleLogger(logger_stream, Logging.Info))
-    @info "Setting up distributed run on $nprocs \
+    @info "Using ClimaCore in distributed mode with $nprocs \
         processor$(nprocs == 1 ? "" : "s")"
 else
     using TerminalLoggers: TerminalLogger
@@ -48,13 +78,16 @@ atexit() do
 end
 
 import ClimaCore: enable_threading
-enable_threading() = false
+if haskey(ENV, "CLIMACORE_MULTITHREADED")
+    enable_threading() = true
+    @info "Using ClimaCore in multi-threaded mode with $(Threads.nthreads()) \
+        thread$(Threads.nthreads() == 1 ? "" : "s")"
+else
+    enable_threading() = false
+end
 
-using OrdinaryDiffEq
 using DiffEqCallbacks
 using JLD2
-
-const FT = get(ENV, "FLOAT_TYPE", "Float32") == "Float32" ? Float32 : Float64
 
 include("../implicit_solver_debugging_tools.jl")
 include("../ordinary_diff_eq_bug_fixes.jl")
@@ -66,91 +99,13 @@ else
     error("ENV[\"TEST_NAME\"] required (e.g., \"sphere/baroclinic_wave_rhoe\")")
 end
 include(joinpath(test_dir, "$test_file_name.jl"))
+@info "Running `$test_dir/$test_file_name`"
 
-# TODO: When is_distributed is true, automatically compute the maximum number of
-# bytes required to store an element from Y.c or Y.f (or, really, from any Field
-# on which gather() or weighted_dss!() will get called). One option is to make a
-# non-distributed space, extract the local_geometry type, and find the sizes of
-# the output types of center_initial_condition() and face_initial_condition()
-# for that local_geometry type. This is rather inefficient, though, so for now
-# we will just hardcode the value of 4.
-max_field_element_size = 4 # ρ = 1 byte, 𝔼 = 1 byte, uₕ = 2 bytes
-
-if haskey(ENV, "RESTART_FILE")
-    restart_file_name = ENV["RESTART_FILE"]
-    if is_distributed
-        restart_file_name =
-            split(restart_file_name, ".jld2")[1] * "_pid$pid.jld2"
-    end
-    restart_data = jldopen(restart_file_name)
-    t_start = restart_data["t"]
-    Y = restart_data["Y"]
-    close(restart_data)
-    ᶜlocal_geometry = Fields.local_geometry_field(Y.c)
-    ᶠlocal_geometry = Fields.local_geometry_field(Y.f)
-    if is_distributed
-        comms_ctx = Spaces.setup_comms(
-            Context,
-            axes(Y.c).horizontal_space.topology,
-            Spaces.Quadratures.GLL{npoly + 1}(),
-            z_elem + 1,
-            max_field_element_size,
-        )
-    else
-        comms_ctx = nothing
-    end
-else
-    t_start = FT(0)
-    if is_distributed
-        h_space, comms_ctx = make_distributed_horizontal_space(
-            horizontal_mesh,
-            npoly,
-            Context,
-            z_elem + 1,
-            max_field_element_size,
-        )
-    else
-        h_space = make_horizontal_space(horizontal_mesh, npoly)
-        comms_ctx = nothing
-    end
-    center_space, face_space = make_hybrid_spaces(h_space, z_max, z_elem)
-    ᶜlocal_geometry = Fields.local_geometry_field(center_space)
-    ᶠlocal_geometry = Fields.local_geometry_field(face_space)
-    Y = Fields.FieldVector(
-        c = center_initial_condition.(ᶜlocal_geometry),
-        f = face_initial_condition.(ᶠlocal_geometry),
-    )
-end
-p = get_cache(ᶜlocal_geometry, ᶠlocal_geometry, comms_ctx, dt)
-
-if ode_algorithm <: Union{
-    OrdinaryDiffEq.OrdinaryDiffEqImplicitAlgorithm,
-    OrdinaryDiffEq.OrdinaryDiffEqAdaptiveImplicitAlgorithm,
-}
-    use_transform = !(ode_algorithm in (Rosenbrock23, Rosenbrock32))
-    W = SchurComplementW(Y, use_transform, jacobian_flags, test_implicit_solver)
-    jac_kwargs =
-        use_transform ? (; jac_prototype = W, Wfact_t = Wfact!) :
-        (; jac_prototype = W, Wfact = Wfact!)
-
-    alg_kwargs = (; linsolve = linsolve!)
-    if ode_algorithm <: Union{
-        OrdinaryDiffEq.OrdinaryDiffEqNewtonAlgorithm,
-        OrdinaryDiffEq.OrdinaryDiffEqNewtonAdaptiveAlgorithm,
-    }
-        alg_kwargs =
-            (; alg_kwargs..., nlsolve = NLNewton(; max_iter = max_newton_iters))
-    end
-else
-    jac_kwargs = alg_kwargs = (;)
-end
-
-if haskey(ENV, "OUTPUT_DIR")
-    output_dir = ENV["OUTPUT_DIR"]
-else
-    output_dir =
-        joinpath(@__DIR__, test_dir, "output", test_file_name, string(FT))
-end
+output_dir = get(
+    ENV,
+    "OUTPUT_DIR",
+    joinpath(@__DIR__, test_dir, "output", test_file_name, string(FT)),
+)
 mkpath(output_dir)
 
 function make_dss_func(comms_ctx)
@@ -171,89 +126,232 @@ function make_save_to_disk_func(output_dir, test_file_name, is_distributed)
     return save_to_disk_func
 end
 
-dss_func = make_dss_func(comms_ctx)
-save_to_disk_func =
-    make_save_to_disk_func(output_dir, test_file_name, is_distributed)
+set_zero_tgrad!(∂Y∂t, Y, p, t) = ∂Y∂t .= FT(0)
 
-dss_callback = FunctionCallingCallback(dss_func, func_start = true)
-if dt_save_to_disk == 0
-    save_to_disk_callback = nothing
-else
-    save_to_disk_callback = PeriodicCallback(
-        save_to_disk_func,
-        dt_save_to_disk;
-        initial_affect = true,
-    )
-end
-callback =
-    CallbackSet(dss_callback, save_to_disk_callback, additional_callbacks...)
+# Using @goto and @label instead of a for loop removes the need for `global`
+# annotations on all variables useful for debugging. If any setup causes the
+# simulation to crash, all the variables defined below for that
+# TODO: Eliminate redundant operations (e.g., if multiple setups use the same
+# initial conditions, don't recompute the initial conditions every time).
+# TODO: Allow multiple setups to be run in parallel.
+indices = 1:length(setups)
+sols = similar(setups, SciMLBase.AbstractODESolution)
+begin
+    iterator = iterate(indices)
+    @label driver_loop
+    if !isnothing(iterator)
+        index, state = iterator
+        (;
+            additional_cache,
+            additional_tendency!,
+            center_initial_condition,
+            face_initial_condition,
+            horizontal_mesh,
+            npoly,
+            z_max,
+            z_elem,
+            restart_file_name,
+            t_end,
+            dt,
+            dt_save_to_sol,
+            dt_save_to_disk,
+            ode_algorithm,
+            jacobian_flags,
+            max_newton_iters,
+            additional_callbacks,
+            additional_solver_kwargs,
+        ) = setups[index]
 
-problem = SplitODEProblem(
-    ODEFunction(
-        implicit_tendency!;
-        jac_kwargs...,
-        tgrad = (∂Y∂t, Y, p, t) -> (∂Y∂t .= FT(0)),
-    ),
-    remaining_tendency!,
-    Y,
-    (t_start, t_end),
-    p,
-)
-integrator = OrdinaryDiffEq.init(
-    problem,
-    ode_algorithm(; alg_kwargs...);
-    saveat = dt_save_to_sol == 0 ? [] : dt_save_to_sol,
-    callback = callback,
-    dt = dt,
-    adaptive = false,
-    progress = show_progress_bar,
-    progress_steps = 1,
-    additional_solver_kwargs...,
-)
+        restart_file_name = get(ENV, "RESTART_FILE", restart_file_name)
+        if restart_file_name == ""
+            t_start = FT(0)
+            if is_distributed
+                # TODO: When is_distributed is true, automatically compute the
+                # maximum number base type objects required to store an element
+                # from Y.c or Y.f (or, to be accurate, an element from any Field
+                # on which gather() or weighted_dss!() will get called). One
+                # option is to make a non-distributed space, extract the
+                # local_geometry type, and find the sizes of the output types of
+                # center_initial_condition() and face_initial_condition() for
+                # that local_geometry type. This is rather inefficient, though,
+                # so for now we will just hardcode the value of 4.
+                max_field_element_size = 4 # ρ = 1 FT, 𝔼 = 1 FT, uₕ = 2 FTs
+                h_space, comms_ctx = make_distributed_horizontal_space(
+                    horizontal_mesh,
+                    npoly,
+                    Context,
+                    z_elem + 1,
+                    max_field_element_size,
+                )
+            else
+                h_space = make_horizontal_space(horizontal_mesh, npoly)
+                comms_ctx = nothing
+            end
+            center_space, face_space =
+                make_hybrid_spaces(h_space, z_max, z_elem)
+            ᶜlocal_geometry = Fields.local_geometry_field(center_space)
+            ᶠlocal_geometry = Fields.local_geometry_field(face_space)
+            Y = Fields.FieldVector(
+                c = center_initial_condition.(ᶜlocal_geometry),
+                f = face_initial_condition.(ᶠlocal_geometry),
+            )
+        else
+            if is_distributed
+                restart_file_name =
+                    split(restart_file_name, ".jld2")[1] * "_pid$pid.jld2"
+            end
+            restart_data = jldopen(restart_file_name)
+            t_start = restart_data["t"]
+            Y = restart_data["Y"]
+            close(restart_data)
+            ᶜlocal_geometry = Fields.local_geometry_field(Y.c)
+            ᶠlocal_geometry = Fields.local_geometry_field(Y.f)
+            if is_distributed
+                comms_ctx = Spaces.setup_comms(
+                    Context,
+                    axes(Y.c).horizontal_space.topology, # Y.f would also work
+                    Spaces.Quadratures.GLL{npoly + 1}(),
+                    Spaces.nlevels(axes(Y.f)),
+                    max(sizeof(eltype(Y.c)), sizeof(eltype(Y.f))) ÷
+                    sizeof(eltype(Y)),
+                )
+            else
+                comms_ctx = nothing
+            end
+        end
+        p = get_cache(
+            ᶜlocal_geometry,
+            ᶠlocal_geometry,
+            additional_cache,
+            additional_tendency!,
+            comms_ctx,
+            dt,
+        )
 
-if haskey(ENV, "CI_PERF_SKIP_RUN") # for performance analysis
-    throw(:exit_profile)
-end
-
-@info "Running `$test_dir/$test_file_name` test case"
-sol = @timev OrdinaryDiffEq.solve!(integrator)
-
-if is_distributed # replace sol.u on the root processor with the global sol.u
-    if ClimaComms.iamroot(Context)
-        global_h_space = make_horizontal_space(horizontal_mesh, npoly)
-        global_center_space, global_face_space =
-            make_hybrid_spaces(global_h_space, z_max, z_elem)
-        global_Y_c_type = Fields.Field{
-            typeof(Fields.field_values(Y.c)),
-            typeof(global_center_space),
+        if ode_algorithm <: Union{
+            OrdinaryDiffEq.OrdinaryDiffEqImplicitAlgorithm,
+            OrdinaryDiffEq.OrdinaryDiffEqAdaptiveImplicitAlgorithm,
         }
-        global_Y_f_type = Fields.Field{
-            typeof(Fields.field_values(Y.f)),
-            typeof(global_face_space),
-        }
-        global_Y_type = Fields.FieldVector{
-            FT,
-            NamedTuple{(:c, :f), Tuple{global_Y_c_type, global_Y_f_type}},
-        }
-        global_sol_u = similar(sol.u, global_Y_type)
-    end
-    for i in 1:length(sol.u)
-        global_Y_c =
-            DataLayouts.gather(comms_ctx, Fields.field_values(sol.u[i].c))
-        global_Y_f =
-            DataLayouts.gather(comms_ctx, Fields.field_values(sol.u[i].f))
-        if ClimaComms.iamroot(Context)
-            global_sol_u[i] = Fields.FieldVector(
-                c = Fields.Field(global_Y_c, global_center_space),
-                f = Fields.Field(global_Y_f, global_face_space),
+            use_transform = !(ode_algorithm in (Rosenbrock23, Rosenbrock32))
+            W = SchurComplementW(
+                Y,
+                use_transform,
+                jacobian_flags,
+                test_implicit_solver,
+            )
+            jac_kwargs =
+                use_transform ? (; jac_prototype = W, Wfact_t = Wfact!) :
+                (; jac_prototype = W, Wfact = Wfact!)
+
+            alg_kwargs = (; linsolve = linsolve!)
+            if ode_algorithm <: Union{
+                OrdinaryDiffEq.OrdinaryDiffEqNewtonAlgorithm,
+                OrdinaryDiffEq.OrdinaryDiffEqNewtonAdaptiveAlgorithm,
+            }
+                alg_kwargs = (;
+                    alg_kwargs...,
+                    nlsolve = NLNewton(; max_iter = max_newton_iters),
+                )
+            end
+        else
+            jac_kwargs = alg_kwargs = (;)
+        end
+
+        dss_callback =
+            FunctionCallingCallback(make_dss_func(comms_ctx); func_start = true)
+        if dt_save_to_disk == 0
+            save_to_disk_callback = nothing
+        else
+            save_to_disk_callback = PeriodicCallback(
+                make_save_to_disk_func(
+                    output_dir,
+                    test_file_name,
+                    is_distributed,
+                ),
+                dt_save_to_disk;
+                initial_affect = true,
             )
         end
+        callback = CallbackSet(
+            dss_callback,
+            save_to_disk_callback,
+            additional_callbacks...,
+        )
+
+        ode_function = SplitFunction(
+            ODEFunction(
+                implicit_tendency!;
+                jac_kwargs...,
+                tgrad = set_zero_tgrad!,
+            ),
+            remaining_tendency!;
+        )
+        integrator = init(
+            SplitODEProblem(ode_function, Y, (t_start, t_end), p),
+            ode_algorithm(; alg_kwargs...);
+            saveat = dt_save_to_sol == 0 ? [] : dt_save_to_sol,
+            callback = callback,
+            dt = dt,
+            adaptive = false,
+            progress = isinteractive(), # show progress bar when running in REPL
+            progress_steps = 1,
+            additional_solver_kwargs...,
+        )
+
+        if haskey(ENV, "CI_PERF_SKIP_RUN") # for performance analysis
+            throw(:exit_profile)
+        end
+
+        sols[index] = @timev solve!(integrator)
+
+        iterator = iterate(indices, state)
+        @goto driver_loop
     end
-    if ClimaComms.iamroot(Context)
-        sol = DiffEqBase.sensitivity_solution(sol, global_sol_u, sol.t)
+end
+
+if is_distributed
+    # Replace sol.u on the root processor with the sol.u.
+    function global_sol(sol, setup)
+        (; horizontal_mesh, npoly, z_max, z_elem) = setup
+        if ClimaComms.iamroot(Context)
+            global_h_space = make_horizontal_space(horizontal_mesh, npoly)
+            global_center_space, global_face_space =
+                make_hybrid_spaces(global_h_space, z_max, z_elem)
+            global_Y_c_type = Fields.Field{
+                typeof(Fields.field_values(Y.c)),
+                typeof(global_center_space),
+            }
+            global_Y_f_type = Fields.Field{
+                typeof(Fields.field_values(Y.f)),
+                typeof(global_face_space),
+            }
+            global_Y_type = Fields.FieldVector{
+                FT,
+                NamedTuple{(:c, :f), Tuple{global_Y_c_type, global_Y_f_type}},
+            }
+            global_sol_u = similar(sol.u, global_Y_type)
+        end
+        for i in 1:length(sol.u)
+            global_Y_c =
+                DataLayouts.gather(comms_ctx, Fields.field_values(sol.u[i].c))
+            global_Y_f =
+                DataLayouts.gather(comms_ctx, Fields.field_values(sol.u[i].f))
+            if ClimaComms.iamroot(Context)
+                global_sol_u[i] = Fields.FieldVector(
+                    c = Fields.Field(global_Y_c, global_center_space),
+                    f = Fields.Field(global_Y_f, global_face_space),
+                )
+            end
+        end
+        if ClimaComms.iamroot(Context)
+            return DiffEqBase.sensitivity_solution(sol, global_sol_u, sol.t)
+        else
+            return nothing
+        end
     end
+    sols = map(global_sol, sols, setups)
 end
 if !is_distributed || (is_distributed && ClimaComms.iamroot(Context))
     ENV["GKSwstype"] = "nul" # avoid displaying plots
-    postprocessing(sol, output_dir)
+    postprocessing(sols, output_dir)
 end

--- a/examples/hybrid/sphere/balanced_flow_rhoe.jl
+++ b/examples/hybrid/sphere/balanced_flow_rhoe.jl
@@ -19,6 +19,7 @@ setups = [
         t_end = FT(60 * 60),
         dt = FT(5),
         dt_save_to_sol = FT(50),
+        dt_save_to_disk = FT(0), # 0 means don't save to disk
         ode_algorithm = SSPRK33,
     ),
 ]

--- a/examples/hybrid/sphere/balanced_flow_rhotheta.jl
+++ b/examples/hybrid/sphere/balanced_flow_rhotheta.jl
@@ -3,33 +3,28 @@ using ClimaCore.DataLayouts
 
 include("baroclinic_wave_utilities.jl")
 
-const sponge = false
+sponge = false
 
-# Variables required for driver.jl (modify as needed)
-horizontal_mesh = cubed_sphere_mesh(; radius = R, h_elem = 4)
-npoly = 4
-z_max = FT(30e3)
-z_elem = 10
-t_end = FT(60 * 60 * 24 * 10)
-dt = FT(400)
-dt_save_to_sol = FT(60 * 60 * 24)
-dt_save_to_disk = FT(0) # 0 means don't save to disk
-ode_algorithm = OrdinaryDiffEq.Rosenbrock23
-jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)
+setups = [
+    HybridDriverSetup(;
+        additional_cache = make_additional_cache(sponge; κ₄ = FT(2e17)),
+        additional_tendency! = make_additional_tendency(sponge),
+        center_initial_condition = make_center_initial_condition(:ρθ, true),
+        face_initial_condition = make_face_initial_condition(),
+        horizontal_mesh = cubed_sphere_mesh(; radius = R, h_elem = 4),
+        npoly = 4,
+        z_max = FT(30e3),
+        z_elem = 10,
+        t_end = FT(60 * 60 * 24 * 10),
+        dt = FT(400),
+        dt_save_to_sol = FT(60 * 60 * 24),
+        ode_algorithm = Rosenbrock23,
+        jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact),
+    ),
+]
 
-additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = merge(
-    hyperdiffusion_cache(ᶜlocal_geometry, ᶠlocal_geometry; κ₄ = FT(2e17)),
-    sponge ? rayleigh_sponge_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) : (;),
-)
-function additional_tendency!(Yₜ, Y, p, t)
-    hyperdiffusion_tendency!(Yₜ, Y, p, t)
-    sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
-end
-
-center_initial_condition(local_geometry) =
-    center_initial_condition(local_geometry, Val(:ρθ); is_balanced_flow = true)
-
-function postprocessing(sol, output_dir)
+function postprocessing(sols, output_dir)
+    sol = sols[1]
     @info "L₂ norm of ρθ at t = $(sol.t[1]): $(norm(sol.u[1].c.ρθ))"
     @info "L₂ norm of ρθ at t = $(sol.t[end]): $(norm(sol.u[end].c.ρθ))"
 

--- a/examples/hybrid/sphere/balanced_flow_rhotheta.jl
+++ b/examples/hybrid/sphere/balanced_flow_rhotheta.jl
@@ -18,6 +18,7 @@ setups = [
         t_end = FT(60 * 60 * 24 * 10),
         dt = FT(400),
         dt_save_to_sol = FT(60 * 60 * 24),
+        dt_save_to_disk = FT(0), # 0 means don't save to disk
         ode_algorithm = Rosenbrock23,
         jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact),
     ),

--- a/examples/hybrid/sphere/baroclinic_wave_rhoe.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhoe.jl
@@ -3,32 +3,28 @@ using ClimaCore.DataLayouts
 
 include("baroclinic_wave_utilities.jl")
 
-const sponge = false
+sponge = false
 
-# Variables required for driver.jl (modify as needed)
-horizontal_mesh = cubed_sphere_mesh(; radius = R, h_elem = 4)
-npoly = 4
-z_max = FT(30e3)
-z_elem = 10
-t_end = FT(60 * 60 * 24 * 10)
-dt = FT(400)
-dt_save_to_sol = FT(60 * 60 * 24)
-dt_save_to_disk = FT(0) # 0 means don't save to disk
-ode_algorithm = OrdinaryDiffEq.Rosenbrock23
-jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :no_∂ᶜp∂ᶜK, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)
+setups = [
+    HybridDriverSetup(;
+        additional_cache = make_additional_cache(sponge; κ₄ = FT(2e17)),
+        additional_tendency! = make_additional_tendency(sponge),
+        center_initial_condition = make_center_initial_condition(:ρe),
+        face_initial_condition = make_face_initial_condition(),
+        horizontal_mesh = cubed_sphere_mesh(; radius = R, h_elem = 4),
+        npoly = 4,
+        z_max = FT(30e3),
+        z_elem = 10,
+        t_end = FT(60 * 60 * 24 * 10),
+        dt = FT(400),
+        dt_save_to_sol = FT(60 * 60 * 24),
+        ode_algorithm = Rosenbrock23,
+        jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :no_∂ᶜp∂ᶜK, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact),
+    ),
+]
 
-additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = merge(
-    hyperdiffusion_cache(ᶜlocal_geometry, ᶠlocal_geometry; κ₄ = FT(2e17)),
-    sponge ? rayleigh_sponge_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) : (;),
-)
-function additional_tendency!(Yₜ, Y, p, t)
-    hyperdiffusion_tendency!(Yₜ, Y, p, t)
-    sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
-end
-
-center_initial_condition(local_geometry) =
-    center_initial_condition(local_geometry, Val(:ρe))
-function postprocessing(sol, output_dir)
+function postprocessing(sols, output_dir)
+    sol = sols[1]
     @info "L₂ norm of ρe at t = $(sol.t[1]): $(norm(sol.u[1].c.ρe))"
     @info "L₂ norm of ρe at t = $(sol.t[end]): $(norm(sol.u[end].c.ρe))"
 

--- a/examples/hybrid/sphere/baroclinic_wave_rhoe.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhoe.jl
@@ -18,6 +18,7 @@ setups = [
         t_end = FT(60 * 60 * 24 * 10),
         dt = FT(400),
         dt_save_to_sol = FT(60 * 60 * 24),
+        dt_save_to_disk = FT(0), # 0 means don't save to disk
         ode_algorithm = Rosenbrock23,
         jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :no_∂ᶜp∂ᶜK, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact),
     ),

--- a/examples/hybrid/sphere/baroclinic_wave_rhotheta.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhotheta.jl
@@ -3,33 +3,28 @@ using ClimaCore.DataLayouts
 
 include("baroclinic_wave_utilities.jl")
 
-const sponge = false
+sponge = false
 
-# Variables required for driver.jl (modify as needed)
-horizontal_mesh = cubed_sphere_mesh(; radius = R, h_elem = 4)
-npoly = 4
-z_max = FT(30e3)
-z_elem = 10
-t_end = FT(60 * 60 * 24 * 10)
-dt = FT(400)
-dt_save_to_sol = FT(60 * 60 * 24)
-dt_save_to_disk = FT(0) # 0 means don't save to disk
-ode_algorithm = OrdinaryDiffEq.Rosenbrock23
-jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)
+setups = [
+    HybridDriverSetup(;
+        additional_cache = make_additional_cache(sponge; κ₄ = FT(2e17)),
+        additional_tendency! = make_additional_tendency(sponge),
+        center_initial_condition = make_center_initial_condition(:ρθ),
+        face_initial_condition = make_face_initial_condition(),
+        horizontal_mesh = cubed_sphere_mesh(; radius = R, h_elem = 4),
+        npoly = 4,
+        z_max = FT(30e3),
+        z_elem = 10,
+        t_end = FT(60 * 60 * 24 * 10),
+        dt = FT(400),
+        dt_save_to_sol = FT(60 * 60 * 24),
+        ode_algorithm = Rosenbrock23,
+        jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact),
+    ),
+]
 
-additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = merge(
-    hyperdiffusion_cache(ᶜlocal_geometry, ᶠlocal_geometry; κ₄ = FT(2e17)),
-    sponge ? rayleigh_sponge_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) : (;),
-)
-function additional_tendency!(Yₜ, Y, p, t)
-    hyperdiffusion_tendency!(Yₜ, Y, p, t)
-    sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
-end
-
-center_initial_condition(local_geometry) =
-    center_initial_condition(local_geometry, Val(:ρθ))
-
-function postprocessing(sol, output_dir)
+function postprocessing(sols, output_dir)
+    sol = sols[1]
     @info "L₂ norm of ρθ at t = $(sol.t[1]): $(norm(sol.u[1].c.ρθ))"
     @info "L₂ norm of ρθ at t = $(sol.t[end]): $(norm(sol.u[end].c.ρθ))"
 

--- a/examples/hybrid/sphere/baroclinic_wave_rhotheta.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhotheta.jl
@@ -18,6 +18,7 @@ setups = [
         t_end = FT(60 * 60 * 24 * 10),
         dt = FT(400),
         dt_save_to_sol = FT(60 * 60 * 24),
+        dt_save_to_disk = FT(0), # 0 means don't save to disk
         ode_algorithm = Rosenbrock23,
         jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact),
     ),

--- a/examples/hybrid/sphere/held_suarez_rhoe.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe.jl
@@ -3,35 +3,28 @@ using ClimaCore.DataLayouts
 
 include("baroclinic_wave_utilities.jl")
 
-const sponge = false
+sponge = false
 
-# Variables required for driver.jl (modify as needed)
-horizontal_mesh = cubed_sphere_mesh(; radius = R, h_elem = 4)
-npoly = 4
-z_max = FT(30e3)
-z_elem = 10
-t_end = FT(60 * 60 * 24 * 10)
-dt = FT(400)
-dt_save_to_sol = FT(60 * 60 * 24)
-dt_save_to_disk = FT(0) # 0 means don't save to disk
-ode_algorithm = OrdinaryDiffEq.Rosenbrock23
-jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :no_∂ᶜp∂ᶜK, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)
+setups = [
+    HybridDriverSetup(;
+        additional_cache = make_additional_cache(sponge, true; κ₄ = FT(2e17)),
+        additional_tendency! = make_additional_tendency(sponge, true),
+        center_initial_condition = make_center_initial_condition(:ρe),
+        face_initial_condition = make_face_initial_condition(),
+        horizontal_mesh = cubed_sphere_mesh(; radius = R, h_elem = 4),
+        npoly = 4,
+        z_max = FT(30e3),
+        z_elem = 10,
+        t_end = FT(60 * 60 * 24 * 10),
+        dt = FT(400),
+        dt_save_to_sol = FT(60 * 60 * 24),
+        ode_algorithm = Rosenbrock23,
+        jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :no_∂ᶜp∂ᶜK, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact),
+    ),
+]
 
-additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = merge(
-    hyperdiffusion_cache(ᶜlocal_geometry, ᶠlocal_geometry; κ₄ = FT(2e17)),
-    sponge ? rayleigh_sponge_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) : (;),
-    held_suarez_cache(ᶜlocal_geometry),
-)
-function additional_tendency!(Yₜ, Y, p, t)
-    hyperdiffusion_tendency!(Yₜ, Y, p, t)
-    sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
-    held_suarez_tendency!(Yₜ, Y, p, t)
-end
-
-center_initial_condition(local_geometry) =
-    center_initial_condition(local_geometry, Val(:ρe))
-
-function postprocessing(sol, output_dir)
+function postprocessing(sols, output_dir)
+    sol = sols[1]
     @info "L₂ norm of ρe at t = $(sol.t[1]): $(norm(sol.u[1].c.ρe))"
     @info "L₂ norm of ρe at t = $(sol.t[end]): $(norm(sol.u[end].c.ρe))"
 

--- a/examples/hybrid/sphere/held_suarez_rhoe.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe.jl
@@ -18,6 +18,7 @@ setups = [
         t_end = FT(60 * 60 * 24 * 10),
         dt = FT(400),
         dt_save_to_sol = FT(60 * 60 * 24),
+        dt_save_to_disk = FT(0), # 0 means don't save to disk
         ode_algorithm = Rosenbrock23,
         jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :no_∂ᶜp∂ᶜK, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact),
     ),

--- a/examples/hybrid/sphere/held_suarez_rhoe_int.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe_int.jl
@@ -3,35 +3,28 @@ using ClimaCore.DataLayouts
 
 include("baroclinic_wave_utilities.jl")
 
-const sponge = false
+sponge = false
 
-# Variables required for driver.jl (modify as needed)
-horizontal_mesh = cubed_sphere_mesh(; radius = R, h_elem = 4)
-npoly = 4
-z_max = FT(30e3)
-z_elem = 10
-t_end = FT(60 * 60 * 24 * 10)
-dt = FT(400)
-dt_save_to_sol = FT(60 * 60 * 24)
-dt_save_to_disk = FT(0) # 0 means don't save to disk
-ode_algorithm = OrdinaryDiffEq.Rosenbrock23
-jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)
+setups = [
+    HybridDriverSetup(;
+        additional_cache = make_additional_cache(sponge, true; κ₄ = FT(2e17)),
+        additional_tendency! = make_additional_tendency(sponge, true),
+        center_initial_condition = make_center_initial_condition(:ρe_int),
+        face_initial_condition = make_face_initial_condition(),
+        horizontal_mesh = cubed_sphere_mesh(; radius = R, h_elem = 4),
+        npoly = 4,
+        z_max = FT(30e3),
+        z_elem = 10,
+        t_end = FT(60 * 60 * 24 * 10),
+        dt = FT(400),
+        dt_save_to_sol = FT(60 * 60 * 24),
+        ode_algorithm = Rosenbrock23,
+        jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact),
+    ),
+]
 
-additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = merge(
-    hyperdiffusion_cache(ᶜlocal_geometry, ᶠlocal_geometry; κ₄ = FT(2e17)),
-    sponge ? rayleigh_sponge_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) : (;),
-    held_suarez_cache(ᶜlocal_geometry),
-)
-function additional_tendency!(Yₜ, Y, p, t)
-    hyperdiffusion_tendency!(Yₜ, Y, p, t)
-    sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
-    held_suarez_tendency!(Yₜ, Y, p, t)
-end
-
-center_initial_condition(local_geometry) =
-    center_initial_condition(local_geometry, Val(:ρe_int))
-
-function postprocessing(sol, output_dir)
+function postprocessing(sols, output_dir)
+    sol = sols[1]
     @info "L₂ norm of ρe_int at t = $(sol.t[1]): $(norm(sol.u[1].c.ρe_int))"
     @info "L₂ norm of ρe_int at t = $(sol.t[end]): $(norm(sol.u[end].c.ρe_int))"
 

--- a/examples/hybrid/sphere/held_suarez_rhoe_int.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe_int.jl
@@ -18,6 +18,7 @@ setups = [
         t_end = FT(60 * 60 * 24 * 10),
         dt = FT(400),
         dt_save_to_sol = FT(60 * 60 * 24),
+        dt_save_to_disk = FT(0), # 0 means don't save to disk
         ode_algorithm = Rosenbrock23,
         jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact),
     ),

--- a/examples/hybrid/sphere/held_suarez_rhotheta.jl
+++ b/examples/hybrid/sphere/held_suarez_rhotheta.jl
@@ -4,35 +4,28 @@ using ClimaCore
 
 include("baroclinic_wave_utilities.jl")
 
-const sponge = false
+sponge = false
 
-# Variables required for driver.jl (modify as needed)
-horizontal_mesh = cubed_sphere_mesh(; radius = R, h_elem = 4)
-npoly = 4
-z_max = FT(30e3)
-z_elem = 10
-t_end = FT(60 * 60 * 24 * 10)
-dt = FT(400)
-dt_save_to_sol = FT(60 * 60 * 24)
-dt_save_to_disk = FT(0) # 0 means don't save to disk
-ode_algorithm = OrdinaryDiffEq.Rosenbrock23
-jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)
+setups = [
+    HybridDriverSetup(;
+        additional_cache = make_additional_cache(sponge, true; κ₄ = FT(2e17)),
+        additional_tendency! = make_additional_tendency(sponge, true),
+        center_initial_condition = make_center_initial_condition(:ρθ),
+        face_initial_condition = make_face_initial_condition(),
+        horizontal_mesh = cubed_sphere_mesh(; radius = R, h_elem = 4),
+        npoly = 4,
+        z_max = FT(30e3),
+        z_elem = 10,
+        t_end = FT(60 * 60 * 24 * 10),
+        dt = FT(400),
+        dt_save_to_sol = FT(60 * 60 * 24),
+        ode_algorithm = Rosenbrock23,
+        jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact),
+    ),
+]
 
-additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = merge(
-    hyperdiffusion_cache(ᶜlocal_geometry, ᶠlocal_geometry; κ₄ = FT(2e17)),
-    sponge ? rayleigh_sponge_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) : (;),
-    held_suarez_cache(ᶜlocal_geometry),
-)
-function additional_tendency!(Yₜ, Y, p, t)
-    hyperdiffusion_tendency!(Yₜ, Y, p, t)
-    sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
-    held_suarez_tendency!(Yₜ, Y, p, t)
-end
-
-center_initial_condition(local_geometry) =
-    center_initial_condition(local_geometry, Val(:ρθ))
-
-function postprocessing(sol, output_dir)
+function postprocessing(sols, output_dir)
+    sol = sols[1]
     @info "L₂ norm of ρθ at t = $(sol.t[1]): $(norm(sol.u[1].c.ρθ))"
     @info "L₂ norm of ρθ at t = $(sol.t[end]): $(norm(sol.u[end].c.ρθ))"
 

--- a/examples/hybrid/sphere/held_suarez_rhotheta.jl
+++ b/examples/hybrid/sphere/held_suarez_rhotheta.jl
@@ -19,6 +19,7 @@ setups = [
         t_end = FT(60 * 60 * 24 * 10),
         dt = FT(400),
         dt_save_to_sol = FT(60 * 60 * 24),
+        dt_save_to_disk = FT(0), # 0 means don't save to disk
         ode_algorithm = Rosenbrock23,
         jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact),
     ),

--- a/examples/hybrid/sphere/held_suarez_rhotheta_tempest.jl
+++ b/examples/hybrid/sphere/held_suarez_rhotheta_tempest.jl
@@ -23,6 +23,7 @@ setups = [
         t_end = FT(60 * 60 * 24 * 10),
         dt = FT(400),
         dt_save_to_sol = FT(60 * 60 * 24),
+        dt_save_to_disk = FT(0), # 0 means don't save to disk
         ode_algorithm = Rosenbrock23,
         jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact),
     ),

--- a/examples/hybrid/sphere/held_suarez_rhotheta_tempest.jl
+++ b/examples/hybrid/sphere/held_suarez_rhotheta_tempest.jl
@@ -3,40 +3,33 @@ using ClimaCore.DataLayouts
 
 include("baroclinic_wave_utilities.jl")
 
-const sponge = false
+sponge = false
 
-# Variables required for driver.jl (modify as needed)
-horizontal_mesh = cubed_sphere_mesh(; radius = R, h_elem = 4)
-npoly = 4
-z_max = FT(30e3)
-z_elem = 10
-t_end = FT(60 * 60 * 24 * 10)
-dt = FT(400)
-dt_save_to_sol = FT(60 * 60 * 24)
-dt_save_to_disk = FT(0) # 0 means don't save to disk
-ode_algorithm = OrdinaryDiffEq.Rosenbrock23
-jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)
-
-additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = merge(
-    hyperdiffusion_cache(
-        ᶜlocal_geometry,
-        ᶠlocal_geometry;
-        κ₄ = FT(2e17),
-        use_tempest_mode = true,
+setups = [
+    HybridDriverSetup(;
+        additional_cache = make_additional_cache(
+            sponge,
+            true;
+            κ₄ = FT(2e17),
+            use_tempest_mode = true,
+        ),
+        additional_tendency! = make_additional_tendency(sponge, true),
+        center_initial_condition = make_center_initial_condition(:ρθ),
+        face_initial_condition = make_face_initial_condition(),
+        horizontal_mesh = cubed_sphere_mesh(; radius = R, h_elem = 4),
+        npoly = 4,
+        z_max = FT(30e3),
+        z_elem = 10,
+        t_end = FT(60 * 60 * 24 * 10),
+        dt = FT(400),
+        dt_save_to_sol = FT(60 * 60 * 24),
+        ode_algorithm = Rosenbrock23,
+        jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact),
     ),
-    sponge ? rayleigh_sponge_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) : (;),
-    held_suarez_cache(ᶜlocal_geometry),
-)
-function additional_tendency!(Yₜ, Y, p, t)
-    hyperdiffusion_tendency!(Yₜ, Y, p, t)
-    sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
-    held_suarez_tendency!(Yₜ, Y, p, t)
-end
+]
 
-center_initial_condition(local_geometry) =
-    center_initial_condition(local_geometry, Val(:ρθ))
-
-function postprocessing(sol, output_dir)
+function postprocessing(sols, output_dir)
+    sol = sols[1]
     @info "L₂ norm of ρθ at t = $(sol.t[1]): $(norm(sol.u[1].c.ρθ))"
     @info "L₂ norm of ρθ at t = $(sol.t[end]): $(norm(sol.u[end].c.ρθ))"
 


### PR DESCRIPTION
This PR modifies the hybrid examples driver so that it can handle more than one setup (model specification + domain/initial condition specification + timestepping specification). Instead of each test case file passing several variables to the driver, it now passes a list of setups, and the driver loops over those setups. Post-processing can then be done on a list of `sols`, each of which corresponds to a given setup.

This PR also modifies the inertial gravity wave test case to loop over multiple discretizations (though not all the ones used in the paper because that would be too slow).