### PR TITLE
Restrict arg types for better error messages

### DIFF
--- a/src/Meshes/interval.jl
+++ b/src/Meshes/interval.jl
@@ -83,7 +83,7 @@ struct Uniform <: StretchingRule end
 function IntervalMesh(
     domain::IntervalDomain{CT},
     ::Uniform = Uniform();
-    nelems,
+    nelems::Int,
 ) where {CT <: Geometry.Abstract1DPoint{FT}} where {FT}
     if nelems < 1
         throw(ArgumentError("`nelems` must be ≥ 1"))
@@ -114,7 +114,7 @@ end
 function IntervalMesh(
     domain::IntervalDomain{CT},
     stretch::ExponentialStretching{FT};
-    nelems,
+    nelems::Int,
 ) where {CT <: Geometry.Abstract1DPoint{FT}} where {FT}
     if nelems < 1
         throw(ArgumentError("`nelems` must be ≥ 1"))
@@ -144,7 +144,7 @@ end
 function IntervalMesh(
     domain::IntervalDomain{CT},
     stretch::GeneralizedExponentialStretching{FT};
-    nelems,
+    nelems::Int,
 ) where {CT <: Geometry.Abstract1DPoint{FT}} where {FT}
     if nelems ≤ 1
         throw(ArgumentError("`nelems` must be ≥ 2"))

--- a/src/Meshes/rectangle.jl
+++ b/src/Meshes/rectangle.jl
@@ -15,7 +15,7 @@ struct RectilinearMesh{I1 <: IntervalMesh, I2 <: IntervalMesh} <: AbstractMesh2D
     intervalmesh1::I1
     intervalmesh2::I2
 end
-RectilinearMesh(domain::RectangleDomain, n1, n2) = RectilinearMesh(
+RectilinearMesh(domain::RectangleDomain, n1::Int, n2::Int) = RectilinearMesh(
     IntervalMesh(domain.interval1; nelems = n1),
     IntervalMesh(domain.interval2; nelems = n2),
 )


### PR DESCRIPTION
This PR restricts some argument types to improve some error messages.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
