### PR TITLE
Fix  ThirdOrderOneSided stencil right boundary assert

### DIFF
--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -1229,7 +1229,7 @@ function stencil_right_boundary(
     arg,
 )
     space = axes(arg)
-    @assert idx <= right_face_boundary_idx(space) + 1
+    @assert idx <= right_face_boundary_idx(space) - 1
 
     vᶠ = Geometry.contravariant3(
         getidx(velocity, loc, idx),

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -1094,6 +1094,9 @@ Supported boundary conditions are:
   and the first-order upwind scheme to compute `x` on the right boundary.
 - [`ThirdOrderOneSided(x₀)`](@ref): uses the third-order downwind reconstruction to compute `x` on the left boundary,
 and the third-order upwind reconstruction to compute `x` on the right boundary.
+
+!!! note
+    These boundary conditions do not define the value at the actual boundary faces, and so this operator cannot be materialized directly: it needs to be composed with another operator that does not make use of this value, e.g. a [`DivergenceF2C`](@ref) operator, with a [`SetValue`](@ref) boundary.
 """
 struct Upwind3rdOrderBiasedProductC2F{BCS} <: AdvectionOperator
     bcs::BCS


### PR DESCRIPTION
While reviewing the usage of the `Upwind3rdOrderBiasedProductC2F` operator, I think I stumbled in a small bug that was not caught by the unit test, since it's an assertion for a corner/limit case. 

I also attempted at describing the materialization issue, if one tries to use this operator with a temporary assignment. 

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
