### PR TITLE
Add `PointSpace`

### DIFF
--- a/.github/workflows/Linux-UnitTests.yml
+++ b/.github/workflows/Linux-UnitTests.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 80
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/OS-UnitTests.yml
+++ b/.github/workflows/OS-UnitTests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test-os:
-    timeout-minutes: 60
+    timeout-minutes: 80
     strategy:
       fail-fast: true
       matrix:

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -8,6 +8,7 @@ CurrentModule = ClimaCore
 
 ```@docs
 DataLayouts
+DataLayouts.DataF
 DataLayouts.IF
 DataLayouts.IJF
 DataLayouts.VF

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -32,6 +32,9 @@ Field(values::V, space::S) where {V <: AbstractData, S <: AbstractSpace} =
 Field(::Type{T}, space::S) where {T, S <: AbstractSpace} =
     Field(similar(Spaces.coordinates_data(space), T), space)
 
+# Point Field
+const PointField{V, S} =
+    Field{V, S} where {V <: AbstractData, S <: Spaces.PointSpace}
 
 # Spectral Element Field
 const SpectralElementField2D{V, S} =

--- a/src/Spaces/Spaces.jl
+++ b/src/Spaces/Spaces.jl
@@ -31,6 +31,7 @@ coordinates_data(space::AbstractSpace) = local_geometry_data(space).coordinates
 include("quadrature.jl")
 import .Quadratures
 
+include("pointspace.jl")
 include("spectralelement.jl")
 include("finitedifference.jl")
 include("hybrid.jl")

--- a/src/Spaces/finitedifference.jl
+++ b/src/Spaces/finitedifference.jl
@@ -161,3 +161,9 @@ function right_boundary_name(space::FiniteDifferenceSpace)
     boundaries = Topologies.boundaries(Spaces.topology(space))
     propertynames(boundaries)[2]
 end
+
+function level(space::FiniteDifferenceSpace, v)
+    local_geometry = local_geometry_data(space)
+    local_geometry = level(local_geometry, v)
+    PointSpace(local_geometry)
+end

--- a/src/Spaces/pointspace.jl
+++ b/src/Spaces/pointspace.jl
@@ -1,0 +1,34 @@
+abstract type AbstractPointSpace <: AbstractSpace end
+
+local_geometry_data(space::AbstractPointSpace) = space.local_geometry
+
+"""
+    PointSpace <: AbstractSpace
+
+A zero-dimensional space. 
+"""
+struct PointSpace{LG} <: AbstractPointSpace
+    local_geometry::LG
+end
+
+function PointSpace(local_geometry::LG) where {LG <: Geometry.LocalGeometry}
+    FT = Geometry.undertype(LG)
+    local_geometry_data = DataLayouts.DataF{LG}(Matrix{FT})
+    local_geometry_data[] = local_geometry
+    return PointSpace(local_geometry_data)
+end
+
+function PointSpace(coord::Geometry.Abstract1DPoint{FT}) where {FT}
+    CoordType = typeof(coord)
+    AIdx = Geometry.coordinate_axis(CoordType)
+    local_geometry = Geometry.LocalGeometry(
+        coord,
+        FT(1.0),
+        FT(1.0),
+        Geometry.AxisTensor(
+            (Geometry.LocalAxis{AIdx}(), Geometry.CovariantAxis{AIdx}()),
+            FT(1.0),
+        ),
+    )
+    return PointSpace(local_geometry)
+end

--- a/src/Spaces/spectralelement.jl
+++ b/src/Spaces/spectralelement.jl
@@ -426,6 +426,17 @@ function slab(space::AbstractSpectralElementSpace, v, h)
 end
 slab(space::AbstractSpectralElementSpace, h) = slab(space, 1, h)
 
+function column(space::SpectralElementSpace1D, i, h)
+    local_geometry = local_geometry_data(space)
+    local_geometry = column(local_geometry, i, h)
+    PointSpace(local_geometry)
+end
+
+function column(space::SpectralElementSpace2D, i, j, h)
+    local_geometry = local_geometry_data(space)
+    local_geometry = column(local_geometry, i, j, h)
+    PointSpace(local_geometry)
+end
 
 # XXX: this cannot take `space` as it must be constructed beforehand so
 # that the `space` constructor can do DSS (to compute DSS weights)

--- a/test/Fields/field.jl
+++ b/test/Fields/field.jl
@@ -79,6 +79,9 @@ end
         f1_slab .= q .+ f2_slab
     end
     @test all(parent(f1) .== 3)
+
+    point_field = Fields.column(field, 1, 1, 1)
+    @test axes(point_field) isa Spaces.PointSpace
 end
 
 @testset "Broadcasting interception for tuple-valued fields" begin
@@ -271,4 +274,21 @@ end
         sin(local_geom.coordinates.x * local_geom.coordinates.y) + 3
     Fields.set!(foo, Y.x)
     @test all((parent(Y.x) .> 1))
+end
+
+@testset "PointField" begin
+    FT = Float64
+    coord = Geometry.XPoint(FT(π))
+    space = Spaces.PointSpace(coord)
+    @test parent(Spaces.local_geometry_data(space)) ==
+          FT[Geometry.component(coord, 1) 1.0 1.0 1.0 1.0]
+    field = Fields.coordinate_field(space)
+    @test field isa Fields.PointField
+    @test Fields.field_values(field)[] == coord
+
+    field = ones(space) .* π
+    sin_field = sin.(field)
+    add_field = field .+ field
+    @test isapprox(Fields.field_values(sin_field)[], FT(0.0); atol = √eps(FT))
+    @test isapprox(Fields.field_values(add_field)[], FT(2π))
 end

--- a/test/Spaces/sphere.jl
+++ b/test/Spaces/sphere.jl
@@ -28,6 +28,11 @@ using Test
     # unique nodes
     @test length(collect(Spaces.unique_nodes(space))) ==
           nn - nn2 - 2 * nn3 - 3 * nn4
+
+    point_space = column(space, 1, 1, 1)
+    @test point_space isa Spaces.PointSpace
+    @test Spaces.coordinates_data(point_space)[] ==
+          column(Spaces.coordinates_data(space), 1, 1, 1)[]
 end
 
 @testset "Volume of a spherical shell" begin


### PR DESCRIPTION
Adds a 0D `PointSpace` to `ClimaCore.Spaces`. The `PointSpace` allows for the creation of a space existing at a single point. This makes `Spaces` consistent. Calling `level` on a column field and calling `column` on a 2D horizontal field will return a field at that point. Enables #325 to be completed.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.