### PR TITLE
Split implicit operator tests to reduce ci times

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -81,10 +81,27 @@ steps:
       slurm_mem: 64GB
       slurm_ntasks: 1
 
-  - label: ":computer: test implicit_stencil"
-    key: "cpu_implicit_stencil"
+  - label: ":computer: test implicit_stencil Float32"
+    key: "cpu_implicit_stencil_float32"
     command:
-      - "julia -O0 --color=yes --check-bounds=yes --project=test test/Operators/finitedifference/implicit_stencils.jl"
+      - "julia -O0 --color=yes --check-bounds=yes --project=test test/Operators/finitedifference/implicit_stencils.jl --float_type Float32"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
+  - label: ":computer: test implicit_stencil Float64"
+    key: "cpu_implicit_stencil_float64"
+    command:
+      - "julia -O0 --color=yes --check-bounds=yes --project=test test/Operators/finitedifference/implicit_stencils.jl --float_type Float64"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
+  - label: ":computer: test implicit_stencil opt"
+    key: "cpu_implicit_stencil_opt"
+    command:
       - "julia --color=yes --check-bounds=yes --project=test test/Operators/finitedifference/opt_implicit_stencils.jl"
     agents:
       config: cpu

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -178,7 +178,7 @@ integrator = OrdinaryDiffEq.init(
     dt = dt,
     adaptive = false,
     progress = show_progress_bar,
-    progress_steps = 1,
+    progress_steps = 20,
     additional_solver_kwargs...,
 )
 

--- a/test/Operators/finitedifference/implicit_stencils.jl
+++ b/test/Operators/finitedifference/implicit_stencils.jl
@@ -4,6 +4,23 @@ using Random: seed!
 using ClimaCore: Geometry, Domains, Meshes, Topologies, Spaces, Fields
 using ClimaCore: Operators
 
+import ArgParse
+function parse_commandline()
+    s = ArgParse.ArgParseSettings()
+    ArgParse.@add_arg_table s begin
+        "--float_type"
+        help = "Float type"
+        arg_type = String
+        default = "Float32"
+    end
+    parsed_args = ArgParse.parse_args(ARGS, s)
+    return (s, parsed_args)
+end
+
+(s, parsed_args) = parse_commandline()
+
+const FT = parsed_args["float_type"] == "Float64" ? Float64 : Float32
+
 # Let stencil_op1 = Operator2Stencil(op1), stencil_op2 = Operator2Stencil(op2),
 # apply = ApplyStencil(), and compose = ComposeStencils().
 
@@ -39,173 +56,171 @@ Operators.Operator2Stencil(op::CurriedTwoArgOperator) =
 @testset "Pointwise Stencil Construction/Composition/Application" begin
     seed!(1) # ensures reproducibility
 
-    for FT in (Float32, Float64)
-        radius = FT(1e7)
-        zmax = FT(1e4)
-        helem = npoly = 2
-        velem = 4
+    radius = FT(1e7)
+    zmax = FT(1e4)
+    helem = npoly = 2
+    velem = 4
 
-        hdomain = Domains.SphereDomain(radius)
-        hmesh = Meshes.EquiangularCubedSphere(hdomain, helem)
-        htopology = Topologies.Topology2D(hmesh)
-        quad = Spaces.Quadratures.GLL{npoly + 1}()
-        hspace = Spaces.SpectralElementSpace2D(htopology, quad)
+    hdomain = Domains.SphereDomain(radius)
+    hmesh = Meshes.EquiangularCubedSphere(hdomain, helem)
+    htopology = Topologies.Topology2D(hmesh)
+    quad = Spaces.Quadratures.GLL{npoly + 1}()
+    hspace = Spaces.SpectralElementSpace2D(htopology, quad)
 
-        vdomain = Domains.IntervalDomain(
-            Geometry.ZPoint{FT}(zero(FT)),
-            Geometry.ZPoint{FT}(zmax);
-            boundary_tags = (:bottom, :top),
-        )
-        vmesh = Meshes.IntervalMesh(vdomain, nelems = velem)
-        vspace = Spaces.CenterFiniteDifferenceSpace(vmesh)
+    vdomain = Domains.IntervalDomain(
+        Geometry.ZPoint{FT}(zero(FT)),
+        Geometry.ZPoint{FT}(zmax);
+        boundary_tags = (:bottom, :top),
+    )
+    vmesh = Meshes.IntervalMesh(vdomain, nelems = velem)
+    vspace = Spaces.CenterFiniteDifferenceSpace(vmesh)
 
-        # TODO: Replace this with a space that includes topography.
-        center_space = Spaces.ExtrudedFiniteDifferenceSpace(hspace, vspace)
-        center_coords = Fields.coordinate_field(center_space)
-        face_coords = Fields.coordinate_field(
-            Spaces.FaceExtrudedFiniteDifferenceSpace(center_space),
-        )
+    # TODO: Replace this with a space that includes topography.
+    center_space = Spaces.ExtrudedFiniteDifferenceSpace(hspace, vspace)
+    center_coords = Fields.coordinate_field(center_space)
+    face_coords = Fields.coordinate_field(
+        Spaces.FaceExtrudedFiniteDifferenceSpace(center_space),
+    )
 
-        # We can't use non-zero non-extrapolation BCs because Operator2Stencil
-        # does not account for them (it only handles linear transformations).
-        zero_scalar = Operators.SetValue(zero(FT))
-        zero_vector = Operators.SetValue(Geometry.Covariant3Vector(zero(FT)))
-        zero_grad = Operators.SetGradient(Geometry.Covariant3Vector(zero(FT)))
-        zero_div = Operators.SetDivergence(zero(FT))
-        zero_curl = Operators.SetCurl(Geometry.Contravariant3Vector(zero(FT)))
-        extrap = Operators.Extrapolate()
+    # We can't use non-zero non-extrapolation BCs because Operator2Stencil
+    # does not account for them (it only handles linear transformations).
+    zero_scalar = Operators.SetValue(zero(FT))
+    zero_vector = Operators.SetValue(Geometry.Covariant3Vector(zero(FT)))
+    zero_grad = Operators.SetGradient(Geometry.Covariant3Vector(zero(FT)))
+    zero_div = Operators.SetDivergence(zero(FT))
+    zero_curl = Operators.SetCurl(Geometry.Contravariant3Vector(zero(FT)))
+    extrap = Operators.Extrapolate()
 
-        # `C` denotes "center" and `F` denotes "face"
-        # `S` denotes "scalar" and `V` denotes "vector"
+    # `C` denotes "center" and `F` denotes "face"
+    # `S` denotes "scalar" and `V` denotes "vector"
 
-        rand_scalar(coord) = randn(Geometry.float_type(coord))
-        rand_vector(coord) =
-            Geometry.Covariant3Vector(randn(Geometry.float_type(coord)))
-        a_CS = map(rand_scalar, center_coords)
-        a_FS = map(rand_scalar, face_coords)
-        a_CV = map(rand_vector, center_coords)
-        a_FV = map(rand_vector, face_coords)
+    rand_scalar(coord) = randn(Geometry.float_type(coord))
+    rand_vector(coord) =
+        Geometry.Covariant3Vector(randn(Geometry.float_type(coord)))
+    a_CS = map(rand_scalar, center_coords)
+    a_FS = map(rand_scalar, face_coords)
+    a_CV = map(rand_vector, center_coords)
+    a_FV = map(rand_vector, face_coords)
 
-        ops_F2C_⍰2⍰ = (
-            Operators.InterpolateF2C(),
-            Operators.LeftBiasedF2C(),
-            Operators.RightBiasedF2C(),
-        )
-        ops_C2F_⍰2⍰ = (Operators.InterpolateC2F(bottom = extrap, top = extrap),)
-        ops_F2C_S2S = (
-            ops_F2C_⍰2⍰...,
-            Operators.LeftBiasedF2C(bottom = zero_scalar),
-            Operators.RightBiasedF2C(top = zero_scalar),
-        )
-        ops_C2F_S2S = (
-            ops_C2F_⍰2⍰...,
-            Operators.InterpolateC2F(bottom = zero_scalar, top = zero_scalar),
-            Operators.InterpolateC2F(bottom = zero_grad, top = zero_grad),
-            Operators.LeftBiasedC2F(bottom = zero_scalar),
-            Operators.RightBiasedC2F(top = zero_scalar),
-        )
-        ops_F2C_V2V = (
-            ops_F2C_⍰2⍰...,
-            Operators.LeftBiasedF2C(bottom = zero_vector),
-            Operators.RightBiasedF2C(top = zero_vector),
-            CurriedTwoArgOperator(
-                Operators.AdvectionC2C(bottom = zero_vector, top = zero_vector),
-                a_CV,
-            ),
-            CurriedTwoArgOperator(
-                Operators.AdvectionC2C(bottom = extrap, top = extrap),
-                a_CV,
-            ),
-            CurriedTwoArgOperator(
-                Operators.FluxCorrectionC2C(bottom = extrap, top = extrap),
-                a_CV,
-            ),
-        )
-        ops_C2F_V2V = (
-            ops_C2F_⍰2⍰...,
-            Operators.InterpolateC2F(bottom = zero_vector, top = zero_vector),
-            Operators.LeftBiasedC2F(bottom = zero_vector),
-            Operators.RightBiasedC2F(top = zero_vector),
-            CurriedTwoArgOperator(
-                Operators.FluxCorrectionF2F(bottom = extrap, top = extrap),
-                a_FV,
-            ),
-            Operators.CurlC2F(bottom = zero_vector, top = zero_vector),
-            Operators.CurlC2F(bottom = zero_curl, top = zero_curl),
-        )
-        ops_F2C_S2V = (
-            Operators.GradientF2C(),
-            Operators.GradientF2C(bottom = zero_scalar, top = zero_scalar),
-        )
-        ops_C2F_S2V = (
-            Operators.GradientC2F(bottom = zero_scalar, top = zero_scalar),
-            Operators.GradientC2F(bottom = zero_grad, top = zero_grad),
-        )
-        ops_F2C_V2S = (
-            CurriedTwoArgOperator(
-                Operators.AdvectionC2C(bottom = zero_scalar, top = zero_scalar),
-                a_CS,
-            ),
-            CurriedTwoArgOperator(
-                Operators.AdvectionC2C(bottom = extrap, top = extrap),
-                a_CS,
-            ),
-            CurriedTwoArgOperator(
-                Operators.FluxCorrectionC2C(bottom = extrap, top = extrap),
-                a_CS,
-            ),
-            Operators.DivergenceF2C(),
-            Operators.DivergenceF2C(bottom = zero_vector, top = zero_vector),
-        )
-        ops_C2F_V2S = (
-            CurriedTwoArgOperator(
-                Operators.FluxCorrectionF2F(bottom = extrap, top = extrap),
-                a_FS,
-            ),
-            Operators.DivergenceC2F(bottom = zero_vector, top = zero_vector),
-            Operators.DivergenceC2F(bottom = zero_div, top = zero_div),
-        )
+    ops_F2C_⍰2⍰ = (
+        Operators.InterpolateF2C(),
+        Operators.LeftBiasedF2C(),
+        Operators.RightBiasedF2C(),
+    )
+    ops_C2F_⍰2⍰ = (Operators.InterpolateC2F(bottom = extrap, top = extrap),)
+    ops_F2C_S2S = (
+        ops_F2C_⍰2⍰...,
+        Operators.LeftBiasedF2C(bottom = zero_scalar),
+        Operators.RightBiasedF2C(top = zero_scalar),
+    )
+    ops_C2F_S2S = (
+        ops_C2F_⍰2⍰...,
+        Operators.InterpolateC2F(bottom = zero_scalar, top = zero_scalar),
+        Operators.InterpolateC2F(bottom = zero_grad, top = zero_grad),
+        Operators.LeftBiasedC2F(bottom = zero_scalar),
+        Operators.RightBiasedC2F(top = zero_scalar),
+    )
+    ops_F2C_V2V = (
+        ops_F2C_⍰2⍰...,
+        Operators.LeftBiasedF2C(bottom = zero_vector),
+        Operators.RightBiasedF2C(top = zero_vector),
+        CurriedTwoArgOperator(
+            Operators.AdvectionC2C(bottom = zero_vector, top = zero_vector),
+            a_CV,
+        ),
+        CurriedTwoArgOperator(
+            Operators.AdvectionC2C(bottom = extrap, top = extrap),
+            a_CV,
+        ),
+        CurriedTwoArgOperator(
+            Operators.FluxCorrectionC2C(bottom = extrap, top = extrap),
+            a_CV,
+        ),
+    )
+    ops_C2F_V2V = (
+        ops_C2F_⍰2⍰...,
+        Operators.InterpolateC2F(bottom = zero_vector, top = zero_vector),
+        Operators.LeftBiasedC2F(bottom = zero_vector),
+        Operators.RightBiasedC2F(top = zero_vector),
+        CurriedTwoArgOperator(
+            Operators.FluxCorrectionF2F(bottom = extrap, top = extrap),
+            a_FV,
+        ),
+        Operators.CurlC2F(bottom = zero_vector, top = zero_vector),
+        Operators.CurlC2F(bottom = zero_curl, top = zero_curl),
+    )
+    ops_F2C_S2V = (
+        Operators.GradientF2C(),
+        Operators.GradientF2C(bottom = zero_scalar, top = zero_scalar),
+    )
+    ops_C2F_S2V = (
+        Operators.GradientC2F(bottom = zero_scalar, top = zero_scalar),
+        Operators.GradientC2F(bottom = zero_grad, top = zero_grad),
+    )
+    ops_F2C_V2S = (
+        CurriedTwoArgOperator(
+            Operators.AdvectionC2C(bottom = zero_scalar, top = zero_scalar),
+            a_CS,
+        ),
+        CurriedTwoArgOperator(
+            Operators.AdvectionC2C(bottom = extrap, top = extrap),
+            a_CS,
+        ),
+        CurriedTwoArgOperator(
+            Operators.FluxCorrectionC2C(bottom = extrap, top = extrap),
+            a_CS,
+        ),
+        Operators.DivergenceF2C(),
+        Operators.DivergenceF2C(bottom = zero_vector, top = zero_vector),
+    )
+    ops_C2F_V2S = (
+        CurriedTwoArgOperator(
+            Operators.FluxCorrectionF2F(bottom = extrap, top = extrap),
+            a_FS,
+        ),
+        Operators.DivergenceC2F(bottom = zero_vector, top = zero_vector),
+        Operators.DivergenceC2F(bottom = zero_div, top = zero_div),
+    )
 
-        # TODO: Make these test cases work.
-        for (a, op) in (
-            (a_FS, Operators.GradientF2C(bottom = extrap, top = extrap)),
-            (a_FV, Operators.DivergenceF2C(bottom = extrap, top = extrap)),
-        )
-            @test_throws ArgumentError Operators.Operator2Stencil(op).(a)
+    # TODO: Make these test cases work.
+    for (a, op) in (
+        (a_FS, Operators.GradientF2C(bottom = extrap, top = extrap)),
+        (a_FV, Operators.DivergenceF2C(bottom = extrap, top = extrap)),
+    )
+        @test_throws ArgumentError Operators.Operator2Stencil(op).(a)
+    end
+
+    apply = Operators.ApplyStencil()
+    compose = Operators.ComposeStencils()
+    for (a0, a1, op1s) in (
+        (a_FS, a_FS, (ops_F2C_S2S..., ops_F2C_S2V...)),
+        (a_CS, a_CS, (ops_C2F_S2S..., ops_C2F_S2V...)),
+        (a_FS, a_FV, (ops_F2C_V2V..., ops_F2C_V2S...)),
+        (a_CS, a_CV, (ops_C2F_V2V..., ops_C2F_V2S...)),
+    )
+        for op1 in op1s
+            stencil_op1 = Operators.Operator2Stencil(op1)
+            tested_value = apply.(stencil_op1.(a1), a0)
+            @test tested_value ≈ op1.(a1 .* a0) atol = 1e-6
         end
-
-        apply = Operators.ApplyStencil()
-        compose = Operators.ComposeStencils()
-        for (a0, a1, op1s) in (
-            (a_FS, a_FS, (ops_F2C_S2S..., ops_F2C_S2V...)),
-            (a_CS, a_CS, (ops_C2F_S2S..., ops_C2F_S2V...)),
-            (a_FS, a_FV, (ops_F2C_V2V..., ops_F2C_V2S...)),
-            (a_CS, a_CV, (ops_C2F_V2V..., ops_C2F_V2S...)),
-        )
-            for op1 in op1s
+    end
+    for (a0, a1, a2, op1s, op2s) in (
+        (a_FS, a_FS, a_CS, ops_F2C_S2S, (ops_C2F_S2S..., ops_C2F_S2V...)),
+        (a_CS, a_CS, a_FS, ops_C2F_S2S, (ops_F2C_S2S..., ops_F2C_S2V...)),
+        (a_FS, a_FS, a_CV, ops_F2C_S2S, (ops_C2F_V2V..., ops_C2F_V2S...)),
+        (a_CS, a_CS, a_FV, ops_C2F_S2S, (ops_F2C_V2V..., ops_F2C_V2S...)),
+        (a_FS, a_FV, a_CS, ops_F2C_V2S, (ops_C2F_S2S..., ops_C2F_S2V...)),
+        (a_CS, a_CV, a_FS, ops_C2F_V2S, (ops_F2C_S2S..., ops_F2C_S2V...)),
+        (a_FS, a_FV, a_CV, ops_F2C_V2S, (ops_C2F_V2V..., ops_C2F_V2S...)),
+        (a_CS, a_CV, a_FV, ops_C2F_V2S, (ops_F2C_V2V..., ops_F2C_V2S...)),
+    )
+        for op1 in op1s
+            for op2 in op2s
                 stencil_op1 = Operators.Operator2Stencil(op1)
-                tested_value = apply.(stencil_op1.(a1), a0)
-                @test tested_value ≈ op1.(a1 .* a0) atol = 1e-6
-            end
-        end
-        for (a0, a1, a2, op1s, op2s) in (
-            (a_FS, a_FS, a_CS, ops_F2C_S2S, (ops_C2F_S2S..., ops_C2F_S2V...)),
-            (a_CS, a_CS, a_FS, ops_C2F_S2S, (ops_F2C_S2S..., ops_F2C_S2V...)),
-            (a_FS, a_FS, a_CV, ops_F2C_S2S, (ops_C2F_V2V..., ops_C2F_V2S...)),
-            (a_CS, a_CS, a_FV, ops_C2F_S2S, (ops_F2C_V2V..., ops_F2C_V2S...)),
-            (a_FS, a_FV, a_CS, ops_F2C_V2S, (ops_C2F_S2S..., ops_C2F_S2V...)),
-            (a_CS, a_CV, a_FS, ops_C2F_V2S, (ops_F2C_S2S..., ops_F2C_S2V...)),
-            (a_FS, a_FV, a_CV, ops_F2C_V2S, (ops_C2F_V2V..., ops_C2F_V2S...)),
-            (a_CS, a_CV, a_FV, ops_C2F_V2S, (ops_F2C_V2V..., ops_F2C_V2S...)),
-        )
-            for op1 in op1s
-                for op2 in op2s
-                    stencil_op1 = Operators.Operator2Stencil(op1)
-                    stencil_op2 = Operators.Operator2Stencil(op2)
-                    tested_value =
-                        apply.(compose.(stencil_op2.(a2), stencil_op1.(a1)), a0)
-                    @test tested_value ≈ op2.(a2 .* op1.(a1 .* a0)) atol = 1e-6
-                end
+                stencil_op2 = Operators.Operator2Stencil(op2)
+                tested_value =
+                    apply.(compose.(stencil_op2.(a2), stencil_op1.(a1)), a0)
+                @test tested_value ≈ op2.(a2 .* op1.(a1 .* a0)) atol = 1e-6
             end
         end
     end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 AssociatedLegendrePolynomials = "2119f1ac-fb78-50f5-8cc0-dda848ebdb19"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"


### PR DESCRIPTION
This PR splits the implicit operator tests in efforts to reduce CI times. I've also lowered the frequency of the progress bar output, since things are running faster now.

A step towards closing #837.