### PR TITLE
Update remap_weights in wrappers.jl

### DIFF
--- a/lib/ClimaCoreTempestRemap/src/wrappers.jl
+++ b/lib/ClimaCoreTempestRemap/src/wrappers.jl
@@ -77,7 +77,9 @@ Keyword arguments are passed as command-line options. These include:
   - `"cgll"`: continuous GLL finite element method (a single value for colocated nodes)
   - `"dgll"`: discontinuous GLL finite element method (duplicate values for colocated nodes)
 - 'in_np'/'out_np': Order of input and output meshes
+- 'mono': Monotonicity of remapping. Note: must be used with in_np = 1
 
+Set `mono = true` and `in_np = 1` for monotone remapping
 Set `verbose=true` to print information.
 
 See [Tempest remap: offline map generation](https://github.com/ClimateGlobalChange/tempestremap/#offline-map-generation)
@@ -98,7 +100,11 @@ function remap_weights(
     --out_map $weightfile
     ```
     for (k, v) in kwargs
-        append!(cmd.exec, [string("--", k), string(v)])
+        if typeof(v) == Bool && v
+            append!(cmd.exec, [string("--", k)])
+        else
+            append!(cmd.exec, [string("--", k), string(v)])
+        end
     end
     run(pipeline(cmd, stdout = verbose ? stdout : devnull))
 end


### PR DESCRIPTION
Co-authored-by: LenkaNovak <LenkaNovak@users.noreply.github.com>

Add functionality in remap_weights to correctly parse arguments without a value, for example the flag `--mono`. This is used for the function `TempestRemap_jll.GenerateOfflineMap_exe()` by the coupler.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
