### PR TITLE
Improve `Cannot infer eltype` error message

### DIFF
--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -10,7 +10,7 @@ import ..Utilities: PlusHalf
 
 using ..RecursiveApply
 
-import LinearAlgebra, Statistics, InteractiveUtils
+import StaticArrays, LinearAlgebra, Statistics, InteractiveUtils
 
 """
     Field(values, space)

--- a/test/Fields/field.jl
+++ b/test/Fields/field.jl
@@ -1,5 +1,6 @@
 using Test
 using StaticArrays, IntervalSets
+import ClimaCore
 import ClimaCore.DataLayouts: IJFH
 import ClimaCore:
     Fields, slab, Domains, Topologies, Meshes, Operators, Spaces, Geometry
@@ -7,6 +8,8 @@ import ClimaCore:
 using LinearAlgebra: norm
 using Statistics: mean
 using ForwardDiff
+
+include(joinpath(@__DIR__, "util_spaces.jl"))
 
 function spectral_space_2D(; n1 = 1, n2 = 1, Nij = 4)
     domain = Domains.RectangleDomain(
@@ -309,4 +312,57 @@ end
         field2
     @test parent(field1) == parent(field2)
     Fields.allow_mismatched_diagonalized_spaces() = false
+end
+
+struct InferenceFoo{FT}
+    bar::FT
+end
+Base.broadcastable(x::InferenceFoo) = Ref(x)
+@testset "Inference failure message" begin
+    function FieldFromNamedTuple(space, nt::NamedTuple)
+        cmv(z) = nt
+        return cmv.(Fields.coordinate_field(space))
+    end
+    function ics_foo(::Type{FT}, lg, foo) where {FT}
+        uv = Geometry.UVVector(FT(0), FT(0))
+        z = Geometry.Covariant12Vector(uv, lg)
+        y = foo.bingo
+        return (; x = FT(0) + y)
+    end
+    function ics_foo_with_field(::Type{FT}, lg, foo, f) where {FT}
+        uv = Geometry.UVVector(FT(0), FT(0))
+        z = Geometry.Covariant12Vector(uv, lg)
+        ζ = f.a
+        y = foo.baz
+        return (; x = FT(0) + y - ζ)
+    end
+    function FieldFromNamedTupleBroken(
+        space,
+        ics::Function,
+        ::Type{FT},
+        params...,
+    ) where {FT}
+        lg = Fields.local_geometry_field(space)
+        return ics.(FT, lg, params...)
+    end
+    FT = Float64
+    foo = InferenceFoo(2.0)
+
+    for space in all_spaces(FT)
+        Y = FieldFromNamedTuple(space, (; a = FT(0), b = FT(1)))
+        @test_throws ErrorException("type InferenceFoo has no field bingo") FieldFromNamedTupleBroken(
+            space,
+            ics_foo,
+            FT,
+            foo,
+        )
+        @test_throws ErrorException("type InferenceFoo has no field baz") FieldFromNamedTupleBroken(
+            space,
+            ics_foo_with_field,
+            FT,
+            foo,
+            Y,
+        )
+    end
+
 end

--- a/test/Fields/util_spaces.jl
+++ b/test/Fields/util_spaces.jl
@@ -1,0 +1,81 @@
+import ClimaCore as CC
+
+#=
+Return a vector of toy spaces for testing
+=#
+function all_spaces(::Type{FT}) where {FT}
+
+    # 1d domain space
+    domain = CC.Domains.IntervalDomain(
+        CC.Geometry.XPoint{FT}(-3) .. CC.Geometry.XPoint{FT}(5),
+        periodic = true,
+    )
+    mesh = CC.Meshes.IntervalMesh(domain; nelems = 1)
+    topology = CC.Topologies.IntervalTopology(mesh)
+
+    quad = CC.Spaces.Quadratures.GLL{4}()
+    points, weights = CC.Spaces.Quadratures.quadrature_points(FT, quad)
+
+    space1 = CC.Spaces.SpectralElementSpace1D(topology, quad)
+
+    # finite difference spaces
+    domain = CC.Domains.IntervalDomain(
+        CC.Geometry.ZPoint{FT}(0) .. CC.Geometry.ZPoint{FT}(5),
+        boundary_names = (:bottom, :top),
+    )
+    mesh = CC.Meshes.IntervalMesh(domain; nelems = 1)
+    topology = CC.Topologies.IntervalTopology(mesh)
+
+    space2 = CC.Spaces.CenterFiniteDifferenceSpace(topology)
+    space3 = CC.Spaces.FaceFiniteDifferenceSpace(topology)
+
+    # 1×1 domain space
+    domain = CC.Domains.RectangleDomain(
+        CC.Geometry.XPoint{FT}(-3) .. CC.Geometry.XPoint{FT}(5),
+        CC.Geometry.YPoint{FT}(-2) .. CC.Geometry.YPoint{FT}(8),
+        x1periodic = true,
+        x2periodic = false,
+        x2boundary = (:south, :north),
+    )
+    mesh = CC.Meshes.RectilinearMesh(domain, 1, 1)
+    grid_topology = CC.Topologies.Topology2D(mesh)
+
+    quad = CC.Spaces.Quadratures.GLL{4}()
+    points, weights = CC.Spaces.Quadratures.quadrature_points(FT, quad)
+
+    space4 = CC.Spaces.SpectralElementSpace2D(grid_topology, quad)
+
+    # sphere space
+    radius = FT(3)
+    ne = 4
+    Nq = 4
+    domain = CC.Domains.SphereDomain(radius)
+    mesh = CC.Meshes.EquiangularCubedSphere(domain, ne)
+    topology = CC.Topologies.Topology2D(mesh)
+    quad = CC.Spaces.Quadratures.GLL{Nq}()
+    space5 = CC.Spaces.SpectralElementSpace2D(topology, quad)
+
+    radius = FT(128)
+    zlim = (0, 1)
+    helem = 4
+    zelem = 10
+    Nq = 4
+
+    vertdomain = CC.Domains.IntervalDomain(
+        CC.Geometry.ZPoint{FT}(zlim[1]),
+        CC.Geometry.ZPoint{FT}(zlim[2]);
+        boundary_tags = (:bottom, :top),
+    )
+    vertmesh = CC.Meshes.IntervalMesh(vertdomain, nelems = zelem)
+    space6 = CC.Spaces.CenterFiniteDifferenceSpace(vertmesh)
+
+    horzdomain = CC.Domains.SphereDomain(radius)
+    horzmesh = CC.Meshes.EquiangularCubedSphere(horzdomain, helem)
+    horztopology = CC.Topologies.Topology2D(horzmesh)
+    quad = CC.Spaces.Quadratures.GLL{Nq}()
+    space7 = CC.Spaces.SpectralElementSpace2D(horztopology, quad)
+
+    space8 = CC.Spaces.ExtrudedFiniteDifferenceSpace(space7, space6)
+
+    return [space1, space2, space3, space4, space5, space6, space7, space8]
+end


### PR DESCRIPTION
This PR is an attempt to improve the `Cannot infer eltype` error message, which can be very opaque. This is an attempt to close #720.

The error message in the added test in main:
```julia
Inference failure message: Error During Test at /Users/charliekawczynski/Dropbox/Caltech/work/dev/CliMA/ClimaCore.jl/test/Fields/field.jl:319
  Got exception outside of a @test
  BroadcastInferenceError: cannot infer eltype.
  MethodInstance for (::var"#ics_foo#4")(::Type{Float64}, ::ClimaCore.Geometry.LocalGeometry{(1, 2), ClimaCore.Geometry.XYPoint{Float64}, Float64, SMatrix{2, 2, Float64, 4}}, ::InferenceFoo{Float64})
    from (::var"#ics_foo#4")(::Type{FT}, lg, foo) where FT in Main at /Users/charliekawczynski/Dropbox/Caltech/work/dev/CliMA/ClimaCore.jl/test/Fields/field.jl:321
  Static Parameters
    FT = Float64
  Arguments
    #self#::Core.Const(var"#ics_foo#4"())
    _::Core.Const(Float64)
    lg::ClimaCore.Geometry.LocalGeometry{(1, 2), ClimaCore.Geometry.XYPoint{Float64}, Float64, SMatrix{2, 2, Float64, 4}}
    foo::InferenceFoo{Float64}
  Locals
    y::Union{}
    z::ClimaCore.Geometry.Covariant12Vector{Float64}
    uv::ClimaCore.Geometry.UVVector{Float64}
  Body::Union{}
  1 ─ %1 = ClimaCore.Geometry.UVVector::Core.Const(ClimaCore.Geometry.UVVector)
  │   %2 = ($(Expr(:static_parameter, 1)))(0)::Core.Const(0.0)
  │   %3 = ($(Expr(:static_parameter, 1)))(0)::Core.Const(0.0)
  │        (uv = (%1)(%2, %3))
  │   %5 = ClimaCore.Geometry.Covariant12Vector::Core.Const(ClimaCore.Geometry.Covariant12Vector)
  │   %6 = uv::Core.Const([0.0, 0.0])
  │        (z = (%5)(%6, lg))
  │        (y = Base.getproperty(foo, :baz))
  │        Core.Const((:x,))
  │        Core.Const(:(Core.apply_type(Core.NamedTuple, %9)))
  │        Core.Const(:(($(Expr(:static_parameter, 1)))(0)))
  │        Core.Const(:(%11 + y))
  │        Core.Const(:(Core.tuple(%12)))
  │        Core.Const(:((%10)(%13)))
  └──      Core.Const(:(return %14))
  
  
  Stacktrace:
    [1] copy(bc::Base.Broadcast.Broadcasted{
```

The error message in the added test in this PR:
```julia
┌ Warning: Attempting to throw more informative error message:
└ @ ClimaCore.Fields ~/Dropbox/Caltech/work/dev/CliMA/ClimaCore.jl/src/Fields/broadcast.jl:83
Test Summary:             |
Inference failure message | No tests
ERROR: LoadError: type InferenceFoo has no field baz
Stacktrace:
  [1] getproperty
    @ ./Base.jl:42 [inlined]
  [2] (::var"#ics_foo#7")(#unused#::Type{Float64}, lg::ClimaCore.Geometry.LocalGeometry{(1, 2), ClimaCore.Geometry.XYPoint{Float64}, Float64, SMatrix{2, 2, Float64, 4}}, foo::InferenceFoo{Float64})
    @ Main ~/Dropbox/Caltech/work/dev/CliMA/ClimaCore.jl/test/Fields/field.jl:324
```