### PR TITLE
Widen compat range for ClimaCoreTempestRemap NC

### DIFF
--- a/lib/ClimaCoreTempestRemap/Project.toml
+++ b/lib/ClimaCoreTempestRemap/Project.toml
@@ -5,7 +5,7 @@ version = "0.3.3"
 
 [compat]
 ClimaCore = "0.8, 0.9, 0.10"
-NCDatasets = "0.11"
+NCDatasets = "0.11, 0.12"
 PkgVersion = "0.1"
 TempestRemap_jll = "2.1.2"
 julia = "1.7"


### PR DESCRIPTION
@dennisYatunin is trying to add RRTMGP.jl as a dep in ClimaAtmos, and we have a compat incompatibility with NCDatasets (need at least 0.12).

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
