### PR TITLE
Add a missing 'is' to tutorial.

### DIFF
--- a/docs/tutorials/introduction.jl
+++ b/docs/tutorials/introduction.jl
@@ -18,7 +18,7 @@ using ClimaCore,
 
 # ### 1.1 Domains
 #
-# A _domain_ a region of space (think of a mathematical domain).
+# A _domain_ is a region of space (think of a mathematical domain).
 
 column_domain = ClimaCore.Domains.IntervalDomain(
     ClimaCore.Geometry.ZPoint(0.0) .. ClimaCore.Geometry.ZPoint(10.0),


### PR DESCRIPTION
Tutorial should say, a domain _is_ a region of space.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
