### PR TITLE
Add broken allocation test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -92,13 +92,13 @@ steps:
       slurm_ntasks: 1
 
   - label: ":computer: Field broadcast performance"
-    key: "cpu_field_broadcast_perf"
+    key: "cpu_field_perf"
     command:
-      - "julia --color=yes --project=test test/Fields/field_bc.jl"
+      - "julia --color=yes --project=test test/Fields/field_opt.jl"
     agents:
       config: cpu
       queue: central
-      slurm_mem: 64GB
+      slurm_mem: 20GB
       slurm_ntasks: 1
 
   - label: ":flower_playing_cards: unit tests"


### PR DESCRIPTION
This PR adds a broken allocation test for `getproperty` with FieldVectors.

I spent a few minutes trying to see what's going on. I tried applying `@inline` to `_values` and `unwrap`, but that didn't work. So, for now I figure we can just add it as a broken test.

Relevant issue: #949.