### PR TITLE
Plane lim use time history

### DIFF
--- a/examples/Manifest.toml
+++ b/examples/Manifest.toml
@@ -172,10 +172,10 @@ uuid = "c8b6d40d-e815-466f-95ae-c48aefa668fa"
 version = "0.7.0"
 
 [[deps.ClimaTimeSteppers]]
-deps = ["CUDA", "DiffEqBase", "KernelAbstractions", "LinearAlgebra", "MPI", "SciMLBase", "StaticArrays"]
-git-tree-sha1 = "4e49bf1b897d233c914acbcf381505f4788e0b6b"
+deps = ["CUDA", "DiffEqBase", "DiffEqCallbacks", "KernelAbstractions", "LinearAlgebra", "MPI", "SciMLBase", "StaticArrays"]
+git-tree-sha1 = "bcd531eff2eea0e29e35d255bfa8450bb696748b"
 uuid = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
-version = "0.1.1"
+version = "0.2.0"
 
 [[deps.CloseOpenIntervals]]
 deps = ["ArrayInterface", "Static"]

--- a/examples/plane/limiters_advection.jl
+++ b/examples/plane/limiters_advection.jl
@@ -255,7 +255,7 @@ for (k, ne) in enumerate(ne_seq)
         (0.0, end_time),
         parameters,
     )
-    yend = solve(
+    sol = solve(
         prob,
         SSPRK33ShuOsher(),
         dt = dt,
@@ -264,7 +264,7 @@ for (k, ne) in enumerate(ne_seq)
         adaptive = false,
         progress_message = (dt, u, p, t) -> t,
     )
-    sol = (u = [yend],)
+
     L1err[k] =
         norm(
             (sol.u[end].ρq ./ sol.u[end].ρ .- y0.ρq ./ y0.ρ) ./ (y0.ρq ./ y0.ρ),


### PR DESCRIPTION
This updates the 2D plane limiters example after ClimaTimeSteppers.jl [PR #39](https://github.com/CliMA/ClimaTimeSteppers.jl/pull/39) to save history of all outputs