### PR TITLE
Remove unused type parameters

### DIFF
--- a/src/Spaces/dss.jl
+++ b/src/Spaces/dss.jl
@@ -62,7 +62,7 @@ end
     arg::Geometry.CartesianVector,
     local_geometry::Geometry.LocalGeometry,
     weight,
-) where {T, N} = arg * weight
+) = arg * weight
 @inline dss_transform(
     arg::Geometry.AxisTensor{T, N, <:Tuple{Vararg{Geometry.LocalAxis}}},
     local_geometry::Geometry.LocalGeometry,
@@ -72,7 +72,7 @@ end
     arg::Geometry.LocalVector,
     local_geometry::Geometry.LocalGeometry,
     weight,
-) where {T, N} = arg * weight
+) = arg * weight
 @inline dss_transform(
     arg::Geometry.Covariant3Vector,
     local_geometry::Geometry.LocalGeometry,


### PR DESCRIPTION
This PR removes some unused type parameters. This turned out to be a performance bug in RootSolvers.jl, which was fixed in [RS#36](https://github.com/CliMA/RootSolvers.jl/pull/36).

Hopefully this will reduce the allocations in the dss operations.