### PR TITLE
Cache contravariant metric tensor

### DIFF
--- a/src/Geometry/localgeometry.jl
+++ b/src/Geometry/localgeometry.jl
@@ -17,10 +17,14 @@ struct LocalGeometry{I, C <: AbstractPoint, FT, S}
     ∂x∂ξ::Axis2Tensor{FT, Tuple{LocalAxis{I}, CovariantAxis{I}}, S}
     "Partial derivatives of the map from `x` to `ξ`: `∂ξ∂x[i,j]` is ∂ξⁱ/∂xʲ"
     ∂ξ∂x::Axis2Tensor{FT, Tuple{ContravariantAxis{I}, LocalAxis{I}}, S}
+    "Contravariant metric tensor (inverse of gᵢⱼ), transforms covariant to contravariant vector components"
+    gⁱʲ::Axis2Tensor{FT, Tuple{ContravariantAxis{I}, ContravariantAxis{I}}, S}
 end
 
-@inline LocalGeometry(coordinates, J, WJ, ∂x∂ξ) =
-    LocalGeometry(coordinates, J, WJ, inv(J), ∂x∂ξ, inv(∂x∂ξ))
+@inline function LocalGeometry(coordinates, J, WJ, ∂x∂ξ)
+    ∂ξ∂x = inv(∂x∂ξ)
+    return LocalGeometry(coordinates, J, WJ, inv(J), ∂x∂ξ, ∂ξ∂x, ∂ξ∂x * ∂ξ∂x')
+end
 
 """
     SurfaceGeometry

--- a/test/Fields/field.jl
+++ b/test/Fields/field.jl
@@ -307,7 +307,7 @@ end
     coord = Geometry.XPoint(FT(π))
     space = Spaces.PointSpace(coord)
     @test parent(Spaces.local_geometry_data(space)) ==
-          FT[Geometry.component(coord, 1) 1.0 1.0 1.0 1.0 1.0]
+          FT[Geometry.component(coord, 1) 1.0 1.0 1.0 1.0 1.0 1.0]
     field = Fields.coordinate_field(space)
     @test field isa Fields.PointField
     @test Fields.field_values(field)[] == coord


### PR DESCRIPTION
This PR caches the contravariant metric tensor, which is needed as a part of the next steps for improving performance. Co-authored with @simonbyrne 