### PR TITLE
Removed reshaped arrays when making a DataF DataLayout

### DIFF
--- a/src/DataLayouts/DataLayouts.jl
+++ b/src/DataLayouts/DataLayouts.jl
@@ -328,7 +328,7 @@ end
 @inline function column(data::IJFH{S, Nij}, i, j, h) where {S, Nij}
     @boundscheck (1 <= j <= Nij && 1 <= i <= Nij && 1 <= h <= length(data)) ||
                  throw(BoundsError(data, (i, j, h)))
-    dataview = @inbounds view(parent(data), [i], j, :, h)
+    dataview = @inbounds view(parent(data), i:i, j, :, h)
     DataF{S}(dataview)
 end
 
@@ -407,7 +407,7 @@ slab(data::IFH, v::Integer, h::Integer) = slab(data, h)
 @inline function column(data::IFH{S, Ni}, i, h) where {S, Ni}
     @boundscheck (1 <= h <= length(data) && 1 <= i <= Ni) ||
                  throw(BoundsError(data, (i, h)))
-    dataview = @inbounds view(parent(data), [i], :, h)
+    dataview = @inbounds view(parent(data), i:i, :, h)
     DataF{S}(dataview)
 end
 @inline column(data::IFH{S, Ni}, i, j, h) where {S, Ni} = column(data, i, h)
@@ -625,7 +625,7 @@ end
 @inline function column(data::IJF{S, Nij}, i, j) where {S, Nij}
     @boundscheck (1 <= j <= Nij && 1 <= i <= Nij) ||
                  throw(BoundsError(data, (i, j)))
-    dataview = @inbounds view(parent(data), [i], j, :)
+    dataview = @inbounds view(parent(data), i:i, j, :)
     DataF{S}(dataview)
 end
 
@@ -722,7 +722,7 @@ end
 
 @inline function column(data::IF{S, Ni}, i) where {S, Ni}
     @boundscheck (1 <= i <= Ni) || throw(BoundsError(data, (i,)))
-    dataview = @inbounds view(parent(data), [i], :)
+    dataview = @inbounds view(parent(data), i:i, :)
     DataF{S}(dataview)
 end
 
@@ -833,7 +833,7 @@ end
     Nv = size(data, 4)
     @boundscheck (1 <= v <= Nv) || throw(BoundsError(data, (v)))
     array = parent(data)
-    dataview = @inbounds view(array, [v], :)
+    dataview = @inbounds view(array, v:v, :)
     DataF{S}(dataview)
 end
 

--- a/src/DataLayouts/DataLayouts.jl
+++ b/src/DataLayouts/DataLayouts.jl
@@ -328,8 +328,8 @@ end
 @inline function column(data::IJFH{S, Nij}, i, j, h) where {S, Nij}
     @boundscheck (1 <= j <= Nij && 1 <= i <= Nij && 1 <= h <= length(data)) ||
                  throw(BoundsError(data, (i, j, h)))
-    dataview = @inbounds view(parent(data), i, j, :, h)
-    DataF{S}(reshape(dataview, (1, :)))
+    dataview = @inbounds view(parent(data), [i], j, :, h)
+    DataF{S}(dataview)
 end
 
 function gather(
@@ -407,8 +407,8 @@ slab(data::IFH, v::Integer, h::Integer) = slab(data, h)
 @inline function column(data::IFH{S, Ni}, i, h) where {S, Ni}
     @boundscheck (1 <= h <= length(data) && 1 <= i <= Ni) ||
                  throw(BoundsError(data, (i, h)))
-    dataview = @inbounds view(parent(data), i, :, h)
-    DataF{S}(reshape(dataview, (1, :)))
+    dataview = @inbounds view(parent(data), [i], :, h)
+    DataF{S}(dataview)
 end
 @inline column(data::IFH{S, Ni}, i, j, h) where {S, Ni} = column(data, i, h)
 
@@ -625,8 +625,8 @@ end
 @inline function column(data::IJF{S, Nij}, i, j) where {S, Nij}
     @boundscheck (1 <= j <= Nij && 1 <= i <= Nij) ||
                  throw(BoundsError(data, (i, j)))
-    dataview = @inbounds view(parent(data), i, j, :)
-    DataF{S}(reshape(dataview, (1, :)))
+    dataview = @inbounds view(parent(data), [i], j, :)
+    DataF{S}(dataview)
 end
 
 # ======================
@@ -722,8 +722,8 @@ end
 
 @inline function column(data::IF{S, Ni}, i) where {S, Ni}
     @boundscheck (1 <= i <= Ni) || throw(BoundsError(data, (i,)))
-    dataview = @inbounds view(parent(data), i, :)
-    DataF{S}(reshape(dataview, (1, :)))
+    dataview = @inbounds view(parent(data), [i], :)
+    DataF{S}(dataview)
 end
 
 # ======================
@@ -833,8 +833,8 @@ end
     Nv = size(data, 4)
     @boundscheck (1 <= v <= Nv) || throw(BoundsError(data, (v)))
     array = parent(data)
-    dataview = @inbounds view(array, v, :)
-    DataF{S}(reshape(dataview, (1, :)))
+    dataview = @inbounds view(array, [v], :)
+    DataF{S}(dataview)
 end
 
 # ======================

--- a/test/Fields/field.jl
+++ b/test/Fields/field.jl
@@ -338,6 +338,24 @@ fc_index(
             lg_space.local_geometry.coordinates ===
             lg_field_space.local_geometry.coordinates,
         )
+        @test Fields.zeros(lg_space)
+    end
+end
+
+@testset "Column" begin
+    FT = Float64
+    for space in all_spaces(FT)
+        if space isa Spaces.SpectralElementSpace1D
+            Y = FieldFromNamedTuple(space, (; x = FT(2)))
+            point_space = Spaces.column(space, 1, 1)
+            @test Fields.zeros(lg_space)
+        end
+        if space isa Spaces.SpectralElementSpace2D
+            Y = FieldFromNamedTuple(space, (; x = FT(2)))
+            point_space = Spaces.column(space, 1, 1, 1)
+            @test Fields.zeros(lg_space)
+        end
+
     end
 end
 

--- a/test/Fields/field.jl
+++ b/test/Fields/field.jl
@@ -342,18 +342,22 @@ fc_index(
     end
 end
 
-@testset "Column" begin
+@testset "Points from Columns" begin
     FT = Float64
     for space in all_spaces(FT)
         if space isa Spaces.SpectralElementSpace1D
             Y = FieldFromNamedTuple(space, (; x = FT(1)))
+            point_space_from_field = axes(Fields.column(Y.x, 1, 1))
             point_space = Spaces.column(space, 1, 1)
-            @test Fields.ones(point_space) == Fields.column(Y.x, 1, 1)
+            @test Fields.ones(point_space) ==
+                  Fields.ones(point_space_from_field)
         end
         if space isa Spaces.SpectralElementSpace2D
             Y = FieldFromNamedTuple(space, (; x = FT(1)))
+            point_space_from_field = axes(Fields.column(Y.x, 1, 1, 1))
             point_space = Spaces.column(space, 1, 1, 1)
-            @test Fields.ones(point_space) == Fields.column(Y.x, 1, 1, 1)
+            @test Fields.ones(point_space) ==
+                  Fields.ones(point_space_from_field)
         end
 
     end

--- a/test/Fields/field.jl
+++ b/test/Fields/field.jl
@@ -338,7 +338,7 @@ fc_index(
             lg_space.local_geometry.coordinates ===
             lg_field_space.local_geometry.coordinates,
         )
-        @test Fields.zeros(lg_space)
+        @test all(Fields.zeros(lg_space) === Fields.zeros(lg_field_space))
     end
 end
 
@@ -346,14 +346,14 @@ end
     FT = Float64
     for space in all_spaces(FT)
         if space isa Spaces.SpectralElementSpace1D
-            Y = FieldFromNamedTuple(space, (; x = FT(2)))
+            Y = FieldFromNamedTuple(space, (; x = FT(1)))
             point_space = Spaces.column(space, 1, 1)
-            @test Fields.zeros(lg_space)
+            @test Fields.ones(point_space) === Fields.column(Y.x, 1, 1)
         end
         if space isa Spaces.SpectralElementSpace2D
-            Y = FieldFromNamedTuple(space, (; x = FT(2)))
+            Y = FieldFromNamedTuple(space, (; x = FT(1)))
             point_space = Spaces.column(space, 1, 1, 1)
-            @test Fields.zeros(lg_space)
+            @test Fields.ones(point_space) === Fields.column(Y.x, 1, 1, 1)
         end
 
     end

--- a/test/Fields/field.jl
+++ b/test/Fields/field.jl
@@ -338,7 +338,7 @@ fc_index(
             lg_space.local_geometry.coordinates ===
             lg_field_space.local_geometry.coordinates,
         )
-        @test all(Fields.zeros(lg_space) === Fields.zeros(lg_field_space))
+        @test all(Fields.zeros(lg_space) == Fields.zeros(lg_field_space))
     end
 end
 
@@ -348,12 +348,12 @@ end
         if space isa Spaces.SpectralElementSpace1D
             Y = FieldFromNamedTuple(space, (; x = FT(1)))
             point_space = Spaces.column(space, 1, 1)
-            @test Fields.ones(point_space) === Fields.column(Y.x, 1, 1)
+            @test Fields.ones(point_space) == Fields.column(Y.x, 1, 1)
         end
         if space isa Spaces.SpectralElementSpace2D
             Y = FieldFromNamedTuple(space, (; x = FT(1)))
             point_space = Spaces.column(space, 1, 1, 1)
-            @test Fields.ones(point_space) === Fields.column(Y.x, 1, 1, 1)
+            @test Fields.ones(point_space) == Fields.column(Y.x, 1, 1, 1)
         end
 
     end


### PR DESCRIPTION
<!-- Provide a clear description of the content -->
Possible way to address Issue https://github.com/CliMA/ClimaCore.jl/issues/877

The root cause of that was that level and column, when applied to data layouts where a point `DataF` layout was returned, returned something with a `ReshapedArray` subtype. `parent_array_type` was not defined for this, so this was a bug. This addresses that issue by making the returned `DataF` have subtype `SubArray`, for which `parent_array_type` is defined.

Another option would be to define `parent_array_type` for `ReshapedArray`s.

Open to suggestions on how to improve the tests :)
- [X] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [X] Unit tests are included OR N/A.
- [X] Code is exercised in an integration test OR N/A.
- [X] Documentation has been added/updated OR N/A.
