### PR TITLE
Simple FCT in deformation flow example

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -539,5 +539,6 @@ The flow (reversed halfway trhough the time period) is specified as ``\boldsymbo
     u_d &= \frac{\omega_0  R}{ b / p_{\textrm{top}}} \cos (\lambda') \cos(\phi)^2 \cos(2 \pi t / \tau) \left[-exp(\frac{(p - p_0)}{ b p_{\textrm{top}}}) + exp(\frac{(p_{\textrm{top}} - p(zc)}{b p_{\textrm{top}}}) \nonumber
 \label{eq:3d-sphere-lim-flow}
 \end{align}
+```
 
 where all values of the parameters can be found in Table 1.1 in the reference [Ullrich2012DynamicalCM](@cite).


### PR DESCRIPTION
This PR will close #852 

It provide the simplest implementation of flux-corrected transport in which the correction coefficient is constant throughout and identically equal to 1, so that we recover the previous case in this example (i.e., third-order upwinding only). 

This is to verify that indeed we recover one operator and the test passes with same identical error and tolerances, so it is unaltered.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
