### PR TITLE
Do inlining and inbounds more carefully

### DIFF
--- a/src/Fields/broadcast.jl
+++ b/src/Fields/broadcast.jl
@@ -82,7 +82,7 @@ function Base.copy(
     return copyto!(similar(bc, ElType), bc)
 end
 
-function slab(
+Base.@propagate_inbounds function slab(
     bc::Base.Broadcast.Broadcasted{Style},
     v,
     h,
@@ -92,14 +92,14 @@ function slab(
     Base.Broadcast.Broadcasted{Style}(bc.f, _args, _axes)
 end
 
-@inline function column(
+Base.@propagate_inbounds function column(
     bc::Base.Broadcast.Broadcasted{Style},
     i,
     j,
     h,
 ) where {Style <: AbstractFieldStyle}
-    @inbounds _args = column_args(bc.args, i, j, h)
-    @inbounds _axes = column(axes(bc), i, j, h)
+    _args = column_args(bc.args, i, j, h)
+    _axes = column(axes(bc), i, j, h)
     Base.Broadcast.Broadcasted{Style}(bc.f, _args, _axes)
 end
 

--- a/src/Fields/fieldvector.jl
+++ b/src/Fields/fieldvector.jl
@@ -95,23 +95,32 @@ BlockArrays.blockaxes(fv::FieldVector) =
 Base.axes(fv::FieldVector) =
     (BlockArrays.blockedrange(map(length ∘ backing_array, Tuple(_values(fv)))),)
 
-Base.getindex(fv::FieldVector, block::BlockArrays.Block{1}) =
-    backing_array(_values(fv)[block.n...])
-function Base.getindex(fv::FieldVector, bidx::BlockArrays.BlockIndex{1})
+Base.@propagate_inbounds Base.getindex(
+    fv::FieldVector,
+    block::BlockArrays.Block{1},
+) = backing_array(_values(fv)[block.n...])
+Base.@propagate_inbounds function Base.getindex(
+    fv::FieldVector,
+    bidx::BlockArrays.BlockIndex{1},
+)
     X = fv[BlockArrays.block(bidx)]
     X[bidx.α...]
 end
 
 # TODO: drop support for this
-Base.getindex(fv::FieldVector, i::Integer) =
+Base.@propagate_inbounds Base.getindex(fv::FieldVector, i::Integer) =
     getindex(fv, BlockArrays.findblockindex(axes(fv, 1), i))
 
-function Base.setindex!(fv::FieldVector, val, bidx::BlockArrays.BlockIndex{1})
+Base.@propagate_inbounds function Base.setindex!(
+    fv::FieldVector,
+    val,
+    bidx::BlockArrays.BlockIndex{1},
+)
     X = fv[BlockArrays.block(bidx)]
     X[bidx.α...] = val
 end
 # TODO: drop support for this
-Base.setindex!(fv::FieldVector, val, i::Integer) =
+Base.@propagate_inbounds Base.setindex!(fv::FieldVector, val, i::Integer) =
     setindex!(fv, val, BlockArrays.findblockindex(axes(fv, 1), i))
 
 Base.similar(fv::FieldVector{T}) where {T} =

--- a/src/Geometry/axistensors.jl
+++ b/src/Geometry/axistensors.jl
@@ -27,19 +27,19 @@ ClimaCore.Geometry.CartesianAxis{(1, 2, 3)}()
 function dual end
 
 struct CovariantAxis{I} <: AbstractAxis{I} end
-@inline symbols(::CovariantAxis) = (:u₁, :u₂, :u₃)
+symbols(::CovariantAxis) = (:u₁, :u₂, :u₃)
 
 struct ContravariantAxis{I} <: AbstractAxis{I} end
-@inline symbols(::ContravariantAxis) = (:u¹, :u², :u³)
+symbols(::ContravariantAxis) = (:u¹, :u², :u³)
 dual(::CovariantAxis{I}) where {I} = ContravariantAxis{I}()
 dual(::ContravariantAxis{I}) where {I} = CovariantAxis{I}()
 
 struct LocalAxis{I} <: AbstractAxis{I} end
-@inline symbols(::LocalAxis) = (:u, :v, :w)
+symbols(::LocalAxis) = (:u, :v, :w)
 dual(::LocalAxis{I}) where {I} = LocalAxis{I}()
 
 struct CartesianAxis{I} <: AbstractAxis{I} end
-@inline symbols(::CartesianAxis) = (:u1, :u2, :u3)
+symbols(::CartesianAxis) = (:u1, :u2, :u3)
 dual(::CartesianAxis{I}) where {I} = CartesianAxis{I}()
 
 coordinate_axis(::Type{<:XPoint}) = (1,)
@@ -133,7 +133,7 @@ struct AxisTensor{
     components::S
 end
 
-@inline AxisTensor(
+AxisTensor(
     axes::A,
     components::S,
 ) where {
@@ -141,14 +141,14 @@ end
     S <: StaticArray{<:Tuple, T, N},
 } where {T, N} = AxisTensor{T, N, A, S}(axes, components)
 
-@inline AxisTensor(axes::Tuple{Vararg{AbstractAxis}}, components) =
+AxisTensor(axes::Tuple{Vararg{AbstractAxis}}, components) =
     AxisTensor(axes, SArray{Tuple{map(length, axes)...}}(components))
 
 # if the axes are already defined
-@inline (AxisTensor{T, N, A, S} where {S})(
+(AxisTensor{T, N, A, S} where {S})(
     components::AbstractArray{T, N},
 ) where {T, N, A} = AxisTensor(A.instance, components)
-@inline (AxisTensor{T, N, A, S} where {T, S})(
+(AxisTensor{T, N, A, S} where {T, S})(
     components::AbstractArray{<:Any, N},
 ) where {N, A} = AxisTensor(A.instance, components)
 
@@ -175,31 +175,31 @@ end
 
 Returns a `StaticArray` containing the components of `a` in its stored basis.
 """
-@inline components(a::AxisTensor) = getfield(a, :components)
+components(a::AxisTensor) = getfield(a, :components)
 
-@inline Base.getindex(v::AxisTensor, i...) =
-    @inbounds getindex(components(v), i...)
+Base.@propagate_inbounds Base.getindex(v::AxisTensor, i...) =
+    getindex(components(v), i...)
 
 
-@inline function Base.getindex(
+Base.@propagate_inbounds function Base.getindex(
     v::AxisTensor{<:Any, 2, Tuple{A1, A2}},
     ::Colon,
     i::Integer,
 ) where {A1, A2}
-    AxisVector(axes(v, 1), @inbounds getindex(components(v), :, i))
+    AxisVector(axes(v, 1), getindex(components(v), :, i))
 end
-@inline function Base.getindex(
+Base.@propagate_inbounds function Base.getindex(
     v::AxisTensor{<:Any, 2, Tuple{A1, A2}},
     i::Integer,
     ::Colon,
 ) where {A1, A2}
-    AxisVector(axes(v, 2), @inbounds getindex(components(v), i, :))
+    AxisVector(axes(v, 2), getindex(components(v), i, :))
 end
 
 
-@inline Base.map(f::F, a::AxisTensor) where {F} =
+Base.map(f::F, a::AxisTensor) where {F} =
     AxisTensor(axes(a), map(f, components(a)))
-@inline Base.map(
+Base.map(
     f::F,
     a::AxisTensor{Ta, N, A},
     b::AxisTensor{Tb, N, A},
@@ -234,7 +234,7 @@ import Base: +, -, *, /, \, ==
 # vectors
 const AxisVector{T, A1, S} = AxisTensor{T, 1, Tuple{A1}, S}
 
-@inline AxisVector(ax::A1, v::SVector{N, T}) where {A1 <: AbstractAxis, N, T} =
+AxisVector(ax::A1, v::SVector{N, T}) where {A1 <: AbstractAxis, N, T} =
     AxisVector{T, A1, SVector{N, T}}((ax,), v)
 
 (AxisVector{T, A, SVector{1, T}} where {T})(arg1::Real) where {A} =
@@ -265,11 +265,11 @@ end
 
 const AdjointAxisVector{T, A1, S} = Adjoint{T, AxisVector{T, A1, S}}
 
-@inline components(va::AdjointAxisVector) = components(parent(va))'
-@inline Base.getindex(va::AdjointAxisVector, i::Int) =
-    @inbounds getindex(components(va), i)
-@inline Base.getindex(va::AdjointAxisVector, i::Int, j::Int) =
-    @inbounds getindex(components(va), i, j)
+components(va::AdjointAxisVector) = components(parent(va))'
+Base.@propagate_inbounds Base.getindex(va::AdjointAxisVector, i::Int) =
+    getindex(components(va), i)
+Base.@propagate_inbounds Base.getindex(va::AdjointAxisVector, i::Int, j::Int) =
+    getindex(components(va), i, j)
 
 # 2-tensors
 const Axis2Tensor{T, A, S} = AxisTensor{T, 2, A, S}
@@ -279,7 +279,7 @@ Axis2Tensor(
 ) = AxisTensor(axes, components)
 
 const AdjointAxis2Tensor{T, A, S} = Adjoint{T, Axis2Tensor{T, A, S}}
-@inline components(va::AdjointAxis2Tensor) = components(parent(va))'
+components(va::AdjointAxis2Tensor) = components(parent(va))'
 
 const Axis2TensorOrAdj{T, A, S} =
     Union{Axis2Tensor{T, A, S}, AdjointAxis2Tensor{T, A, S}}
@@ -335,27 +335,27 @@ _check_dual(ax1, ax2, _) =
     throw(DimensionMismatch("$ax1 is not dual with $ax2"))
 
 
-@inline function LinearAlgebra.dot(x::AxisVector, y::AxisVector)
+function LinearAlgebra.dot(x::AxisVector, y::AxisVector)
     check_dual(axes(x, 1), axes(y, 1))
     return LinearAlgebra.dot(components(x), components(y))
 end
 
-@inline function Base.:*(x::AxisVector, y::AdjointAxisVector)
+function Base.:*(x::AxisVector, y::AdjointAxisVector)
     AxisTensor((axes(x, 1), axes(y, 2)), components(x) * components(y))
 end
-@inline function Base.:*(A::Axis2TensorOrAdj, x::AxisVector)
+function Base.:*(A::Axis2TensorOrAdj, x::AxisVector)
     check_dual(axes(A, 2), axes(x, 1))
     return AxisVector(axes(A, 1), components(A) * components(x))
 end
-@inline function Base.:*(A::Axis2TensorOrAdj, B::Axis2TensorOrAdj)
+function Base.:*(A::Axis2TensorOrAdj, B::Axis2TensorOrAdj)
     check_dual(axes(A, 2), axes(B, 1))
     return AxisTensor((axes(A, 1), axes(B, 2)), components(A) * components(B))
 end
 
-@inline function Base.inv(A::Axis2TensorOrAdj)
+function Base.inv(A::Axis2TensorOrAdj)
     return AxisTensor((dual(axes(A, 2)), dual(axes(A, 1))), inv(components(A)))
 end
-@inline function Base.:\(A::Axis2TensorOrAdj, x::AxisVector)
+function Base.:\(A::Axis2TensorOrAdj, x::AxisVector)
     check_axes(axes(A, 1), axes(x, 1))
     return AxisVector(dual(axes(A, 2)), components(A) \ components(x))
 end
@@ -379,24 +379,24 @@ LinearAlgebra.cross(y::Cartesian3Vector, x::Cartesian12Vector) =
 LinearAlgebra.cross(x::UVVector, y::WVector) = UVVector(x.v * y.w, -x.u * y.w)
 LinearAlgebra.cross(y::WVector, x::UVVector) = UVVector(-x.v * y.w, x.u * y.w)
 
-@inline function Base.:(+)(A::Axis2Tensor, b::LinearAlgebra.UniformScaling)
+function Base.:(+)(A::Axis2Tensor, b::LinearAlgebra.UniformScaling)
     check_dual(axes(A)...)
     AxisTensor(axes(A), components(A) + b)
 end
-@inline function Base.:(-)(A::Axis2Tensor, b::LinearAlgebra.UniformScaling)
+function Base.:(-)(A::Axis2Tensor, b::LinearAlgebra.UniformScaling)
     check_dual(axes(A)...)
     AxisTensor(axes(A), components(A) - b)
 end
 
 
-@inline function _transform(
+function _transform(
     ato::Ato,
     x::AxisVector{T, Afrom, SVector{N, T}},
 ) where {Ato <: AbstractAxis{I}, Afrom <: AbstractAxis{I}} where {I, T, N}
     x
 end
 
-@inline function _project(
+function _project(
     ato::Ato,
     x::AxisVector{T, Afrom, SVector{N, T}},
 ) where {Ato <: AbstractAxis{I}, Afrom <: AbstractAxis{I}} where {I, T, N}
@@ -458,7 +458,7 @@ end
     return :(@inbounds AxisVector(ato, SVector($(vals...))))
 end
 
-@inline function _transform(
+function _transform(
     ato::Ato,
     x::Axis2Tensor{T, Tuple{Afrom, A2}},
 ) where {
@@ -469,7 +469,7 @@ end
     x
 end
 
-@inline function _project(
+function _project(
     ato::Ato,
     x::Axis2Tensor{T, Tuple{Afrom, A2}},
 ) where {

--- a/src/Geometry/coordinates.jl
+++ b/src/Geometry/coordinates.jl
@@ -137,7 +137,7 @@ component(p::AbstractPoint{FT}, i::Integer) where {FT} = getfield(p, i)::FT
 
 @inline ncomponents(p::AbstractPoint) = nfields(p)
 @inline ncomponents(::Type{P}) where {P <: AbstractPoint} = fieldcount(P)
-@inline components(p::AbstractPoint) =
+components(p::AbstractPoint) =
     SVector(ntuple(i -> component(p, i), ncomponents(p)))
 
 _coordinate_type(ptyp::Type{Abstract1DPoint}, ::Val{1}) = ptyp

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -414,7 +414,13 @@ return_space(
 ) = Spaces.CenterExtrudedFiniteDifferenceSpace(space)
 
 stencil_interior_width(::InterpolateF2C, arg) = ((-half, half),)
-@inline function stencil_interior(::InterpolateF2C, loc, idx, hidx, arg)
+Base.@propagate_inbounds function stencil_interior(
+    ::InterpolateF2C,
+    loc,
+    idx,
+    hidx,
+    arg,
+)
     a⁺ = getidx(arg, loc, idx + half, hidx)
     a⁻ = getidx(arg, loc, idx - half, hidx)
     RecursiveApply.rdiv(a⁺ ⊞ a⁻, 2)
@@ -460,14 +466,20 @@ return_space(
 ) = Spaces.FaceExtrudedFiniteDifferenceSpace(space)
 
 stencil_interior_width(::InterpolateC2F, arg) = ((-half, half),)
-@inline function stencil_interior(::InterpolateC2F, loc, idx, hidx, arg)
+Base.@propagate_inbounds function stencil_interior(
+    ::InterpolateC2F,
+    loc,
+    idx,
+    hidx,
+    arg,
+)
     a⁺ = getidx(arg, loc, idx + half, hidx)
     a⁻ = getidx(arg, loc, idx - half, hidx)
     RecursiveApply.rdiv(a⁺ ⊞ a⁻, 2)
 end
 
 boundary_width(::InterpolateC2F, ::SetValue, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::InterpolateC2F,
     bc::SetValue,
     loc,
@@ -478,7 +490,7 @@ boundary_width(::InterpolateC2F, ::SetValue, arg) = 1
     @assert idx == left_face_boundary_idx(arg)
     getidx(bc.val, loc, nothing, hidx)
 end
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::InterpolateC2F,
     bc::SetValue,
     loc,
@@ -491,7 +503,7 @@ end
 end
 
 boundary_width(::InterpolateC2F, ::SetGradient, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::InterpolateC2F,
     bc::SetGradient,
     loc,
@@ -508,7 +520,7 @@ boundary_width(::InterpolateC2F, ::SetGradient, arg) = 1
     )
     a⁺ ⊟ RecursiveApply.rdiv(v₃, 2)
 end
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::InterpolateC2F,
     bc::SetGradient,
     loc,
@@ -527,7 +539,7 @@ end
 end
 
 boundary_width(::InterpolateC2F, ::Extrapolate, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::InterpolateC2F,
     bc::Extrapolate,
     loc,
@@ -539,7 +551,7 @@ boundary_width(::InterpolateC2F, ::Extrapolate, arg) = 1
     a⁺ = getidx(arg, loc, idx + half, hidx)
     a⁺
 end
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::InterpolateC2F,
     bc::Extrapolate,
     loc,
@@ -580,11 +592,16 @@ return_space(
 ) = Spaces.FaceExtrudedFiniteDifferenceSpace(space)
 
 stencil_interior_width(::LeftBiasedC2F, arg) = ((-half, -half),)
-@inline stencil_interior(::LeftBiasedC2F, loc, idx, hidx, arg) =
-    getidx(arg, loc, idx - half, hidx)
+Base.@propagate_inbounds stencil_interior(
+    ::LeftBiasedC2F,
+    loc,
+    idx,
+    hidx,
+    arg,
+) = getidx(arg, loc, idx - half, hidx)
 
 boundary_width(::LeftBiasedC2F, ::SetValue, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::LeftBiasedC2F,
     bc::SetValue,
     loc,
@@ -622,11 +639,16 @@ return_space(::LeftBiasedF2C, space::Spaces.FaceExtrudedFiniteDifferenceSpace) =
     Spaces.CenterExtrudedFiniteDifferenceSpace(space)
 
 stencil_interior_width(::LeftBiasedF2C, arg) = ((-half, -half),)
-@inline stencil_interior(::LeftBiasedF2C, loc, idx, hidx, arg) =
-    getidx(arg, loc, idx - half, hidx)
+Base.@propagate_inbounds stencil_interior(
+    ::LeftBiasedF2C,
+    loc,
+    idx,
+    hidx,
+    arg,
+) = getidx(arg, loc, idx - half, hidx)
 
 boundary_width(::LeftBiasedF2C, ::SetValue, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::LeftBiasedF2C,
     bc::SetValue,
     loc,
@@ -668,7 +690,13 @@ return_space(
 ) = Spaces.FaceExtrudedFiniteDifferenceSpace(space)
 
 stencil_interior_width(::LeftBiased3rdOrderC2F, arg) = ((-half - 1, half + 1),)
-@inline stencil_interior(::LeftBiased3rdOrderC2F, loc, idx, hidx, arg) =
+Base.@propagate_inbounds stencil_interior(
+    ::LeftBiased3rdOrderC2F,
+    loc,
+    idx,
+    hidx,
+    arg,
+) =
     (
         -2 * getidx(arg, loc, idx - 1 - half, hidx) +
         10 * getidx(arg, loc, idx - half, hidx) +
@@ -676,7 +704,7 @@ stencil_interior_width(::LeftBiased3rdOrderC2F, arg) = ((-half - 1, half + 1),)
     ) / 12
 
 boundary_width(::LeftBiased3rdOrderC2F, ::SetValue, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::LeftBiased3rdOrderC2F,
     bc::SetValue,
     loc,
@@ -716,7 +744,13 @@ return_space(
 ) = Spaces.CenterExtrudedFiniteDifferenceSpace(space)
 
 stencil_interior_width(::LeftBiased3rdOrderF2C, arg) = ((-half - 1, half + 1),)
-@inline stencil_interior(::LeftBiased3rdOrderF2C, loc, idx, hidx, arg) =
+Base.@propagate_inbounds stencil_interior(
+    ::LeftBiased3rdOrderF2C,
+    loc,
+    idx,
+    hidx,
+    arg,
+) =
     (
         -2 * getidx(arg, loc, idx - 1 - half, hidx) +
         10 * getidx(arg, loc, idx - half, hidx) +
@@ -724,7 +758,7 @@ stencil_interior_width(::LeftBiased3rdOrderF2C, arg) = ((-half - 1, half + 1),)
     ) / 12
 
 boundary_width(::LeftBiased3rdOrderF2C, ::SetValue, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::LeftBiased3rdOrderF2C,
     bc::SetValue,
     loc,
@@ -764,11 +798,16 @@ return_space(
 ) = Spaces.FaceExtrudedFiniteDifferenceSpace(space)
 
 stencil_interior_width(::RightBiasedC2F, arg) = ((half, half),)
-@inline stencil_interior(::RightBiasedC2F, loc, idx, hidx, arg) =
-    getidx(arg, loc, idx + half, hidx)
+Base.@propagate_inbounds stencil_interior(
+    ::RightBiasedC2F,
+    loc,
+    idx,
+    hidx,
+    arg,
+) = getidx(arg, loc, idx + half, hidx)
 
 boundary_width(::RightBiasedC2F, ::SetValue, arg) = 1
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::RightBiasedC2F,
     bc::SetValue,
     loc,
@@ -808,11 +847,16 @@ return_space(
 ) = Spaces.CenterExtrudedFiniteDifferenceSpace(space)
 
 stencil_interior_width(::RightBiasedF2C, arg) = ((half, half),)
-@inline stencil_interior(::RightBiasedF2C, loc, idx, hidx, arg) =
-    getidx(arg, loc, idx + half, hidx)
+Base.@propagate_inbounds stencil_interior(
+    ::RightBiasedF2C,
+    loc,
+    idx,
+    hidx,
+    arg,
+) = getidx(arg, loc, idx + half, hidx)
 
 boundary_width(::RightBiasedF2C, ::SetValue, arg) = 1
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::RightBiasedF2C,
     bc::SetValue,
     loc,
@@ -855,7 +899,13 @@ return_space(
 ) = Spaces.FaceExtrudedFiniteDifferenceSpace(space)
 
 stencil_interior_width(::RightBiased3rdOrderC2F, arg) = ((-half - 1, half + 1),)
-@inline stencil_interior(::RightBiased3rdOrderC2F, loc, idx, hidx, arg) =
+Base.@propagate_inbounds stencil_interior(
+    ::RightBiased3rdOrderC2F,
+    loc,
+    idx,
+    hidx,
+    arg,
+) =
     (
         4 * getidx(arg, loc, idx - half, hidx) +
         10 * getidx(arg, loc, idx + half, hidx) -
@@ -863,7 +913,7 @@ stencil_interior_width(::RightBiased3rdOrderC2F, arg) = ((-half - 1, half + 1),)
     ) / 12
 
 boundary_width(::RightBiased3rdOrderC2F, ::SetValue, arg) = 1
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::RightBiased3rdOrderC2F,
     bc::SetValue,
     loc,
@@ -905,7 +955,13 @@ return_space(
 ) = Spaces.CenterExtrudedFiniteDifferenceSpace(space)
 
 stencil_interior_width(::RightBiased3rdOrderF2C, arg) = ((-half - 1, half + 1),)
-@inline stencil_interior(::RightBiased3rdOrderF2C, loc, idx, hidx, arg) =
+Base.@propagate_inbounds stencil_interior(
+    ::RightBiased3rdOrderF2C,
+    loc,
+    idx,
+    hidx,
+    arg,
+) =
     (
         4 * getidx(arg, loc, idx - half, hidx) +
         10 * getidx(arg, loc, idx + half, hidx) -
@@ -913,7 +969,7 @@ stencil_interior_width(::RightBiased3rdOrderF2C, arg) = ((-half - 1, half + 1),)
     ) / 12
 
 boundary_width(::RightBiased3rdOrderF2C, ::SetValue, arg) = 1
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::RightBiased3rdOrderF2C,
     bc::SetValue,
     loc,
@@ -965,7 +1021,7 @@ return_space(
 
 stencil_interior_width(::WeightedInterpolateF2C, weight, arg) =
     ((-half, half), (-half, half))
-@inline function stencil_interior(
+Base.@propagate_inbounds function stencil_interior(
     ::WeightedInterpolateF2C,
     loc,
     idx,
@@ -1018,7 +1074,7 @@ return_space(
 
 stencil_interior_width(::WeightedInterpolateC2F, weight, arg) =
     ((-half, half), (-half, half))
-@inline function stencil_interior(
+Base.@propagate_inbounds function stencil_interior(
     ::WeightedInterpolateC2F,
     loc,
     idx,
@@ -1034,7 +1090,7 @@ stencil_interior_width(::WeightedInterpolateC2F, weight, arg) =
 end
 
 boundary_width(::WeightedInterpolateC2F, ::SetValue, weight, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::WeightedInterpolateC2F,
     bc::SetValue,
     loc,
@@ -1047,7 +1103,7 @@ boundary_width(::WeightedInterpolateC2F, ::SetValue, weight, arg) = 1
     @assert idx == left_face_boundary_idx(space)
     getidx(bc.val, loc, nothing, hidx)
 end
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::WeightedInterpolateC2F,
     bc::SetValue,
     loc,
@@ -1062,7 +1118,7 @@ end
 end
 
 boundary_width(::WeightedInterpolateC2F, ::SetGradient, weight, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::WeightedInterpolateC2F,
     bc::SetGradient,
     loc,
@@ -1080,7 +1136,7 @@ boundary_width(::WeightedInterpolateC2F, ::SetGradient, weight, arg) = 1
     )
     a⁺ ⊟ RecursiveApply.rdiv(v₃, 2)
 end
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::WeightedInterpolateC2F,
     bc::SetGradient,
     loc,
@@ -1100,7 +1156,7 @@ end
 end
 
 boundary_width(::WeightedInterpolateC2F, ::Extrapolate, weight, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::WeightedInterpolateC2F,
     bc::Extrapolate,
     loc,
@@ -1114,7 +1170,7 @@ boundary_width(::WeightedInterpolateC2F, ::Extrapolate, weight, arg) = 1
     a⁺ = getidx(arg, loc, idx + half, hidx)
     a⁺
 end
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::WeightedInterpolateC2F,
     bc::Extrapolate,
     loc,
@@ -1185,7 +1241,7 @@ return_space(
     arg_space::Spaces.CenterExtrudedFiniteDifferenceSpace,
 ) = velocity_space
 
-@inline function upwind_biased_product(v, a⁻, a⁺)
+function upwind_biased_product(v, a⁻, a⁺)
     RecursiveApply.rdiv(
         ((v ⊞ RecursiveApply.rmap(abs, v)) ⊠ a⁻) ⊞
         ((v ⊟ RecursiveApply.rmap(abs, v)) ⊠ a⁺),
@@ -1196,7 +1252,7 @@ end
 stencil_interior_width(::UpwindBiasedProductC2F, velocity, arg) =
     ((0, 0), (-half, half))
 
-@inline function stencil_interior(
+Base.@propagate_inbounds function stencil_interior(
     ::UpwindBiasedProductC2F,
     loc,
     idx,
@@ -1216,7 +1272,7 @@ end
 
 boundary_width(::UpwindBiasedProductC2F, ::SetValue, velocity, arg) = 1
 
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::UpwindBiasedProductC2F,
     bc::SetValue,
     loc,
@@ -1236,7 +1292,7 @@ boundary_width(::UpwindBiasedProductC2F, ::SetValue, velocity, arg) = 1
     return Geometry.Contravariant3Vector(upwind_biased_product(vᶠ, aᴸᴮ, a⁺))
 end
 
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::UpwindBiasedProductC2F,
     bc::SetValue,
     loc,
@@ -1258,7 +1314,7 @@ end
 
 boundary_width(::UpwindBiasedProductC2F, ::Extrapolate, velocity, arg) = 1
 
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     op::UpwindBiasedProductC2F,
     ::Extrapolate,
     loc,
@@ -1272,7 +1328,7 @@ boundary_width(::UpwindBiasedProductC2F, ::Extrapolate, velocity, arg) = 1
     stencil_interior(op, loc, idx + 1, hidx, velocity, arg)
 end
 
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     op::UpwindBiasedProductC2F,
     ::Extrapolate,
     loc,
@@ -1329,7 +1385,7 @@ return_space(
     arg_space::Spaces.CenterExtrudedFiniteDifferenceSpace,
 ) = velocity_space
 
-@inline function upwind_3rdorder_biased_product(v, a⁻, a⁻⁻, a⁺, a⁺⁺)
+function upwind_3rdorder_biased_product(v, a⁻, a⁻⁻, a⁺, a⁺⁺)
     RecursiveApply.rdiv(
         (v ⊠ (7 ⊠ (a⁺ + a⁻) ⊟ (a⁺⁺ + a⁻⁻))) ⊟
         (RecursiveApply.rmap(abs, v) ⊠ (3 ⊠ (a⁺ - a⁻) ⊟ (a⁺⁺ - a⁻⁻))),
@@ -1340,7 +1396,7 @@ end
 stencil_interior_width(::Upwind3rdOrderBiasedProductC2F, velocity, arg) =
     ((0, 0), (-half - 1, half + 1))
 
-@inline function stencil_interior(
+Base.@propagate_inbounds function stencil_interior(
     ::Upwind3rdOrderBiasedProductC2F,
     loc,
     idx,
@@ -1369,7 +1425,7 @@ boundary_width(
     arg,
 ) = 2
 
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::Upwind3rdOrderBiasedProductC2F,
     bc::FirstOrderOneSided,
     loc,
@@ -1389,7 +1445,7 @@ boundary_width(
     return Geometry.Contravariant3Vector(upwind_biased_product(v, a⁻, a⁺))
 end
 
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::Upwind3rdOrderBiasedProductC2F,
     bc::FirstOrderOneSided,
     loc,
@@ -1417,7 +1473,7 @@ boundary_width(
     arg,
 ) = 2
 
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::Upwind3rdOrderBiasedProductC2F,
     bc::ThirdOrderOneSided,
     loc,
@@ -1438,7 +1494,7 @@ boundary_width(
     return Geometry.Contravariant3Vector(vᶠ * a)
 end
 
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::Upwind3rdOrderBiasedProductC2F,
     bc::ThirdOrderOneSided,
     loc,
@@ -1502,7 +1558,7 @@ return_space(
     arg_space::Spaces.CenterExtrudedFiniteDifferenceSpace,
 ) = velocity_space
 
-@inline function fct_boris_book(v, a⁻⁻, a⁻, a⁺, a⁺⁺)
+function fct_boris_book(v, a⁻⁻, a⁻, a⁺, a⁺⁺)
     if v != zero(eltype(v))
         sign(v) ⊠ (RecursiveApply.rmap(
             max,
@@ -1533,7 +1589,14 @@ end
 stencil_interior_width(::FCTBorisBook, velocity, arg) =
     ((0, 0), (-half - 1, half + 1))
 
-@inline function stencil_interior(::FCTBorisBook, loc, idx, hidx, velocity, arg)
+Base.@propagate_inbounds function stencil_interior(
+    ::FCTBorisBook,
+    loc,
+    idx,
+    hidx,
+    velocity,
+    arg,
+)
     space = axes(arg)
     a⁻⁻ = getidx(arg, loc, idx - half - 1, hidx)
     a⁻ = getidx(arg, loc, idx - half, hidx)
@@ -1548,7 +1611,7 @@ end
 
 boundary_width(::FCTBorisBook, ::FirstOrderOneSided, velocity, arg) = 2
 
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::FCTBorisBook,
     bc::FirstOrderOneSided,
     loc,
@@ -1567,7 +1630,7 @@ boundary_width(::FCTBorisBook, ::FirstOrderOneSided, velocity, arg) = 2
     return Geometry.Contravariant3Vector(zero(eltype(vᶠ)))
 end
 
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::FCTBorisBook,
     bc::FirstOrderOneSided,
     loc,
@@ -1635,7 +1698,7 @@ return_space(
     Φᵗᵈ_space::Spaces.CenterExtrudedFiniteDifferenceSpace,
 ) = A_space
 
-@inline function fct_zalesak(
+function fct_zalesak(
     Aⱼ₋₁₂,
     Aⱼ₊₁₂,
     Aⱼ₊₃₂,
@@ -1687,7 +1750,7 @@ end
 stencil_interior_width(::FCTZalesak, A_space, Φ_space, Φᵗᵈ_space) =
     ((-1, 1), (-half - 1, half + 1), (-half - 1, half + 1))
 
-@inline function stencil_interior(
+Base.@propagate_inbounds function stencil_interior(
     ::FCTZalesak,
     loc,
     idx,
@@ -1748,7 +1811,7 @@ boundary_width(
     Φᵗᵈ_space,
 ) = 2
 
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::FCTZalesak,
     bc::FirstOrderOneSided,
     loc,
@@ -1764,7 +1827,7 @@ boundary_width(
     return Geometry.Contravariant3Vector(zero(eltype(eltype(A_space))))
 end
 
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::FCTZalesak,
     bc::FirstOrderOneSided,
     loc,
@@ -1813,7 +1876,14 @@ return_space(
 ) = arg_space
 
 stencil_interior_width(::AdvectionF2F, velocity, arg) = ((0, 0), (-1, 1))
-@inline function stencil_interior(::AdvectionF2F, loc, idx, hidx, velocity, arg)
+Base.@propagate_inbounds function stencil_interior(
+    ::AdvectionF2F,
+    loc,
+    idx,
+    hidx,
+    velocity,
+    arg,
+)
     space = axes(arg)
     θ⁺ = getidx(arg, loc, idx + 1, hidx)
     θ⁻ = getidx(arg, loc, idx - 1, hidx)
@@ -1868,7 +1938,14 @@ return_space(
 
 stencil_interior_width(::AdvectionC2C, velocity, arg) =
     ((-half, +half), (-1, 1))
-@inline function stencil_interior(::AdvectionC2C, loc, idx, hidx, velocity, arg)
+Base.@propagate_inbounds function stencil_interior(
+    ::AdvectionC2C,
+    loc,
+    idx,
+    hidx,
+    velocity,
+    arg,
+)
     space = axes(arg)
     θ⁺ = getidx(arg, loc, idx + 1, hidx)
     θ = getidx(arg, loc, idx, hidx)
@@ -1887,7 +1964,7 @@ stencil_interior_width(::AdvectionC2C, velocity, arg) =
 end
 
 boundary_width(::AdvectionC2C, ::SetValue, velocity, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::AdvectionC2C,
     bc::SetValue,
     loc,
@@ -1913,7 +1990,7 @@ boundary_width(::AdvectionC2C, ::SetValue, velocity, arg) = 1
     ∂θ₃⁻ = 2 ⊠ (θ ⊟ θ⁻)
     return RecursiveApply.rdiv((w³⁺ ⊠ ∂θ₃⁺) ⊞ (w³⁻ ⊠ ∂θ₃⁻), 2)
 end
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::AdvectionC2C,
     bc::SetValue,
     loc,
@@ -1941,7 +2018,7 @@ end
 end
 
 boundary_width(::AdvectionC2C, ::Extrapolate, velocity, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::AdvectionC2C,
     ::Extrapolate,
     loc,
@@ -1961,7 +2038,7 @@ boundary_width(::AdvectionC2C, ::Extrapolate, velocity, arg) = 1
     ∂θ₃⁺ = θ⁺ ⊟ θ
     return (w³⁺ ⊠ ∂θ₃⁺)
 end
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::AdvectionC2C,
     ::Extrapolate,
     loc,
@@ -2000,7 +2077,7 @@ return_space(
 
 stencil_interior_width(::FluxCorrectionC2C, velocity, arg) =
     ((-half, +half), (-1, 1))
-@inline function stencil_interior(
+Base.@propagate_inbounds function stencil_interior(
     ::FluxCorrectionC2C,
     loc,
     idx,
@@ -2026,7 +2103,7 @@ stencil_interior_width(::FluxCorrectionC2C, velocity, arg) =
 end
 
 boundary_width(::FluxCorrectionC2C, ::Extrapolate, velocity, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::FluxCorrectionC2C,
     ::Extrapolate,
     loc,
@@ -2046,7 +2123,7 @@ boundary_width(::FluxCorrectionC2C, ::Extrapolate, velocity, arg) = 1
     ∂θ₃⁺ = θ⁺ ⊟ θ
     return (abs(w³⁺) ⊠ ∂θ₃⁺)
 end
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::FluxCorrectionC2C,
     ::Extrapolate,
     loc,
@@ -2085,7 +2162,7 @@ return_space(
 
 stencil_interior_width(::FluxCorrectionF2F, velocity, arg) =
     ((-half, +half), (-1, 1))
-@inline function stencil_interior(
+Base.@propagate_inbounds function stencil_interior(
     ::FluxCorrectionF2F,
     loc,
     idx,
@@ -2111,7 +2188,7 @@ stencil_interior_width(::FluxCorrectionF2F, velocity, arg) =
 end
 
 boundary_width(::FluxCorrectionF2F, ::Extrapolate, velocity, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::FluxCorrectionF2F,
     ::Extrapolate,
     loc,
@@ -2131,7 +2208,7 @@ boundary_width(::FluxCorrectionF2F, ::Extrapolate, velocity, arg) = 1
     ∂θ₃⁺ = θ⁺ ⊟ θ
     return (abs(w³⁺) ⊠ ∂θ₃⁺)
 end
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::FluxCorrectionF2F,
     ::Extrapolate,
     loc,
@@ -2174,11 +2251,16 @@ return_space(
 ) = space
 
 stencil_interior_width(::SetBoundaryOperator, arg) = ((0, 0),)
-@inline stencil_interior(::SetBoundaryOperator, loc, idx, hidx, arg) =
-    getidx(arg, loc, idx, hidx)
+Base.@propagate_inbounds stencil_interior(
+    ::SetBoundaryOperator,
+    loc,
+    idx,
+    hidx,
+    arg,
+) = getidx(arg, loc, idx, hidx)
 
 boundary_width(::SetBoundaryOperator, ::SetValue, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::SetBoundaryOperator,
     bc::SetValue,
     loc,
@@ -2189,7 +2271,7 @@ boundary_width(::SetBoundaryOperator, ::SetValue, arg) = 1
     @assert idx == left_face_boundary_idx(arg)
     getidx(bc.val, loc, nothing, hidx)
 end
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::SetBoundaryOperator,
     bc::SetValue,
     loc,
@@ -2247,13 +2329,19 @@ return_space(::GradientF2C, space::Spaces.FaceExtrudedFiniteDifferenceSpace) =
     Spaces.CenterExtrudedFiniteDifferenceSpace(space)
 
 stencil_interior_width(::GradientF2C, arg) = ((-half, half),)
-@inline function stencil_interior(::GradientF2C, loc, idx, hidx, arg)
+Base.@propagate_inbounds function stencil_interior(
+    ::GradientF2C,
+    loc,
+    idx,
+    hidx,
+    arg,
+)
     Geometry.Covariant3Vector(1) ⊗
     (getidx(arg, loc, idx + half, hidx) ⊟ getidx(arg, loc, idx - half, hidx))
 end
 
 boundary_width(::GradientF2C, ::SetValue, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::GradientF2C,
     bc::SetValue,
     loc,
@@ -2265,7 +2353,7 @@ boundary_width(::GradientF2C, ::SetValue, arg) = 1
     Geometry.Covariant3Vector(1) ⊗
     (getidx(arg, loc, idx + half, hidx) ⊟ getidx(bc.val, loc, nothing, hidx))
 end
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::GradientF2C,
     bc::SetValue,
     loc,
@@ -2279,7 +2367,7 @@ end
 end
 
 boundary_width(::GradientF2C, ::Extrapolate, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     op::GradientF2C,
     ::Extrapolate,
     loc,
@@ -2295,7 +2383,7 @@ boundary_width(::GradientF2C, ::Extrapolate, arg) = 1
         Geometry.LocalGeometry(space, idx, hidx),
     )
 end
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     op::GradientF2C,
     ::Extrapolate,
     loc,
@@ -2345,13 +2433,19 @@ return_space(::GradientC2F, space::Spaces.CenterExtrudedFiniteDifferenceSpace) =
     Spaces.FaceExtrudedFiniteDifferenceSpace(space)
 
 stencil_interior_width(::GradientC2F, arg) = ((-half, half),)
-@inline function stencil_interior(::GradientC2F, loc, idx, hidx, arg)
+Base.@propagate_inbounds function stencil_interior(
+    ::GradientC2F,
+    loc,
+    idx,
+    hidx,
+    arg,
+)
     Geometry.Covariant3Vector(1) ⊗
     (getidx(arg, loc, idx + half, hidx) ⊟ getidx(arg, loc, idx - half, hidx))
 end
 
 boundary_width(::GradientC2F, ::SetValue, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::GradientC2F,
     bc::SetValue,
     loc,
@@ -2364,7 +2458,7 @@ boundary_width(::GradientC2F, ::SetValue, arg) = 1
     Geometry.Covariant3Vector(2) ⊗
     (getidx(arg, loc, idx + half, hidx) ⊟ getidx(bc.val, loc, nothing, hidx))
 end
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::GradientC2F,
     bc::SetValue,
     loc,
@@ -2379,7 +2473,7 @@ end
 
 # left / right SetGradient boundary conditions
 boundary_width(::GradientC2F, ::SetGradient, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::GradientC2F,
     bc::SetGradient,
     loc,
@@ -2396,7 +2490,7 @@ boundary_width(::GradientC2F, ::SetGradient, arg) = 1
         Geometry.LocalGeometry(space, idx, hidx),
     )
 end
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::GradientC2F,
     bc::SetGradient,
     loc,
@@ -2456,7 +2550,13 @@ return_space(::DivergenceF2C, space::Spaces.FaceExtrudedFiniteDifferenceSpace) =
     Spaces.CenterExtrudedFiniteDifferenceSpace(space)
 
 stencil_interior_width(::DivergenceF2C, arg) = ((-half, half),)
-@inline function stencil_interior(::DivergenceF2C, loc, idx, hidx, arg)
+Base.@propagate_inbounds function stencil_interior(
+    ::DivergenceF2C,
+    loc,
+    idx,
+    hidx,
+    arg,
+)
     space = axes(arg)
     local_geometry = Geometry.LocalGeometry(space, idx, hidx)
     Ju³₊ = Geometry.Jcontravariant3(
@@ -2471,7 +2571,7 @@ stencil_interior_width(::DivergenceF2C, arg) = ((-half, half),)
 end
 
 boundary_width(::DivergenceF2C, ::SetValue, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::DivergenceF2C,
     bc::SetValue,
     loc,
@@ -2492,7 +2592,7 @@ boundary_width(::DivergenceF2C, ::SetValue, arg) = 1
     )
     (Ju³₊ ⊟ Ju³₋) ⊠ local_geometry.invJ
 end
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::DivergenceF2C,
     bc::SetValue,
     loc,
@@ -2515,7 +2615,7 @@ end
 end
 
 boundary_width(::DivergenceF2C, ::Extrapolate, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     op::DivergenceF2C,
     ::Extrapolate,
     loc,
@@ -2526,7 +2626,7 @@ boundary_width(::DivergenceF2C, ::Extrapolate, arg) = 1
     @assert idx == left_center_boundary_idx(arg)
     stencil_interior(op, loc, idx + 1, hidx, arg)
 end
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     op::DivergenceF2C,
     ::Extrapolate,
     loc,
@@ -2574,7 +2674,13 @@ return_space(
 ) = Spaces.FaceExtrudedFiniteDifferenceSpace(space)
 
 stencil_interior_width(::DivergenceC2F, arg) = ((-half, half),)
-@inline function stencil_interior(::DivergenceC2F, loc, idx, hidx, arg)
+Base.@propagate_inbounds function stencil_interior(
+    ::DivergenceC2F,
+    loc,
+    idx,
+    hidx,
+    arg,
+)
     space = axes(arg)
     local_geometry = Geometry.LocalGeometry(space, idx, hidx)
     Ju³₊ = Geometry.Jcontravariant3(
@@ -2589,7 +2695,7 @@ stencil_interior_width(::DivergenceC2F, arg) = ((-half, half),)
 end
 
 boundary_width(::DivergenceC2F, ::SetValue, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::DivergenceC2F,
     bc::SetValue,
     loc,
@@ -2611,7 +2717,7 @@ boundary_width(::DivergenceC2F, ::SetValue, arg) = 1
     )
     (Ju³₊ ⊟ Ju³) ⊠ (2 * local_geometry.invJ)
 end
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::DivergenceC2F,
     bc::SetValue,
     loc,
@@ -2635,7 +2741,7 @@ end
 
 # left / right SetDivergence boundary conditions
 boundary_width(::DivergenceC2F, ::SetDivergence, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::DivergenceC2F,
     bc::SetDivergence,
     loc,
@@ -2647,7 +2753,7 @@ boundary_width(::DivergenceC2F, ::SetDivergence, arg) = 1
     # imposed flux boundary condition at left most face
     getidx(bc.val, loc, nothing, hidx)
 end
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::DivergenceC2F,
     bc::SetDivergence,
     loc,
@@ -2712,32 +2818,26 @@ return_space(::CurlC2F, space::Spaces.CenterFiniteDifferenceSpace) =
 return_space(::CurlC2F, space::Spaces.CenterExtrudedFiniteDifferenceSpace) =
     Spaces.FaceExtrudedFiniteDifferenceSpace(space)
 
-@inline fd3_curl(
-    u₊::Geometry.Covariant1Vector,
-    u₋::Geometry.Covariant1Vector,
-    invJ,
-) = Geometry.Contravariant2Vector((u₊.u₁ - u₋.u₁) * invJ)
-@inline fd3_curl(
-    u₊::Geometry.Covariant2Vector,
-    u₋::Geometry.Covariant2Vector,
-    invJ,
-) = Geometry.Contravariant1Vector(-(u₊.u₂ - u₋.u₂) * invJ)
-@inline fd3_curl(
-    ::Geometry.Covariant3Vector,
-    ::Geometry.Covariant3Vector,
-    invJ,
-) = Geometry.Contravariant3Vector(zero(eltype(invJ)))
-@inline fd3_curl(
-    u₊::Geometry.Covariant12Vector,
-    u₋::Geometry.Covariant12Vector,
-    invJ,
-) = Geometry.Contravariant12Vector(
-    -(u₊.u₂ - u₋.u₂) * invJ,
-    (u₊.u₁ - u₋.u₁) * invJ,
-)
+fd3_curl(u₊::Geometry.Covariant1Vector, u₋::Geometry.Covariant1Vector, invJ) =
+    Geometry.Contravariant2Vector((u₊.u₁ - u₋.u₁) * invJ)
+fd3_curl(u₊::Geometry.Covariant2Vector, u₋::Geometry.Covariant2Vector, invJ) =
+    Geometry.Contravariant1Vector(-(u₊.u₂ - u₋.u₂) * invJ)
+fd3_curl(::Geometry.Covariant3Vector, ::Geometry.Covariant3Vector, invJ) =
+    Geometry.Contravariant3Vector(zero(eltype(invJ)))
+fd3_curl(u₊::Geometry.Covariant12Vector, u₋::Geometry.Covariant12Vector, invJ) =
+    Geometry.Contravariant12Vector(
+        -(u₊.u₂ - u₋.u₂) * invJ,
+        (u₊.u₁ - u₋.u₁) * invJ,
+    )
 
 stencil_interior_width(::CurlC2F, arg) = ((-half, half),)
-@inline function stencil_interior(::CurlC2F, loc, idx, hidx, arg)
+Base.@propagate_inbounds function stencil_interior(
+    ::CurlC2F,
+    loc,
+    idx,
+    hidx,
+    arg,
+)
     space = axes(arg)
     u₊ = getidx(arg, loc, idx + half, hidx)
     u₋ = getidx(arg, loc, idx - half, hidx)
@@ -2746,7 +2846,7 @@ stencil_interior_width(::CurlC2F, arg) = ((-half, half),)
 end
 
 boundary_width(::CurlC2F, ::SetValue, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::CurlC2F,
     bc::SetValue,
     loc,
@@ -2760,7 +2860,7 @@ boundary_width(::CurlC2F, ::SetValue, arg) = 1
     local_geometry = Geometry.LocalGeometry(space, idx, hidx)
     return fd3_curl(u₊, u, local_geometry.invJ * 2)
 end
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::CurlC2F,
     bc::SetValue,
     loc,
@@ -2776,7 +2876,7 @@ end
 end
 
 boundary_width(::CurlC2F, ::SetCurl, arg) = 1
-@inline function stencil_left_boundary(
+Base.@propagate_inbounds function stencil_left_boundary(
     ::CurlC2F,
     bc::SetCurl,
     loc,
@@ -2786,7 +2886,7 @@ boundary_width(::CurlC2F, ::SetCurl, arg) = 1
 )
     return getidx(bc.val, loc, nothing, hidx)
 end
-@inline function stencil_right_boundary(
+Base.@propagate_inbounds function stencil_right_boundary(
     ::CurlC2F,
     bc::SetCurl,
     loc,
@@ -2909,16 +3009,16 @@ end
     right_idx(space)
 end
 
-@inline function getidx(
+Base.@propagate_inbounds function getidx(
     bc::Base.Broadcast.Broadcasted{StencilStyle},
     loc::Interior,
     idx,
     hidx,
 )
-    @inbounds stencil_interior(bc.f, loc, idx, hidx, bc.args...)
+    stencil_interior(bc.f, loc, idx, hidx, bc.args...)
 end
 
-@inline function getidx(
+Base.@propagate_inbounds function getidx(
     bc::Base.Broadcast.Broadcasted{StencilStyle},
     loc::LeftBoundaryWindow,
     idx,
@@ -2928,7 +3028,7 @@ end
     space = axes(bc)
     if has_boundary(bc.f, loc) &&
        idx < left_idx(space) + boundary_width(bc, loc)
-        @inbounds stencil_left_boundary(
+        stencil_left_boundary(
             op,
             get_boundary(op, loc),
             loc,
@@ -2938,11 +3038,11 @@ end
         )
     else
         # fallback to interior stencil
-        @inbounds stencil_interior(op, loc, idx, hidx, bc.args...)
+        stencil_interior(op, loc, idx, hidx, bc.args...)
     end
 end
 
-@inline function getidx(
+Base.@propagate_inbounds function getidx(
     bc::Base.Broadcast.Broadcasted{StencilStyle},
     loc::RightBoundaryWindow,
     idx,
@@ -2952,7 +3052,7 @@ end
     space = axes(bc)
     if has_boundary(bc.f, loc) &&
        idx > (right_idx(space) - boundary_width(bc, loc))
-        @inbounds stencil_right_boundary(
+        stencil_right_boundary(
             op,
             get_boundary(op, loc),
             loc,
@@ -2962,7 +3062,7 @@ end
         )
     else
         # fallback to interior stencil
-        @inbounds stencil_interior(op, loc, idx, hidx, bc.args...)
+        stencil_interior(op, loc, idx, hidx, bc.args...)
     end
 end
 
@@ -2979,7 +3079,7 @@ Base.Broadcast.BroadcastStyle(
 Base.eltype(bc::Base.Broadcast.Broadcasted{StencilStyle}) =
     return_eltype(bc.f, bc.args...)
 
-@inline function getidx(
+Base.@propagate_inbounds function getidx(
     bc::Fields.CenterFiniteDifferenceField,
     ::Location,
     idx::Integer,
@@ -2992,7 +3092,7 @@ Base.eltype(bc::Base.Broadcast.Broadcasted{StencilStyle}) =
     return @inbounds field_data[idx]
 end
 
-@inline function getidx(
+Base.@propagate_inbounds function getidx(
     bc::Fields.FaceFiniteDifferenceField,
     ::Location,
     idx::PlusHalf,
@@ -3018,9 +3118,13 @@ end
 @noinline inferred_getidx_error(idx_type::Type, space_type::Type) =
     error("Invalid index type `$idx_type` for field on space `$space_type`")
 
-@inline function getidx(field::Fields.Field, loc::Location, idx, hidx)
-    @inbounds col = column(field, hidx...)
-    @inbounds getidx(col, loc, idx)
+Base.@propagate_inbounds function getidx(
+    field::Fields.Field,
+    loc::Location,
+    idx,
+    hidx,
+)
+    getidx(column(field, hidx...), loc, idx)
     # inferred_getidx_error(typeof(idx), typeof(axes(field)))
 end
 
@@ -3035,25 +3139,27 @@ function getidx(
 end
 
 # recursively unwrap getidx broadcast arguments in a way that is statically reducible by the optimizer
-@inline getidx_args(args::Tuple, loc::Location, idx, hidx) = (
+Base.@propagate_inbounds getidx_args(args::Tuple, loc::Location, idx, hidx) = (
     getidx(args[1], loc, idx, hidx),
     getidx_args(Base.tail(args), loc, idx, hidx)...,
 )
-@inline getidx_args(arg::Tuple{Any}, loc::Location, idx, hidx) =
-    (getidx(arg[1], loc, idx, hidx),)
-@inline getidx_args(::Tuple{}, loc::Location, idx, hidx) = ()
+Base.@propagate_inbounds getidx_args(
+    arg::Tuple{Any},
+    loc::Location,
+    idx,
+    hidx,
+) = (getidx(arg[1], loc, idx, hidx),)
+Base.@propagate_inbounds getidx_args(::Tuple{}, loc::Location, idx, hidx) = ()
 
-@inline function getidx(
+Base.@propagate_inbounds function getidx(
     bc::Base.Broadcast.Broadcasted,
     loc::Location,
     idx,
     hidx,
 )
     #_args = tuplemap(arg -> getidx(arg, loc, idx), bc.args)
-    @inbounds begin
-        _args = getidx_args(bc.args, loc, idx, hidx)
-        bc.f(_args...)
-    end
+    _args = getidx_args(bc.args, loc, idx, hidx)
+    bc.f(_args...)
 end
 
 if VERSION >= v"1.7.0"
@@ -3069,7 +3175,7 @@ if VERSION >= v"1.7.0"
 end
 
 # setidx! methods for copyto!
-@inline function setidx!(
+Base.@propagate_inbounds function setidx!(
     field::Union{
         Fields.CenterFiniteDifferenceField,
         Fields.CenterExtrudedFiniteDifferenceField,
@@ -3079,11 +3185,11 @@ end
     val,
 )
     field_data = Fields.field_values(field)
-    @inbounds column(field_data, hidx...)[idx] = val
+    column(field_data, hidx...)[idx] = val
     val
 end
 
-@inline function setidx!(
+Base.@propagate_inbounds function setidx!(
     field::Union{
         Fields.FaceFiniteDifferenceField,
         Fields.FaceExtrudedFiniteDifferenceField,
@@ -3150,16 +3256,6 @@ function Base.Broadcast.materialize!(
     )
 end
 
-@inline function column(
-    bc::Base.Broadcast.Broadcasted{Style},
-    inds...,
-) where {Style <: AbstractStencilStyle}
-    col_f = column_op(bc.f, inds...)
-    col_args = column_args(bc.args, inds...)
-    col_axes = column(axes(bc), inds...)
-    Base.Broadcast.Broadcasted{Style}(col_f, col_args, col_axes)
-end
-
 #TODO: the optimizer dies with column broadcast expressions over a certain complexity
 if VERSION >= v"1.7.0"
     if hasfield(Method, :recursion_relation)
@@ -3188,7 +3284,7 @@ function _serial_copyto!(
     Nj::Int,
     Nh::Int,
 ) where {S <: AbstractStencilStyle}
-    for h in 1:Nh, j in 1:Nj, i in 1:Ni
+    @inbounds for h in 1:Nh, j in 1:Nj, i in 1:Ni
         apply_stencil!(field_out, bc, (i, j, h))
     end
     return field_out
@@ -3201,9 +3297,11 @@ function _threaded_copyto!(
     Nj::Int,
     Nh::Int,
 ) where {S <: AbstractStencilStyle}
-    Threads.@threads for h in 1:Nh
-        for j in 1:Nj, i in 1:Ni
-            apply_stencil!(field_out, bc, (i, j, h))
+    @inbounds begin
+        Threads.@threads for h in 1:Nh
+            for j in 1:Nj, i in 1:Ni
+                apply_stencil!(field_out, bc, (i, j, h))
+            end
         end
     end
     return field_out
@@ -3225,7 +3323,8 @@ end
 function apply_stencil!(field_out, bc, hidx)
     space = axes(bc)
     if Topologies.isperiodic(Spaces.vertical_topology(space))
-        for idx in left_idx(space):(left_idx(space) + length(space) - 1)
+        @inbounds for idx in
+                      left_idx(space):(left_idx(space) + length(space) - 1)
             setidx!(field_out, idx, hidx, getidx(bc, Interior(), idx, hidx))
         end
     else
@@ -3236,13 +3335,13 @@ function apply_stencil!(field_out, bc, hidx)
         ri = right_idx(space)
         rw = right_interior_window_idx(bc, space, rbw)::typeof(ri)
         @assert li <= lw <= rw <= ri
-        for idx in li:(lw - 1)
+        @inbounds for idx in li:(lw - 1)
             setidx!(field_out, idx, hidx, getidx(bc, lbw, idx, hidx))
         end
-        for idx in lw:rw
+        @inbounds for idx in lw:rw
             setidx!(field_out, idx, hidx, getidx(bc, Interior(), idx, hidx))
         end
-        for idx in (rw + 1):ri
+        @inbounds for idx in (rw + 1):ri
             setidx!(field_out, idx, hidx, getidx(bc, rbw, idx, hidx))
         end
     end

--- a/src/Operators/operator2stencil.jl
+++ b/src/Operators/operator2stencil.jl
@@ -88,7 +88,7 @@ stencil_interior_width(op::Operator2Stencil, args...) =
 boundary_width(op::Operator2Stencil, bc::BoundaryCondition, args...) =
     boundary_width(op.op, bc, args...)
 
-
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_interior(
     ::Operator2Stencil{<:Union{InterpolateF2C, InterpolateC2F}},
     loc,
@@ -111,6 +111,7 @@ function stencil_left_boundary(
     T = eltype(arg)
     return StencilCoefs{-half, half}((zero(T), zero(T)))
 end
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_right_boundary(
     ::Operator2Stencil{<:InterpolateC2F},
     bc::SetValue,
@@ -122,6 +123,7 @@ function stencil_right_boundary(
     T = eltype(arg)
     return StencilCoefs{-half, half}((zero(T), zero(T)))
 end
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_left_boundary(
     ::Operator2Stencil{<:InterpolateC2F},
     bc::Union{SetGradient, Extrapolate},
@@ -133,6 +135,7 @@ function stencil_left_boundary(
     val⁺ = getidx(arg, loc, idx + half, hidx)
     return StencilCoefs{-half, half}((zero(val⁺), val⁺))
 end
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_right_boundary(
     ::Operator2Stencil{<:InterpolateC2F},
     bc::Union{SetGradient, Extrapolate},
@@ -146,6 +149,7 @@ function stencil_right_boundary(
 end
 
 
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_interior(
     ::Operator2Stencil{<:Union{LeftBiasedF2C, LeftBiasedC2F}},
     loc,
@@ -166,6 +170,7 @@ stencil_left_boundary(
 ) = StencilCoefs{-half, -half}((zero(eltype(arg)),))
 
 
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_interior(
     ::Operator2Stencil{<:Union{RightBiasedF2C, RightBiasedC2F}},
     loc,
@@ -186,6 +191,7 @@ stencil_right_boundary(
 ) = StencilCoefs{half, half}((zero(eltype(arg)),))
 
 
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_interior(
     ::Operator2Stencil{<:AdvectionC2C},
     loc,
@@ -210,6 +216,7 @@ function stencil_interior(
     val⁺ = RecursiveApply.rdiv(w³⁺ ⊠ (θ⁺ ⊟ θ), 2)
     return StencilCoefs{-half, half}((val⁻, val⁺))
 end
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_left_boundary(
     ::Operator2Stencil{<:AdvectionC2C},
     bc::SetValue,
@@ -235,6 +242,7 @@ function stencil_left_boundary(
     val⁺ = RecursiveApply.rdiv(w³⁺ ⊠ (θ⁺ ⊟ θ), 2)
     return StencilCoefs{-half, half}((val⁻, val⁺))
 end
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_right_boundary(
     ::Operator2Stencil{<:AdvectionC2C},
     bc::SetValue,
@@ -260,6 +268,7 @@ function stencil_right_boundary(
     val⁺ = w³⁺ ⊠ (θ⁺ ⊟ θ)
     return StencilCoefs{-half, half}((val⁻, val⁺))
 end
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_left_boundary(
     ::Operator2Stencil{<:AdvectionC2C},
     bc::Extrapolate,
@@ -279,6 +288,7 @@ function stencil_left_boundary(
     val⁺ = w³⁺ ⊠ (θ⁺ ⊟ θ)
     return StencilCoefs{-half, half}((zero(val⁺), val⁺))
 end
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_right_boundary(
     ::Operator2Stencil{<:AdvectionC2C},
     bc::Extrapolate,
@@ -300,6 +310,7 @@ function stencil_right_boundary(
 end
 
 
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_interior(
     ::Operator2Stencil{<:Union{FluxCorrectionC2C, FluxCorrectionF2F}},
     loc,
@@ -324,6 +335,7 @@ function stencil_interior(
     val⁺ = abs(w³⁺) ⊠ (θ⁺ ⊟ θ)
     return StencilCoefs{-half, half}((val⁻, val⁺))
 end
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_left_boundary(
     ::Operator2Stencil{<:Union{FluxCorrectionC2C, FluxCorrectionF2F}},
     bc::Extrapolate,
@@ -343,6 +355,7 @@ function stencil_left_boundary(
     val⁺ = abs(w³⁺) ⊠ (θ⁺ ⊟ θ)
     return StencilCoefs{-half, half}((zero(val⁺), val⁺))
 end
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_right_boundary(
     ::Operator2Stencil{<:Union{FluxCorrectionC2C, FluxCorrectionF2F}},
     bc::Extrapolate,
@@ -365,6 +378,7 @@ function stencil_right_boundary(
 end
 
 
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_interior(
     ::Operator2Stencil{<:Union{GradientF2C, GradientC2F}},
     loc,
@@ -376,6 +390,7 @@ function stencil_interior(
     val⁺ = Geometry.Covariant3Vector(1) ⊗ getidx(arg, loc, idx + half, hidx)
     return StencilCoefs{-half, half}((val⁻, val⁺))
 end
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_left_boundary(
     ::Operator2Stencil{<:GradientF2C},
     bc::SetValue,
@@ -387,6 +402,7 @@ function stencil_left_boundary(
     val⁺ = Geometry.Covariant3Vector(1) ⊗ getidx(arg, loc, idx + half, hidx)
     return StencilCoefs{-half, half}((zero(val⁺), val⁺))
 end
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_right_boundary(
     ::Operator2Stencil{<:GradientF2C},
     bc::SetValue,
@@ -414,6 +430,7 @@ stencil_right_boundary(
     hidx,
     arg,
 ) = extrapolation_increases_bandwidth_error(GradientF2C)
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_left_boundary(
     ::Operator2Stencil{<:GradientC2F},
     bc::SetValue,
@@ -425,6 +442,7 @@ function stencil_left_boundary(
     val⁺ = Geometry.Covariant3Vector(2) ⊗ getidx(arg, loc, idx + half, hidx)
     return StencilCoefs{-half, half}((zero(val⁺), val⁺))
 end
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_right_boundary(
     ::Operator2Stencil{<:GradientC2F},
     bc::SetValue,
@@ -460,6 +478,7 @@ function stencil_right_boundary(
 end
 
 
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_interior(
     ::Operator2Stencil{<:Union{DivergenceF2C, DivergenceC2F}},
     loc,
@@ -481,6 +500,7 @@ function stencil_interior(
     val⁺ = Ju³⁺ ⊠ invJ
     return StencilCoefs{-half, half}((val⁻, val⁺))
 end
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_left_boundary(
     ::Operator2Stencil{<:DivergenceF2C},
     bc::SetValue,
@@ -498,6 +518,7 @@ function stencil_left_boundary(
     val⁺ = Ju³⁺ ⊠ invJ
     return StencilCoefs{-half, half}((zero(val⁺), val⁺))
 end
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_right_boundary(
     ::Operator2Stencil{<:DivergenceF2C},
     bc::SetValue,
@@ -531,6 +552,7 @@ stencil_right_boundary(
     hidx,
     arg,
 ) = extrapolation_increases_bandwidth_error(DivergenceF2C)
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_left_boundary(
     ::Operator2Stencil{<:DivergenceC2F},
     bc::SetValue,
@@ -548,6 +570,7 @@ function stencil_left_boundary(
     val⁺ = Ju³⁺ ⊠ (2 * invJ)
     return StencilCoefs{-half, half}((zero(val⁺), val⁺))
 end
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_right_boundary(
     ::Operator2Stencil{<:DivergenceC2F},
     bc::SetValue,
@@ -598,6 +621,7 @@ fd3_curl⁺(::Geometry.Covariant3Vector, invJ) =
 fd3_curl⁺(u::Geometry.Covariant12Vector, invJ) =
     Geometry.Contravariant12Vector(-u.u₂ * invJ, u.u₁ * invJ)
 
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_interior(::Operator2Stencil{<:CurlC2F}, loc, idx, hidx, arg)
     space = axes(arg)
     u₋ = getidx(arg, loc, idx - half, hidx)
@@ -607,6 +631,7 @@ function stencil_interior(::Operator2Stencil{<:CurlC2F}, loc, idx, hidx, arg)
     val⁺ = fd3_curl⁺(u₊, invJ)
     return StencilCoefs{-half, half}((val⁻, val⁺))
 end
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_left_boundary(
     ::Operator2Stencil{<:CurlC2F},
     bc::SetValue,
@@ -621,6 +646,7 @@ function stencil_left_boundary(
     val⁺ = fd3_curl⁺(u₊, 2 * invJ)
     return StencilCoefs{-half, half}((zero(val⁺), val⁺))
 end
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_right_boundary(
     ::Operator2Stencil{<:CurlC2F},
     bc::SetValue,

--- a/src/Operators/pointwisestencil.jl
+++ b/src/Operators/pointwisestencil.jl
@@ -368,6 +368,7 @@ return_eltype(::ApplyStencil, stencil, arg) = eltype(eltype(stencil))
 
 return_space(::ApplyStencil, stencil_space, arg_space) = stencil_space
 
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function apply_stencil_at_idx(i_vals, stencil, arg, loc, idx, hidx)
     coefs = getidx(stencil, loc, idx, hidx)
     lbw = bandwidths(eltype(stencil))[1]
@@ -379,12 +380,14 @@ function apply_stencil_at_idx(i_vals, stencil, arg, loc, idx, hidx)
     return val
 end
 
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_interior(::ApplyStencil, loc, idx, hidx, stencil, arg)
     lbw, ubw = bandwidths(eltype(stencil))
     i_vals = lbw:ubw
     return apply_stencil_at_idx(i_vals, stencil, arg, loc, idx, hidx)
 end
 
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_left_boundary(
     ::ApplyStencil,
     ::LeftStencilBoundary,
@@ -399,6 +402,7 @@ function stencil_left_boundary(
     return apply_stencil_at_idx(i_vals, stencil, arg, loc, idx, hidx)
 end
 
+# TODO: find out why using Base.@propagate_inbounds blows up compilation time
 function stencil_right_boundary(
     ::ApplyStencil,
     ::RightStencilBoundary,
@@ -443,6 +447,7 @@ function bandwidth_info(stencil1, stencil2)
     return lbw1, ubw1, bw1, bw2
 end
 
+# TODO: find out why using Base.@propagate_inbounds hangs
 function compose_stencils_at_idx(
     ::Type{ir_type},
     stencil1,
@@ -473,6 +478,7 @@ function compose_stencils_at_idx(
     return StencilCoefs{lbw, ubw}(ntup)
 end
 
+# TODO: find out why using Base.@propagate_inbounds hangs
 function stencil_interior(::ComposeStencils, loc, idx, hidx, stencil1, stencil2)
     return compose_stencils_at_idx(
         IndexRangeInteriorType,
@@ -484,6 +490,7 @@ function stencil_interior(::ComposeStencils, loc, idx, hidx, stencil1, stencil2)
     )
 end
 
+# TODO: find out why using Base.@propagate_inbounds hangs
 function stencil_left_boundary(
     ::ComposeStencils,
     ::LeftStencilBoundary,
@@ -503,6 +510,7 @@ function stencil_left_boundary(
     )
 end
 
+# TODO: find out why using Base.@propagate_inbounds hangs
 function stencil_right_boundary(
     ::ComposeStencils,
     ::RightStencilBoundary,

--- a/src/RecursiveApply/RecursiveApply.jl
+++ b/src/RecursiveApply/RecursiveApply.jl
@@ -96,8 +96,7 @@ const ⊞ = radd
 # Adapted from Base/operators.jl for general nary operator fallbacks
 for op in (:rmul, :radd)
     @eval begin
-        @inline ($op)(a, b, c, xs...) =
-            Base.afoldl($op, ($op)(($op)(a, b), c), xs...)
+        ($op)(a, b, c, xs...) = Base.afoldl($op, ($op)(($op)(a, b), c), xs...)
     end
 end
 
@@ -143,8 +142,8 @@ Recursive matrix product along the 1st dimension of `S`. Equivalent to:
 """
 function rmatmul1(W, S, i, j)
     Nq = size(W, 2)
-    r = W[i, 1] ⊠ S[1, j]
-    for ii in 2:Nq
+    @inbounds r = W[i, 1] ⊠ S[1, j]
+    @inbounds for ii in 2:Nq
         r = rmuladd(W[i, ii], S[ii, j], r)
     end
     return r
@@ -160,8 +159,8 @@ Recursive matrix product along the 2nd dimension `S`. Equivalent to:
 """
 function rmatmul2(W, S, i, j)
     Nq = size(W, 2)
-    r = W[j, 1] ⊠ S[i, 1]
-    for jj in 2:Nq
+    @inbounds r = W[j, 1] ⊠ S[i, 1]
+    @inbounds for jj in 2:Nq
         r = rmuladd(W[j, jj], S[i, jj], r)
     end
     return r

--- a/src/Spaces/dss.jl
+++ b/src/Spaces/dss.jl
@@ -201,8 +201,8 @@ function dss_1d!(
     Nv = size(data, 4)
     idx1 = CartesianIndex(1, 1, 1, 1, 1)
     idx2 = CartesianIndex(Nq, 1, 1, 1, 1)
-    for (elem1, face1, elem2, face2, reversed) in
-        Topologies.interior_faces(htopology)
+    @inbounds for (elem1, face1, elem2, face2, reversed) in
+                  Topologies.interior_faces(htopology)
         for level in 1:Nv
             @assert face1 == 1 && face2 == 2 && !reversed
             local_geometry_slab1 = slab(local_geometry_data, level, elem1)
@@ -310,7 +310,7 @@ function fill_send_buffer!(
 
     Nv = size(data, 4)
     send_data = ghost_buffer.send_data
-    for (sidx, lidx) in enumerate(topology.send_elem_lidx)
+    @inbounds for (sidx, lidx) in enumerate(topology.send_elem_lidx)
         for level in 1:Nv
             src_slab = slab(data, level, lidx)
             send_slab = slab(send_data, level, sidx)
@@ -339,8 +339,8 @@ function dss_interior_faces!(
     Nq = size(data, 1)
     Nv = size(data, 4)
 
-    for (lidx1, face1, lidx2, face2, reversed) in
-        Topologies.interior_faces(topology)
+    @inbounds for (lidx1, face1, lidx2, face2, reversed) in
+                  Topologies.interior_faces(topology)
         for level in 1:Nv
 
             data_slab1 = slab(data, level, lidx1)
@@ -402,7 +402,7 @@ function dss_local_vertices!(
     Nq = size(data, 1)
     Nv = size(data, 4)
 
-    for vertex in Topologies.local_vertices(topology)
+    @inbounds for vertex in Topologies.local_vertices(topology)
         # for each level
         for level in 1:Nv
             # gather: compute sum over shared vertices
@@ -454,8 +454,8 @@ function dss_ghost_faces!(
     Nq = size(data, 1)
     Nv = size(data, 4)
 
-    for (lidx1, face1, ridx2, face2, reversed) in
-        Topologies.ghost_faces(topology)
+    @inbounds for (lidx1, face1, ridx2, face2, reversed) in
+                  Topologies.ghost_faces(topology)
         for level in 1:Nv
 
             data_slab1 = slab(data, level, lidx1)
@@ -525,7 +525,7 @@ function dss_ghost_vertices!(
     Nq = size(data, 1)
     Nv = size(data, 4)
 
-    for vertex in Topologies.ghost_vertices(topology)
+    @inbounds for vertex in Topologies.ghost_vertices(topology)
         # for each level
         for level in 1:Nv
             # gather: compute sum over shared vertices

--- a/src/Spaces/finitedifference.jl
+++ b/src/Spaces/finitedifference.jl
@@ -163,13 +163,17 @@ function right_boundary_name(space::FiniteDifferenceSpace)
     propertynames(boundaries)[2]
 end
 
-function level(space::FaceFiniteDifferenceSpace, v::PlusHalf)
-    local_geometry = local_geometry_data(space)
-    local_geometry = level(local_geometry, v.i + 1)
+Base.@propagate_inbounds function level(
+    space::FaceFiniteDifferenceSpace,
+    v::PlusHalf,
+)
+    @inbounds local_geometry = level(local_geometry_data(space), v.i + 1)
     PointSpace(local_geometry)
 end
-function level(space::CenterFiniteDifferenceSpace, v::Int)
-    local_geometry = local_geometry_data(space)
-    local_geometry = level(local_geometry, v)
+Base.@propagate_inbounds function level(
+    space::CenterFiniteDifferenceSpace,
+    v::Int,
+)
+    local_geometry = level(local_geometry_data(space), v)
     PointSpace(local_geometry)
 end

--- a/src/Spaces/hybrid.jl
+++ b/src/Spaces/hybrid.jl
@@ -128,25 +128,35 @@ topology(space::ExtrudedFiniteDifferenceSpace) = space.horizontal_space.topology
 vertical_topology(space::ExtrudedFiniteDifferenceSpace) =
     space.vertical_topology
 
-function slab(space::ExtrudedFiniteDifferenceSpace, v, h)
+Base.@propagate_inbounds function slab(
+    space::ExtrudedFiniteDifferenceSpace,
+    v,
+    h,
+)
     SpectralElementSpaceSlab(
         space.horizontal_space.quadrature_style,
         slab(local_geometry_data(space), v, h),
     )
 end
 
-@inline function column(space::ExtrudedFiniteDifferenceSpace, i, j, h)
-    @inbounds clg = column(space.center_local_geometry, i, j, h)
-    @inbounds flg = column(space.face_local_geometry, i, j, h)
+Base.@propagate_inbounds function column(
+    space::ExtrudedFiniteDifferenceSpace,
+    i,
+    j,
+    h,
+)
     FiniteDifferenceSpace(
         space.staggering,
         space.vertical_topology,
         Geometry.CartesianGlobalGeometry(),
-        clg,
-        flg,
+        column(space.center_local_geometry, i, j, h),
+        column(space.face_local_geometry, i, j, h),
     )
 end
-function level(space::CenterExtrudedFiniteDifferenceSpace, v::Integer)
+Base.@propagate_inbounds function level(
+    space::CenterExtrudedFiniteDifferenceSpace,
+    v::Integer,
+)
     horizontal_space = space.horizontal_space
     if horizontal_space isa SpectralElementSpace1D
         SpectralElementSpace1D(
@@ -172,10 +182,13 @@ function level(space::CenterExtrudedFiniteDifferenceSpace, v::Integer)
         error("Unsupported horizontal space")
     end
 end
-function level(space::FaceExtrudedFiniteDifferenceSpace, v::PlusHalf)
+Base.@propagate_inbounds function level(
+    space::FaceExtrudedFiniteDifferenceSpace,
+    v::PlusHalf,
+)
     horizontal_space = space.horizontal_space
     if horizontal_space isa SpectralElementSpace1D
-        SpectralElementSpace1D(
+        @inbounds SpectralElementSpace1D(
             horizontal_space.topology,
             horizontal_space.quadrature_style,
             horizontal_space.global_geometry,
@@ -183,7 +196,7 @@ function level(space::FaceExtrudedFiniteDifferenceSpace, v::PlusHalf)
             horizontal_space.dss_weights,
         )
     elseif horizontal_space isa SpectralElementSpace2D
-        SpectralElementSpace2D(
+        @inbounds SpectralElementSpace2D(
             horizontal_space.topology,
             horizontal_space.quadrature_style,
             horizontal_space.global_geometry,

--- a/src/Spaces/spectralelement.jl
+++ b/src/Spaces/spectralelement.jl
@@ -418,24 +418,28 @@ const SpectralElementSpaceSlab2D =
 nlevels(space::SpectralElementSpaceSlab1D) = 1
 nlevels(space::SpectralElementSpaceSlab2D) = 1
 
-function slab(space::AbstractSpectralElementSpace, v, h)
+Base.@propagate_inbounds function slab(
+    space::AbstractSpectralElementSpace,
+    v,
+    h,
+)
     SpectralElementSpaceSlab(
         space.quadrature_style,
         slab(space.local_geometry, v, h),
     )
 end
-slab(space::AbstractSpectralElementSpace, h) = slab(space, 1, h)
+Base.@propagate_inbounds slab(space::AbstractSpectralElementSpace, h) =
+    @inbounds slab(space, 1, h)
 
-@inline function column(space::SpectralElementSpace1D, i, h)
-    local_geometry = local_geometry_data(space)
-    @inbounds local_geometry = column(local_geometry, i, h)
+Base.@propagate_inbounds function column(space::SpectralElementSpace1D, i, h)
+    local_geometry = column(local_geometry_data(space), i, h)
     PointSpace(local_geometry)
 end
-@inline column(space::SpectralElementSpace1D, i, j, h) = column(space, i, h)
+Base.@propagate_inbounds column(space::SpectralElementSpace1D, i, j, h) =
+    column(space, i, h)
 
-@inline function column(space::SpectralElementSpace2D, i, j, h)
-    local_geometry = local_geometry_data(space)
-    @inbounds local_geometry = column(local_geometry, i, j, h)
+Base.@propagate_inbounds function column(space::SpectralElementSpace2D, i, j, h)
+    local_geometry = column(local_geometry_data(space), i, j, h)
     PointSpace(local_geometry)
 end
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -22,15 +22,16 @@ data layout `data` at location `h`.
 function slab end
 
 # generic fallback
-@inline slab(x, inds...) = x
-@inline slab(tup::Tuple, inds...) = slab_args(tup, inds...)
+Base.@propagate_inbounds slab(x, inds...) = x
+Base.@propagate_inbounds slab(tup::Tuple, inds...) = slab_args(tup, inds...)
 
 # Recursively call slab() on broadcast arguments in a way that is statically reducible by the optimizer
 # see Base.Broadcast.preprocess_args
-@inline slab_args(args::Tuple, inds...) =
+Base.@propagate_inbounds slab_args(args::Tuple, inds...) =
     (slab(args[1], inds...), slab_args(Base.tail(args), inds...)...)
-@inline slab_args(args::Tuple{Any}, inds...) = (slab(args[1], inds...),)
-@inline slab_args(args::Tuple{}, inds...) = ()
+Base.@propagate_inbounds slab_args(args::Tuple{Any}, inds...) =
+    (slab(args[1], inds...),)
+Base.@propagate_inbounds slab_args(args::Tuple{}, inds...) = ()
 
 """
     column(data::AbstractData, i::Integer)
@@ -41,14 +42,15 @@ data layout `data` at nodal point index `i`.
 function column end
 
 # generic fallback
-@inline column(x, inds...) = x
-@inline column(tup::Tuple, inds...) = column_args(tup, inds...)
+Base.@propagate_inbounds column(x, inds...) = x
+Base.@propagate_inbounds column(tup::Tuple, inds...) = column_args(tup, inds...)
 
 # Recursively call column() on broadcast arguments in a way that is statically reducible by the optimizer
 # see Base.Broadcast.preprocess_args
-@inline column_args(args::Tuple, inds...) =
+Base.@propagate_inbounds column_args(args::Tuple, inds...) =
     (column(args[1], inds...), column_args(Base.tail(args), inds...)...)
-@inline column_args(args::Tuple{Any}, inds...) = (column(args[1], inds...),)
-@inline column_args(args::Tuple{}, inds...) = ()
+Base.@propagate_inbounds column_args(args::Tuple{Any}, inds...) =
+    (column(args[1], inds...),)
+Base.@propagate_inbounds column_args(args::Tuple{}, inds...) = ()
 
 function level end

--- a/test/Operators/finitedifference/linsolve.jl
+++ b/test/Operators/finitedifference/linsolve.jl
@@ -57,6 +57,7 @@ function _linsolve!(x, A, b, update_matrix = false; kwargs...)
 
     # Compute remaining components of x
     @. xᶜρ = -bᶜρ + apply(∂ᶜρₜ∂ᶠ𝕄, xᶠ𝕄)
+    return nothing
 end
 
 import ClimaCore


### PR DESCRIPTION
This PR is an attempt to partially revert (and extend/complete) #829, by:
 - More properly using `@inline`, `@inbounds` and `Base.@propagate_inbounds`
 - Removing `@inline` for "expensive" functions that do not have or uses indices which require boundscheck elision
 - Applying inlining and `@inbounds` to slab functions

The only thing that I'm not 100% sure about is the `@inbounds` around the threading loops, does what I've done look okay? cc @simonbyrne 

Supersedes #891.