### PR TITLE
change default ordering of DistributedTopology back

### DIFF
--- a/src/Topologies/dtopology2d.jl
+++ b/src/Topologies/dtopology2d.jl
@@ -143,7 +143,7 @@ end
 function DistributedTopology2D(
     context::ClimaComms.AbstractCommsContext,
     mesh::Meshes.AbstractMesh{2},
-    elemorder = spacefillingcurve(mesh), # obtain elemorder from space-filling curve
+    elemorder = Meshes.elements(mesh),
     elempid = nothing, # array of same size as elemorder, containing owning pid for each element (it should be sorted)
     orderindex = Meshes.linearindices(elemorder), # inverse mapping of elemorder (e.g. map CartesianIndex => Int)
 )


### PR DESCRIPTION
This reverts the default ordering made in #752, so that it is consistent with `Topology2D`, and it won't be a breaking change (so we don't need to bump the version number).

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
