### PR TITLE
Add TempestRemap Nq=5 monotone test

### DIFF
--- a/lib/ClimaCoreTempestRemap/test/netcdf.jl
+++ b/lib/ClimaCoreTempestRemap/test/netcdf.jl
@@ -154,16 +154,16 @@ end
     end
 end
 
-@testset "write remap 3d sphere data $node_type to rll and back" for node_type in
-                                                                     [
-    "cgll",
-    "dgll",
-]
+@testset "write remap 3d sphere data $node_type to rll and back with Nq = $Nq" for node_type in
+                                                                                   [
+        "cgll",
+        "dgll",
+    ],
+    Nq in [4, 5]
     # generate CC mesh
     ne = 4
     R = 1000.0
     nlevels = 10
-    Nq = 4
     hdomain = Domains.SphereDomain(R)
     hmesh = Meshes.EquiangularCubedSphere(hdomain, ne)
     htopology = Topologies.Topology2D(hmesh)


### PR DESCRIPTION
This PR adds a test for ClimaCoreTempestRemap with an order 5 monotone remapping (`Nq=5 mono=true`). This is in response to the recent update of TempestRemap_jll ([v2.1.4](https://github.com/ClimateGlobalChange/tempestremap)).

Relevant issue: #951 

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
