### PR TITLE
Fix missing @docs in HDF5 reader. Add REPL example usage

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -236,7 +236,7 @@ InputOutput.write!
 ```
 
 ### Readers
-```
+```@docs
 InputOutput.HDF5Reader
 InputOutput.read_domain
 InputOutput.read_mesh

--- a/src/InputOutput/readers.jl
+++ b/src/InputOutput/readers.jl
@@ -57,9 +57,30 @@ HDF5 library with MPI support.
 
 ```julia
 reader = InputOutput.HDF5Reader(filename)
-field = read_field(reader, "Y")
+Y = read_field(reader, "Y")
+Y.c |> propertynames
+Y.f |> propertynames
+ρ_field = read_field(reader, "Y.c.ρ")
+w_field = read_field(reader, "Y.f.w")
 close(reader)
 ```
+
+To explore the contents of the `reader`, use either
+```julia
+julia> reader |> propertynames
+``` 
+e.g, to explore the components of the `space`, 
+```julia
+julia> reader.space_cache
+Dict{Any, Any} with 3 entries:
+  "center_extruded_finite_difference_space" => CenterExtrudedFiniteDifferenceSpace:…
+  "horizontal_space"                        => SpectralElementSpace2D:…
+  "face_extruded_finite_difference_space"   => FaceExtrudedFiniteDifferenceSpace:…
+``` 
+
+Once "unpacked" as shown above, `ClimaCorePlots` or `ClimaCoreMakie` can be used to visualise
+fields. `ClimaCoreTempestRemap` supports interpolation onto user-specified grids if necessary.
+
 """
 struct HDF5Reader{C <: ClimaComms.AbstractCommsContext}
     file::HDF5.File


### PR DESCRIPTION
Documentation PR. Adds missing `@docs` to HDF5 reader docs, this should populate the `reader` component of  https://clima.github.io/ClimaCore.jl/dev/api/#InputOutput link correctly. Adds additional REPL example statements on reader usage. 

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
