### PR TITLE
Add option for unthreaded bycolumn

### DIFF
--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -1,5 +1,6 @@
 module Fields
 
+import ..enable_threading
 import ..slab, ..slab_args, ..column, ..column_args, ..level
 import ..DataLayouts: DataLayouts, AbstractData, DataStyle
 import ..Domains

--- a/src/Fields/indices.jl
+++ b/src/Fields/indices.jl
@@ -65,9 +65,17 @@ function bycolumn(fn, space::Spaces.SpectralElementSpace1D)
     Nh = Topologies.nlocalelems(space)
     Nq = Spaces.Quadratures.degrees_of_freedom(Spaces.quadrature_style(space))
     @inbounds begin
-        Threads.@threads for h in 1:Nh
-            for i in 1:Nq
-                fn(ColumnIndex((i,), h))
+        if enable_threading()
+            Threads.@threads for h in 1:Nh
+                for i in 1:Nq
+                    fn(ColumnIndex((i,), h))
+                end
+            end
+        else
+            for h in 1:Nh
+                for i in 1:Nq
+                    fn(ColumnIndex((i,), h))
+                end
             end
         end
     end
@@ -77,9 +85,17 @@ function bycolumn(fn, space::Spaces.SpectralElementSpace2D)
     Nh = Topologies.nlocalelems(space)
     Nq = Spaces.Quadratures.degrees_of_freedom(Spaces.quadrature_style(space))
     @inbounds begin
-        Threads.@threads for h in 1:Nh
-            for j in 1:Nq, i in 1:Nq
-                fn(ColumnIndex((i, j), h))
+        if enable_threading()
+            Threads.@threads for h in 1:Nh
+                for j in 1:Nq, i in 1:Nq
+                    fn(ColumnIndex((i, j), h))
+                end
+            end
+        else
+            for h in 1:Nh
+                for j in 1:Nq, i in 1:Nq
+                    fn(ColumnIndex((i, j), h))
+                end
             end
         end
     end


### PR DESCRIPTION
This will help us fix [CA#737](https://github.com/CliMA/ClimaAtmos.jl/issues/737), and it will help us unify the threaded / unthreaded versions of ClimaAtmos kernels without losing flame graphs. and I think it also just makes sense that threading is just on or off, regardless of whether we're threading for individual broadcast expressions or by columns.