### PR TITLE
Make BBFCT stencil symmetric

### DIFF
--- a/examples/column/bb_fct_advection.jl
+++ b/examples/column/bb_fct_advection.jl
@@ -75,7 +75,6 @@ end
 
 FT = Float64
 t₀ = FT(0.0)
-t₁ = FT(1.0)
 z₀ = FT(0.0)
 zₕ = FT(1.0)
 z₁ = FT(1.0)


### PR DESCRIPTION
This is a shift in the indexing of the BB FCT operator (does not change test results)

cc: @Zhengyu-Huang 

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
