### PR TITLE
Update def_coord_space for TerrainWarpedIntervalTopology remapped output

### DIFF
--- a/lib/ClimaCoreTempestRemap/src/netcdf.jl
+++ b/lib/ClimaCoreTempestRemap/src/netcdf.jl
@@ -228,10 +228,12 @@ function def_space_coord(
     type = "dgll",
 ) where {S <: Spaces.Staggering}
     hvar = def_space_coord(nc, space.horizontal_space; type = type)
-    vvar = def_space_coord(
-        nc,
-        Spaces.FiniteDifferenceSpace{S}(space.vertical_topology),
-    )
+    vertical_topology =
+        space.vertical_topology isa
+        ClimaCore.Hypsography.TerrainWarpedIntervalTopology ?
+        space.vertical_topology.topology : space.vertical_topology
+    vvar =
+        def_space_coord(nc, Spaces.FiniteDifferenceSpace{S}(vertical_topology))
     (hvar..., vvar...)
 end
 


### PR DESCRIPTION
Update `def_space_coord` to handle TerrainWarpedIntervalTopology. Existing tests remain unaffected 

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
