### PR TITLE
Generalize remap2latlon

### DIFF
--- a/examples/hybrid/sphere/remap_pipeline.jl
+++ b/examples/hybrid/sphere/remap_pipeline.jl
@@ -42,6 +42,21 @@ jld2_files = filter(x -> endswith(x, ".jld2"), readdir(jld2_dir, join = true))
 
 function remap2latlon(filein, nc_dir, nlat, nlon)
     datain = jldopen(filein)
+    t_now = datain["t"]
+    Y = datain["Y"]
+    ClimaCoreTempestRemap.remap2latlon(
+        Y;
+        t_now,
+        nc_dir,
+        filename = filein,
+        nlat,
+        nlon,
+    )
+end
+
+# TODO: delete if above function is okay
+function remap2latlon(filein, nc_dir, nlat, nlon)
+    datain = jldopen(filein)
 
     # get time and states from jld2 data
     t_now = datain["t"]


### PR DESCRIPTION
This PR generalizes the `remap2latlon` function in `examples/hybrid/sphere/remap_pipeline.jl`. AFAIU, this function was used to create the animations for the recent Held Suarez runs. This function accepts a FieldVector and exports an NC file. Exporting this NC file during IO callbacks will be useful for both visualization and regression tests. This interface no longer relies on an existing JLD2 file, and is independent of the structure of `Y` (e.g., `Y.c` doesn't need to exist).