### PR TITLE
reduce timeout on parallel hdf5 tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -130,6 +130,7 @@ steps:
     key: "cpu_parallel_hdf5"
     command:
       - "mpiexec julia --color=yes --project=test test/InputOutput/hybrid3dcubedsphere.jl"
+    timeout_in_minutes: 5
     env:
       CLIMACORE_DISTRIBUTED: "MPI"
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -133,6 +133,8 @@ steps:
     timeout_in_minutes: 5
     env:
       CLIMACORE_DISTRIBUTED: "MPI"
+    retry:
+      automatic: true
     agents:
       config: cpu
       queue: central


### PR DESCRIPTION
Avoid getting stuck waiting for failing tests
- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
