### PR TITLE
Add remapping for diagnostic output on latlong grids

### DIFF
--- a/src/Meshes/Meshes.jl
+++ b/src/Meshes/Meshes.jl
@@ -110,6 +110,7 @@ include("common.jl")
 include("interval.jl")
 include("rectangle.jl")
 include("cubedsphere.jl")
+include("latlong.jl")
 
 # deprecations
 @deprecate EquispacedRectangleMesh(args...) RectilinearMesh(args...)

--- a/src/Meshes/cubedsphere.jl
+++ b/src/Meshes/cubedsphere.jl
@@ -282,11 +282,30 @@ function containing_element(
     return CartesianIndex(x, y, panel)
 end
 
+function containing_element(
+    mesh::AbstractCubedSphere,
+    coord::Geometry.LatLongPoint,
+)
+    geom = Geometry.SphericalGlobalGeometry(domain(mesh).radius)
+    coord = Geometry.CartesianPoint(coord, geom)
+    return containing_element(mesh, coord)
+end
+
 reference_coordinates(
     mesh::AbstractCubedSphere,
     elem::CartesianIndex{3},
     coord::Geometry.Cartesian123Point,
 ) = reference_coordinates(mesh, elem, coord, mesh.localelementmap)
+
+function reference_coordinates(
+    mesh::AbstractCubedSphere,
+    elem::CartesianIndex{3},
+    coord::Geometry.LatLongPoint,
+)
+    geom = Geometry.SphericalGlobalGeometry(domain(mesh).radius)
+    coord = Geometry.CartesianPoint(coord, geom)
+    return reference_coordinates(mesh, elem, coord)
+end
 
 function reference_coordinates(
     mesh::AbstractCubedSphere,

--- a/src/Meshes/latlong.jl
+++ b/src/Meshes/latlong.jl
@@ -35,13 +35,10 @@ ncoordinates(mesh::RegularLatLongMesh) = length(mesh.lat) * length(mesh.long)
 
 function rllcoords(mesh::RegularLatLongMesh)
     latitude, longitude = mesh.lat, mesh.long
-
     # store latlong coords and associated elements
-    coords = []
-    for lat in latitude
-        for long in longitude
-            push!(coords, Geometry.LatLongPoint(lat, long))
-        end
-    end
+    coords = [
+        Geometry.LatLongPoint(lat, long) for lat in latitude for
+        long in longitude
+    ]
     return coords
 end

--- a/src/Meshes/latlong.jl
+++ b/src/Meshes/latlong.jl
@@ -18,14 +18,14 @@ function RegularLatLongMesh(
     @assert -180 <= long_bounds[1] < long_bounds[2] <= 180
 
     FT = typeof(domain.radius)
-    lat = range(ClosedInterval{FT}(lat_bounds[1], lat_bounds[2]), nlat) # lat [-90, 90]
+    lat = range(lat_bounds[1], lat_bounds[2], length = nlat)
     if long_bounds[1] + 360 ≈ long_bounds[2] # periodic, long_bounds[2] "=" long_bounds[1]
         long = range(
             Interval{:closed, :open, FT}(long_bounds[1], long_bounds[2]),
             nlong,
-        ) # long (-180, 180]
+        )
     else
-        long = range(ClosedInterval{FT}(long_bounds[1], long_bounds[2]), nlong) # long (-180, 180]
+        long = range(long_bounds[1], long_bounds[2], length = nlong)
     end
     return RegularLatLongMesh{typeof.((domain, lat))...}(domain, lat, long)
 end

--- a/src/Meshes/latlong.jl
+++ b/src/Meshes/latlong.jl
@@ -1,0 +1,61 @@
+using IntervalSets
+
+struct RegularLatLongMesh <: AbstractMesh2D
+    domain::Domains.SphereDomain
+    nlat::Int
+    nlong::Int
+end
+
+domain(mesh::RegularLatLongMesh) = mesh.domain
+
+function coordinates_list(
+    mesh::RegularLatLongMesh,
+)
+    r = domain(mesh).radius
+    nlat, nlong = mesh.nlat, mesh.nlong
+    FT = typeof(r)
+    θ = range(Interval{:closed, :open}(FT(0), FT(2π)), nlong) # long (0, 2π]
+    ϕ = range(ClosedInterval{FT}(0, π), nlat) # lat [0, π]
+    coords = []
+    for lat in ϕ
+        for long in θ
+            push!(coords, Geometry.LatLongPoint(lat, long))
+        end
+    end
+    return coords
+end
+
+# space needs a spherical setup
+# operator array will need to map from nodes in src space to pts..
+using SparseArrays
+function generate_midpoint_remap(target::Meshes.RegularLatLongMesh, source)
+    target_coords = coordinates_list(target)
+    nelems = Topologies.nlocalelems(source)
+    QS_s = Spaces.quadrature_style(source)
+    Nq_s = Quadratures.degrees_of_freedom(QS_s)
+    op = spzeros(length(target_coords), nelems * Nq_s)
+    source_mesh = Spaces.topology(space).mesh
+    for coord in target_coords
+        elem = Meshes.containing_element(source_mesh, coord)
+        ξ = Meshes.reference_coordinates(source_mesh, elem, coord)
+
+    end
+
+
+end
+
+#= playground
+FT = Float64
+radius = FT(3)
+ne = 4
+Nq = 4
+spheredomain = Domains.SphereDomain(radius)
+mesh = Meshes.EquiangularCubedSphere(spheredomain, ne)
+topology = Topologies.Topology2D(mesh)
+quad = Spaces.Quadratures.GLL{Nq}()
+space = Spaces.SpectralElementSpace2D(topology, quad)
+
+rllmesh = Meshes.RegularLatLongMesh(spheredomain, 5, 5)
+
+
+=#

--- a/src/Meshes/latlong.jl
+++ b/src/Meshes/latlong.jl
@@ -11,21 +11,21 @@ function RegularLatLongMesh(
     domain,
     nlat::Int,
     nlong::Int,
-    lat_bounds = (-π / 2, π / 2),
-    long_bounds = (-π, π),
+    lat_bounds = (-90, 90),
+    long_bounds = (-180, 180),
 )
-    @assert 0 < (lat_bounds[2] - lat_bounds[1]) <= π
-    @assert 0 < (long_bounds[2] - long_bounds[1]) <= 2π
+    @assert -90 <= lat_bounds[1] < lat_bounds[2] <= 90
+    @assert -180 <= long_bounds[1] < long_bounds[2] <= 180
 
     FT = typeof(domain.radius)
-    lat = range(ClosedInterval{FT}(lat_bounds[1], lat_bounds[2]), nlat) # lat [-π/2, π/2]
-    if long_bounds[1] + 2π ≈ long_bounds[2] # periodic, long_bounds[2] "=" long_bounds[1]
+    lat = range(ClosedInterval{FT}(lat_bounds[1], lat_bounds[2]), nlat) # lat [-90, 90]
+    if long_bounds[1] + 360 ≈ long_bounds[2] # periodic, long_bounds[2] "=" long_bounds[1]
         long = range(
             Interval{:closed, :open, FT}(long_bounds[1], long_bounds[2]),
             nlong,
-        ) # long (-π, π]
+        ) # long (-180, 180]
     else
-        long = range(ClosedInterval{FT}(long_bounds[1], long_bounds[2]), nlong) # long (-π, π]
+        long = range(ClosedInterval{FT}(long_bounds[1], long_bounds[2]), nlong) # long (-180, 180]
     end
     return RegularLatLongMesh{typeof.((domain, lat))...}(domain, lat, long)
 end

--- a/src/Meshes/latlong.jl
+++ b/src/Meshes/latlong.jl
@@ -32,3 +32,16 @@ end
 
 domain(mesh::RegularLatLongMesh) = mesh.domain
 ncoordinates(mesh::RegularLatLongMesh) = length(mesh.lat) * length(mesh.long)
+
+function rllcoords(mesh::RegularLatLongMesh)
+    latitude, longitude = mesh.lat, mesh.long
+
+    # store latlong coords and associated elements
+    coords = []
+    for lat in latitude
+        for long in longitude
+            push!(coords, Geometry.LatLongPoint(lat, long))
+        end
+    end
+    return coords
+end

--- a/src/Meshes/latlong.jl
+++ b/src/Meshes/latlong.jl
@@ -1,9 +1,23 @@
 using IntervalSets
 
-struct RegularLatLongMesh <: AbstractMesh2D
-    domain::Domains.SphereDomain
-    nlat::Int
-    nlong::Int
+struct RegularLatLongMesh{S <: Domains.SphereDomain, R <: StepRangeLen} <: AbstractMesh2D
+    domain::S
+    lat::R
+    long::R
+end
+
+function RegularLatLongMesh(domain, nlat::Int, nlong::Int, lat_bounds = (-π/2, π/2), long_bounds = (-π, π))
+    @assert 0 < (lat_bounds[2] - lat_bounds[1]) <= π
+    @assert 0 < (long_bounds[2] - long_bounds[1]) <= 2π
+    
+    FT = typeof(domain.radius)
+    lat = range(ClosedInterval{FT}(lat_bounds[1], lat_bounds[2]), nlat) # lat [-π/2, π/2]
+    if long_bounds[1] + 2π ≈ long_bounds[2] # periodic, long_bounds[2] "=" long_bounds[1]
+        long = range(Interval{:closed, :open, FT}(long_bounds[1], long_bounds[2]), nlong) # long (-π, π]
+    else
+        long = range(ClosedInterval{FT}(long_bounds[1], long_bounds[2]), nlong) # long (-π, π]
+    end
+    return RegularLatLongMesh{typeof.((domain, lat))...}(domain, lat, long)
 end
 
 domain(mesh::RegularLatLongMesh) = mesh.domain
@@ -11,14 +25,10 @@ domain(mesh::RegularLatLongMesh) = mesh.domain
 function coordinates_list(
     mesh::RegularLatLongMesh,
 )
-    r = domain(mesh).radius
-    nlat, nlong = mesh.nlat, mesh.nlong
-    FT = typeof(r)
-    θ = range(Interval{:closed, :open}(FT(0), FT(2π)), nlong) # long (0, 2π]
-    ϕ = range(ClosedInterval{FT}(0, π), nlat) # lat [0, π]
+    latitude, longitude = mesh.lat, mesh.long
     coords = []
-    for lat in ϕ
-        for long in θ
+    for lat in latitude
+        for long in longitude
             push!(coords, Geometry.LatLongPoint(lat, long))
         end
     end

--- a/src/Meshes/latlong.jl
+++ b/src/Meshes/latlong.jl
@@ -1,19 +1,29 @@
 using IntervalSets
 
-struct RegularLatLongMesh{S <: Domains.SphereDomain, R <: StepRangeLen} <: AbstractMesh2D
+struct RegularLatLongMesh{S <: Domains.SphereDomain, R <: StepRangeLen} <:
+       AbstractMesh2D
     domain::S
     lat::R
     long::R
 end
 
-function RegularLatLongMesh(domain, nlat::Int, nlong::Int, lat_bounds = (-π/2, π/2), long_bounds = (-π, π))
+function RegularLatLongMesh(
+    domain,
+    nlat::Int,
+    nlong::Int,
+    lat_bounds = (-π / 2, π / 2),
+    long_bounds = (-π, π),
+)
     @assert 0 < (lat_bounds[2] - lat_bounds[1]) <= π
     @assert 0 < (long_bounds[2] - long_bounds[1]) <= 2π
-    
+
     FT = typeof(domain.radius)
     lat = range(ClosedInterval{FT}(lat_bounds[1], lat_bounds[2]), nlat) # lat [-π/2, π/2]
     if long_bounds[1] + 2π ≈ long_bounds[2] # periodic, long_bounds[2] "=" long_bounds[1]
-        long = range(Interval{:closed, :open, FT}(long_bounds[1], long_bounds[2]), nlong) # long (-π, π]
+        long = range(
+            Interval{:closed, :open, FT}(long_bounds[1], long_bounds[2]),
+            nlong,
+        ) # long (-π, π]
     else
         long = range(ClosedInterval{FT}(long_bounds[1], long_bounds[2]), nlong) # long (-π, π]
     end
@@ -21,51 +31,4 @@ function RegularLatLongMesh(domain, nlat::Int, nlong::Int, lat_bounds = (-π/2, 
 end
 
 domain(mesh::RegularLatLongMesh) = mesh.domain
-
-function coordinates_list(
-    mesh::RegularLatLongMesh,
-)
-    latitude, longitude = mesh.lat, mesh.long
-    coords = []
-    for lat in latitude
-        for long in longitude
-            push!(coords, Geometry.LatLongPoint(lat, long))
-        end
-    end
-    return coords
-end
-
-# space needs a spherical setup
-# operator array will need to map from nodes in src space to pts..
-using SparseArrays
-function generate_midpoint_remap(target::Meshes.RegularLatLongMesh, source)
-    target_coords = coordinates_list(target)
-    nelems = Topologies.nlocalelems(source)
-    QS_s = Spaces.quadrature_style(source)
-    Nq_s = Quadratures.degrees_of_freedom(QS_s)
-    op = spzeros(length(target_coords), nelems * Nq_s)
-    source_mesh = Spaces.topology(space).mesh
-    for coord in target_coords
-        elem = Meshes.containing_element(source_mesh, coord)
-        ξ = Meshes.reference_coordinates(source_mesh, elem, coord)
-
-    end
-
-
-end
-
-#= playground
-FT = Float64
-radius = FT(3)
-ne = 4
-Nq = 4
-spheredomain = Domains.SphereDomain(radius)
-mesh = Meshes.EquiangularCubedSphere(spheredomain, ne)
-topology = Topologies.Topology2D(mesh)
-quad = Spaces.Quadratures.GLL{Nq}()
-space = Spaces.SpectralElementSpace2D(topology, quad)
-
-rllmesh = Meshes.RegularLatLongMesh(spheredomain, 5, 5)
-
-
-=#
+ncoordinates(mesh::RegularLatLongMesh) = length(mesh.lat) * length(mesh.long)

--- a/src/Operators/remapping.jl
+++ b/src/Operators/remapping.jl
@@ -317,10 +317,7 @@ function RLLRemap(target_mesh::Meshes.RegularLatLongMesh, source_space)
         for long in longitude
             coord = Geometry.LatLongPoint(lat, long)
             elem = Meshes.containing_element(source_mesh, coord)
-            push!(
-                coords,
-                (coord = coord, elem = elem),
-            )
+            push!(coords, (coord = coord, elem = elem))
         end
     end
 

--- a/test/Operators/remapping.jl
+++ b/test/Operators/remapping.jl
@@ -754,4 +754,16 @@ end
     source_field = ones(space)
     remap!(remap_vec, R, source_field)
     @test isapprox(remap_vec, ones(length(rllcoords)))
+
+    topology = Topologies.spacefillingcurve(mesh)
+    space = Spaces.SpectralElementSpace2D(topology, quad)
+    coords = Fields.coordinate_field(space)
+
+    R = Operators.RLLRemap(rllmesh, space)
+    source_field = sind.(coords.long) .* cosd.(coords.lat)
+    remap_vec = Operators.remap(R, source_field)
+    truth_vec =
+        sind.(getproperty.(rllcoords, :long)) .*
+        cosd.(getproperty.(rllcoords, :lat))
+    @test isapprox(remap_vec, truth_vec; atol = 1e-4)
 end

--- a/test/Operators/remapping.jl
+++ b/test/Operators/remapping.jl
@@ -750,4 +750,8 @@ end
         sind.(getproperty.(rllcoords, :long)) .*
         cosd.(getproperty.(rllcoords, :lat))
     @test isapprox(remap_vec, truth_vec; atol = 1e-4)
+
+    source_field = ones(space)
+    remap!(remap_vec, R, source_field)
+    @test isapprox(remap_vec, ones(length(rllcoords)))
 end


### PR DESCRIPTION
Addresses #742 

- Introduces a lightweight `RegularLatLongMesh` struct describing the grid to record output on.
- Introduces `RLLRemap`, a remapping operator storing the interpolation matrix between a field and the lat/long mesh.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
