### PR TITLE
Make unique_nodes call all_nodes for GL quads

### DIFF
--- a/src/Spaces/spectralelement.jl
+++ b/src/Spaces/spectralelement.jl
@@ -484,7 +484,12 @@ first `((i,j), e)` triple.
 
 This function is experimental, and may change in future.
 """
-unique_nodes(space::SpectralElementSpace2D) = UniqueNodeIterator(space)
+unique_nodes(space::SpectralElementSpace2D) =
+    unique_nodes(space, space.quadrature_style)
+
+unique_nodes(space::SpectralElementSpace2D, quad::Quadratures.QuadratureStyle) =
+    UniqueNodeIterator(space)
+unique_nodes(space::SpectralElementSpace2D, ::Quadratures.GL) = all_nodes(space)
 
 struct UniqueNodeIterator{S}
     space::S

--- a/test/Spaces/spaces.jl
+++ b/test/Spaces/spaces.jl
@@ -70,6 +70,32 @@ end
         @test Spaces.coordinates_data(point_space)[] ==
               Spaces.level(coord_data, 1)[]
     end
+
+    x_max = FT(0)
+    y_max = FT(1)
+    x_elem = 2
+    y_elem = 2
+    x_domain = Domains.IntervalDomain(
+        Geometry.XPoint(zero(x_max)),
+        Geometry.XPoint(x_max);
+        periodic = true,
+    )
+    y_domain = Domains.IntervalDomain(
+        Geometry.YPoint(zero(y_max)),
+        Geometry.YPoint(y_max);
+        periodic = true,
+    )
+    domain = Domains.RectangleDomain(x_domain, y_domain)
+    hmesh = Meshes.RectilinearMesh(domain, x_elem, y_elem)
+
+    quad = Spaces.Quadratures.GL{1}()
+    htopology = Topologies.Topology2D(hmesh)
+    hspace = Spaces.SpectralElementSpace2D(htopology, quad)
+
+    @test collect(Spaces.unique_nodes(hspace)) ==
+          [((1, 1), 1);;; ((1, 1), 2);;; ((1, 1), 3);;; ((1, 1), 4)]
+    @test length(Spaces.unique_nodes(hspace)) == 4
+    @test length(Spaces.all_nodes(hspace)) == 4
 end
 
 @testset "1×1 domain space" begin


### PR DESCRIPTION
Right now, `length(Spaces.unique_nodes(hspace))` returns 0 when using `GL` quadratures for a column mesh. This PR special cases this so that we call `Spaces.unique_nodes(hspace)` when the quadrature is `GL`.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
