### PR TITLE
ClimaCorePlots: support for space-filling curves

### DIFF
--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.7.2"
+julia_version = "1.7.3"
 manifest_format = "2.0"
 
 [[deps.ANSIColoredPrinters]]
@@ -215,7 +215,7 @@ version = "0.2.3"
 deps = ["ClimaCore", "RecipesBase", "StaticArrays", "TriplotBase"]
 path = "../lib/ClimaCorePlots"
 uuid = "cf7c7e5a-b407-4c48-9047-11a94a308626"
-version = "0.2.3"
+version = "0.2.4"
 
 [[deps.ClimaCoreTempestRemap]]
 deps = ["ClimaCore", "Dates", "LinearAlgebra", "NCDatasets", "PkgVersion", "TempestRemap_jll", "Test"]
@@ -399,7 +399,7 @@ uuid = "daee34ce-89f3-4625-b898-19384cb65244"
 version = "0.2.12"
 
 [[deps.Downloads]]
-deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 
 [[deps.DualNumbers]]
@@ -482,6 +482,9 @@ deps = ["Pkg", "Requires", "UUIDs"]
 git-tree-sha1 = "9267e5f50b0e12fdfd5a2455534345c4cf2c7f7a"
 uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 version = "1.14.0"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[deps.FillArrays]]
 deps = ["LinearAlgebra", "Random", "SparseArrays", "Statistics"]

--- a/examples/Manifest.toml
+++ b/examples/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.7.2"
+julia_version = "1.7.3"
 manifest_format = "2.0"
 
 [[deps.AbstractFFTs]]
@@ -169,7 +169,7 @@ version = "0.10.6"
 deps = ["ClimaCore", "RecipesBase", "StaticArrays", "TriplotBase"]
 path = "../lib/ClimaCorePlots"
 uuid = "cf7c7e5a-b407-4c48-9047-11a94a308626"
-version = "0.2.3"
+version = "0.2.4"
 
 [[deps.ClimaCoreTempestRemap]]
 deps = ["ClimaCore", "Dates", "LinearAlgebra", "NCDatasets", "PkgVersion", "TempestRemap_jll", "Test"]
@@ -370,7 +370,7 @@ uuid = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"
 version = "0.5.11"
 
 [[deps.Downloads]]
-deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 
 [[deps.DualNumbers]]
@@ -435,6 +435,9 @@ deps = ["Pkg", "Requires", "UUIDs"]
 git-tree-sha1 = "9267e5f50b0e12fdfd5a2455534345c4cf2c7f7a"
 uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 version = "1.14.0"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[deps.FillArrays]]
 deps = ["LinearAlgebra", "Random", "SparseArrays", "Statistics"]

--- a/lib/ClimaCorePlots/Project.toml
+++ b/lib/ClimaCorePlots/Project.toml
@@ -1,10 +1,10 @@
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
 name = "ClimaCorePlots"
 uuid = "cf7c7e5a-b407-4c48-9047-11a94a308626"
-version = "0.2.3"
+version = "0.2.4"
 
 [compat]
-ClimaCore = "0.7, 0.8, 0.9, 0.10"
+ClimaCore = "0.10"
 RecipesBase = "1"
 StaticArrays = "1"
 TriplotBase = "0.1"

--- a/lib/ClimaCorePlots/src/ClimaCorePlots.jl
+++ b/lib/ClimaCorePlots/src/ClimaCorePlots.jl
@@ -432,20 +432,16 @@ function _unfolded_pannel_matrix(field, interpolate)
     Operators.tensor_product!(interpolated_data, field_data, Imat)
 
     # element index ordering defined by a specific layout
-    eidx = 1
-    for panel_idx in 1:6
+    for (lidx, elem) in enumerate(topology.elemorder)
+        ex1, ex2, panel_idx = elem.I
         panel_data = panels[panel_idx]
-        # elements are ordered along fastest axis defined in sphere box mesh
-        for ex2 in 1:panel_size, ex1 in 1:panel_size
-            # compute the nodal extent index range for this element
-            x1_nodal_range = (dof * (ex1 - 1) + 1):(dof * ex1)
-            x2_nodal_range = (dof * (ex2 - 1) + 1):(dof * ex2)
-            # transpose the data as our plotting axis order is
-            # reverse nodal element order (x1 axis varies fastest)
-            data_element = permutedims(parent(interpolated_data)[:, :, 1, eidx])
-            panel_data[x2_nodal_range, x1_nodal_range] = data_element
-            eidx += 1
-        end
+        # compute the nodal extent index range for this element
+        x1_nodal_range = (dof * (ex1 - 1) + 1):(dof * ex1)
+        x2_nodal_range = (dof * (ex2 - 1) + 1):(dof * ex2)
+        # transpose the data as our plotting axis order is
+        # reverse nodal element order (x1 axis varies fastest)
+        data_element = permutedims(parent(interpolated_data)[:, :, 1, lidx])
+        panel_data[x2_nodal_range, x1_nodal_range] = data_element
     end
 
     # (px, py, rot) for each panel

--- a/lib/ClimaCorePlots/test/runtests.jl
+++ b/lib/ClimaCorePlots/test/runtests.jl
@@ -57,6 +57,33 @@ end
     fig_png = joinpath(OUTPUT_DIR, "2D_cubed_sphere_field.png")
     Plots.png(field_fig, fig_png)
     @test isfile(fig_png)
+
+    # check different ordering
+    grid_topology = ClimaCore.Topologies.Topology2D(
+        mesh,
+        ClimaCore.Topologies.spacefillingcurve(mesh),
+    )
+    quad = ClimaCore.Spaces.Quadratures.GLL{5}()
+    space = ClimaCore.Spaces.SpectralElementSpace2D(grid_topology, quad)
+    coords = ClimaCore.Fields.coordinate_field(space)
+
+    u = map(coords) do coord
+        u0 = 20.0
+        α0 = 45.0
+        ϕ = coord.lat
+        λ = coord.long
+
+        uu = u0 * (cosd(α0) * cosd(ϕ) + sind(α0) * cosd(λ) * sind(ϕ))
+        uv = -u0 * sind(α0) * sind(λ)
+        ClimaCore.Geometry.UVVector(uu, uv)
+    end
+
+    field_fig = Plots.plot(u.components.data.:1)
+    @test field_fig !== nothing
+
+    fig_png = joinpath(OUTPUT_DIR, "2D_cubed_sphere_field_spacefilling.png")
+    Plots.png(field_fig, fig_png)
+    @test isfile(fig_png)
 end
 
 @testset "spectral element 3D extruded cubed-sphere" begin


### PR DESCRIPTION
As noted in https://github.com/CliMA/ClimaAtmos.jl/pull/574#issuecomment-1171944512, the plotting fields using for space-filling curve topologies doesn't currently work. This fixes the issue.


- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
