### PR TITLE
use .JuliaFormatter.toml

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,6 @@
+indent = 4
+margin = 80
+always_for_in = true
+whitespace_typedefs = true
+whitespace_ops_in_indices = true
+remove_extra_newlines = false

--- a/.dev/clima_formatter_options.jl
+++ b/.dev/clima_formatter_options.jl
@@ -1,8 +1,0 @@
-clima_formatter_options = (
-    indent = 4,
-    margin = 80,
-    always_for_in = true,
-    whitespace_typedefs = true,
-    whitespace_ops_in_indices = true,
-    remove_extra_newlines = false,
-)

--- a/.dev/climaformat.jl
+++ b/.dev/climaformat.jl
@@ -31,8 +31,6 @@ Pkg.instantiate()
 
 using JuliaFormatter
 
-include("clima_formatter_options.jl")
-
 help = """
 Usage: climaformat.jl [flags] [FILE/PATH]...
 
@@ -82,4 +80,4 @@ else
     filenames = ARGS
 end
 
-format(filenames; clima_formatter_options..., opts...)
+format(filenames; opts...)


### PR DESCRIPTION
Switch to configuring the formatter via the .toml file. This makes it easier to format using the VS code formatter: https://www.julia-vscode.org/docs/stable/userguide/formatter/

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
