### PR TITLE
Limiters: use q_min/q_max instead of Q_min/Q_max

### DIFF
--- a/src/Limiters/limiter.jl
+++ b/src/Limiters/limiter.jl
@@ -1,11 +1,11 @@
 """
-    quasimonotone_limiter!(ρq, ρ, min_ρq, max_ρq; rtol)
+    quasimonotone_limiter!(ρq, ρ, min_q, max_q; rtol)
 
 Arguments:
 - `ρq`: tracer density Field, where `q` denotes tracer concentration per unit mass
 - `ρ`: fluid density Field
-- `min_ρq`: Matrix of min(ρq) per element, per level: shape [horz_n_elems, vert_n_elems]
-- `max_ρq`: Matrix of max(ρq) per element, per level: shape [horz_n_elems, vert_n_elems]
+- `min_q`: Matrix of min(q) per element, per level: shape [horz_n_elems, vert_n_elems]
+- `max_q`: Matrix of max(q) per element, per level: shape [horz_n_elems, vert_n_elems]
 - `rtol`: relative tolerance needed to solve element-wise optimization problem
 
 This limiter is inspired by the one presented in Guba et al [GubaOpt2014](@cite).
@@ -25,11 +25,11 @@ a few iterations (typically a couple).
 function quasimonotone_limiter!(
     ρq::Fields.Field,
     ρ::Fields.Field,
-    min_ρq,
-    max_ρq;
+    min_q,
+    max_q;
     rtol,
 )
-    if ndims(min_ρq) == 1
+    if ndims(min_q) == 1
         space = axes(ρ)
     else
         space = axes(ρ).horizontal_space
@@ -38,16 +38,14 @@ function quasimonotone_limiter!(
     # Initialize temp variables
     FT = Spaces.undertype(space)
     Nq = Spaces.Quadratures.degrees_of_freedom(Spaces.quadrature_style(space))
-    horz_n_elems = size(min_ρq, 1)
-    vert_n_elems = size(min_ρq, 2)
+    horz_n_elems = size(min_q, 1)
+    vert_n_elems = size(min_q, 2)
     slab_space = axes(Fields.slab(ρ, 1, 1))
     q_he_data = Fields.field_values(zeros(slab_space))
     ρ_wJ_data = Fields.field_values(zeros(slab_space))
 
     # Traverse vertical levels
     for ve in 1:vert_n_elems
-        ρ_level_mass = sum(Fields.slab(ρ, ve))
-        ρq_level_mass = sum(Fields.slab(ρq, ve))
         # On each level, traverse horizontal elements
         for he in 1:horz_n_elems
             ρ_he_slab = Fields.slab(ρ, ve, he)
@@ -66,12 +64,12 @@ function quasimonotone_limiter!(
             # Relax constraints to ensure limiter has a solution:
             # This is only needed if running with the SSP CFL>1 or
             # due to roundoff errors.
-            if ρq_he_mass < min_ρq[he, ve] * ρ_he_mass
-                min_ρq[he, ve] = ρq_he_mass / ρ_he_mass
+            if ρq_he_mass < min_q[he, ve] * ρ_he_mass
+                min_q[he, ve] = ρq_he_mass / ρ_he_mass
             end
 
-            if ρq_he_mass > max_ρq[he, ve] * ρ_he_mass
-                max_ρq[he, ve] = ρq_he_mass / ρ_he_mass
+            if ρq_he_mass > max_q[he, ve] * ρ_he_mass
+                max_q[he, ve] = ρq_he_mass / ρ_he_mass
             end
 
             local_geometry_slab = Fields.slab(space.local_geometry, he)
@@ -87,14 +85,14 @@ function quasimonotone_limiter!(
                         local_geometry_slab[i, j].WJ * ρ_he_data[i, j]
                     # Compute the error tolerance and project q into the
                     # upper and lower bounds
-                    if q_he_data[i, j] > max_ρq[he, ve]
+                    if q_he_data[i, j] > max_q[he, ve]
                         mass_change +=
-                            (q_he_data[i, j] - max_ρq[he, ve]) * ρ_wJ_data[i, j]
-                        q_he_data[i, j] = max_ρq[he, ve]
-                    elseif q_he_data[i, j] < min_ρq[he, ve]
+                            (q_he_data[i, j] - max_q[he, ve]) * ρ_wJ_data[i, j]
+                        q_he_data[i, j] = max_q[he, ve]
+                    elseif q_he_data[i, j] < min_q[he, ve]
                         mass_change -=
-                            (min_ρq[he, ve] - q_he_data[i, j]) * ρ_wJ_data[i, j]
-                        q_he_data[i, j] = min_ρq[he, ve]
+                            (min_q[he, ve] - q_he_data[i, j]) * ρ_wJ_data[i, j]
+                        q_he_data[i, j] = min_q[he, ve]
                     end
                 end
 
@@ -111,24 +109,24 @@ function quasimonotone_limiter!(
                 if mass_change > 0
                     # Iterate over quadrature points
                     for j in 1:Nq, i in 1:Nq
-                        if q_he_data[i, j] < max_ρq[he, ve]
+                        if q_he_data[i, j] < max_q[he, ve]
                             weights_sum += ρ_wJ_data[i, j]
                         end
                     end
                     for j in 1:Nq, i in 1:Nq
-                        if q_he_data[i, j] < max_ρq[he, ve]
+                        if q_he_data[i, j] < max_q[he, ve]
                             q_he_data[i, j] += mass_change / weights_sum
                         end
                     end
                 else # If the change was negative, the added mass is removed
                     # Iterate over quadrature points
                     for j in 1:Nq, i in 1:Nq
-                        if q_he_data[i, j] > min_ρq[he, ve]
+                        if q_he_data[i, j] > min_q[he, ve]
                             weights_sum += ρ_wJ_data[i, j]
                         end
                     end
                     for j in 1:Nq, i in 1:Nq
-                        if q_he_data[i, j] > min_ρq[he, ve]
+                        if q_he_data[i, j] > min_q[he, ve]
                             q_he_data[i, j] += mass_change / weights_sum
                         end
                     end

--- a/test/Limiters/limiter.jl
+++ b/test/Limiters/limiter.jl
@@ -96,10 +96,10 @@ end
 
     # Initialize variables needed for limiters
     n_elems = Topologies.nlocalelems(space.topology)
-    min_ρq = zeros(n_elems)
-    max_ρq = ones(n_elems)
+    min_q = zeros(n_elems)
+    max_q = ones(n_elems)
 
-    Limiters.quasimonotone_limiter!(ρq, ρ, min_ρq, max_ρq, rtol = lim_tol)
+    Limiters.quasimonotone_limiter!(ρq, ρ, min_q, max_q, rtol = lim_tol)
     @test parent(ρq)[:, :, 1, 1] ≈ [0.0 0.0; 0.950005 0.950005] rtol = 10eps()
     # Check mass conservation after application of limiter
     @test sum(ρq) ≈ initial_Q_mass rtol = 10eps()
@@ -127,16 +127,16 @@ end
 
     # Initialize variables needed for limiters
     n_elems = Topologies.nlocalelems(space.topology)
-    min_ρq = zeros(n_elems)
-    max_ρq = ones(n_elems)
-    max_ρq[2] = 0.5
+    min_q = zeros(n_elems)
+    max_q = ones(n_elems)
+    max_q[2] = 0.5
 
-    Limiters.quasimonotone_limiter!(ρq, ρ, min_ρq, max_ρq, rtol = lim_tol)
-    # Check elem 1 values, with min_ρq = 0, max_ρq = 1
+    Limiters.quasimonotone_limiter!(ρq, ρ, min_q, max_q, rtol = lim_tol)
+    # Check elem 1 values, with min_q = 0, max_q = 1
     @test parent(ρq)[:, :, 1, 1] ≈ [0.0 0.0; 0.950005 0.950005] rtol = 10eps()
-    # Check elem 2 values, with min_ρq = 0, max_ρq = 0.5
+    # Check elem 2 values, with min_q = 0, max_q = 0.5
     @test parent(ρq)[:, :, 1, 2] ≈ [0.45 0.45001; 0.5 0.5] rtol = 10eps()
-    # Check elem 3, vertex 1 value that was between min_ρq = 0, max_ρq = 1 bounds
+    # Check elem 3, vertex 1 value that was between min_q = 0, max_q = 1 bounds
     @test parent(ρq)[9] ≈ 1 rtol = 10eps()
     # Check mass conservation after application of limiter
     @test sum(ρq) ≈ initial_Q_mass rtol = 10eps()
@@ -161,10 +161,10 @@ end
 
     # Initialize variables needed for limiters
     horz_n_elems = Topologies.nlocalelems(horzspace.topology)
-    min_ρq = zeros(horz_n_elems, n3)
-    max_ρq = ones(horz_n_elems, n3)
+    min_q = zeros(horz_n_elems, n3)
+    max_q = ones(horz_n_elems, n3)
 
-    Limiters.quasimonotone_limiter!(ρq, ρ, min_ρq, max_ρq, rtol = lim_tol)
+    Limiters.quasimonotone_limiter!(ρq, ρ, min_q, max_q, rtol = lim_tol)
     @test parent(ρq)[1, :, :, 1, 1] ≈ [0.0 0.0; 0.950005 0.950005] rtol =
         10eps()
 
@@ -195,18 +195,18 @@ end
 
     # Initialize variables needed for limiters
     horz_n_elems = Topologies.nlocalelems(horzspace.topology)
-    min_ρq = zeros(horz_n_elems, n3)
-    max_ρq = ones(horz_n_elems, n3)
+    min_q = zeros(horz_n_elems, n3)
+    max_q = ones(horz_n_elems, n3)
     # Change max only for level 1, elem 2
-    max_ρq[2, 1] = 0.5
+    max_q[2, 1] = 0.5
 
-    Limiters.quasimonotone_limiter!(ρq, ρ, min_ρq, max_ρq, rtol = lim_tol)
-    # Check level 1, elem 1 values, with min_ρq = 0, max_ρq = 1
+    Limiters.quasimonotone_limiter!(ρq, ρ, min_q, max_q, rtol = lim_tol)
+    # Check level 1, elem 1 values, with min_q = 0, max_q = 1
     @test parent(ρq)[1, :, :, 1, 1] ≈ [0.0 0.0; 0.950005 0.950005] rtol =
         10eps()
-    # Check level 1, elem 2 values, with min_ρq = 0, max_ρq = 0.5
+    # Check level 1, elem 2 values, with min_q = 0, max_q = 0.5
     @test parent(ρq)[1, :, :, 1, 2] ≈ [0.45 0.45001; 0.5 0.5] rtol = 10eps()
-    # Check level 2, elem 5 values, with min_ρq = 0, max_ρq = 1
+    # Check level 2, elem 5 values, with min_q = 0, max_q = 1
     @test parent(ρq)[2, :, :, 1, 5] ≈ [0.0 0.0; 0.950005 0.950005] rtol =
         10eps()
     # Check level 3, elem 7 values, with unvaried entries


### PR DESCRIPTION
This PR addresses #687 . 

It modifies the limiters function and existing examples to use the q_min/q_max instead of Q_min/Q_max. As suspected, since we were always using a ρ starting = 1, we don't notice any difference up to round off precision.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
