### PR TITLE
Add ref for simple FTC regression test

### DIFF
--- a/examples/hybrid/sphere/deformation_flow.jl
+++ b/examples/hybrid/sphere/deformation_flow.jl
@@ -224,6 +224,8 @@ function rhs!(dydt, y, parameters, t, alpha, beta)
     cw = If2c.(w)
     cuvw = Geometry.Covariant123Vector.(uₕ) .+ Geometry.Covariant123Vector.(cw)
 
+    # The following, simple Flux-corrected Transport regression test (falling back to the 3rd-order upwinding, with C=1) is implemented following
+    # Ref: https://link.springer.com/book/10.1007/978-1-4419-6412-0 , Sec. 5.4 (p. 221)
     corrected_antidiff_flux = similar(dρq1)
     @. dρq1 = beta * dρq1 - alpha * hdiv(cuvw * ρq1) + alpha * ystar.ρq1
     @. corrected_antidiff_flux = vdivf2c(


### PR DESCRIPTION
Missing reference from #856 

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
