### PR TITLE
Don't run formatter suggestions on draft PRs

### DIFF
--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -8,6 +8,11 @@ on:
       - staging
     tags: '*'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 jobs:
   format:
@@ -40,7 +45,13 @@ jobs:
 
     - name: Suggester
       uses: reviewdog/action-suggester@v1
+      if: github.event.pull_request.draft == false
       with:
         tool_name: JuliaFormatter
         level: error
         fail_on_error: true
+
+    - name: Check formatting diff
+      if: steps.filter.outputs.julia_file_change == 'true'
+      run: |
+        git diff --color=always --exit-code


### PR DESCRIPTION
Currently produces a lot of noise

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
