### PR TITLE
Remove reviewdog

### DIFF
--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -43,14 +43,6 @@ jobs:
       run: |
         julia --color=yes --project=.dev .dev/climaformat.jl --verbose .
 
-    - name: Suggester
-      uses: reviewdog/action-suggester@v1
-      if: github.event.pull_request.draft == false
-      with:
-        tool_name: JuliaFormatter
-        level: error
-        fail_on_error: true
-
     - name: Check formatting diff
       if: steps.filter.outputs.julia_file_change == 'true'
       run: |


### PR DESCRIPTION
I'm afraid I find review dog to be really noisy. It can basically ruin the landing page of PRs if someone forgets to format before pushing / forgetting to start with a draft PR (e.g., #887). Am I alone? 🐶