### PR TITLE
Add great_circle_distance between LatLongZPoints

### DIFF
--- a/src/Geometry/globalgeometry.jl
+++ b/src/Geometry/globalgeometry.jl
@@ -147,6 +147,25 @@ function great_circle_distance(
 end
 
 """
+    great_circle_distance(pt1::LatLongZPoint, pt2::LatLongZPoint, global_geometry::SphericalGlobalGeometry)
+
+Compute the great circle (spherical geodesic) distance between `pt1` and `pt2`.
+"""
+function great_circle_distance(
+    pt1::LatLongZPoint,
+    pt2::LatLongZPoint,
+    global_geom::SphericalGlobalGeometry,
+)
+    ϕ1 = pt1.lat
+    λ1 = pt1.long
+    ϕ2 = pt2.lat
+    λ2 = pt2.long
+    latlong_pt1 = LatLongPoint(ϕ1, λ1)
+    latlong_pt2 = LatLongPoint(ϕ2, λ2)
+    return great_circle_distance(latlong_pt1, latlong_pt2, global_geom)
+end
+
+"""
     euclidean_distance(pt1::XYPoint, pt2::XYPoint)
 
 Compute the 2D or 3D Euclidean distance between `pt1` and `pt2`.

--- a/test/Geometry/geometry.jl
+++ b/test/Geometry/geometry.jl
@@ -573,6 +573,12 @@ end
         global_geom,
     ) ≈ 2 * deg2rad(180.0) rtol = 2eps()
 
+    # test between two LatLongZPoints
+    @test Geometry.great_circle_distance(
+        Geometry.LatLongZPoint(22.0, 32.0, 2.0),
+        Geometry.LatLongZPoint(22.0, 32.0, 2.0),
+        global_geom,
+    ) == 0.0
 end
 
 @testset "1D XPoint Euclidean distance" begin


### PR DESCRIPTION
While working on PR #702 , I realized that this small utility function could have been handy (and would have made the 3d sphere example consistent with the 2d sphere one). 

It basically ignores the Z coordinate and calls the existing method for LatLongPoints. 
Since basically re-uses the same method, I did not repeat all of the cases in the unit tests, but only one.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
