### PR TITLE
Add Aqua ambiguities test

### DIFF
--- a/src/Geometry/axistensors.jl
+++ b/src/Geometry/axistensors.jl
@@ -177,7 +177,7 @@ Returns a `StaticArray` containing the components of `a` in its stored basis.
 """
 components(a::AxisTensor) = getfield(a, :components)
 
-Base.@propagate_inbounds Base.getindex(v::AxisTensor, i...) =
+Base.@propagate_inbounds Base.getindex(v::AxisTensor, i::Int...) =
     getindex(components(v), i...)
 
 
@@ -226,7 +226,7 @@ import Base: +, -, *, /, \, ==
 @inline *(a::Number, b::AxisTensor) = map(c -> a * c, b)
 @inline *(a::AxisTensor, b::Number) = map(c -> c * b, a)
 @inline /(a::AxisTensor, b::Number) = map(c -> c / b, a)
-@inline \(a, b::AxisTensor) = map(c -> a \ c, b)
+@inline \(a::Number, b::AxisTensor) = map(c -> a \ c, b)
 
 @inline (==)(a::AxisTensor, b::AxisTensor) =
     axes(a) == axes(b) && components(a) == components(b)

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -3237,7 +3237,7 @@ allow_mismatched_fd_spaces() = false
 )
 
 function Base.Broadcast.materialize!(
-    ::Base.Broadcast.BroadcastStyle,
+    ::DataLayouts.DataStyle,
     dest::Fields.Field,
     bc::Base.Broadcast.Broadcasted{Style},
 ) where {Style <: AbstractStencilStyle}

--- a/src/Operators/stencilcoefs.jl
+++ b/src/Operators/stencilcoefs.jl
@@ -94,11 +94,12 @@ for op in (:+, :-)
         ($op)(a::StencilCoefs) = map($op, a)
     end
 end
+const OPTYPES = Union{Number, Geometry.AxisTensor}
 for op in (:+, :-, :*, :/, :÷, :\, :^, :%)
     @eval begin
         import Base: $op
         ($op)(a::StencilCoefs, b::StencilCoefs) = map($op, a, b)
-        ($op)(a::StencilCoefs, b) = map(c -> ($op)(c, b), a)
-        ($op)(a, b::StencilCoefs) = map(c -> ($op)(a, c), b)
+        ($op)(a::StencilCoefs, b::OPTYPES) = map(c -> ($op)(c, b), a)
+        ($op)(a::OPTYPES, b::StencilCoefs) = map(c -> ($op)(a, c), b)
     end
 end

--- a/src/RecursiveApply/RecursiveApply.jl
+++ b/src/RecursiveApply/RecursiveApply.jl
@@ -130,6 +130,7 @@ Recursively add elements of `w * X + Y`.
 """
 rmuladd(w::Number, X, Y) = rmap((x, y) -> muladd(w, x, y), X, Y)
 rmuladd(X, w::Number, Y) = rmap((x, y) -> muladd(x, w, y), X, Y)
+rmuladd(X::Number, w::Number, Y) = rmap((x, y) -> muladd(x, w, y), X, Y)
 rmuladd(w::Number, x::Number, y::Number) = muladd(w, x, y)
 
 """

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -7,6 +7,21 @@ using Aqua
     # https://github.com/JuliaLang/julia/issues/29393
     Aqua.test_unbound_args(ClimaCore)
 
+    # See: https://github.com/SciML/OrdinaryDiffEq.jl/issues/1750
+    # Test that we're not introducing method ambiguities across deps
+    ambs = Aqua.detect_ambiguities(ClimaCore; recursive = true)
+    pkg_match(pkgname, pkdir::Nothing) = false
+    pkg_match(pkgname, pkdir::AbstractString) = occursin(pkgname, pkdir)
+    filter!(x -> pkg_match("ClimaCore", pkgdir(last(x).module)), ambs)
+    for method_ambiguity in ambs
+        @show method_ambiguity
+    end
+    # If the number of ambiguities is less than the limit below,
+    # then please lower the limit based on the new number of ambiguities.
+    # We're trying to drive this number down to zero to reduce latency.
+    @info "Number of method ambiguities: $(length(ambs))"
+    @test length(ambs) ≤ 129
+
     # returns a vector of all unbound args
     # ua = Aqua.detect_unbound_args_recursively(ClimaCore)
 end

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -20,7 +20,7 @@ using Aqua
     # then please lower the limit based on the new number of ambiguities.
     # We're trying to drive this number down to zero to reduce latency.
     @info "Number of method ambiguities: $(length(ambs))"
-    @test length(ambs) ≤ 129
+    @test length(ambs) ≤ 17
 
     # returns a vector of all unbound args
     # ua = Aqua.detect_unbound_args_recursively(ClimaCore)


### PR DESCRIPTION
This PR adds an Aqua test for method ambiguities that ClimaCore creates. Apparently this can hurt [compile times](https://github.com/SciML/OrdinaryDiffEq.jl/issues/1750), so I think it'd be good to hook in a test and try to drive them down.

This PR also fixes some of our most egregious ambiguities and knocks them down from 129 to 17 🚀.