### PR TITLE
Move links to sidebar

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -68,6 +68,8 @@ withenv("GKSwstype" => "nul") do
             "Home" => "index.md",
             "Introduction" => "intro.md",
             "API" => "api.md",
+            "Intro to Vectors" => "intro-to-vectors.md",
+            "Intro to SEM" => "intro-to-sem.md",
             "Operators" => "operators.md",
             "Developer docs" => ["Performance tips" => "performance_tips.md"],
             "Tutorials" => [

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -47,9 +47,6 @@ useful for converting everything to a full Cartesian domain (e.g. for visualizat
 purposes). These are distinct from `XYZPoint` as `ZPoint` can mean different
 things in different domains.
 
-### Vectors and vector fields
-[Introduction to Vectors and Vector Fields in ClimaCore.jl](intro-to-vectors.md)
-
 ## Domains
 
 ### Types
@@ -159,9 +156,6 @@ or the interfaces (faces in 3D, edges in 2D or points in 1D) between elements
 Users should construct either the center or face space from the mesh, then construct
 the other space from the original one: this internally reuses the same data structures, and avoids allocating additional memory.
 
-### Spectral Element Spaces
-
-[Introduction to the Finite/Spectral Element Method](intro-to-sem.md)
 
 ### Quadratures
 

--- a/docs/src/intro-to-sem.md
+++ b/docs/src/intro-to-sem.md
@@ -1,4 +1,4 @@
-#### Introduction to the Finite/Spectral Element Method
+# Introduction to the Finite/Spectral Element Method
 
 In finite element formulations, the weak form of a Partial Differential Equation
 (PDE)---which involves integrating all terms in the PDE over the domain---is

--- a/docs/src/intro-to-vectors.md
+++ b/docs/src/intro-to-vectors.md
@@ -1,4 +1,4 @@
-#### Introduction to Vectors and Vector Fields in ClimaCore.jl
+# Introduction to Vectors and Vector Fields in ClimaCore.jl
 _Vector_ can mean a few things depending on context:
 
 - In Julia, a `Vector` is just an ordered collection of values (i.e., a container).
@@ -23,7 +23,7 @@ ClmaCore supports different coordinate systems and, therefore, vector representa
 In fact, one of the key requirements of ClimaCore is to support vectors specified
 in orthogonal (Cartesian) and curvilinear coordinate systems.
 
-#### `LocalVector`: `UVector`, `UVVector`, and `UVWVector`, etc; a "universal" basis
+# `LocalVector`: `UVector`, `UVVector`, and `UVWVector`, etc; a "universal" basis
 
 The easiest basis to use is the "UVW" basis, which can be defined in both Cartesian
 or spherical domains:
@@ -48,7 +48,7 @@ that can be equally defined on Cartesian or spherical spaces.
 But if users need to compute with them, or feed differential operators with them,
 then may want to consider different bases, as not all operators accept all bases.
 
-#### Covariant and Contravariant bases
+# Covariant and Contravariant bases
 
 ![Different bases supported in ClimaCore.jl](Bases.png)
 
@@ -79,12 +79,12 @@ while the _contravariant basis_ is the opposite: gradient in ``x`` of the coordi
 * things get a little more complicated in the presence of terrain, but ``\xi^3`` is radially aligned
   - the 3rd covariant component is aligned with W, but the 3rd contravariant component may not be (e.g. at the surface it is normal to the boundary).
 
-#### Cartesian bases
+# Cartesian bases
 Analogously to `CartesianPoint`s, in ClimaCore, there are also `CartesianVector`s:
 these allow conversion to a global Cartesian basis. It is intended mainly for
 visualization purposes.
 
-#### Conversions
+# Conversions
 
 To convert between different vector bases, you need a `LocalGeometry` object:
 this contains all the necessary information (coordinates, metric terms, etc)


### PR DESCRIPTION
This PR moves the `intro-to-vectors.md` and `intro-to-sem.md` to the sidebar. It's not easily findable as a link in the API page.

I think we need to generalize the `intro-to-vectors.md` page a bit more. Specifically, adding:

gradient: scalar => covariant
divergence: contravariant => scalar
curl: covariant => contravariant
dot product: (covariant, contravariant) => scalar
cross product: (contravariant, contravariant) => covariant


- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
