### PR TITLE
Update BB FCT BCs

### DIFF
--- a/docs/src/operators.md
+++ b/docs/src/operators.md
@@ -67,6 +67,7 @@ WeightedInterpolateC2F
 WeightedInterpolateF2C
 UpwindBiasedProductC2F
 Upwind3rdOrderBiasedProductC2F
+FCTBorisBook
 LeftBiasedC2F
 RightBiasedC2F
 LeftBiasedF2C

--- a/examples/column/bb_fct_advection.jl
+++ b/examples/column/bb_fct_advection.jl
@@ -56,8 +56,8 @@ function f!(dydt, y, parameters, t, alpha, beta)
         top = Operators.SetValue(Geometry.WVector(FT(0.0))),
     )
     FCTBB = Operators.FCTBorisBook(
-        bottom = Operators.ThirdOrderOneSided(),
-        top = Operators.ThirdOrderOneSided(),
+        bottom = Operators.FirstOrderOneSided(),
+        top = Operators.FirstOrderOneSided(),
     )
 
     @. y_td = beta * dydt - alpha * divf2c(first_order_fluxᶠ(w, y))

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -1475,8 +1475,8 @@ where ``s[i] = +1`` if  `` v[i] \\geq 0`` and ``s[i] = -1`` if  `` v[i] \\leq 0`
 This formulation is based on [BorisBook1973](@cite).
 
 Supported boundary conditions are:
-- [`ThirdOrderOneSided(x₀)`](@ref): uses the third-order downwind reconstruction to compute `x` on the left boundary,
-and the third-order upwind reconstruction to compute `x` on the right boundary.
+- [`FirstOrderOneSided(x₀)`](@ref): uses the first-order downwind reconstruction to compute `x` on the left boundary,
+and the first-order upwind reconstruction to compute `x` on the right boundary.
 
 !!! note
     Similar to the [`Upwind3rdOrderBiasedProductC2F`](@ref) operator, these boundary conditions do not define the value at the actual boundary faces,
@@ -1549,11 +1549,11 @@ stencil_interior_width(::FCTBorisBook, velocity, arg) =
     )
 end
 
-boundary_width(::FCTBorisBook, ::ThirdOrderOneSided, velocity, arg) = 2
+boundary_width(::FCTBorisBook, ::FirstOrderOneSided, velocity, arg) = 2
 
 @inline function stencil_left_boundary(
     ::FCTBorisBook,
-    bc::ThirdOrderOneSided,
+    bc::FirstOrderOneSided,
     loc,
     idx,
     hidx,
@@ -1567,12 +1567,12 @@ boundary_width(::FCTBorisBook, ::ThirdOrderOneSided, velocity, arg) = 2
         getidx(velocity, loc, idx, hidx),
         Geometry.LocalGeometry(space, idx, hidx),
     )
-    return Geometry.Contravariant3Vector(vᶠ)
+    return Geometry.Contravariant3Vector(zero(eltype(vᶠ)))
 end
 
 @inline function stencil_right_boundary(
     ::FCTBorisBook,
-    bc::ThirdOrderOneSided,
+    bc::FirstOrderOneSided,
     loc,
     idx,
     hidx,
@@ -1586,7 +1586,7 @@ end
         getidx(velocity, loc, idx, hidx),
         Geometry.LocalGeometry(space, idx, hidx),
     )
-    return Geometry.Contravariant3Vector(vᶠ)
+    return Geometry.Contravariant3Vector(zero(eltype(vᶠ)))
 end
 
 """

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -1468,19 +1468,20 @@ Input arguments:
 - a face-valued vector field `v`
 - a center-valued field `x`
 ```math
-U(v,x)[i] = \\begin{cases}
-  v[i] \\left(-2 x[i-\\tfrac{3}{2}] + 10 x[i-\\tfrac{1}{2}] + 4 x[i+\\tfrac{1}{2}] \\right) / 12  \\textrm{, if } v[i] > 0 \\\\
-  v[i] \\left(4 x[i-\\tfrac{1}{2}] + 10 x[i+\\tfrac{1}{2}] -2 x[i+\\tfrac{3}{2}]  \\right) / 12  \\textrm{, if } v[i] < 0
-  \\end{cases}
+Ac(v,x)[i] =
+  s[i] \\max \\left\\{0, \\min \\left[ |v[i] |, s[i] \\left( x[i+\\tfrac{3}{2}] - x[i+\\tfrac{1}{2}]  \\right) \\Delta z ,  s[i] \\left( x[i-\\tfrac{1}{2}] - x[i-\\tfrac{3}{2}]  \\right) \\Delta z \\right] \\right\\},
 ```
-This stencil is based on [BorisBook1973](@cite).
+where ``s[i] = +1`` if  `` v[i] \\geq 0`` and ``s[i] = -1`` if  `` v[i] \\leq 0``, and ``Ac`` represents the resulting corrected antidiffusive flux.
+This formulation is based on [BorisBook1973](@cite).
 
 Supported boundary conditions are:
 - [`ThirdOrderOneSided(x₀)`](@ref): uses the third-order downwind reconstruction to compute `x` on the left boundary,
 and the third-order upwind reconstruction to compute `x` on the right boundary.
 
 !!! note
-    Similar to the [`Upwind3rdOrderBiasedProductC2F`](@ref) operator, these boundary conditions do not define the value at the actual boundary faces, and so this operator cannot be materialized directly: it needs to be composed with another operator that does not make use of this value, e.g. a [`DivergenceF2C`](@ref) operator, with a [`SetValue`](@ref) boundary.
+    Similar to the [`Upwind3rdOrderBiasedProductC2F`](@ref) operator, these boundary conditions do not define the value at the actual boundary faces,
+    and so this operator cannot be materialized directly: it needs to be composed with another operator that does not make use of this value, e.g. a
+    [`DivergenceF2C`](@ref) operator, with a [`SetValue`](@ref) boundary.
 """
 struct FCTBorisBook{BCS} <: AdvectionOperator
     bcs::BCS


### PR DESCRIPTION
This PR improves the BCs of the Boris&Book FCT operator to fall back on the 1st-order upwinding and updates its docs and example. There is more positivity-preserving, since the first-order operator is more positivity-preserving. 

See, e.g.: 

```
Old BCs:
julia> maximum(sol.u[end].y)
0.9999999999999948
julia> minimum(sol.u[end].y)
-0.006687007673322604
New BC:
julia> maximum(sol.u[end].y)
0.9999999999999948
julia> minimum(sol.u[end].y)
0.0
```

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
