### PR TITLE
Expand column perf tests to include hspaces

### DIFF
--- a/test/Operators/finitedifference/column_benchmark.jl
+++ b/test/Operators/finitedifference/column_benchmark.jl
@@ -1,8 +1,12 @@
 include("column_benchmark_utils.jl")
 
-@testset "Benchmark cases" begin
-    (; cfield, ffield, vars_contig) = get_fields(1000, Float64)
-    benchmark_cases(vars_contig, cfield, ffield)
+@testset "Benchmark operators" begin
+    # (; cfield, ffield, vars_contig) = get_fields(1000, Float64, false)
+    # benchmark_arrays(vars_contig)
+    # benchmark_operators(cfield, ffield, vars_contig.has_h_space)
+    # (; cfield, ffield, vars_contig) = get_fields(1000, Float64, true)
+    # benchmark_operators(cfield, ffield, vars_contig.has_h_space)
+    benchmark_operators(1000, Float64)
 end
 
 nothing


### PR DESCRIPTION
This PR expands the column performance tests to include horizontal spaces, so that we can test a case with field BCs (and when using horizontal spaces on its own).