### PR TITLE
Non-zero metric term in warped spaces

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -402,6 +402,17 @@ steps:
       config: cpu
       queue: central
       slurm_ntasks: 1
+  
+  - label: ":computer: Density current 2D hybrid invariant total energy (topography mesh interface)"
+    key: "cpu_density_current_2d_hybrid_invariant_total_energy_no-warp_topography"
+    command:
+      - "julia --color=yes --project=examples examples/hybrid/plane/topo_dc_2dinvariant_rhoe.jl"
+    artifact_paths:
+      - "examples/hybrid/plane/output/dc_invariant_etot_topo/*"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
 
   - label: ":computer: Density current 2D hybrid invariant potential temperature"
     key: "cpu_density_current_2d_hybrid_invariant_potential_temperature"

--- a/examples/hybrid/plane/topo_dc_2dinvariant_rhoe.jl
+++ b/examples/hybrid/plane/topo_dc_2dinvariant_rhoe.jl
@@ -1,0 +1,359 @@
+using Test
+using StaticArrays, IntervalSets, LinearAlgebra, UnPack
+
+import ClimaCore:
+    ClimaCore,
+    slab,
+    Spaces,
+    Domains,
+    Meshes,
+    Geometry,
+    Topologies,
+    Spaces,
+    Fields,
+    Operators,
+    Hypsography
+using ClimaCore.Geometry
+
+using Logging: global_logger
+using TerminalLoggers: TerminalLogger
+global_logger(TerminalLogger())
+
+function no_warp(coord)
+    x = Geometry.component(coord, 1)
+    FT = eltype(x)
+    return FT(0) * x
+end
+
+function hvspace_2D(
+    xlim = (-π, π),
+    zlim = (0, 4π),
+    xelem = 64,
+    zelem = 32,
+    npoly = 4,
+    warp_fn = no_warp,
+)
+    FT = Float64
+    vertdomain = Domains.IntervalDomain(
+        Geometry.ZPoint{FT}(zlim[1]),
+        Geometry.ZPoint{FT}(zlim[2]);
+        boundary_names = (:bottom, :top),
+    )
+    vertmesh = Meshes.IntervalMesh(vertdomain, nelems = zelem)
+    vert_face_space = Spaces.FaceFiniteDifferenceSpace(vertmesh)
+
+    horzdomain = Domains.IntervalDomain(
+        Geometry.XPoint{FT}(xlim[1]),
+        Geometry.XPoint{FT}(xlim[2]);
+        periodic = true,
+    )
+    horzmesh = Meshes.IntervalMesh(horzdomain, nelems = xelem)
+    horztopology = Topologies.IntervalTopology(horzmesh)
+    quad = Spaces.Quadratures.GLL{npoly + 1}()
+    horzspace = Spaces.SpectralElementSpace1D(horztopology, quad)
+    z_surface = warp_fn.(Fields.coordinate_field(horzspace))
+    hv_face_space = Spaces.ExtrudedFiniteDifferenceSpace(
+        horzspace,
+        vert_face_space,
+        Hypsography.LinearAdaption(),
+        z_surface,
+    )
+    hv_center_space = Spaces.CenterExtrudedFiniteDifferenceSpace(hv_face_space)
+    return (hv_center_space, hv_face_space)
+end
+
+# set up 2D domain - doubly periodic box
+hv_center_space, hv_face_space = hvspace_2D((-25600, 25600), (0, 6400))
+
+const MSLP = 1e5 # mean sea level pressure
+const grav = 9.8 # gravitational constant
+const R_d = 287.058 # R dry (gas constant / mol mass dry air)
+const γ = 1.4 # heat capacity ratio
+const C_p = R_d * γ / (γ - 1) # heat capacity at constant pressure
+const C_v = R_d / (γ - 1) # heat capacity at constant volume
+const T_0 = 273.16 # triple point temperature
+
+Φ(z) = grav * z
+
+# Reference: https://journals.ametsoc.org/view/journals/mwre/140/4/mwr-d-10-05073.1.xml, Section 5a
+# Prognostic thermodynamic variable: Total Energy
+function init_dry_density_current_2d(x, z)
+    x_c = 0.0
+    z_c = 3000.0
+    r_c = 1.0
+    x_r = 4000.0
+    z_r = 2000.0
+    θ_b = 300.0
+    θ_c = -15.0
+    cp_d = C_p
+    cv_d = C_v
+    p_0 = MSLP
+    g = grav
+
+    # auxiliary quantities
+    r = sqrt((x - x_c)^2 / x_r^2 + (z - z_c)^2 / z_r^2)
+    θ_p = r < r_c ? 0.5 * θ_c * (1.0 + cospi(r / r_c)) : 0.0 # potential temperature perturbation
+
+    θ = θ_b + θ_p # potential temperature
+    π_exn = 1.0 - Φ(z) / cp_d / θ # exner function
+    T = π_exn * θ # temperature
+    p = p_0 * π_exn^(cp_d / R_d) # pressure
+    ρ = p / R_d / T # density
+    e = cv_d * (T - T_0) + Φ(z)
+    ρe = ρ * e # total energy
+
+    return (ρ = ρ, ρe = ρe)
+end
+
+# initial conditions
+coords = Fields.coordinate_field(hv_center_space)
+face_coords = Fields.coordinate_field(hv_face_space)
+
+Yc = map(coord -> init_dry_density_current_2d(coord.x, coord.z), coords)
+uₕ = map(_ -> Geometry.Covariant1Vector(0.0), coords)
+w = map(_ -> Geometry.Covariant3Vector(0.0), face_coords)
+Y = Fields.FieldVector(Yc = Yc, uₕ = uₕ, w = w)
+
+energy_0 = sum(Y.Yc.ρe)
+mass_0 = sum(Y.Yc.ρ)
+
+function rhs_invariant!(dY, Y, _, t)
+
+    cρ = Y.Yc.ρ # scalar on centers
+    fw = Y.w # Covariant3Vector on faces
+    cuₕ = Y.uₕ # Covariant1Vector on centers
+    cρe = Y.Yc.ρe
+
+    dρ = dY.Yc.ρ
+    dw = dY.w
+    duₕ = dY.uₕ
+    dρe = dY.Yc.ρe
+    z = coords.z
+
+    # 0) update w at the bottom
+    # fw = -g^31 cuₕ/ g^33
+
+    hdiv = Operators.Divergence()
+    hwdiv = Operators.WeakDivergence()
+    hgrad = Operators.Gradient()
+    hwgrad = Operators.WeakGradient()
+    hcurl = Operators.Curl()
+
+    If2c = Operators.InterpolateF2C()
+    Ic2f = Operators.InterpolateC2F(
+        bottom = Operators.Extrapolate(),
+        top = Operators.Extrapolate(),
+    )
+
+    dρ .= 0 .* cρ
+
+    cw = If2c.(fw)
+    fuₕ = Ic2f.(cuₕ)
+    cuw = Geometry.Covariant13Vector.(cuₕ) .+ Geometry.Covariant13Vector.(cw)
+
+    ce = @. cρe / cρ
+    cI = @. ce - Φ(z) - (norm(cuw)^2) / 2
+    cT = @. cI / C_v + T_0
+    cp = @. cρ * R_d * cT
+
+    h_tot = @. ce + cp / cρ # Total enthalpy at cell centers
+
+    ### HYPERVISCOSITY
+    # 1) compute hyperviscosity coefficients
+    χe = @. dρe = hwdiv(hgrad(h_tot)) # we store χe in dρe
+    χuₕ = @. duₕ = hwgrad(hdiv(cuₕ))
+
+    Spaces.weighted_dss!(dρe)
+    Spaces.weighted_dss!(duₕ)
+
+    κ₄ = 0.0 # m^4/s
+    @. dρe = -κ₄ * hwdiv(cρ * hgrad(χe))
+    @. duₕ = -κ₄ * (hwgrad(hdiv(χuₕ)))
+
+    # 1) Mass conservation
+    dw .= fw .* 0
+
+    # 1.a) horizontal divergence
+    dρ .-= hdiv.(cρ .* (cuw))
+
+    # 1.b) vertical divergence
+    vdivf2c = Operators.DivergenceF2C(
+        top = Operators.SetValue(Geometry.Contravariant3Vector(0.0)),
+        bottom = Operators.SetValue(Geometry.Contravariant3Vector(0.0)),
+    )
+    vdivc2f = Operators.DivergenceC2F(
+        top = Operators.SetValue(Geometry.Contravariant3Vector(0.0)),
+        bottom = Operators.SetValue(Geometry.Contravariant3Vector(0.0)),
+    )
+    # we want the total u³ at the boundary to be zero: we can either constrain
+    # both to be zero, or allow one to be non-zero and set the other to be its
+    # negation
+
+    # explicit part
+    dρ .-= vdivf2c.(Ic2f.(cρ .* cuₕ))
+    # implicit part
+    dρ .-= vdivf2c.(Ic2f.(cρ) .* fw)
+
+    # 2) Momentum equation
+
+    # curl term
+    hcurl = Operators.Curl()
+    # effectively a homogeneous Dirichlet condition on u₁ at the boundary
+    vcurlc2f = Operators.CurlC2F(
+        bottom = Operators.SetCurl(Geometry.Contravariant2Vector(0.0)),
+        top = Operators.SetCurl(Geometry.Contravariant2Vector(0.0)),
+    )
+
+    fω¹ = hcurl.(fw)
+    fω¹ .+= vcurlc2f.(cuₕ)
+
+    # cross product
+    # convert to contravariant
+    # these will need to be modified with topography
+    fu =
+        Geometry.Contravariant13Vector.(Ic2f.(cuₕ)) .+
+        Geometry.Contravariant13Vector.(fw)
+    fu¹ = Geometry.project.(Ref(Geometry.Contravariant1Axis()), fu)
+    fu³ = Geometry.project.(Ref(Geometry.Contravariant3Axis()), fu)
+    @. dw -= fω¹ × fu¹ # Covariant3Vector on faces
+    @. duₕ -= If2c(fω¹ × fu³)
+
+
+    @. duₕ -= hgrad(cp) / cρ
+    vgradc2f = Operators.GradientC2F(
+        bottom = Operators.SetGradient(Geometry.Covariant3Vector(0.0)),
+        top = Operators.SetGradient(Geometry.Covariant3Vector(0.0)),
+    )
+    @. dw -= vgradc2f(cp) / Ic2f(cρ)
+
+    cE = @. (norm(cuw)^2) / 2 + Φ(z)
+    @. duₕ -= hgrad(cE)
+    @. dw -= vgradc2f(cE)
+
+    # 3) total energy
+
+    @. dρe -= hdiv(cuw * (cρe + cp))
+    @. dρe -= vdivf2c(fw * Ic2f(cρe + cp))
+    @. dρe -= vdivf2c(Ic2f(cuₕ * (cρe + cp)))
+
+    # Uniform 2nd order diffusion
+    ∂c = Operators.GradientF2C()
+    fρ = @. Ic2f(cρ)
+    κ₂ = 75.0 # m^2/s
+
+    ᶠ∇ᵥuₕ = @. vgradc2f(cuₕ.components.data.:1)
+    ᶜ∇ᵥw = @. ∂c(fw.components.data.:1)
+    ᶠ∇ᵥh_tot = @. vgradc2f(h_tot)
+
+    ᶜ∇ₕuₕ = @. hgrad(cuₕ.components.data.:1)
+    ᶠ∇ₕw = @. hgrad(fw.components.data.:1)
+    ᶜ∇ₕh_tot = @. hgrad(h_tot)
+
+    hκ₂∇²uₕ = @. hwdiv(κ₂ * ᶜ∇ₕuₕ)
+    vκ₂∇²uₕ = @. vdivf2c(κ₂ * ᶠ∇ᵥuₕ)
+    hκ₂∇²w = @. hwdiv(κ₂ * ᶠ∇ₕw)
+    vκ₂∇²w = @. vdivc2f(κ₂ * ᶜ∇ᵥw)
+    hκ₂∇²h_tot = @. hwdiv(cρ * κ₂ * ᶜ∇ₕh_tot)
+    vκ₂∇²h_tot = @. vdivf2c(fρ * κ₂ * ᶠ∇ᵥh_tot)
+
+    dfw = dY.w.components.data.:1
+    dcu = dY.uₕ.components.data.:1
+
+    # Laplacian Diffusion (Uniform)
+    @. dcu += hκ₂∇²uₕ
+    @. dcu += vκ₂∇²uₕ
+    @. dfw += hκ₂∇²w
+    @. dfw += vκ₂∇²w
+    @. dρe += hκ₂∇²h_tot
+    @. dρe += vκ₂∇²h_tot
+
+    Spaces.weighted_dss!(dY.Yc)
+    Spaces.weighted_dss!(dY.uₕ)
+    Spaces.weighted_dss!(dY.w)
+
+    return dY
+end
+
+dYdt = similar(Y);
+rhs_invariant!(dYdt, Y, nothing, 0.0);
+
+# run!
+using OrdinaryDiffEq
+timeend = 900.0
+Δt = 0.3
+prob = ODEProblem(rhs_invariant!, Y, (0.0, timeend))
+integrator = OrdinaryDiffEq.init(
+    prob,
+    SSPRK33(),
+    dt = Δt,
+    saveat = 10.0,
+    progress = true,
+    progress_message = (dt, u, p, t) -> t,
+);
+
+if haskey(ENV, "CI_PERF_SKIP_RUN") # for performance analysis
+    throw(:exit_profile)
+end
+
+sol = @timev OrdinaryDiffEq.solve!(integrator)
+
+ENV["GKSwstype"] = "nul"
+import Plots, ClimaCorePlots
+Plots.GRBackend()
+
+dir = "dc_invariant_etot_no_warp"
+path = joinpath(@__DIR__, "output", dir)
+mkpath(path)
+
+anim = Plots.@animate for u in sol.u
+    Plots.plot(u.Yc.ρe ./ u.Yc.ρ)
+end
+Plots.mp4(anim, joinpath(path, "total_energy.mp4"), fps = 20)
+
+If2c = Operators.InterpolateF2C()
+anim = Plots.@animate for u in sol.u
+    ᶜuw = @. Geometry.Covariant13Vector(u.uₕ) +
+       Geometry.Covariant13Vector(If2c(u.w))
+    w = @. Geometry.project(Geometry.WAxis(), ᶜuw)
+    Plots.plot(w)
+end
+Plots.mp4(anim, joinpath(path, "vel_w.mp4"), fps = 20)
+
+anim = Plots.@animate for u in sol.u
+    ᶜuw = @. Geometry.Covariant13Vector(u.uₕ) +
+       Geometry.Covariant13Vector(If2c(u.w))
+    u = @. Geometry.project(Geometry.UAxis(), ᶜuw)
+    Plots.plot(u)
+end
+Plots.mp4(anim, joinpath(path, "vel_u.mp4"), fps = 20)
+
+# post-processing
+Es = [sum(u.Yc.ρe) for u in sol.u]
+Mass = [sum(u.Yc.ρ) for u in sol.u]
+
+Plots.png(
+    Plots.plot((Es .- energy_0) ./ energy_0),
+    joinpath(path, "energy_cons.png"),
+)
+Plots.png(
+    Plots.plot((Mass .- mass_0) ./ mass_0),
+    joinpath(path, "mass_cons.png"),
+)
+
+function linkfig(figpath, alt = "")
+    # buildkite-agent upload figpath
+    # link figure in logs if we are running on CI
+    if get(ENV, "BUILDKITE", "") == "true"
+        artifact_url = "artifact://$figpath"
+        print("\033]1338;url='$(artifact_url)';alt='$(alt)'\a\n")
+    end
+end
+
+linkfig(
+    relpath(joinpath(path, "energy_cons.png"), joinpath(@__DIR__, "../..")),
+    "Total Energy",
+)
+linkfig(
+    relpath(joinpath(path, "mass_cons.png"), joinpath(@__DIR__, "../..")),
+    "Mass",
+)

--- a/src/Hypsography/adaptspace.jl
+++ b/src/Hypsography/adaptspace.jl
@@ -87,7 +87,6 @@ function adapt_space!(
         face_column = column(space.face_local_geometry, i, j, h)
         fZ_column = column(Fields.field_values(fZ), i, j, h)
         f∇Z_column = column(Fields.field_values(f∇Z), i, j, h)
-
         center_column = column(space.center_local_geometry, i, j, h)
         cZ_column = column(Fields.field_values(cZ), i, j, h)
         c∇Z_column = column(Fields.field_values(c∇Z), i, j, h)
@@ -111,7 +110,7 @@ function adapt_space!(
             elseif v == Nv + 1
                 # if this is the domain max face level compute the metric
                 # extrapolating from the top face level of the domain
-                2 * fZ_column[v] - cZ_column[v - 1]
+                2 * (fZ_column[v] - cZ_column[v - 1])
             else
                 cZ_column[v] - cZ_column[v - 1]
             end

--- a/src/Spaces/dss.jl
+++ b/src/Spaces/dss.jl
@@ -73,6 +73,11 @@ end
     local_geometry::Geometry.LocalGeometry,
     weight,
 ) where {T, N} = arg * weight
+@inline dss_transform(
+    arg::Geometry.Covariant3Vector,
+    local_geometry::Geometry.LocalGeometry,
+    weight,
+) = arg * weight
 
 @inline function dss_transform(
     arg::Geometry.AxisVector,

--- a/test/Spaces/terrain_warp.jl
+++ b/test/Spaces/terrain_warp.jl
@@ -5,6 +5,7 @@ import ClimaCore:
     Domains,
     Geometry,
     Fields,
+    Operators,
     Meshes,
     Spaces,
     Topologies,
@@ -12,17 +13,18 @@ import ClimaCore:
 
 function warp_test_2d(coord)
     x = Geometry.component(coord, 1)
-    FT = eltype(x)
-    FT(0.5) * sin(x)
+    eltype(x)(0.5) * sin(x)
+end
+function nowarp_test_2d(coord)
+    x = Geometry.component(coord, 1)
+    eltype(x)(0) * sin(x)
 end
 function warp_test_3d(coord)
     x = Geometry.component(coord, 1)
     y = Geometry.component(coord, 2)
-    FT = eltype(x)
-    FT(0.5) * sin(x)^2 * cos(y)^2
+    eltype(x)(0.5) * sin(x)^2 * cos(y)^2
 end
-
-function hvspace_2D(
+function warpedspace_2D(
     FT = Float64,
     xlim = (0, π),
     zlim = (0, 1),
@@ -63,8 +65,42 @@ function hvspace_2D(
 
     return (c_space, f_space)
 end
+function hybridspace_2D(
+    FT = Float64,
+    xlim = (0, π),
+    zlim = (0, 1),
+    helem = 2,
+    velem = 10,
+    npoly = 5;
+    stretch = Meshes.Uniform(),
+)
+    vertdomain = Domains.IntervalDomain(
+        Geometry.ZPoint{FT}(zlim[1]),
+        Geometry.ZPoint{FT}(zlim[2]);
+        boundary_tags = (:bottom, :top),
+    )
+    vertmesh = Meshes.IntervalMesh(vertdomain, stretch, nelems = velem)
+    vert_face_space = Spaces.FaceFiniteDifferenceSpace(vertmesh)
 
-function hvspace_3D(
+    # Generate Horizontal Space
+    horzdomain = Domains.IntervalDomain(
+        Geometry.XPoint{FT}(xlim[1]),
+        Geometry.XPoint{FT}(xlim[2]);
+        periodic = true,
+    )
+    horzmesh = Meshes.IntervalMesh(horzdomain; nelems = helem)
+    horztopology = Topologies.IntervalTopology(horzmesh)
+    quad = Spaces.Quadratures.GLL{npoly + 1}()
+    hspace = Spaces.SpectralElementSpace1D(horztopology, quad)
+
+    # Extrusion
+    f_space = Spaces.ExtrudedFiniteDifferenceSpace(hspace, vert_face_space)
+    c_space = Spaces.CenterExtrudedFiniteDifferenceSpace(f_space)
+
+    return (c_space, f_space)
+end
+
+function warpedspace_3D(
     FT = Float64,
     xlim = (0, π),
     ylim = (0, π),
@@ -114,6 +150,7 @@ function hvspace_3D(
     return (c_space, f_space)
 end
 
+# 2D Tests
 @testset "2D Extruded Terrain Warped Space" begin
     # Generated "negative space" should be unity
     for FT in (Float32, Float64)
@@ -124,17 +161,73 @@ end
         polynom = 2:2:10
         horzelem = 2:2:10
         for nl in levels, np in polynom, nh in horzelem
+            ʷhv_center_space, ʷhv_face_space =
+                warpedspace_2D(FT, (xmin, xmax), (zmin, zmax), nh, nl, np;)
             hv_center_space, hv_face_space =
-                hvspace_2D(FT, (xmin, xmax), (zmin, zmax), nh, nl, np;)
-            ᶜcoords = Fields.coordinate_field(hv_center_space)
-            ᶠcoords = Fields.coordinate_field(hv_face_space)
-            z₀ = ClimaCore.Fields.level(ᶜcoords.z, 1)
+                hybridspace_2D(FT, (xmin, xmax), (zmin, zmax), nh, nl, np)
+            ⁿhv_center_space, ⁿhv_face_space = warpedspace_2D(
+                FT,
+                (xmin, xmax),
+                (zmin, zmax),
+                nh,
+                nl,
+                np;
+                warp_fn = warp_test_2d,
+            )
+            ʷᶜcoords = Fields.coordinate_field(ʷhv_center_space)
+            ʷᶠcoords = Fields.coordinate_field(ʷhv_face_space)
+
+            z₀ = ClimaCore.Fields.level(ʷᶜcoords.z, 1)
             # Check ∫ₓ(z_sfc)dx == known value from warp_test_2d
             @test sum(z₀ .- zmax / 2nl) - FT(1) <= FT(0.1 / np * nh * nl)
             @test abs(maximum(z₀) - FT(0.5)) <= FT(0.125)
         end
     end
 end
+
+@testset "2D Warped Mesh RHS Integration Test" begin
+    for FT in (Float64,)
+        xmin, xmax = FT(0), FT(π)
+        zmin, zmax = FT(0), FT(1)
+        levels = 10
+        polynom = 4
+        horzelem = 5
+        ⁿhv_center_space, ⁿhv_face_space = warpedspace_2D(
+            FT,
+            (xmin, xmax),
+            (zmin, zmax),
+            horzelem,
+            levels,
+            polynom;
+            warp_fn = nowarp_test_2d,
+        )
+        ⁿᶜcoords = Fields.coordinate_field(ⁿhv_center_space)
+        ⁿᶠcoords = Fields.coordinate_field(ⁿhv_face_space)
+
+        uₕ = map(_ -> Geometry.UVector(1.0), ⁿᶜcoords)
+        w = map(_ -> Geometry.WVector(0.0), ⁿᶠcoords)
+
+        uₕ = @. Geometry.Covariant1Vector(uₕ)
+        w = @. Geometry.Covariant3Vector(w)
+        Y = Fields.FieldVector(uₕ = uₕ, w = w)
+        dY = similar(Y)
+        function rhs(dY, Y, _, t)
+            dY.uₕ = uₕ
+            dY.w = w
+            Spaces.weighted_dss!(dY.uₕ)
+            Spaces.weighted_dss!(dY.w)
+            return (dY, Y)
+        end
+        (dY, Y) = rhs(dY, Y, nothing, 0.0)
+        @test maximum(
+            abs.(dY.uₕ.components.data.:1 .- uₕ.components.data.:1),
+        ) <= eps(FT)
+        @test maximum(abs.(dY.w.components.data.:1 .- w.components.data.:1)) <=
+              eps(FT)
+    end
+end
+
+# 3D Tests
 @testset "3D Extruded Terrain Warped Space" begin
     # Generated "negative space" should be unity
     for FT in (Float32, Float64)
@@ -146,7 +239,7 @@ end
         polynom = 2:2:10
         horzelem = 2:2:10
         for nl in levels, np in polynom, nh in horzelem
-            hv_center_space, hv_face_space = hvspace_3D(
+            hv_center_space, hv_face_space = warpedspace_3D(
                 FT,
                 (xmin, xmax),
                 (ymin, ymax),


### PR DESCRIPTION
@simonbyrne This is an example which results in the inexact transform error when attempting to return a "do-nothing" warp. 

E.g. See f∇Z_column[v](horizontal gradient of z field in warped space) in `adaptspace.jl` which is used to `reconstruct_metric` terms.  
```
f∇Z_column[v] = [3.183231456205249e-12]
f∇Z_column[v] = [2.0463630789890885e-12]
f∇Z_column[v] = [0.0]
f∇Z_column[v] = [-2.842170943040401e-14]
```
Error is an inexact transform
```
LoadError: InexactError: transform(ClimaCore.Geometry.CovariantAxis{(3,)}, [-8.185202263645752e-34, -0.026239656928510158])
```
Enforcing f∇Z_column[v]  to be zero results in a run that reproduces the results from the corresponding unwarped simulation. 