### PR TITLE
Remove develop for perf env

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,7 +20,6 @@ steps:
       - "julia --project=test -e 'using Pkg; Pkg.precompile(;strict=true)'"
 
       - echo "--- Instantiate perf"
-      - "julia --project=perf -e 'using Pkg; Pkg.develop(path=\".\")'"
       - "julia --project=perf -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "julia --project=perf -e 'using Pkg; Pkg.precompile(;strict=true)'"
 


### PR DESCRIPTION
We track the manifest file in the perf env, so we don't need to develop ClimaCore in CI.