### PR TITLE
Add copy method for DataF.

### DIFF
--- a/src/DataLayouts/DataLayouts.jl
+++ b/src/DataLayouts/DataLayouts.jl
@@ -505,6 +505,8 @@ end
     col[] = val
 end
 
+Base.copy(data::DataF{S}) where {S} = DataF{S}(copy(parent(data)))
+
 # ======================
 # DataSlab2D DataLayout
 # ======================

--- a/test/DataLayouts/data0d.jl
+++ b/test/DataLayouts/data0d.jl
@@ -26,6 +26,10 @@ TestFloatTypes = (Float32, Float64)
             10eps()
 
         @test sum(x -> x[2], data) ≈ sum(array[:, 3]) atol = 10eps()
+
+        data_copy = copy(data)
+        @test data_copy isa DataF
+        @test data_copy[] == data[]
     end
 end
 


### PR DESCRIPTION
Adds a `Base.copy` method for `DataF`. Necessary for copying `PointFields` around.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
