### PR TITLE
`DataLayouts` F Dimension Constructor Checks

### DIFF
--- a/src/DataLayouts/DataLayouts.jl
+++ b/src/DataLayouts/DataLayouts.jl
@@ -191,6 +191,7 @@ function IJKFVH{S, Nij, Nk}(array::AbstractArray{T, 6}) where {S, Nij, Nk, T}
     @assert size(array, 2) == Nij
     @assert size(array, 3) == Nk
     check_basetype(T, S)
+    @assert size(array, 4) == typesize(T, S)
     IJKFVH{S, Nij, Nk, typeof(array)}(array)
 end
 
@@ -257,6 +258,7 @@ function IJFH{S, Nij}(array::AbstractArray{T, 4}) where {S, Nij, T}
     @assert size(array, 1) == Nij
     @assert size(array, 2) == Nij
     check_basetype(T, S)
+    @assert size(array, 3) == typesize(T, S)
     IJFH{S, Nij, typeof(array)}(array)
 end
 
@@ -412,6 +414,7 @@ end
 function IFH{S, Ni}(array::AbstractArray{T, 3}) where {S, Ni, T}
     @assert size(array, 1) == Ni
     check_basetype(T, S)
+    @assert size(array, 2) == typesize(T, S)
     IFH{S, Ni, typeof(array)}(array)
 end
 
@@ -665,6 +668,7 @@ function IJF{S, Nij}(array::AbstractArray{T, 3}) where {S, Nij, T}
     @assert size(array, 1) == Nij
     @assert size(array, 2) == Nij
     check_basetype(T, S)
+    @assert size(array, 3) == typesize(T, S)
     IJF{S, Nij, typeof(array)}(array)
 end
 
@@ -803,6 +807,7 @@ end
 function IF{S, Ni}(array::AbstractArray{T, 2}) where {S, Ni, T}
     @assert size(array, 1) == Ni
     check_basetype(T, S)
+    @assert size(array, 2) == typesize(T, S)
     IF{S, Ni, typeof(array)}(array)
 end
 function IF{S, Ni}(::Type{MArray}, ::Type{T}) where {S, Ni, T}
@@ -901,16 +906,19 @@ end
 function VF{S, Nv}(array::AbstractArray{T, 2}) where {S, Nv, T}
     check_basetype(T, S)
     @assert size(array, 1) == Nv
+    @assert size(array, 2) == typesize(T, S)
     VF{S, Nv, typeof(array)}(array)
 end
 
 function VF{S, Nv}(array::AbstractVector{T}) where {S, Nv, T}
+    check_basetype(T, S)
     @assert typesize(T, S) == 1
     VF{S, Nv}(reshape(array, (:, 1)))
 end
 
 function VF{S, Nv}(ArrayType, nelements) where {S, Nv}
     T = eltype(ArrayType)
+    check_basetype(T, S)
     VF{S, Nv}(ArrayType(undef, nelements, typesize(T, S)))
 end
 
@@ -1018,6 +1026,8 @@ end
 
 function VIJFH{S, Nv, Nij}(array::AbstractArray{T, 5}) where {S, Nv, Nij, T}
     @assert size(array, 2) == size(array, 3) == Nij
+    @assert size(array, 4) == typesize(T, S)
+    check_basetype(T, S)
     VIJFH{S, Nv, Nij, typeof(array)}(array)
 end
 
@@ -1188,6 +1198,7 @@ end
 
 function VIFH{S, Nv, Ni}(array::AbstractArray{T, 4}) where {S, Nv, Ni, T}
     @assert size(array, 2) == Ni
+    @assert size(array, 3) == typesize(T, S)
     check_basetype(T, S)
     VIFH{S, Nv, Ni, typeof(array)}(array)
 end

--- a/test/DataLayouts/data0d.jl
+++ b/test/DataLayouts/data0d.jl
@@ -189,7 +189,7 @@ end
     S = Complex{FT}
     data_f = DataF{S}(ones(FT, 2))
     Nv = 10
-    data_vifh = VIFH{S, Nv, 4}(ones(FT, Nv, 4, 3, 10))
+    data_vifh = VIFH{S, Nv, 4}(ones(FT, Nv, 4, 2, 10))
     data_vifh2 = data_f .+ data_vifh
     @test data_vifh2 isa VIFH{S, Nv}
     @test size(data_vifh2) == (4, 1, 1, Nv, 10)

--- a/test/DataLayouts/data1d.jl
+++ b/test/DataLayouts/data1d.jl
@@ -119,7 +119,7 @@ end
         for FT in TestFloatTypes
             Nv = 2
             S1 = NamedTuple{(:a, :b), Tuple{Complex{FT}, FT}}
-            data1 = ones(FT, Nv, 2)
+            data1 = ones(FT, Nv, 3)
             S2 = NamedTuple{(:c,), Tuple{FT}}
             data2 = ones(FT, Nv, 1)
 

--- a/test/Spaces/ddss1.jl
+++ b/test/Spaces/ddss1.jl
@@ -1,3 +1,7 @@
+#=
+julia --project=test
+using Revise; include(joinpath("test", "Spaces", "ddss1.jl"))
+=#
 using Logging
 using Test
 import CUDA
@@ -114,11 +118,6 @@ end
     Nq = 3
     space, comms_ctx = distributed_space((4, 1), (true, true), (Nq, 1, 1))
     y0 = init_state_scalar.(Fields.local_geometry_field(space), Ref(nothing))
-
-    dims = (Nq, Nq, 0, 4)
-    array = similar(parent(y0), dims)
-    data = DataLayouts.rebuild(Fields.field_values(y0), array)
-    space = axes(y0)
     empty_field = similar(y0, Tuple{})
     dss_buffer = Spaces.create_dss_buffer(empty_field)
     @test empty_field == Spaces.weighted_dss!(empty_field)


### PR DESCRIPTION
Adds `F` dimension checks on backing data arrays for `DataLayouts`. See #664 