### PR TITLE
3D box limiters example: apply limiters between horz/vert tendency

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -8,7 +8,7 @@
 
 ### Flux Limiters advection
 
-The 3D Cartesian advection/transport example in [`examples/hybrid/box/limiters_advection.jl`](https://github.com/CliMA/ClimaCore.jl/tree/main/examples/hybrid/box/limiters_advection.jl) demonstrates the application of flux limiters, namely [`quasimonotone_limiter!`](@ref), in a hybrid Cartesian domain. It also demonstrates the usage of the high-order upwinding scheme in the vertical direction, called [`Upwind3rdOrderBiasedProductC2F`](@ref).
+The 3D Cartesian advection/transport example in [`examples/hybrid/box/limiters_advection.jl`](https://github.com/CliMA/ClimaCore.jl/tree/main/examples/hybrid/box/limiters_advection.jl) demonstrates the application of flux limiters in the horizontal direction, namely [`QuasiMonotoneLimiter`](https://clima.github.io/ClimaCore.jl/previews/PR729/api/#ClimaCore.Limiters.QuasiMonotoneLimiter), in a hybrid Cartesian domain. It also demonstrates the usage of the high-order upwinding scheme in the vertical direction, called [`Upwind3rdOrderBiasedProductC2F`](@ref).
 
 #### Equations and discretizations
 

--- a/examples/hybrid/box/limiters_advection.jl
+++ b/examples/hybrid/box/limiters_advection.jl
@@ -299,16 +299,18 @@ for (k, horz_ne) in enumerate(horz_ne_seq)
         # 2.2) Horizontal advective flux with vertical velocity
         # already accounted for in 2.1)
 
-        # 2.3) Vertical advective flux with horizontal/vertical velocity
-        @. dy.ρq -= alpha * vert_flux_wρq
-
-        # 2.4) Vertical advective flux with vertical velocity
-        # already accounted for in 2.3)
-
+        # 2.3) Apply the limiters:
         if lim_flag
             Limiters.compute_bounds!(parameters.limiter, y.ρq, y.ρ)
             Limiters.apply_limiter!(dy.ρq, dy.ρ, parameters.limiter)
         end
+
+        # 2.4) Vertical advective flux with horizontal/vertical velocity
+        @. dy.ρq -= alpha * vert_flux_wρq
+
+        # 2.5) Vertical advective flux with vertical velocity
+        # already accounted for in 2.4)
+
         Spaces.weighted_dss!(dy.ρ)
         Spaces.weighted_dss!(dy.ρq)
     end
@@ -384,7 +386,7 @@ Plots.png(
     joinpath(path, "L1error.png"),
 )
 linkfig(
-    relpath(joinpath(path, "L1error.png"), joinpath(@__DIR__, "../..")),
+    relpath(joinpath(path, "L1error.png"), joinpath(@__DIR__, "../../..")),
     "L₁ error Vs Nₑ",
 )
 
@@ -402,7 +404,7 @@ Plots.png(
     joinpath(path, "L2error.png"),
 )
 linkfig(
-    relpath(joinpath(path, "L2error.png"), joinpath(@__DIR__, "../..")),
+    relpath(joinpath(path, "L2error.png"), joinpath(@__DIR__, "../../..")),
     "L₂ error Vs Nₑ",
 )
 
@@ -419,6 +421,6 @@ Plots.png(
     joinpath(path, "Linferror.png"),
 )
 linkfig(
-    relpath(joinpath(path, "Linferror.png"), joinpath(@__DIR__, "../..")),
+    relpath(joinpath(path, "Linferror.png"), joinpath(@__DIR__, "../../..")),
     "L∞ error Vs Nₑ",
 )


### PR DESCRIPTION
This PR implements the suggestion of applying limiters after the horizontal tendency specification, but before the vertical one in the 3D box limiters example. The results are comparable with what we had already. So the change is not significant.  

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
