### PR TITLE
Fix AxisTensor show

### DIFF
--- a/src/Geometry/axistensors.jl
+++ b/src/Geometry/axistensors.jl
@@ -159,7 +159,7 @@ Base.axes(::Type{AxisTensor{T, N, A, S}}) where {T, N, A, S} = A.instance
 Base.size(a::AxisTensor) = map(length, axes(a))
 
 function Base.show(io::IO, a::AxisTensor{T, N, A, S}) where {T, N, A, S}
-    println(
+    print(
         io,
         "AxisTensor{$T, $N, $A, $S}($(getfield(a, :axes)), $(getfield(a, :components)))",
     )

--- a/test/Geometry/axistensors.jl
+++ b/test/Geometry/axistensors.jl
@@ -71,7 +71,7 @@ end
     ats = T(axes_T, components)
     s = sprint(show, ats)
     @test s ==
-          "AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.LocalAxis{(1, 2)}, ClimaCore.Geometry.CovariantAxis{(1, 2)}}, StaticArraysCore.SMatrix{2, 2, Float64, 4}}((ClimaCore.Geometry.LocalAxis{(1, 2)}(), ClimaCore.Geometry.CovariantAxis{(1, 2)}()), [4.0 0.0; 0.0 5.0])\n"
+          "AxisTensor{Float64, 2, Tuple{ClimaCore.Geometry.LocalAxis{(1, 2)}, ClimaCore.Geometry.CovariantAxis{(1, 2)}}, StaticArraysCore.SMatrix{2, 2, Float64, 4}}((ClimaCore.Geometry.LocalAxis{(1, 2)}(), ClimaCore.Geometry.CovariantAxis{(1, 2)}()), [4.0 0.0; 0.0 5.0])"
 end
 
 @testset "transform" begin


### PR DESCRIPTION
This PR fixes the AxisTensor `show`, which should not include printing a newline.