### PR TITLE
Widen column benchmark tests

### DIFF
--- a/test/Operators/finitedifference/column_benchmark_kernels.jl
+++ b/test/Operators/finitedifference/column_benchmark_kernels.jl
@@ -93,6 +93,12 @@ function op_div_interp_FF!(c, f, bcs)
     @. f.y = div(interp(f.contra3))
     return nothing
 end
+function op_divgrad_uₕ!(c, f, bcs)
+    grad = Operators.GradientC2F(bcs.inner)
+    div = Operators.DivergenceF2C(bcs.outer)
+    @. c.uₕ2 = div(f.y * grad(c.uₕ))
+    return nothing
+end
 function op_divUpwind3rdOrderBiasedProductC2F!(c, f, bcs)
     upwind = Operators.Upwind3rdOrderBiasedProductC2F(bcs.inner)
     divf2c = Operators.DivergenceF2C(bcs.outer)

--- a/test/Operators/finitedifference/column_benchmark_profile.jl
+++ b/test/Operators/finitedifference/column_benchmark_profile.jl
@@ -4,6 +4,8 @@ include("column_benchmark_utils.jl")
 function apply_kernel!(cfield, ffield, D, U, xarr, yarr)
     # op_GradientF2C!(cfield, ffield)
     # op_2mul_1add!(xarr, yarr, D, U)
+    bcs = (; inner = (), outer = set_value_divgrad_uₕ_bcs(cfield))
+    op_divgrad_uₕ!(cfield, ffield, bcs)
 end
 
 function apply_kernel_loop!(cfield, ffield, D, U, xarr, yarr)


### PR DESCRIPTION
This PR adds another column performance benchmark for computing divergence of the gradient of `uₕ`. I've added a todo on how to handle field BCs, which is where I think we're not performing well in ClimaAtmos' `vertical_diffusion_boundary_layer_tendency!`. However, I'd like to confirm this.