### PR TITLE
fix error in warning when loading HDF5 from a newer file

### DIFF
--- a/src/InputOutput/readers.jl
+++ b/src/InputOutput/readers.jl
@@ -84,8 +84,9 @@ function HDF5Reader(
         error("Not a ClimaCore HDF5 file")
     end
     file_version = VersionNumber(attrs(file)["ClimaCore version"])
-    if file_version > VERSION
-        @warn "$filename was written using a newer version of ClimaCore than is currently loaded" file_version package_version
+    current_version = VERSION
+    if file_version > current_version
+        @warn "$filename was written using a newer version of ClimaCore than is currently loaded" file_version current_version
     end
     return HDF5Reader(
         file,


### PR DESCRIPTION
Found by @szy21.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
