### PR TITLE
Bump patch version for new release

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -78,6 +78,7 @@ steps:
     agents:
       config: cpu
       queue: central
+      slurm_mem: 64GB
       slurm_ntasks: 1
 
   - label: ":computer: test implicit_stencil"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.10.7"
+version = "0.10.8"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/perf/Project.toml
+++ b/perf/Project.toml
@@ -32,3 +32,7 @@ TerminalLoggers = "5d786b92-1e48-4d6f-9151-6b4477ca9bed"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
+
+[compat]
+OrdinaryDiffEq = "5.64.0"
+Plots = "1.30.1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,14 @@ using Base: operator_associativity
 #! format: off
 # Order of tests is intended to reflect dependency order of functionality
 
+#= TODO: add windows test back in. Currently getting
+ReadOnlyMemoryError()
+ERROR: Package ClimaCore errored during testing (exit code: 541541187)
+Stacktrace:
+ [1] pkgerror(msg::String)
+=#
+if !Sys.iswindows()
+
 @safetestset "Recursive" begin @time include("recursive.jl") end
 @safetestset "PlusHalf" begin @time include("Utilities/plushalf.jl") end
 
@@ -47,13 +55,6 @@ using Base: operator_associativity
 @safetestset "Spectral elem - sphere hyperdiffusion" begin @time include("Operators/spectralelement/sphere_hyperdiffusion.jl") end
 @safetestset "Spectral elem - sphere hyperdiffusion vec" begin @time include("Operators/spectralelement/sphere_hyperdiffusion_vec.jl") end
 
-#= TODO: add windows test back in. Currently getting
-ReadOnlyMemoryError()
-ERROR: Package ClimaCore errored during testing (exit code: 541541187)
-Stacktrace:
- [1] pkgerror(msg::String)
-=#
-if !Sys.iswindows()
 @safetestset "FD ops - column" begin @time include("Operators/finitedifference/column.jl") end
 @safetestset "FD ops - opt" begin @time include("Operators/finitedifference/opt.jl") end
 @safetestset "FD ops - wfact" begin @time include("Operators/finitedifference/wfact.jl") end


### PR DESCRIPTION
This PR
 - Bumps the patch version for a new release
 - Adds compat bounds to the perf environment
 - Removes more windows tests. Here is a [gist](https://gist.github.com/charleskawczynski/da8c036dff25c9094c2d3e1c5e106f65) of the stack trace issue.
 - Increases memory request for unit tests