### PR TITLE
add vector aliases

### DIFF
--- a/src/Geometry/Geometry.jl
+++ b/src/Geometry/Geometry.jl
@@ -6,6 +6,23 @@ import LinearAlgebra
 using StaticArrays
 
 export ⊗
+export UVector, VVector, WVector, UVVector, UWVector, VWVector, UVWVector
+export Covariant1Vector,
+    Covariant2Vector,
+    Covariant3Vector,
+    Covariant12Vector,
+    Covariant13Vector,
+    Covariant23Vector,
+    Covariant123Vector
+export Contravariant1Vector,
+    Contravariant2Vector,
+    Contravariant3Vector,
+    Contravariant12Vector,
+    Contravariant13Vector,
+    Contravariant23Vector,
+    Contravariant123Vector
+
+
 
 include("coordinates.jl")
 include("axistensors.jl")


### PR DESCRIPTION
Julia aliases are determined by exports, so if we export them we get nicer printing:
```
julia> UVVector(1.0,2.0)
2-element UVVector{Float64} with indices ClimaCore.Geometry.LocalAxis{(1, 2)}():
 1.0
 2.0
```