### PR TITLE
Fix show for AxisTensors

### DIFF
--- a/src/Geometry/axistensors.jl
+++ b/src/Geometry/axistensors.jl
@@ -133,6 +133,13 @@ Base.axes(a::AxisTensor) = getfield(a, :axes)
 Base.axes(::Type{AxisTensor{T, N, A, S}}) where {T, N, A, S} = A.instance
 Base.size(a::AxisTensor) = map(length, axes(a))
 
+function Base.show(io::IO, a::AxisTensor{T, N, A, S}) where {T, N, A, S}
+    println(
+        io,
+        "AxisTensor{$T, $N, $A, $S}($(getfield(a, :axes)), $(getfield(a, :components)))",
+    )
+end
+
 """
     components(a::AxisTensor)
 

--- a/test/Geometry/axistensors.jl
+++ b/test/Geometry/axistensors.jl
@@ -58,6 +58,22 @@ using LinearAlgebra, StaticArrays
     @test DataLayouts.typesize(Float64, typeof(x)) == 2
 end
 
+@testset "Printing" begin
+    # https://github.com/CliMA/ClimaCore.jl/issues/768
+    T = Geometry.AxisTensor{
+        Float64,
+        2,
+        Tuple{Geometry.LocalAxis{(1, 2)}, Geometry.CovariantAxis{(1, 2)}},
+        SMatrix{2, 2, Float64, 4},
+    }
+    components = SMatrix{2, 2, Float64, 4}([4.0 0.0; 0.0 5.0])
+    axes_T = (Geometry.LocalAxis{(1, 2)}(), Geometry.CovariantAxis{(1, 2)}())
+    ats = T(axes_T, components)
+    s = sprint(show, ats)
+    @test s ==
+          "AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.LocalAxis{(1, 2)}, ClimaCore.Geometry.CovariantAxis{(1, 2)}}, SMatrix{2, 2, Float64, 4}}((ClimaCore.Geometry.LocalAxis{(1, 2)}(), ClimaCore.Geometry.CovariantAxis{(1, 2)}()), [4.0 0.0; 0.0 5.0])\n"
+end
+
 @testset "transform" begin
     @test Geometry.transform(
         Geometry.Covariant12Axis(),


### PR DESCRIPTION
This PR fixes `@show` for AxisTensors. Closes #768.

I added two ways of printing, the first is what I imagine julia Base would look like, the second is a more pretty printing, but more verbose, format, I have no strong feelings about which one.