### PR TITLE
Examples: Use 3rd-order-upwind in inertial gravity wave

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -823,7 +823,7 @@ steps:
       queue: central
       slurm_ntasks: 1
 
-  - label: ":computer: 3D sphere inertial gravity wave"
+  - label: ":computer: 2D plane inertial gravity wave"
     key: "cpu_inertial_gravity_wave"
     command:
       - "julia --color=yes --project=examples examples/hybrid/driver.jl"

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -1,5 +1,6 @@
 # Test-specific definitions (may be overwritten in each test case file)
 # TODO: Allow some of these to be enironment variables or command line arguments
+upwinding_mode = :none
 horizontal_mesh = nothing # must be object of type AbstractMesh
 npoly = 0
 z_max = 0
@@ -95,7 +96,7 @@ else
         f = face_initial_condition.(ᶠlocal_geometry),
     )
 end
-p = get_cache(ᶜlocal_geometry, ᶠlocal_geometry, Y, dt)
+p = get_cache(ᶜlocal_geometry, ᶠlocal_geometry, Y, dt, upwinding_mode)
 if ode_algorithm <: Union{
     OrdinaryDiffEq.OrdinaryDiffEqImplicitAlgorithm,
     OrdinaryDiffEq.OrdinaryDiffEqAdaptiveImplicitAlgorithm,

--- a/examples/hybrid/plane/inertial_gravity_wave.jl
+++ b/examples/hybrid/plane/inertial_gravity_wave.jl
@@ -28,6 +28,9 @@ const v₀ = FT(0)
 const T₀ = FT(250)
 const ΔT = FT(0.01)
 
+# Additional values required for driver
+upwinding_mode = :third_order
+
 # Other convenient constants used in reference paper
 const δ = grav / (R_d * T₀)        # Bretherton height parameter
 const cₛ² = cp_d / cv_d * R_d * T₀ # speed of sound squared


### PR DESCRIPTION
Co-authored-by: Dennis Yatunin <dyatun@gmail.com>

This PR builds up on @dennisYatunin 's work in #765 and includes the 3rd-order-upwinding operator to investigate potential restrictions on time-step size or resolution, if any. 

Findings: there are _no_ restrictions at all on time-step size or resolution and this PR produces better results than the current ones from this example on `main`.

This will close #766 

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
