### PR TITLE
fix DSS performance

### DIFF
--- a/src/RecursiveApply/RecursiveApply.jl
+++ b/src/RecursiveApply/RecursiveApply.jl
@@ -14,7 +14,7 @@ export ⊞, ⊠, ⊟, tuplemap
 
 A `map` impl for mapping function `fn` a tuple argument `tup`
 
-Currently just calls `Base.map` behind the scenes but is left 
+Currently just calls `Base.map` behind the scenes but is left
 stubbed out for potential specialization in the future.
 """
 @inline function tuplemap(fn::F, tup::Tuple) where {F}
@@ -26,7 +26,7 @@ end
 
 A `map` impl for mapping function `fn` over `tup1`, `tup2` tuple arguments.
 
-Currently just calls `Base.map` behind the scenes but is left 
+Currently just calls `Base.map` behind the scenes but is left
 stubbed out for potential specialization in the future.
 """
 @inline function tuplemap(fn::F, tup1::Tuple, tup2::Tuple) where {F}
@@ -41,8 +41,9 @@ Recursively apply `fn` to each element of `X`
 rmap(fn::F, X) where {F} = fn(X)
 rmap(fn::F, X, Y) where {F} = fn(X, Y)
 rmap(fn::F, X::Tuple) where {F} = tuplemap(x -> rmap(fn, x), X)
+rmap(fn, X::Tuple{}, Y::Tuple{}) = ()
 rmap(fn::F, X::Tuple, Y::Tuple) where {F} =
-    tuplemap((x, y) -> rmap(fn, x, y), X, Y)
+    (rmap(fn, first(X), first(Y)), rmap(fn, Base.tail(X), Base.tail(Y))...)
 rmap(fn::F, X::NamedTuple{names}) where {F, names} =
     NamedTuple{names}(rmap(fn, Tuple(X)))
 rmap(fn::F, X::NamedTuple{names}, Y::NamedTuple{names}) where {F, names} =

--- a/test/Operators/hybrid/dss_opt.jl
+++ b/test/Operators/hybrid/dss_opt.jl
@@ -1,0 +1,41 @@
+using Test
+using StaticArrays, IntervalSets, LinearAlgebra
+
+import ClimaCore:
+    ClimaCore,
+    slab,
+    Spaces,
+    Domains,
+    Meshes,
+    Geometry,
+    Topologies,
+    Spaces,
+    Fields,
+    Operators
+
+import ClimaCore.Utilities: half
+import ClimaCore.DataLayouts: level
+
+const FT = Float64
+
+vertdomain = Domains.IntervalDomain(
+    Geometry.ZPoint{FT}(0.0),
+    Geometry.ZPoint{FT}(1.0);
+    boundary_tags = (:bottom, :top),
+)
+vertmesh = Meshes.IntervalMesh(vertdomain, nelems = 10)
+vert_center_space = Spaces.CenterFiniteDifferenceSpace(vertmesh)
+
+horzdomain = Domains.SphereDomain(30.0)
+horzmesh = Meshes.EquiangularCubedSphere(horzdomain, 4)
+horztopology = Topologies.Topology2D(horzmesh)
+quad = Spaces.Quadratures.GLL{5}()
+horzspace = Spaces.SpectralElementSpace2D(horztopology, quad)
+
+hv_center_space =
+    Spaces.ExtrudedFiniteDifferenceSpace(horzspace, vert_center_space)
+
+coords = Fields.coordinate_field(hv_center_space)
+x = Geometry.UVWVector.(cosd.(coords.lat), 0.0, 0.0)
+
+ww = map(x -> (w = Geometry.Covariant3Vector(x),), ones(hv_center_space))


### PR DESCRIPTION
Fixes a key performance regression in ClimaCore 0.10. The compiler wasn't able to recurse through nested types for DSS.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
