### PR TITLE
Define set! on fields

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -196,6 +196,7 @@ Base.ones(::Spaces.AbstractSpace)
 Base.sum(::Fields.Field)
 Fields.Statistics.mean(::Fields.Field)
 Fields.LinearAlgebra.norm(::Fields.Field)
+Fields.set!
 ```
 
 ## Limiters

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -332,4 +332,22 @@ function level(field::FaceExtrudedFiniteDifferenceField, v::PlusHalf)
     Field(data, hspace)
 end
 
+"""
+    set!(f::Function, field::Field, args = ())
+
+Apply function `f` to populate
+values in field `field`. `f` must
+have a function signature with signature
+`f(::LocalGeometry[, args...])`.
+Additional arguments may be passed to
+`f` with `args`.
+"""
+function set!(f::Function, field::Field, args = ())
+    space = axes(field)
+    local_geometry = local_geometry_field(space)
+    field .= f.(local_geometry, args...)
+    return nothing
+end
+
+
 end # module

--- a/test/Fields/field.jl
+++ b/test/Fields/field.jl
@@ -257,3 +257,18 @@ end
         @test var === Fields.single_field(Y, prop_chain)
     end
 end
+
+@testset "Set!" begin
+    space = spectral_space_2D()
+    function FieldFromNamedTuple(space, nt::NamedTuple)
+        cmv(z) = nt
+        return cmv.(Fields.coordinate_field(space))
+    end
+    FT = Float64
+    nt = (; x = FT(0), y = FT(0))
+    Y = FieldFromNamedTuple(space, nt)
+    foo(local_geom) =
+        sin(local_geom.coordinates.x * local_geom.coordinates.y) + 3
+    Fields.set!(foo, Y.x)
+    @test all((parent(Y.x) .> 1))
+end


### PR DESCRIPTION
This PR adds a function, `set!`:
```julia
"""
    set!(f::Function, field::Field, args = ())
Apply function `f` to populate
values in field `field`. `f` must
have a function signature with signature
`f(::LocalGeometry[, args...])`.
Additional arguments may be passed to
`f` with `args`.
"""
```
This is used in Oceananigans, ClimaAtmos, and it would be useful in TC. I think it makes sense to make it a ClimaCore feature.