### PR TITLE
add bycolumn function

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -196,7 +196,6 @@ RecursiveApply.tuplemap
 
 ## Fields
 
-
 ```@docs
 Fields.Field
 Fields.coordinate_field
@@ -207,6 +206,8 @@ Base.sum(::Fields.Field)
 Fields.Statistics.mean(::Fields.Field)
 Fields.LinearAlgebra.norm(::Fields.Field)
 Fields.set!
+Fields.ColumnIndex
+Fields.bycolumn
 ```
 
 ## Limiters

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -258,6 +258,7 @@ include("mapreduce.jl")
 include("compat_diffeq.jl")
 include("fieldvector.jl")
 include("field_iterator.jl")
+include("indices.jl")
 
 function interpcoord(elemrange, x::Real)
     n = length(elemrange) - 1

--- a/src/Fields/indices.jl
+++ b/src/Fields/indices.jl
@@ -43,8 +43,8 @@ multiple column-wise operations in a single pass, making use of multiple threads
 div = DivergenceC2F()
 
 bycolumn(axes(f)) do colidx
-    @. dg[colidx] = ∇(f[colidx])
-    @. df[colidx] = div(g[colidx])
+    @. ∇f[colidx] = ∇(f[colidx])
+    @. df[colidx] = div(∇f[colidx])
 end
 ```
 """

--- a/src/Fields/indices.jl
+++ b/src/Fields/indices.jl
@@ -1,0 +1,75 @@
+"""
+    ColumnIndex(ij,h)
+
+An index into a column of a field. This can be used as an argument to `getindex`
+of a `Field`, to return a field on that column.
+
+# Example
+```julia
+colidx = ColumnIndex((1,1),1)
+field[colidx]
+```
+"""
+struct ColumnIndex{N}
+    ij::NTuple{N, Int}
+    h::Int
+end
+
+Base.getindex(field::Field, colidx::ColumnIndex) = column(field, colidx)
+
+function column(field::SpectralElementField1D, colidx::ColumnIndex{1})
+    column(field, colidx.ij[1], colidx.h)
+end
+function column(field::ExtrudedFiniteDifferenceField, colidx::ColumnIndex{1})
+    column(field, colidx.ij[1], colidx.h)
+end
+function column(field::SpectralElementField2D, colidx::ColumnIndex{2})
+    column(field, colidx.ij[1], colidx.ij[2], colidx.h)
+end
+function column(field::ExtrudedFiniteDifferenceField, colidx::ColumnIndex{2})
+    column(field, colidx.ij[1], colidx.ij[2], colidx.h)
+end
+
+"""
+    Fields.bycolumn(fn, space)
+
+Call `fn(colidx)` to every [`ColumnIndex`](@ref) `colidx` of `space`. This can be used to apply
+multiple column-wise operations in a single pass, making use of multiple threads.
+
+# Example
+
+```julia
+∇ = GradientF2C()
+div = DivergenceC2F()
+
+bycolumn(axes(f)) do colidx
+    @. dg[colidx] = ∇(f[colidx])
+    @. df[colidx] = div(g[colidx])
+end
+```
+"""
+function bycolumn(fn, space::Spaces.SpectralElementSpace1D)
+    Nh = Topologies.nlocalelems(space)
+    Nq = Spaces.Quadratures.degrees_of_freedom(Spaces.quadrature_style(space))
+    Threads.@threads for h in 1:Nh
+        for i in 1:Nq
+            fn(ColumnIndex((i,), h))
+        end
+    end
+    return nothing
+end
+function bycolumn(fn, space::Spaces.SpectralElementSpace2D)
+    Nh = Topologies.nlocalelems(space)
+    Nq = Spaces.Quadratures.degrees_of_freedom(Spaces.quadrature_style(space))
+    Threads.@threads for h in 1:Nh
+        for j in 1:Nq, i in 1:Nq
+            fn(ColumnIndex((i, j), h))
+        end
+    end
+    return nothing
+end
+bycolumn(fn, space::Spaces.ExtrudedFiniteDifferenceSpace) =
+    bycolumn(fn, space.horizontal_space)
+
+# potential TODO:
+# - define a ColumnIndices type, make it work with https://github.com/JuliaFolds/FLoops.jl

--- a/test/Operators/hybrid/2d.jl
+++ b/test/Operators/hybrid/2d.jl
@@ -626,3 +626,18 @@ end
 
     @test ∇⁴y_ref ≈ ∇⁴y rtol = 2e-2
 end
+
+
+@testset "bycolumn fuse" begin
+    hv_center_space, hv_face_space =
+        hvspace_2D(xlim = (-pi, pi), zlim = (-pi, pi))
+
+    fz = Fields.coordinate_field(hv_face_space).z
+    ∇ = Operators.GradientF2C()
+    ∇z = map(coord -> WVector(0.0), Fields.coordinate_field(hv_center_space))
+    Fields.bycolumn(hv_center_space) do colidx
+        @. ∇z[colidx] = WVector(∇(fz[colidx]))
+    end
+    @test ∇z == WVector.(∇.(fz))
+
+end

--- a/test/Operators/hybrid/3d.jl
+++ b/test/Operators/hybrid/3d.jl
@@ -282,3 +282,17 @@ end
     @show err
     @test err[4] ≤ err[3] ≤ err[2] ≤ err[1]
 end
+
+
+@testset "bycolumn fuse" begin
+    hv_center_space, hv_face_space =
+        hvspace_3D((-1.0, 1.0), (-1.0, 1.0), (-1.0, 1.0))
+
+    fz = Fields.coordinate_field(hv_face_space).z
+    ∇ = Operators.GradientF2C()
+    ∇z = map(coord -> WVector(0.0), Fields.coordinate_field(hv_center_space))
+    Fields.bycolumn(hv_center_space) do colidx
+        @. ∇z[colidx] = WVector(∇(fz[colidx]))
+    end
+    @test ∇z == WVector.(∇.(fz))
+end


### PR DESCRIPTION
This should make it easier to apply multiple column operations in a single pass, and leverage threading.

Example:
```
bycolumn(axes(f)) do colidx
    @. dg[colidx] = ∇(f[colidx])
    @. df[colidx] = div(g[colidx])
end
```

The reason to use `getindex` here is that it doesn't get broadcasted by `@.`, so makes writing these operations easier.


- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
