### PR TITLE
Add JET test for apply in linsolve kernel

### DIFF
--- a/test/Operators/finitedifference/linsolve.jl
+++ b/test/Operators/finitedifference/linsolve.jl
@@ -1,0 +1,101 @@
+using Test
+
+import ClimaCore
+# To avoid JET failures in the error message
+ClimaCore.Operators.allow_mismatched_fd_spaces() = true
+
+using ClimaCore: Geometry, Domains, Meshes, Topologies, Spaces, Fields
+
+FT = Float32
+radius = FT(1e7)
+zmax = FT(1e4)
+helem = npoly = 2
+velem = 4
+
+hdomain = Domains.SphereDomain(radius)
+hmesh = Meshes.EquiangularCubedSphere(hdomain, helem)
+htopology = Topologies.Topology2D(hmesh)
+quad = Spaces.Quadratures.GLL{npoly + 1}()
+hspace = Spaces.SpectralElementSpace2D(htopology, quad)
+
+vdomain = Domains.IntervalDomain(
+    Geometry.ZPoint{FT}(zero(FT)),
+    Geometry.ZPoint{FT}(zmax);
+    boundary_tags = (:bottom, :top),
+)
+vmesh = Meshes.IntervalMesh(vdomain, nelems = velem)
+center_space = Spaces.CenterFiniteDifferenceSpace(vmesh)
+
+#=
+# TODO: Replace this with a space that includes topography.
+center_space = Spaces.ExtrudedFiniteDifferenceSpace(hspace, vspace)
+center_coords = Fields.coordinate_field(center_space)
+face_space = Spaces.FaceExtrudedFiniteDifferenceSpace(center_space)
+=#
+face_space = Spaces.FaceFiniteDifferenceSpace(center_space)
+
+function _linsolve!(x, A, b, update_matrix = false; kwargs...)
+
+    FT = Spaces.undertype(axes(x.c))
+
+    (; ∂ᶜρₜ∂ᶠ𝕄, ∂ᶠ𝕄ₜ∂ᶜ𝔼, ∂ᶠ𝕄ₜ∂ᶜρ) = A
+
+    is_momentum_var(symbol) = symbol in (:uₕ, :ρuₕ, :w, :ρw)
+
+    # Compute Schur complement
+    # Compute xᶠ𝕄
+    xᶜρ = x.c.ρ
+    bᶜρ = b.c.ρ
+    ᶜ𝕄_name = Base.filter(is_momentum_var, propertynames(x.c))[1]
+    xᶜ𝕄 = getproperty(x.c, ᶜ𝕄_name)
+    bᶜ𝕄 = getproperty(b.c, ᶜ𝕄_name)
+    ᶠ𝕄_name = Base.filter(is_momentum_var, propertynames(x.f))[1]
+    xᶠ𝕄 = getproperty(x.f, ᶠ𝕄_name).components.data.:1
+    bᶠ𝕄 = getproperty(b.f, ᶠ𝕄_name).components.data.:1
+
+    @. xᶠ𝕄 = bᶠ𝕄 + (apply(∂ᶠ𝕄ₜ∂ᶜρ, bᶜρ))
+
+    # Compute remaining components of x
+    @. xᶜρ = -bᶜρ + apply(∂ᶜρₜ∂ᶠ𝕄, xᶠ𝕄)
+end
+
+import ClimaCore
+include(
+    joinpath(pkgdir(ClimaCore), "examples", "hybrid", "schur_complement_W.jl"),
+)
+jacobi_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :no_∂ᶜp∂ᶜK, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact);
+use_transform = false;
+
+# Allow one() to be called on vectors.
+Base.one(::T) where {T <: Geometry.AxisTensor} = one(T)
+Base.one(::Type{T}) where {T′, A, S, T <: Geometry.AxisTensor{T′, 1, A, S}} =
+    T(axes(T), S(one(T′)))
+
+Y = Fields.FieldVector(
+    c = map(
+        coord -> (
+            ρ = Float32(0),
+            ρe = Float32(0),
+            uₕ = Geometry.Covariant12Vector(Float32(0), Float32(0)),
+        ),
+        Fields.coordinate_field(center_space),
+    ),
+    f = map(
+        _ -> (; w = Geometry.Covariant3Vector(Float32(0))),
+        Fields.coordinate_field(face_space),
+    ),
+)
+
+b = similar(Y)
+W = SchurComplementW(Y, use_transform, jacobi_flags)
+
+using JET
+using Test
+@time _linsolve!(Y, W, b)
+@time _linsolve!(Y, W, b)
+
+@testset "JET test for `apply` in linsolve! kernel" begin
+    @test_opt _linsolve!(Y, W, b)
+end
+
+ClimaCore.Operators.allow_mismatched_fd_spaces() = false

--- a/test/Operators/finitedifference/wfact.jl
+++ b/test/Operators/finitedifference/wfact.jl
@@ -107,4 +107,8 @@ end
 @time wfact_test(∂ᶜ𝔼ₜ∂ᶠ𝕄, ∂ᶜK∂ᶠw_data, ᶜρe, ᶜρ, ᶜp, ᶠw)
 
 using JET
-@test_opt wfact_test(∂ᶜ𝔼ₜ∂ᶠ𝕄, ∂ᶜK∂ᶠw_data, ᶜρe, ᶜρ, ᶜp, ᶠw)
+@testset "JET test for `compose` in wfact! kernel" begin
+    @test_opt wfact_test(∂ᶜ𝔼ₜ∂ᶠ𝕄, ∂ᶜK∂ᶠw_data, ᶜρe, ᶜρ, ᶜp, ᶠw)
+end
+
+ClimaCore.Operators.allow_mismatched_fd_spaces() = false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,6 +49,7 @@ using Base: operator_associativity
 @time include("Operators/finitedifference/column.jl")
 @time include("Operators/finitedifference/opt.jl")
 @time include("Operators/finitedifference/wfact.jl")
+@time include("Operators/finitedifference/linsolve.jl")
 @time include("Operators/finitedifference/opt_examples.jl")
 # @time include("Operators/finitedifference/implicit_stencils.jl") now part of buildkite
 # @time include("Operators/finitedifference/opt_implicit_stencils.jl")


### PR DESCRIPTION
This PR adds a JET test for `apply` in the `linsolve!` kernel, a complement to the JET test for `compose` in the `Wfact!` kernel.

I've also added

```julia
ClimaCore.Operators.allow_mismatched_fd_spaces() = false
```

to the end of the `Wfact!` test and wrapped it in a `@testset`.

We could apply the same pattern from the `compose` source code to the `apply` code, but it looks like there may not be a performance improvement? I suppose we could compare timings if we think it's important.