### PR TITLE
Fix more performance tests

### DIFF
--- a/test/Operators/finitedifference/opt_implicit_stencils.jl
+++ b/test/Operators/finitedifference/opt_implicit_stencils.jl
@@ -201,7 +201,6 @@ Operators.Operator2Stencil(op::CurriedTwoArgOperator) =
     #     @show k, success_tabs[k]
     # end
 
-    compose = Operators.ComposeStencils()
     apply_configs = (
         (a_FS, a_FS, a_CS, ops_F2C_S2S, (ops_C2F_S2S..., ops_C2F_S2V...)),
         (a_CS, a_CS, a_FS, ops_C2F_S2S, (ops_F2C_S2S..., ops_F2C_S2V...)),
@@ -216,6 +215,7 @@ Operators.Operator2Stencil(op::CurriedTwoArgOperator) =
     compressed_keys(op1, op2) = (nameof(typeof(op1)), nameof(typeof(op2)))
 
     function apply_single_composed_stencils(a0, a1, a2, op1, op2)
+        compose = Operators.ComposeStencils()
         apply = Operators.ApplyStencil()
         stencil_op1 = Operators.Operator2Stencil(op1)
         stencil_op2 = Operators.Operator2Stencil(op2)
@@ -233,73 +233,74 @@ Operators.Operator2Stencil(op::CurriedTwoArgOperator) =
                 end
             end
         end
+        return success_compose_tabs
     end
     success_compose_tabs = apply_composed_stencils(apply_configs)
 
-    @test_broken success_compose_tabs[(:CurriedTwoArgOperator, :DivergenceF2C)] == 0          # p = 1332272
-    @test_broken success_compose_tabs[(:InterpolateC2F, :GradientF2C)] == 0                   # p = 1227712
-    @test_broken success_compose_tabs[(:RightBiasedF2C, :LeftBiasedC2F)] == 0                 # p = 645296
-    @test_broken success_compose_tabs[(:DivergenceF2C, :RightBiasedC2F)] == 0                 # p = 1260464
-    @test_broken success_compose_tabs[(:DivergenceF2C, :CurriedTwoArgOperator)] == 0          # p = 2550512
-    @test_broken success_compose_tabs[(:CurriedTwoArgOperator, :CurriedTwoArgOperator)] == 0  # p = 1471040
-    @test_broken success_compose_tabs[(:DivergenceC2F, :LeftBiasedF2C)] == 0                  # p = 567536
-    @test_broken success_compose_tabs[(:CurriedTwoArgOperator, :RightBiasedF2C)] == 0         # p = 620336
-    @test_broken success_compose_tabs[(:RightBiasedF2C, :InterpolateC2F)] == 0                # p = 1543856
-    @test_broken success_compose_tabs[(:LeftBiasedF2C, :InterpolateC2F)] == 0                 # p = 1547312
-    @test_broken success_compose_tabs[(:CurriedTwoArgOperator, :CurlC2F)] == 0                # p = 2550512
-    @test_broken success_compose_tabs[(:DivergenceC2F, :GradientF2C)] == 0                    # p = 1158592
-    @test_broken success_compose_tabs[(:DivergenceC2F, :InterpolateF2C)] == 0                 # p = 1158512
-    @test_broken success_compose_tabs[(:InterpolateF2C, :InterpolateC2F)] == 0                # p = 1758128
-    @test_broken success_compose_tabs[(:LeftBiasedF2C, :LeftBiasedC2F)] == 0                  # p = 987440
-    @test_broken success_compose_tabs[(:RightBiasedF2C, :CurriedTwoArgOperator)] == 0         # p = 1714160
-    @test_broken success_compose_tabs[(:RightBiasedC2F, :LeftBiasedF2C)] == 0                 # p = 208112
-    @test_broken success_compose_tabs[(:RightBiasedC2F, :CurriedTwoArgOperator)] == 0         # p = 834608
-    @test_broken success_compose_tabs[(:CurriedTwoArgOperator, :InterpolateF2C)] == 0         # p = 1332272
-    @test_broken success_compose_tabs[(:RightBiasedF2C, :GradientC2F)] == 0                   # p = 1543856
-    @test_broken success_compose_tabs[(:CurriedTwoArgOperator, :GradientC2F)] == 0            # p = 2550512
-    @test_broken success_compose_tabs[(:DivergenceC2F, :RightBiasedF2C)] == 0                 # p = 567536
-    @test_broken success_compose_tabs[(:InterpolateF2C, :LeftBiasedC2F)] == 0                 # p = 811184
-    @test_broken success_compose_tabs[(:InterpolateC2F, :DivergenceF2C)] == 0                 # p = 1227712
-    @test_broken success_compose_tabs[(:CurriedTwoArgOperator, :RightBiasedC2F)] == 0         # p = 1372016
-    @test_broken success_compose_tabs[(:LeftBiasedC2F, :GradientF2C)] == 0                    # p = 781808
-    @test_broken success_compose_tabs[(:LeftBiasedC2F, :InterpolateF2C)] == 0                 # p = 567536
-    @test_broken success_compose_tabs[(:DivergenceF2C, :GradientC2F)] == 0                    # p = 2328448
-    @test_broken success_compose_tabs[(:DivergenceC2F, :CurriedTwoArgOperator)] == 0          # p = 1263152
-    @test_broken success_compose_tabs[(:DivergenceF2C, :DivergenceC2F)] == 0                  # p = 2328448
-    @test_broken success_compose_tabs[(:InterpolateF2C, :GradientC2F)] == 0                   # p = 1758128
-    @test_broken success_compose_tabs[(:LeftBiasedC2F, :RightBiasedF2C)] == 0                 # p = 208112
-    @test_broken success_compose_tabs[(:DivergenceF2C, :CurlC2F)] == 0                        # p = 2328448
-    @test_broken success_compose_tabs[(:RightBiasedC2F, :DivergenceF2C)] == 0                 # p = 781808
-    @test_broken success_compose_tabs[(:LeftBiasedC2F, :LeftBiasedF2C)] == 0                  # p = 546800
-    @test_broken success_compose_tabs[(:InterpolateC2F, :LeftBiasedF2C)] == 0                 # p = 567536
-    @test_broken success_compose_tabs[(:RightBiasedF2C, :CurlC2F)] == 0                       # p = 1543856
-    @test_broken success_compose_tabs[(:CurriedTwoArgOperator, :LeftBiasedF2C)] == 0          # p = 620336
-    @test_broken success_compose_tabs[(:LeftBiasedF2C, :GradientC2F)] == 0                    # p = 1547312
-    @test_broken success_compose_tabs[(:CurriedTwoArgOperator, :LeftBiasedC2F)] == 0          # p = 1375472
-    @test_broken success_compose_tabs[(:InterpolateF2C, :RightBiasedC2F)] == 0                # p = 811184
-    @test_broken success_compose_tabs[(:InterpolateF2C, :DivergenceC2F)] == 0                 # p = 1758128
-    @test_broken success_compose_tabs[(:RightBiasedF2C, :DivergenceC2F)] == 0                 # p = 1543856
-    @test_broken success_compose_tabs[(:RightBiasedC2F, :InterpolateF2C)] == 0                # p = 567536
-    @test_broken success_compose_tabs[(:LeftBiasedF2C, :DivergenceC2F)] == 0                  # p = 1547312
-    @test_broken success_compose_tabs[(:CurriedTwoArgOperator, :InterpolateC2F)] == 0         # p = 2550512
-    @test_broken success_compose_tabs[(:InterpolateC2F, :InterpolateF2C)] == 0                # p = 1227632
-    @test_broken success_compose_tabs[(:LeftBiasedF2C, :RightBiasedC2F)] == 0                 # p = 645296
-    @test_broken success_compose_tabs[(:CurriedTwoArgOperator, :DivergenceC2F)] == 0          # p = 2550512
-    @test_broken success_compose_tabs[(:DivergenceF2C, :LeftBiasedC2F)] == 0                  # p = 1263920
-    @test_broken success_compose_tabs[(:RightBiasedC2F, :RightBiasedF2C)] == 0                # p = 546800
-    @test_broken success_compose_tabs[(:InterpolateF2C, :CurlC2F)] == 0                       # p = 1758128
-    @test_broken success_compose_tabs[(:LeftBiasedF2C, :CurlC2F)] == 0                        # p = 1547312
-    @test_broken success_compose_tabs[(:InterpolateC2F, :RightBiasedF2C)] == 0                # p = 567536
-    @test_broken success_compose_tabs[(:LeftBiasedF2C, :CurriedTwoArgOperator)] == 0          # p = 1717616
-    @test_broken success_compose_tabs[(:LeftBiasedC2F, :DivergenceF2C)] == 0                  # p = 781808
-    @test_broken success_compose_tabs[(:DivergenceF2C, :InterpolateC2F)] == 0                 # p = 2328448
-    @test_broken success_compose_tabs[(:InterpolateF2C, :CurriedTwoArgOperator)] == 0         # p = 1980272
-    @test_broken success_compose_tabs[(:InterpolateC2F, :CurriedTwoArgOperator)] == 0         # p = 1332272
-    @test_broken success_compose_tabs[(:LeftBiasedC2F, :CurriedTwoArgOperator)] == 0          # p = 834608
-    @test_broken success_compose_tabs[(:RightBiasedC2F, :GradientF2C)] == 0                   # p = 781808
-    @test_broken success_compose_tabs[(:CurriedTwoArgOperator, :GradientF2C)] == 0            # p = 1332272
-    @test_broken success_compose_tabs[(:RightBiasedF2C, :RightBiasedC2F)] == 0                # p = 987440
-    @test_broken success_compose_tabs[(:DivergenceC2F, :DivergenceF2C)] == 0                  # p = 1158592
+    @test success_compose_tabs[(:CurriedTwoArgOperator, :DivergenceF2C)] == 0
+    @test success_compose_tabs[(:InterpolateC2F, :GradientF2C)] == 0
+    @test success_compose_tabs[(:RightBiasedF2C, :LeftBiasedC2F)] == 0
+    @test success_compose_tabs[(:DivergenceF2C, :RightBiasedC2F)] == 0
+    @test success_compose_tabs[(:DivergenceF2C, :CurriedTwoArgOperator)] == 0
+    @test success_compose_tabs[(:CurriedTwoArgOperator, :CurriedTwoArgOperator)] == 0
+    @test success_compose_tabs[(:DivergenceC2F, :LeftBiasedF2C)] == 0
+    @test success_compose_tabs[(:CurriedTwoArgOperator, :RightBiasedF2C)] == 0
+    @test success_compose_tabs[(:RightBiasedF2C, :InterpolateC2F)] == 0
+    @test success_compose_tabs[(:LeftBiasedF2C, :InterpolateC2F)] == 0
+    @test success_compose_tabs[(:CurriedTwoArgOperator, :CurlC2F)] == 0
+    @test success_compose_tabs[(:DivergenceC2F, :GradientF2C)] == 0
+    @test success_compose_tabs[(:DivergenceC2F, :InterpolateF2C)] == 0
+    @test success_compose_tabs[(:InterpolateF2C, :InterpolateC2F)] == 0
+    @test success_compose_tabs[(:LeftBiasedF2C, :LeftBiasedC2F)] == 0
+    @test success_compose_tabs[(:RightBiasedF2C, :CurriedTwoArgOperator)] == 0
+    @test success_compose_tabs[(:RightBiasedC2F, :LeftBiasedF2C)] == 0
+    @test success_compose_tabs[(:RightBiasedC2F, :CurriedTwoArgOperator)] == 0
+    @test success_compose_tabs[(:CurriedTwoArgOperator, :InterpolateF2C)] == 0
+    @test success_compose_tabs[(:RightBiasedF2C, :GradientC2F)] == 0
+    @test success_compose_tabs[(:CurriedTwoArgOperator, :GradientC2F)] == 0
+    @test success_compose_tabs[(:DivergenceC2F, :RightBiasedF2C)] == 0
+    @test success_compose_tabs[(:InterpolateF2C, :LeftBiasedC2F)] == 0
+    @test success_compose_tabs[(:InterpolateC2F, :DivergenceF2C)] == 0
+    @test success_compose_tabs[(:CurriedTwoArgOperator, :RightBiasedC2F)] == 0
+    @test success_compose_tabs[(:LeftBiasedC2F, :GradientF2C)] == 0
+    @test success_compose_tabs[(:LeftBiasedC2F, :InterpolateF2C)] == 0
+    @test success_compose_tabs[(:DivergenceF2C, :GradientC2F)] == 0
+    @test success_compose_tabs[(:DivergenceC2F, :CurriedTwoArgOperator)] == 0
+    @test success_compose_tabs[(:DivergenceF2C, :DivergenceC2F)] == 0
+    @test success_compose_tabs[(:InterpolateF2C, :GradientC2F)] == 0
+    @test success_compose_tabs[(:LeftBiasedC2F, :RightBiasedF2C)] == 0
+    @test success_compose_tabs[(:DivergenceF2C, :CurlC2F)] == 0
+    @test success_compose_tabs[(:RightBiasedC2F, :DivergenceF2C)] == 0
+    @test success_compose_tabs[(:LeftBiasedC2F, :LeftBiasedF2C)] == 0
+    @test success_compose_tabs[(:InterpolateC2F, :LeftBiasedF2C)] == 0
+    @test success_compose_tabs[(:RightBiasedF2C, :CurlC2F)] == 0
+    @test success_compose_tabs[(:CurriedTwoArgOperator, :LeftBiasedF2C)] == 0
+    @test success_compose_tabs[(:LeftBiasedF2C, :GradientC2F)] == 0
+    @test success_compose_tabs[(:CurriedTwoArgOperator, :LeftBiasedC2F)] == 0
+    @test success_compose_tabs[(:InterpolateF2C, :RightBiasedC2F)] == 0
+    @test success_compose_tabs[(:InterpolateF2C, :DivergenceC2F)] == 0
+    @test success_compose_tabs[(:RightBiasedF2C, :DivergenceC2F)] == 0
+    @test success_compose_tabs[(:RightBiasedC2F, :InterpolateF2C)] == 0
+    @test success_compose_tabs[(:LeftBiasedF2C, :DivergenceC2F)] == 0
+    @test success_compose_tabs[(:CurriedTwoArgOperator, :InterpolateC2F)] == 0
+    @test success_compose_tabs[(:InterpolateC2F, :InterpolateF2C)] == 0
+    @test success_compose_tabs[(:LeftBiasedF2C, :RightBiasedC2F)] == 0
+    @test success_compose_tabs[(:CurriedTwoArgOperator, :DivergenceC2F)] == 0
+    @test success_compose_tabs[(:DivergenceF2C, :LeftBiasedC2F)] == 0
+    @test success_compose_tabs[(:RightBiasedC2F, :RightBiasedF2C)] == 0
+    @test success_compose_tabs[(:InterpolateF2C, :CurlC2F)] == 0
+    @test success_compose_tabs[(:LeftBiasedF2C, :CurlC2F)] == 0
+    @test success_compose_tabs[(:InterpolateC2F, :RightBiasedF2C)] == 0
+    @test success_compose_tabs[(:LeftBiasedF2C, :CurriedTwoArgOperator)] == 0
+    @test success_compose_tabs[(:LeftBiasedC2F, :DivergenceF2C)] == 0
+    @test success_compose_tabs[(:DivergenceF2C, :InterpolateC2F)] == 0
+    @test success_compose_tabs[(:InterpolateF2C, :CurriedTwoArgOperator)] == 0
+    @test success_compose_tabs[(:InterpolateC2F, :CurriedTwoArgOperator)] == 0
+    @test success_compose_tabs[(:LeftBiasedC2F, :CurriedTwoArgOperator)] == 0
+    @test success_compose_tabs[(:RightBiasedC2F, :GradientF2C)] == 0
+    @test success_compose_tabs[(:CurriedTwoArgOperator, :GradientF2C)] == 0
+    @test success_compose_tabs[(:RightBiasedF2C, :RightBiasedC2F)] == 0
+    @test success_compose_tabs[(:DivergenceC2F, :DivergenceF2C)] == 0
 
     # for k in keys(success_tabs) # for debugging
     #     @show k, success_tabs[k]


### PR DESCRIPTION
This is a follow-up to #775.

We're actually doing much better than I thought. This PR fixes a bunch of allocation tests for the implicit operators.