### PR TITLE
2D rising thermal bubble: increase dt and final time

### DIFF
--- a/examples/hybrid/plane/bubble_2d_invariant_rhoe.jl
+++ b/examples/hybrid/plane/bubble_2d_invariant_rhoe.jl
@@ -67,7 +67,7 @@ const T_0 = 273.16 # triple point temperature
 Φ(z) = grav * z
 
 # Reference: https://journals.ametsoc.org/view/journals/mwre/140/4/mwr-d-10-05073.1.xml, Section 5a
-# Prognostic thermodynamic variable: Total Energy 
+# Prognostic thermodynamic variable: Total Energy
 function init_dry_rising_bubble_2d(x, z)
     x_c = 0.0
     z_c = 350.0
@@ -243,8 +243,8 @@ rhs_invariant!(dYdt, Y, nothing, 0.0);
 
 # run!
 using OrdinaryDiffEq
-Δt = 0.02
-prob = ODEProblem(rhs_invariant!, Y, (0.0, 500.0))
+Δt = 0.04
+prob = ODEProblem(rhs_invariant!, Y, (0.0, 1400.0))
 integrator = OrdinaryDiffEq.init(
     prob,
     SSPRK33(),


### PR DESCRIPTION
This closes #756 

I tried to push Δt as large as I could, with this configuration, but it could only be doubled. Also running for longer time to see the interesting stuff happening in the output videos.

cc: @akshaysridhar 

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
