### PR TITLE
Add truncated IntervalMesh constructor

### DIFF
--- a/test/Meshes/interval.jl
+++ b/test/Meshes/interval.jl
@@ -161,3 +161,29 @@ end
     # a residual tol of ~1e-1 or 1e-2 is fine for typical use cases
     @test fₑ - fₑ₋₁ ≈ 7.0 / 45.0 rtol = 1e-2
 end
+
+@testset "TruncatedIntervalMesh" begin
+    nz = 55
+    Δz_s = 30.0
+    Δz_top = 8000.0
+    z_toa_parent = 45000.0
+    z_top = 4000.0
+    z0 = 0.0
+    FT = eltype(z_toa_parent)
+    stretch = Meshes.GeneralizedExponentialStretching(Δz_s, Δz_top)
+    domain = Domains.IntervalDomain(
+        Geometry.ZPoint{FT}(z0),
+        Geometry.ZPoint{FT}(z_toa_parent),
+        boundary_tags = (:bottom, :top),
+    )
+    mesh = Meshes.TruncatedIntervalMesh(
+        domain,
+        stretch,
+        nelems = nz,
+        z_top = z_top,
+    )
+    @test Meshes.nelements(mesh) == 27
+    @test length(mesh.faces) == 28
+    @test mesh.faces[end].z ≈ z_top
+    @test mesh.faces[1].z ≈ FT(0)
+end


### PR DESCRIPTION
Adds a truncated IntervalMesh constructor for Single Column Models in TC.jl.

Example:

```
domain = IntervalDomain(ZPoint(0.0), ZPoint(45000.0); boundary_names = (:bottom, :top))
stretch = ClimaCore.Meshes.GeneralizedExponentialStretching{Float64}(30.0, 8000.0)
julia> t_mesh = CC.Meshes.TruncatedIntervalMesh(domain, stretch, nelems=55, z_top=4000.)
27-element IntervalMesh of IntervalDomain(ZPoint(0.0), ZPoint(4000.0); boundary_names = (:bottom, :top))

julia> t_mesh.faces
28-element Vector{ClimaCore.Geometry.ZPoint{Float64}}:
 ZPoint(0.0)
 ZPoint(29.99999021760984)
 ZPoint(66.42449176386812)
 ZPoint(109.51221065471782)
 ZPoint(159.49352057707952)
 ZPoint(216.59402064846904)
 ZPoint(281.03867753123615)
 ZPoint(353.05620066338093)
 ZPoint(432.8834787303966)
 ZPoint(520.7700273452585)
 ZPoint(616.9824764979967)
 ZPoint(721.8091768954844)
 ZPoint(835.5650391137608)
 ⋮
 ZPoint(1234.0686105247037)
 ZPoint(1387.416817550365)
 ZPoint(1551.873275406308)
 ZPoint(1728.0489390650673)
 ZPoint(1916.6382410262772)
 ZPoint(2118.4345736764644)
 ZPoint(2334.3494613342023)
 ZPoint(2565.436595755618)
 ZPoint(2812.922355385778)
 ZPoint(3078.2450850938553)
 ZPoint(3363.106396864156)
 ZPoint(3669.5392583409653)
 ZPoint(4000.0)
```

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
