### PR TITLE
Use 3rd-order upwinding in HS

### DIFF
--- a/examples/hybrid/sphere/held_suarez_rhoe.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe.jl
@@ -17,6 +17,9 @@ dt_save_to_disk = FT(0) # 0 means don't save to disk
 ode_algorithm = OrdinaryDiffEq.Rosenbrock23
 jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :no_∂ᶜp∂ᶜK, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)
 
+# Additional values required for driver
+upwinding_mode = :third_order
+
 additional_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) = merge(
     hyperdiffusion_cache(ᶜlocal_geometry, ᶠlocal_geometry; κ₄ = FT(2e17)),
     sponge ? rayleigh_sponge_cache(ᶜlocal_geometry, ᶠlocal_geometry, dt) : (;),


### PR DESCRIPTION
This will close #808 

This PR is a one-liner that proves that the 3rd-order-upwinding operator on its own is not the problem of the HS instabilities. Now my suspect is on the parameters that were chosen for `GeneratlizedExponentialStretching` (or the conjunction of the latter with 3rd-order-upwinding and possibly the implicit solver part that deal with this operator).

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
