### PR TITLE
Docs: add 2D/3D limiter examples and SWE examples 

### DIFF
--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -1,3 +1,13 @@
+@article{Bao2014,
+  title = {A mass and momentum flux-form high-order discontinuous Galerkin shallow water model on the cubed-sphere},
+  journal = {Journal of Computational Physics},
+  volume = {271},
+  pages = {224-243},
+  year = {2014},
+  doi = {https://doi.org/10.1016/j.jcp.2013.11.033},
+  author = {Lei Bao and Ramachandran D. Nair and Henry M. Tufo}
+}
+
 @article{Berrut2004,
   title = {Barycentric lagrange interpolation},
   author = {Berrut, Jean-Paul and Trefethen, Lloyd N},
@@ -6,9 +16,20 @@
   number = {3},
   pages = {501--517},
   year = {2004},
-  doi = {10.1137/S0036144502417715},
-  publisher = {SIAM}
+  doi = {10.1137/S0036144502417715}
 }
+
+@article{Galewsky2004,
+  author = {Joseph Galewsky and Richard K. Scott and Lorenzo M. Polvani},
+  title = {An initial-value problem for testing numerical models of the global shallow-water equations},
+  journal = {Tellus A: Dynamic Meteorology and Oceanography},
+  volume = {56},
+  number = {5},
+  pages = {429-440},
+  year  = {2004},
+  doi = {10.3402/tellusa.v56i5.14436}
+}
+
 
 @article{Guba2014,
 	title = {The spectral element method ({SEM}) on variable-resolution grids: evaluating grid sensitivity and resolution-aware numerical viscosity},
@@ -18,7 +39,7 @@
 	number = {6},
 	pages = {2803--2816},
 	year = {2014},
-	doi = {10.5194/gmd-7-2803-2014},
+	doi = {10.5194/gmd-7-2803-2014}
 }
 
 @article{GubaOpt2014,
@@ -39,8 +60,7 @@
   number = {4},
   doi = {doi:10.1175/MWR2890.1},
   pages = {814--828},
-  year = {2005},
-  publisher = {American Meteorological Society}
+  year = {2005}
 }
 
 @article{Rancic1996,
@@ -74,11 +94,23 @@
   pages={5879--5895},
   year={2010},
   publisher={Elsevier},
-	doi = {10.1016/j.jcp.2010.04.008},
+	doi = {10.1016/j.jcp.2010.04.008}
+}
+
+@article{Ullrich2010,
+  author = {Ullrich, Paul A. and Jablonowski, Christiane and van Leer, Bram},
+  title = {High-Order Finite-Volume Methods for the Shallow-Water Equations on the Sphere},
+  year = {2010},
+  volume = {229},
+  number = {17},
+  doi = {10.1016/j.jcp.2010.04.044},
+  journal = {J. Comput. Phys.},
+  pages = {6104–6134}
 }
 
 @inproceedings{Ullrich2012DynamicalCM,
-  title={Dynamical Core Model Intercomparison Project ( DCMIP ) Test Case Document},
+  booktitle={Dynamical Core Model Intercomparison Project ( DCMIP )},
+  title= {Test Case Document},
   author={Paul Aaron Ullrich and Christiane Jablonowski and James Kent and Peter H. Lauritzen and Ramachandran D. Nair},
   year={2012}
 }
@@ -92,7 +124,7 @@
   pages = {2419--2440},
   year = {2015},
   publisher = {American Meteorological Society},
-  doi = {10.1175/MWR-D-14-00343.1},
+  doi = {10.1175/MWR-D-14-00343.1}
 }
 
 @article{Ullrich2016,
@@ -104,7 +136,7 @@
   pages = {1529--1549},
   year = {2016},
   publisher = {American Meteorological Society},
-  doi = {10.1175/MWR-D-15-0301.1},
+  doi = {10.1175/MWR-D-15-0301.1}
 }
 
 @article{WickerSkamarock2002,
@@ -116,4 +148,15 @@
   volume = "130",
   doi = "10.1175/1520-0493(2002)130<2088:TSMFEM>2.0.CO;2",
   pages= "2088 - 2097"
+}
+
+@article{Williamson1992,
+  title = {A standard test set for numerical approximations to the shallow water equations in spherical geometry},
+  journal = {Journal of Computational Physics},
+  volume = {102},
+  number = {1},
+  pages = {211-224},
+  year = {1992},
+  doi = {https://doi.org/10.1016/S0021-9991(05)80016-6},
+  author = {David L. Williamson and John B. Drake and James J. Hack and Rüdiger Jakob and Paul N. Swarztrauber}
 }

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -4,6 +4,99 @@
 
 ## 2D Cartesian examples
 
+### Flux Limiters advection
+
+The 2D Cartesian advection/transport example in [`examples/plane/limiters_advection.jl`](https://github.com/CliMA/ClimaCore.jl/tree/main/examples/plane/limiters_advection.jl) demonstrates the application of flux limiters in the horizontal direction, namely [`QuasiMonotoneLimiter`](https://clima.github.io/ClimaCore.jl/previews/PR729/api/#ClimaCore.Limiters.QuasiMonotoneLimiter), in a 2D Cartesian domain.
+
+#### Equations and discretizations
+
+#### Mass
+
+Follows the continuity equation
+```math
+\begin{equation}
+  \frac{\partial}{\partial t} \rho = - \nabla \cdot(\rho \boldsymbol{u}) .
+\label{eq:2d-plane-advection-lim-continuity}
+\end{equation}
+```
+
+This is discretized using the following
+```math
+\begin{equation}
+  \frac{\partial}{\partial t} \rho \approx - wD[ \rho \boldsymbol{u}] .
+\label{eq:2d-plane-advection-lim-discrete-continuity}
+\end{equation}
+```
+
+#### Tracers
+
+For the tracer concentration per unit mass ``q``, the tracer density (scalar) ``\rho q`` follows the advection/transport equation
+
+```math
+\begin{equation}
+  \frac{\partial}{\partial t} \rho q = - \nabla \cdot(\rho q \boldsymbol{u})  + g(\rho, q).
+\label{eq:2d-plane-advection-lim-tracers}
+\end{equation}
+```
+
+This is discretized using the following
+```math
+\begin{equation}
+\frac{\partial}{\partial t} \rho q \approx - wD[ \rho q \boldsymbol{u}] + g(\rho, q),
+\label{eq:2d-plane-advection-lim-discrete-tracers}
+\end{equation}
+```
+where ``g(\rho, q) = - \nu_4 [\nabla^4_h (\rho q)]`` represents the horizontal hyperdiffusion operator, with ``\nu_4`` (measured in m^4/s) the hyperviscosity constant coefficient (set equal to zero by default in the example).
+
+Currently tracers are only treated explicitly in the time discretization.
+
+
+#### Prognostic variables
+
+* ``\rho``: _density_ measured in kg/m³.
+* ``\boldsymbol{u}`` _velocity_, a vector measured in m/s. Since this is a 2D problem, ``\boldsymbol{u} \equiv \boldsymbol{u}_h``.
+* ``\rho q``: the tracer density scalar, where ``q`` is the tracer concentration per unit mass.
+
+#### Differentiation operators
+
+Because this is a purely 2D problem, there is no staggered vertical discretization, hence, there is no need of specifying variables at cell centers, faces or to reconstruct from faces to centers and vice versa.
+
+- ``wD`` is the [discrete horizontal weak spectral divergence](https://clima.github.io/ClimaCore.jl/stable/operators/#ClimaCore.Operators.WeakDivergence), called `wdiv` in the example code.
+- ``G`` is the [discrete horizontal strong spectral gradient](https://clima.github.io/ClimaCore.jl/stable/operators/#ClimaCore.Operators.Gradient), called `grad` in the example code.
+
+To discretize the hyperdiffusion operator, ``g(\rho, q) = - \nu_4 [\nabla^4 (\rho q)]``, in the horizontal direction, we compose the horizontal weak divergence, ``wD``, and the horizontal gradient operator, ``G_h``, twice, with an intermediate call to [`weighted_dss!`](@ref) between the two compositions, as in ``[g_2(\rho, g) \circ DSS(\rho, q) \circ g_1(\rho, q)]``, with:
+- ``g_1(\rho, q) = wD(G_h(q))``
+- ``DSS(\rho, q) = DSS(g_1(\rho q))``
+- ``g_2(\rho, q) = -\nu_4 wD(\rho G_h(\rho q))``
+    - with ``\nu_4`` the hyperviscosity coefficient.
+
+#### Problem flow and set-up
+
+This test case is set up in a Cartesian planar domain `` [-2 \pi, 2 \pi]^2 ``, doubly periodic.
+
+The flow was chosen to be a horizontal uniform rotation. Moreover, the flow is reversed halfway through the time period so that the tracer blobs go back to its initial configuration (using the same speed scaling constant which was derived to account for the distance travelled in all directions in a half period).
+
+```math
+\begin{align}
+    u &= -u_0 (y - c_y) \cos(\pi t / T_f) \nonumber \\
+    v &= u_0 (x - c_x) \cos(\pi t / T_f)
+\label{eq:2d-plane-advection-lim-flow}
+\end{align}
+```
+where ``u_0 = \pi / 2`` is the speed scaling factor to have the flow reversed halfway through the time period, ``\boldsymbol{c} = (c_x, c_y)`` is the center of the rotational flow, which coincides with the center of the domain, and `` T_f = 2 \pi`` is the final simulation time, which coincides with the temporal period to have a full rotation.
+
+This example is set up to run with three possible initial conditions:
+- `cosine_bells`
+- `gaussian_bells`
+- `cylinders`: two 2D slotted cylinders (test case available in the literature, cfr: [GubaOpt2014](@cite)).
+
+#### Application of Flux Limiters
+
+Because this is a fully 2D problem, the application of limiters does not affect the order of operations, which is implemented as follows:
+
+1. Horizontal trasport with hyperdiffusion (with weak divergence ``wD``)
+2. Horizontal flux limiters
+3. DSS
 ## 3D Cartesian examples
 
 ### Flux Limiters advection
@@ -93,7 +186,7 @@ To discretize the hyperdiffusion operator, ``g(\rho, q) = - \nu_4 [\nabla^4 (\rh
 
 This test case is set up in a Cartesian (box) domain `` [-2 \pi, 2 \pi]^2 \times [0, 4 \pi] ~\textrm{m}^3``, doubly periodic in the horizontal direction, but not in the vertical direction.
 
-The flow was chosen to be a spiral, i.e., so to have a horizontal uniform rotation, and a vertical velocity ``\boldsymbol{u}_v \equiv w = 0`` at the top and bottom boundaries, and ``\boldsymbol{u}_v \equiv w = 1`` in the center of the domain. Moreover, the flow is reversed in all directions halfway through the period so that the tracer blobs go back to its initial configuration (using the same speed scaling constant which was derived to account for the distance travelled in all directions in a half period).
+The flow was chosen to be a spiral, i.e., so to have a horizontal uniform rotation, and a vertical velocity ``\boldsymbol{u}_v \equiv w = 0`` at the top and bottom boundaries, and ``\boldsymbol{u}_v \equiv w = 1`` in the center of the domain. Moreover, the flow is reversed in all directions halfway through the time period so that the tracer blobs go back to its initial configuration (using the same speed scaling constant which was derived to account for the distance travelled in all directions in a half period).
 
 ```math
 \begin{align}
@@ -103,14 +196,118 @@ The flow was chosen to be a spiral, i.e., so to have a horizontal uniform rotati
 \label{eq:3d-box-advection-lim-flow}
 \end{align}
 ```
-where ``u_0 = \pi / 2`` is the speed scaling factor to have the flow reversed halfway through the period, ``\boldsymbol{c} = (c_x, c_y)`` is the center of the rotational flow, which coincides with the center of the domain,  ``z_m = 4 \pi`` is the maximum height of the domain, and `` T_f = 2 \pi`` is the final simulation time, which coincides with the temporal period to have a full rotation in the horizontal direction.
+where ``u_0 = \pi / 2`` is the speed scaling factor to have the flow reversed halfway through the time period, ``\boldsymbol{c} = (c_x, c_y)`` is the center of the rotational flow, which coincides with the center of the domain,  ``z_m = 4 \pi`` is the maximum height of the domain, and `` T_f = 2 \pi`` is the final simulation time, which coincides with the temporal period to have a full rotation in the horizontal direction.
 
 This example is set up to run with three possible initial conditions:
 - `cosine_bells`
 - `gaussian_bells`
 - `slotted_spheres`: a slight modification of the 2D slotted cylinder test case available in the literature (cfr: [GubaOpt2014](@cite)).
 
+#### Application of Flux Limiters
+
+Because this is a Cartesian 3D problem, the application of limiters does not affect the order of operations, which is implemented as follows:
+
+1. Horizontal transport + hyperdiffusion (with weak divergence ``wD_h``)
+2. Horizontal flux limiters
+3. Vertical transport
+4. DSS
+
 ## 2D Sphere examples
+
+### Flux Limiters advection
+
+The 2D sphere advection/transport example in [`examples/sphere/limiters_advection.jl`](https://github.com/CliMA/ClimaCore.jl/tree/main/examples/sphere/limiters_advection.jl) demonstrates the application of flux limiters in the horizontal direction, namely [`QuasiMonotoneLimiter`](https://clima.github.io/ClimaCore.jl/previews/PR729/api/#ClimaCore.Limiters.QuasiMonotoneLimiter), in a 2D spherical domain.
+
+#### Equations and discretizations
+
+#### Mass
+
+Follows the continuity equation
+```math
+\begin{equation}
+  \frac{\partial}{\partial t} \rho = - \nabla \cdot(\rho \boldsymbol{u}) .
+\label{eq:2d-sphere-advection-lim-continuity}
+\end{equation}
+```
+
+This is discretized using the following
+```math
+\begin{equation}
+  \frac{\partial}{\partial t} \rho \approx - wD[ \rho \boldsymbol{u}] .
+\label{eq:2d-sphere-advection-lim-discrete-continuity}
+\end{equation}
+```
+
+#### Tracers
+
+For the tracer concentration per unit mass ``q``, the tracer density (scalar) ``\rho q`` follows the advection/transport equation
+
+```math
+\begin{equation}
+  \frac{\partial}{\partial t} \rho q = - \nabla \cdot(\rho q \boldsymbol{u})  + g(\rho, q).
+\label{eq:2d-sphere-advection-lim-tracers}
+\end{equation}
+```
+
+This is discretized using the following
+```math
+\begin{equation}
+\frac{\partial}{\partial t} \rho q \approx - wD[ \rho q \boldsymbol{u}] + g(\rho, q),
+\label{eq:2d-sphere-advection-lim-discrete-tracers}
+\end{equation}
+```
+where ``g(\rho, q) = - \nu_4 [\nabla^4_h (\rho q)]`` represents the horizontal hyperdiffusion operator, with ``\nu_4`` (measured in m^4/s) the hyperviscosity constant coefficient.
+
+Currently tracers are only treated explicitly in the time discretization.
+
+
+#### Prognostic variables
+
+* ``\rho``: _density_ measured in kg/m³.
+* ``\boldsymbol{u}`` _velocity_, a vector measured in m/s. Since this is a 2D problem, ``\boldsymbol{u} \equiv \boldsymbol{u}_h``.
+* ``\rho q``: the tracer density scalar, where ``q`` is the tracer concentration per unit mass.
+
+#### Differentiation operators
+
+Because this is a purely 2D problem, there is no staggered vertical discretization, hence, there is no need of specifying variables at cell centers, faces or to reconstruct from faces to centers and vice versa.
+
+- ``wD`` is the [discrete horizontal weak spectral divergence](https://clima.github.io/ClimaCore.jl/stable/operators/#ClimaCore.Operators.WeakDivergence), called `wdiv` in the example code.
+- ``G`` is the [discrete horizontal strong spectral gradient](https://clima.github.io/ClimaCore.jl/stable/operators/#ClimaCore.Operators.Gradient), called `grad` in the example code.
+
+To discretize the hyperdiffusion operator, ``g(\rho, q) = - \nu_4 [\nabla^4 (\rho q)]``, in the horizontal direction, we compose the horizontal weak divergence, ``wD``, and the horizontal gradient operator, ``G_h``, twice, with an intermediate call to [`weighted_dss!`](@ref) between the two compositions, as in ``[g_2(\rho, g) \circ DSS(\rho, q) \circ g_1(\rho, q)]``, with:
+- ``g_1(\rho, q) = wD(G_h(q))``
+- ``DSS(\rho, q) = DSS(g_1(\rho q))``
+- ``g_2(\rho, q) = -\nu_4 wD(\rho G_h(\rho q))``
+    - with ``\nu_4`` the hyperviscosity coefficient.
+
+#### Problem flow and set-up
+
+This test case is set up in a Cartesian planar domain `` [-2 \pi, 2 \pi]^2 ``, doubly periodic.
+
+The flow was chosen to be a horizontal uniform rotation. Moreover, the flow is reversed halfway through the time period so that the tracer blobs go back to its initial configuration (using the same speed scaling constant which was derived to account for the distance travelled in all directions in a half period).
+
+```math
+\begin{align}
+    u &= k sin (\lambda)^2  sin (2  \phi)  \cos(\pi  t / T_f) +
+       \frac{2 \pi}{T_f} \cos (\phi) \nonumber \\
+    v &= k \sin (2  \lambda) \cos (\phi) * \cos(\pi t / T_f)
+\label{eq:2d-sphere-lim-flow}
+\end{align}
+```
+where ``u_0 = 2 \pi R / T_f`` is the speed scaling factor to have the flow reversed halfway through the time period, `` T_f = 86400 * 12`` (i.e., ``12`` days in seconds) is the final simulation time, which coincides with the temporal period to have a full rotation around the sphere of radius ``R``.
+
+This example is set up to run with three possible initial conditions:
+- `cosine_bells`
+- `gaussian_bells`
+- `cylinders`: two 2D slotted cylinders (test case available in the literature, cfr: [GubaOpt2014](@cite)).
+
+#### Application of Flux Limiters
+
+Because this is a fully 2D problem, the application of limiters does not affect the order of operations, which is implemented as follows:
+
+1. Horizontal trasport with hyperdiffusion (with weak divergence ``wD``)
+2. Horizontal flux limiters
+3. DSS
 
 ### Shallow-water equations
 
@@ -309,7 +506,7 @@ To discretize the hyperdiffusion operator for each tracer concentration, ``g(\rh
 The order of operations should be the following:
 
 1. Horizontal transport (with strong divergence ``D_h``)
-2. Horizontal flux Limiters
+2. Horizontal flux limiters
 3. Horizontal hyperdiffusion (with weak divergence ``wD_h``)
 4. Vertical transport
 5. DSS


### PR DESCRIPTION
This PR adds documentation of the equations and related discretizations for the following examples that I worked on in the past: 

- [x] 2D plane limiters example
- [x] 3D Cartesian box limiters example
- [x] 2D sphere limiters example
- [x] 2D sphere shallow-water equations suite examples

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
