### PR TITLE
make sure parallel HDF5 tests write to same file

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -161,7 +161,8 @@ steps:
     agents:
       config: cpu
       queue: central
-      slurm_ntasks: 3
+      slurm_nodes: 3
+      slurm_tasks_per_node: 1
 
   - label: ":computer: Column Heat Diffusion Eq"
     key: "cpu_column_heat"

--- a/test/InputOutput/hybrid3dcubedsphere.jl
+++ b/test/InputOutput/hybrid3dcubedsphere.jl
@@ -16,14 +16,18 @@ if usempi
     using ClimaCommsMPI, MPI
     const comms_ctx = ClimaCommsMPI.MPICommsContext()
     pid, nprocs = ClimaComms.init(comms_ctx)
-    filename = MPI.bcast(tempname(), 0, MPI.COMM_WORLD)
+    # use same filename on all processes
+    # must be accessible by all procs
+    filename = tempname(pwd())
+    filename = MPI.bcast(filename, 0, MPI.COMM_WORLD)
     if ClimaComms.iamroot(comms_ctx)
-        @info "Distributed test" nprocs
+        @info "Distributed test" nprocs filename
     end
 else
     const comms_ctx = ClimaComms.SingletonCommsContext()
     ClimaComms.init(comms_ctx)
     filename = tempname()
+    @info "Single process test" filename
 end
 
 @testset "HDF5 restart test for 3d hybrid cubed sphere" begin

--- a/test/InputOutput/hybrid3dcubedsphere_topography.jl
+++ b/test/InputOutput/hybrid3dcubedsphere_topography.jl
@@ -17,14 +17,18 @@ if usempi
     using ClimaCommsMPI, MPI
     const comms_ctx = ClimaCommsMPI.MPICommsContext()
     pid, nprocs = ClimaComms.init(comms_ctx)
-    filename = MPI.bcast(tempname(), 0, MPI.COMM_WORLD)
+    # use same filename on all processes
+    # must be accessible by all procs
+    filename = tempname(pwd())
+    filename = MPI.bcast(filename, 0, MPI.COMM_WORLD)
     if ClimaComms.iamroot(comms_ctx)
-        @info "Distributed test" nprocs
+        @info "Distributed test" nprocs filename
     end
 else
     const comms_ctx = ClimaComms.SingletonCommsContext()
     ClimaComms.init(comms_ctx)
     filename = tempname()
+    @info "Single process test" filename
 end
 
 @testset "HDF5 restart test for 3d hybrid cubed sphere" begin


### PR DESCRIPTION
Parallel HDF5 tests were flaky: I think it is because we were trying to write to `/tmp` which won't work on mutliple nodes

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
