### PR TITLE
Extend and fix Ref broadcasting with StencilCoefs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -118,6 +118,7 @@ steps:
       - "julia -O0 --color=yes --check-bounds=yes --project=test test/Operators/finitedifference/implicit_stencils.jl --float_type Float32"
     agents:
       config: cpu
+      slurm_mem: 10GB
       queue: central
       slurm_ntasks: 1
 
@@ -127,6 +128,7 @@ steps:
       - "julia -O0 --color=yes --check-bounds=yes --project=test test/Operators/finitedifference/implicit_stencils.jl --float_type Float64"
     agents:
       config: cpu
+      slurm_mem: 10GB
       queue: central
       slurm_ntasks: 1
 
@@ -775,6 +777,7 @@ steps:
       - "examples/hybrid/sphere/output/deformation_flow/*"
     agents:
       config: cpu
+      slurm_mem: 20GB
       queue: central
       slurm_ntasks: 1
 
@@ -786,6 +789,7 @@ steps:
       - "examples/hybrid/sphere/output/hadley_circulation/*"
     agents:
       config: cpu
+      slurm_mem: 20GB
       queue: central
       slurm_ntasks: 1
 
@@ -813,6 +817,7 @@ steps:
       TEST_NAME: "sphere/baroclinic_wave_rhoe"
     agents:
       config: cpu
+      slurm_mem: 10GB
       queue: central
       slurm_ntasks: 1
 
@@ -827,6 +832,7 @@ steps:
       CLIMACORE_DISTRIBUTED: "MPI"
     agents:
       config: cpu
+      slurm_mem: 20GB
       queue: central
       slurm_ntasks: 2
 
@@ -841,6 +847,7 @@ steps:
       TEST_NAME: "sphere/baroclinic_wave_rhotheta"
     agents:
       config: cpu
+      slurm_mem: 10GB
       queue: central
       slurm_ntasks: 1
 
@@ -874,6 +881,7 @@ steps:
       TEST_NAME: "sphere/balanced_flow_rhoe"
     agents:
       config: cpu
+      slurm_mem: 20GB
       queue: central
       slurm_ntasks: 1
 
@@ -900,6 +908,7 @@ steps:
       TEST_NAME: "sphere/held_suarez_rhoe"
     agents:
       config: cpu
+      slurm_mem: 10GB
       queue: central
       slurm_ntasks: 1
 
@@ -914,6 +923,7 @@ steps:
       FLOAT_TYPE: "Float64"
     agents:
       config: cpu
+      slurm_mem: 20GB
       queue: central
       slurm_ntasks: 1
 
@@ -940,6 +950,7 @@ steps:
       TEST_NAME: "sphere/held_suarez_rhoe_int"
     agents:
       config: cpu
+      slurm_mem: 10GB
       queue: central
       slurm_ntasks: 1
 
@@ -967,6 +978,7 @@ steps:
       Z_STRETCH: "true"
     agents:
       config: cpu
+      slurm_mem: 10GB
       queue: central
       slurm_ntasks: 1
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.10.15"
+version = "0.10.16"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -205,7 +205,7 @@ version = "0.3.0"
 deps = ["Adapt", "BlockArrays", "CUDA", "ClimaComms", "CubedSphere", "DataStructures", "DiffEqBase", "DocStringExtensions", "ForwardDiff", "GaussQuadrature", "GilbertCurves", "HDF5", "InteractiveUtils", "IntervalSets", "LinearAlgebra", "PkgVersion", "RecursiveArrayTools", "RootSolvers", "Rotations", "SparseArrays", "Static", "StaticArrays", "Statistics", "UnPack"]
 path = ".."
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
-version = "0.10.15"
+version = "0.10.16"
 
 [[deps.ClimaCoreMakie]]
 deps = ["ClimaCore", "Makie"]

--- a/examples/Manifest.toml
+++ b/examples/Manifest.toml
@@ -170,7 +170,7 @@ version = "0.3.2"
 deps = ["Adapt", "BlockArrays", "CUDA", "ClimaComms", "CubedSphere", "DataStructures", "DiffEqBase", "DocStringExtensions", "ForwardDiff", "GaussQuadrature", "GilbertCurves", "HDF5", "InteractiveUtils", "IntervalSets", "LinearAlgebra", "PkgVersion", "RecursiveArrayTools", "RootSolvers", "Rotations", "SparseArrays", "Static", "StaticArrays", "Statistics", "UnPack"]
 path = ".."
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
-version = "0.10.15"
+version = "0.10.16"
 
 [[deps.ClimaCorePlots]]
 deps = ["ClimaCore", "RecipesBase", "StaticArrays", "TriplotBase"]
@@ -529,10 +529,10 @@ uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
 version = "0.16.4"
 
 [[deps.GR]]
-deps = ["Base64", "DelimitedFiles", "GR_jll", "HTTP", "JSON", "Libdl", "LinearAlgebra", "Pkg", "Printf", "Random", "RelocatableFolders", "Serialization", "Sockets", "Test", "UUIDs"]
-git-tree-sha1 = "0ac6f27e784059c68b987f42b909ade0bcfabe69"
+deps = ["Base64", "DelimitedFiles", "GR_jll", "HTTP", "JSON", "Libdl", "LinearAlgebra", "Pkg", "Preferences", "Printf", "Random", "Serialization", "Sockets", "Test", "UUIDs"]
+git-tree-sha1 = "859e9cfa91d21ed87e8ea9f2998c94df1de12045"
 uuid = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
-version = "0.68.0"
+version = "0.69.2"
 
 [[deps.GR_jll]]
 deps = ["Artifacts", "Bzip2_jll", "Cairo_jll", "FFMPEG_jll", "Fontconfig_jll", "GLFW_jll", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libtiff_jll", "Pixman_jll", "Pkg", "Qt5Base_jll", "Zlib_jll", "libpng_jll"]
@@ -671,9 +671,9 @@ version = "1.0.0"
 
 [[deps.JLD2]]
 deps = ["FileIO", "MacroTools", "Mmap", "OrderedCollections", "Pkg", "Printf", "Reexport", "TranscodingStreams", "UUIDs"]
-git-tree-sha1 = "6c38bbe47948f74d63434abed68bdfc8d2c46b99"
+git-tree-sha1 = "0d0ad913e827d13c5e88a73f9333d7e33c424576"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.4.23"
+version = "0.4.24"
 
 [[deps.JLFzf]]
 deps = ["Pipe", "REPL", "Random", "fzf_jll"]
@@ -1146,9 +1146,9 @@ version = "1.3.1"
 
 [[deps.Plots]]
 deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "JLFzf", "JSON", "LaTeXStrings", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "RelocatableFolders", "Requires", "Scratch", "Showoff", "SnoopPrecompile", "SparseArrays", "Statistics", "StatsBase", "UUIDs", "UnicodeFun", "Unzip"]
-git-tree-sha1 = "284a353a34a352a95fca1d61ea28a0d48feaf273"
+git-tree-sha1 = "f60a3090028cdf16b33a62f97eaedf67a6509824"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-version = "1.34.4"
+version = "1.35.0"
 
 [[deps.Polyester]]
 deps = ["ArrayInterface", "BitTwiddlingConvenienceFunctions", "CPUSummary", "IfElse", "ManualMemory", "PolyesterWeave", "Requires", "Static", "StrideArraysCore", "ThreadingUtilities"]
@@ -1230,9 +1230,9 @@ version = "1.3.0"
 
 [[deps.RecipesPipeline]]
 deps = ["Dates", "NaNMath", "PlotUtils", "RecipesBase"]
-git-tree-sha1 = "e7eac76a958f8664f2718508435d058168c7953d"
+git-tree-sha1 = "017f217e647cf20b0081b9be938b78c3443356a0"
 uuid = "01d81517-befc-4cb6-b9ec-a95719d0359c"
-version = "0.6.3"
+version = "0.6.6"
 
 [[deps.RecursiveArrayTools]]
 deps = ["Adapt", "ArrayInterfaceCore", "ArrayInterfaceStaticArraysCore", "ChainRulesCore", "DocStringExtensions", "FillArrays", "GPUArraysCore", "IteratorInterfaceExtensions", "LinearAlgebra", "RecipesBase", "StaticArraysCore", "Statistics", "Tables", "ZygoteRules"]

--- a/perf/Manifest.toml
+++ b/perf/Manifest.toml
@@ -181,7 +181,7 @@ version = "0.3.2"
 deps = ["Adapt", "BlockArrays", "CUDA", "ClimaComms", "CubedSphere", "DataStructures", "DiffEqBase", "DocStringExtensions", "ForwardDiff", "GaussQuadrature", "GilbertCurves", "HDF5", "InteractiveUtils", "IntervalSets", "LinearAlgebra", "PkgVersion", "RecursiveArrayTools", "RootSolvers", "Rotations", "SparseArrays", "Static", "StaticArrays", "Statistics", "UnPack"]
 path = ".."
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
-version = "0.10.15"
+version = "0.10.16"
 
 [[deps.ClimaCorePlots]]
 deps = ["ClimaCore", "RecipesBase", "StaticArrays", "TriplotBase"]
@@ -585,10 +585,10 @@ uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
 version = "0.16.4"
 
 [[deps.GR]]
-deps = ["Base64", "DelimitedFiles", "GR_jll", "HTTP", "JSON", "Libdl", "LinearAlgebra", "Pkg", "Printf", "Random", "RelocatableFolders", "Serialization", "Sockets", "Test", "UUIDs"]
-git-tree-sha1 = "0ac6f27e784059c68b987f42b909ade0bcfabe69"
+deps = ["Base64", "DelimitedFiles", "GR_jll", "HTTP", "JSON", "Libdl", "LinearAlgebra", "Pkg", "Preferences", "Printf", "Random", "Serialization", "Sockets", "Test", "UUIDs"]
+git-tree-sha1 = "859e9cfa91d21ed87e8ea9f2998c94df1de12045"
 uuid = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
-version = "0.68.0"
+version = "0.69.2"
 
 [[deps.GR_jll]]
 deps = ["Artifacts", "Bzip2_jll", "Cairo_jll", "FFMPEG_jll", "Fontconfig_jll", "GLFW_jll", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libtiff_jll", "Pixman_jll", "Pkg", "Qt5Base_jll", "Zlib_jll", "libpng_jll"]
@@ -738,9 +738,9 @@ version = "0.6.5"
 
 [[deps.JLD2]]
 deps = ["FileIO", "MacroTools", "Mmap", "OrderedCollections", "Pkg", "Printf", "Reexport", "TranscodingStreams", "UUIDs"]
-git-tree-sha1 = "6c38bbe47948f74d63434abed68bdfc8d2c46b99"
+git-tree-sha1 = "0d0ad913e827d13c5e88a73f9333d7e33c424576"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.4.23"
+version = "0.4.24"
 
 [[deps.JLFzf]]
 deps = ["Pipe", "REPL", "Random", "fzf_jll"]
@@ -1231,9 +1231,9 @@ version = "1.3.1"
 
 [[deps.Plots]]
 deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "JLFzf", "JSON", "LaTeXStrings", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "RelocatableFolders", "Requires", "Scratch", "Showoff", "SnoopPrecompile", "SparseArrays", "Statistics", "StatsBase", "UUIDs", "UnicodeFun", "Unzip"]
-git-tree-sha1 = "284a353a34a352a95fca1d61ea28a0d48feaf273"
+git-tree-sha1 = "f60a3090028cdf16b33a62f97eaedf67a6509824"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-version = "1.34.4"
+version = "1.35.0"
 
 [[deps.Polyester]]
 deps = ["ArrayInterface", "BitTwiddlingConvenienceFunctions", "CPUSummary", "IfElse", "ManualMemory", "PolyesterWeave", "Requires", "Static", "StrideArraysCore", "ThreadingUtilities"]
@@ -1343,9 +1343,9 @@ version = "1.3.0"
 
 [[deps.RecipesPipeline]]
 deps = ["Dates", "NaNMath", "PlotUtils", "RecipesBase"]
-git-tree-sha1 = "e7eac76a958f8664f2718508435d058168c7953d"
+git-tree-sha1 = "017f217e647cf20b0081b9be938b78c3443356a0"
 uuid = "01d81517-befc-4cb6-b9ec-a95719d0359c"
-version = "0.6.3"
+version = "0.6.6"
 
 [[deps.RecursiveArrayTools]]
 deps = ["Adapt", "ArrayInterfaceCore", "ArrayInterfaceStaticArraysCore", "ChainRulesCore", "DocStringExtensions", "FillArrays", "GPUArraysCore", "IteratorInterfaceExtensions", "LinearAlgebra", "RecipesBase", "StaticArraysCore", "Statistics", "Tables", "ZygoteRules"]

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -3277,7 +3277,7 @@ function Base.similar(
     return Field(Eltype, sp)
 end
 
-function _serial_copyto!(
+@inline function _serial_copyto!(
     field_out::Field,
     bc::Base.Broadcast.Broadcasted{S},
     Ni::Int,
@@ -3290,7 +3290,7 @@ function _serial_copyto!(
     return field_out
 end
 
-function _threaded_copyto!(
+@inline function _threaded_copyto!(
     field_out::Field,
     bc::Base.Broadcast.Broadcasted{S},
     Ni::Int,
@@ -3307,7 +3307,7 @@ function _threaded_copyto!(
     return field_out
 end
 
-function Base.copyto!(
+@inline function Base.copyto!(
     field_out::Field,
     bc::Base.Broadcast.Broadcasted{S},
 ) where {S <: AbstractStencilStyle}
@@ -3320,7 +3320,7 @@ function Base.copyto!(
     return _serial_copyto!(field_out, bc, Ni, Nj, Nh)
 end
 
-function apply_stencil!(field_out, bc, hidx)
+Base.@propagate_inbounds function apply_stencil!(field_out, bc, hidx)
     space = axes(bc)
     if Topologies.isperiodic(Spaces.vertical_topology(space))
         @inbounds for idx in

--- a/test/Fields/field_opt.jl
+++ b/test/Fields/field_opt.jl
@@ -187,7 +187,11 @@ end
 
         allocs_test_Ref_with_compose!(S, ∂ᶠ𝕄ₜ∂ᶜρ, ∂ᶜρₜ∂ᶠ𝕄)
         p = @allocated allocs_test_Ref_with_compose!(S, ∂ᶠ𝕄ₜ∂ᶜρ, ∂ᶜρₜ∂ᶠ𝕄)
-        @test_broken p == 0
+        @test p == 0
+
+        allocs_test_Ref_with_compose_column!(S, ∂ᶠ𝕄ₜ∂ᶜρ, ∂ᶜρₜ∂ᶠ𝕄)
+        p = @allocated allocs_test_Ref_with_compose_column!(S, ∂ᶠ𝕄ₜ∂ᶜρ, ∂ᶜρₜ∂ᶠ𝕄)
+        @test p == 0
     end
 end
 nothing

--- a/test/Operators/finitedifference/opt_examples.jl
+++ b/test/Operators/finitedifference/opt_examples.jl
@@ -19,496 +19,539 @@ Base.@propagate_inbounds Base.getindex(
 a_bcs(::Type{FT}, i::Int) where {FT} =
     (; bottom = Operators.SetValue(FT(0)), top = Operators.Extrapolate())
 
-if VERSION >= v"1.7.0"
-    @testset "FD operator allocation tests" begin
-        FT = Float64
-        n_elems = 1000
-        domain = Domains.IntervalDomain(
-            Geometry.ZPoint{FT}(0.0),
-            Geometry.ZPoint{FT}(pi);
-            boundary_tags = (:bottom, :top),
-        )
-        mesh = Meshes.IntervalMesh(domain; nelems = n_elems)
-        cs = Spaces.CenterFiniteDifferenceSpace(mesh)
-        fs = Spaces.FaceFiniteDifferenceSpace(cs)
-        zc = getproperty(Fields.coordinate_field(cs), :z)
-        zf = getproperty(Fields.coordinate_field(fs), :z)
-        function field_wrapper(space, nt::NamedTuple)
-            cmv(z) = nt
-            return cmv.(Fields.coordinate_field(space))
-        end
-        field_vars() = (; x = FT(0), y = FT(0), z = FT(0), ϕ = FT(0), ψ = FT(0))
-        ntfield_vars() = (; nt = ntuple(i -> field_vars(), n_tuples))
-        cfield = field_wrapper(cs, field_vars())
-        ffield = field_wrapper(fs, field_vars())
-        ntcfield = field_wrapper(cs, ntfield_vars())
-        ntffield = field_wrapper(fs, ntfield_vars())
-        wvec_glob = Geometry.WVector
+function field_wrapper(space, nt::NamedTuple)
+    cmv(z) = nt
+    return cmv.(Fields.coordinate_field(space))
+end
 
-        cx = cfield.x
-        fx = ffield.x
-        cy = cfield.y
-        fy = ffield.y
-        cz = cfield.z
-        fz = ffield.z
-        cϕ = cfield.ϕ
-        fϕ = ffield.ϕ
-        cψ = cfield.ψ
-        fψ = ffield.ψ
-
-        function alloc_test_f2c_interp()
-            Ic = Operators.InterpolateF2C()
-            # Compile first
-            #! format: off
-            @. cfield.z = cfield.x * cfield.y * Ic(ffield.y) * Ic(ffield.x) * cfield.ϕ * cfield.ψ
-            p = @allocated begin
-                @. cfield.z = cfield.x * cfield.y * Ic(ffield.y) * Ic(ffield.x) * cfield.ϕ * cfield.ψ
-            end
-            #! format: off
-            @test p == 0
-            @. cz = cx * cy * Ic(fy) * Ic(fx) * cϕ * cψ
-            p = @allocated begin
-                @. cz = cx * cy * Ic(fy) * Ic(fx) * cϕ * cψ
-            end
-            @test p == 0
-            closure() = @. cz = cx * cy * Ic(fy) * Ic(fx) * cϕ * cψ
-            closure()
-            p = @allocated begin
-                closure()
-            end
-            @test p == 0
-        end
-        alloc_test_f2c_interp()
-
-        function alloc_test_c2f_interp(If)
-            wvec = Geometry.WVector
-            # Compile first
-            #! format: off
-            @. ffield.z = ffield.x * ffield.y * If(cfield.y) * If(cfield.x) * ffield.ϕ * ffield.ψ
-            p = @allocated begin
-                @. ffield.z = ffield.x * ffield.y * If(cfield.y) * If(cfield.x) * ffield.ϕ * ffield.ψ
-            end
-            #! format: on
-            @test p == 0
-            @. fz = fx * fy * If(cy) * If(cx) * fϕ * fψ
-            p = @allocated begin
-                @. fz = fx * fy * If(cy) * If(cx) * fϕ * fψ
-            end
-            @test p == 0
-            fclosure() = @. fz = fx * fy * If(cy) * If(cx) * fϕ * fψ
-            fclosure()
-            p = @allocated begin
-                fclosure()
-            end
-            @test p == 0
-        end
-
-        alloc_test_c2f_interp(
-            Operators.InterpolateC2F(;
-                bottom = Operators.SetValue(0),
-                top = Operators.SetValue(0),
-            ),
-        )
-        alloc_test_c2f_interp(
-            Operators.InterpolateC2F(;
-                bottom = Operators.SetGradient(wvec_glob(0)),
-                top = Operators.SetGradient(wvec_glob(0)),
-            ),
-        )
-        alloc_test_c2f_interp(
-            Operators.InterpolateC2F(;
-                bottom = Operators.Extrapolate(),
-                top = Operators.Extrapolate(),
-            ),
-        )
-        alloc_test_c2f_interp(
-            Operators.LeftBiasedC2F(; bottom = Operators.SetValue(0)),
-        )
-        alloc_test_c2f_interp(
-            Operators.RightBiasedC2F(; top = Operators.SetValue(0)),
-        )
-
-        function alloc_test_derivative(∇c, ∇f)
-            ##### F2C
-            wvec = Geometry.WVector
-            # Compile first
-            #! format: off
-            @. cfield.z =
-                cfield.x * cfield.y * ∇c(wvec(ffield.y)) * ∇c(wvec(ffield.x)) * cfield.ϕ * cfield.ψ
-            p = @allocated begin
-                @. cfield.z = cfield.x * cfield.y * ∇c(wvec(ffield.y)) * ∇c(wvec(ffield.x)) * cfield.ϕ * cfield.ψ
-            end
-            #! format: on
-            @test p == 0
-            @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
-            p = @allocated begin
-                @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
-            end
-            @test p == 0
-            c∇closure() =
-                @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
-            c∇closure()
-            p = @allocated begin
-                c∇closure()
-            end
-            @test p == 0
-
-            ##### C2F
-            # wvec = Geometry.WVector # cannot re-define, otherwise many allocations
-
-            # Compile first
-            @. fz = fx * fy * ∇f(wvec(cy)) * ∇f(wvec(cx)) * fϕ * fψ
-            p = @allocated begin
-                @. fz = fx * fy * ∇f(wvec(cy)) * ∇f(wvec(cx)) * fϕ * fψ
-            end
-            @test p == 0
-        end
-
-        alloc_test_derivative(
-            Operators.DivergenceF2C(),
-            Operators.DivergenceC2F(;
-                bottom = Operators.SetValue(wvec_glob(0)),
-                top = Operators.SetValue(wvec_glob(0)),
-            ),
-        )
-        alloc_test_derivative(
-            Operators.DivergenceF2C(;
-                bottom = Operators.SetValue(wvec_glob(0)),
-                top = Operators.SetValue(wvec_glob(0)),
-            ),
-            Operators.DivergenceC2F(;
-                bottom = Operators.SetValue(wvec_glob(0)),
-                top = Operators.SetValue(wvec_glob(0)),
-            ),
-        )
-        alloc_test_derivative(
-            Operators.DivergenceF2C(;
-                bottom = Operators.Extrapolate(),
-                top = Operators.Extrapolate(),
-            ),
-            Operators.DivergenceC2F(;
-                bottom = Operators.SetDivergence(0),
-                top = Operators.SetDivergence(0),
-            ),
-        )
-
-        function alloc_test_redefined_operators()
-            ∇c = Operators.DivergenceF2C()
-            wvec = Geometry.WVector
-            # Compile first
-            @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
-            p = @allocated begin
-                @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
-            end
-            @test_broken p == 0
-            c∇closure1() =
-                @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
-            c∇closure1()
-            p = @allocated begin
-                c∇closure1()
-            end
-            @test_broken p == 0
-
-            # Now simply repeat above:
-            ∇c = Operators.DivergenceF2C()
-            wvec = Geometry.WVector
-            # Compile first
-            @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
-            p = @allocated begin
-                @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
-            end
-            @test_broken p == 0
-            c∇closure2() =
-                @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
-            c∇closure2()
-            p = @allocated begin
-                c∇closure2()
-            end
-            @test_broken p == 0
-        end
-        alloc_test_redefined_operators()
-
-        function alloc_test_operators_in_loops()
-            for i in 1:3
-                wvec = Geometry.WVector
-                bcval = i * 2
-                bcs = (;
-                    bottom = Operators.SetValue(wvec(bcval)),
-                    top = Operators.SetValue(wvec(bcval)),
-                )
-                ∇c = Operators.DivergenceF2C(; bcs...)
-                # Compile first
-                @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
-                p = @allocated begin
-                    @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
-                end
-                @test p == 0
-                c∇closure() =
-                    @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
-                c∇closure()
-                p = @allocated begin
-                    c∇closure()
-                end
-                @test p == 0
-            end
-        end
-        alloc_test_operators_in_loops()
-
-        function alloc_test_nested_expressions_1()
-
-            ∇c = Operators.DivergenceF2C()
-            wvec = Geometry.WVector
-            LB = Operators.LeftBiasedC2F(; bottom = Operators.SetValue(1))
-            @. cz = cx * cy * ∇c(wvec(LB(cy))) * ∇c(wvec(LB(cx))) * cϕ * cψ # Compile first
-            p = @allocated begin
-                @. cz = cx * cy * ∇c(wvec(LB(cy))) * ∇c(wvec(LB(cx))) * cϕ * cψ
-            end
-            @test p == 0
-        end
-
-        function alloc_test_nested_expressions_2()
-            ∇c = Operators.DivergenceF2C()
-            wvec = Geometry.WVector
-            RB = Operators.RightBiasedC2F(; top = Operators.SetValue(1))
-            @. cz = cx * cy * ∇c(wvec(RB(cy))) * ∇c(wvec(RB(cx))) * cϕ * cψ # Compile first
-            p = @allocated begin
-                @. cz = cx * cy * ∇c(wvec(RB(cy))) * ∇c(wvec(RB(cx))) * cϕ * cψ
-            end
-            @test p == 0
-        end
-
-        function alloc_test_nested_expressions_3()
-            Ic = Operators.InterpolateF2C()
-            ∇c = Operators.DivergenceF2C()
-            wvec = Geometry.WVector
-            LB = Operators.LeftBiasedC2F(; bottom = Operators.SetValue(1))
-            #! format: off
-            @. cz = cx * cy * ∇c(wvec(LB(Ic(fy) * cx))) * ∇c(wvec(LB(Ic(fy) * cx))) * cϕ * cψ # Compile first
-            p = @allocated begin
-                @. cz = cx * cy * ∇c(wvec(LB(Ic(fy) * cx))) * ∇c(wvec(LB(Ic(fy) * cx))) * cϕ * cψ
-            end
-            #! format: on
-            @test p == 0
-        end
-
-        function alloc_test_nested_expressions_4()
-            wvec = Geometry.WVector
-            If = Operators.InterpolateC2F(;
-                bottom = Operators.SetValue(0),
-                top = Operators.SetValue(0),
-            )
-            ∇f = Operators.DivergenceC2F(;
-                bottom = Operators.SetValue(wvec(0)),
-                top = Operators.SetValue(wvec(0)),
-            )
-            LB = Operators.LeftBiasedF2C(; bottom = Operators.SetValue(1))
-            #! format: off
-            @. fz = fx * fy * ∇f(wvec(LB(If(cy) * fx))) * ∇f(wvec(LB(If(cy) * fx))) * fϕ * fψ # Compile first
-            p = @allocated begin
-                @. fz = fx * fy * ∇f(wvec(LB(If(cy) * fx))) * ∇f(wvec(LB(If(cy) * fx))) * fϕ * fψ
-            end
-            #! format: on
-            @test p == 0
-        end
-
-        function alloc_test_nested_expressions_5()
-            wvec = Geometry.WVector
-            If = Operators.InterpolateC2F(;
-                bottom = Operators.SetValue(0),
-                top = Operators.SetValue(0),
-            )
-            ∇c = Operators.DivergenceF2C()
-            #! format: off
-            @. cz = cx * cy * ∇c(wvec(If(cy) * fx)) * ∇c(wvec(If(cy) * fx)) * cϕ * cψ # Compile first
-            p = @allocated begin
-                @. cz = cx * cy * ∇c(wvec(If(cy) * fx)) * ∇c(wvec(If(cy) * fx)) * cϕ * cψ
-            end
-            #! format: off
-            @test p == 0
-        end
-
-        function alloc_test_nested_expressions_6()
-            wvec = Geometry.WVector
-            Ic = Operators.InterpolateF2C()
-            ∇f = Operators.DivergenceC2F(;
-                bottom = Operators.SetValue(wvec(0)),
-                top = Operators.SetValue(wvec(0)),
-            )
-            #! format: off
-            @. fz = fx * fy * ∇f(wvec(Ic(fy) * cx)) * ∇f(wvec(Ic(fy) * cx)) * fϕ * fψ # Compile first
-            p = @allocated begin
-                @. fz = fx * fy * ∇f(wvec(Ic(fy) * cx)) * ∇f(wvec(Ic(fy) * cx)) * fϕ * fψ
-            end
-            #! format: on
-            @test p == 0
-        end
-
-        function alloc_test_nested_expressions_7()
-            # similar to alloc_test_nested_expressions_8
-            Ic = Operators.InterpolateF2C()
-            @. cz = cx * cy * Ic(fy) * Ic(fy) * cϕ * cψ # Compile first
-            p = @allocated begin
-                @. cz = cx * cy * Ic(fy) * Ic(fy) * cϕ * cψ
-            end
-            @test p == 0
-        end
-
-        function alloc_test_nested_expressions_8()
-            wvec = Geometry.WVector
-            Ic = Operators.InterpolateF2C()
-            @. cz = cx * cy * abs(Ic(fy)) * abs(Ic(fy)) * cϕ * cψ # Compile first
-            p = @allocated begin
-                @. cz = cx * cy * abs(Ic(fy)) * abs(Ic(fy)) * cϕ * cψ
-            end
-            @test p == 0
-        end
-
-        function alloc_test_nested_expressions_9()
-            wvec = Geometry.WVector
-            Ic = Operators.InterpolateF2C()
-            @. cz = Int(cx < cy) * abs(Ic(fy)) * abs(Ic(fy)) * cϕ * cψ # Compile first
-            p = @allocated begin
-                @. cz = Int(cx < cy) * abs(Ic(fy)) * abs(Ic(fy)) * cϕ * cψ
-            end
-            @test p == 0
-        end
-
-        function alloc_test_nested_expressions_10()
-            Ic = Operators.InterpolateF2C()
-            @. cz = ifelse(cx < cy, abs(Ic(fy)) * abs(Ic(fy)) * cϕ * cψ, 0) # Compile first
-            p = @allocated begin
-                @. cz = ifelse(cx < cy, abs(Ic(fy)) * abs(Ic(fy)) * cϕ * cψ, 0)
-            end
-            @test p == 0
-        end
-
-        function alloc_test_nested_expressions_11()
-            If = Operators.InterpolateC2F(;
-                bottom = Operators.SetValue(0.0),
-                top = Operators.SetValue(0.0),
-            )
-            @. fz = fx * fy * abs(If(cy * cx)) * abs(If(cy * cx)) * fϕ * fψ # Compile first
-            p = @allocated begin
-                @. fz = fx * fy * abs(If(cy * cx)) * abs(If(cy * cx)) * fϕ * fψ
-            end
-            @test p == 0
-        end
-
-        function alloc_test_nested_expressions_12()
-
-            Ic = Operators.InterpolateF2C()
-            cnt = ntcfield.nt
-            fnt = ntffield.nt
-
-            # Compile first
-            @inbounds for i in 1:n_tuples
-                cnt_i = cnt[i]
-                fnt_i = fnt[i]
-                cxnt = cnt_i.x
-                fxnt = fnt_i.x
-                cynt = cnt_i.y
-                fynt = fnt_i.y
-                cznt = cnt_i.z
-                fznt = fnt_i.z
-                cϕnt = cnt_i.ϕ
-                fϕnt = fnt_i.ϕ
-                cψnt = cnt_i.ψ
-                fψnt = fnt_i.ψ
-                @. cznt = cxnt * cynt * Ic(fynt) * Ic(fynt) * cϕnt * cψnt
-            end
-
-            @inbounds for i in 1:n_tuples
-                p_i = @allocated begin
-                    cnt_i = cnt[i]
-                    fnt_i = fnt[i]
-                end
-                @test p_i == 0
-                cxnt = cnt_i.x
-                fxnt = fnt_i.x
-                cynt = cnt_i.y
-                fynt = fnt_i.y
-                cznt = cnt_i.z
-                fznt = fnt_i.z
-                cϕnt = cnt_i.ϕ
-                fϕnt = fnt_i.ϕ
-                cψnt = cnt_i.ψ
-                fψnt = fnt_i.ψ
-                p = @allocated begin
-                    @. cznt = cxnt * cynt * Ic(fynt) * Ic(fynt) * cϕnt * cψnt
-                end
-                @test p == 0
-            end
-        end
-
-        function alloc_test_nested_expressions_13(::Type{FT}) where {FT}
-
-            Ic = Operators.InterpolateF2C()
-            cnt = ntcfield.nt
-            fnt = ntffield.nt
-            wvec = Geometry.WVector
-
-            adv_bcs = (;
-                bottom = Operators.SetValue(wvec(FT(0))),
-                top = Operators.SetValue(wvec(FT(0))),
-            )
-            LBC = Operators.LeftBiasedF2C(; bottom = Operators.SetValue(FT(0)))
-            zero_bcs = (;
-                bottom = Operators.SetValue(FT(0)),
-                top = Operators.SetValue(FT(0)),
-            )
-            I0f = Operators.InterpolateC2F(; zero_bcs...)
-            ∇f = Operators.DivergenceC2F(; adv_bcs...)
-
-            # Compile first
-            @inbounds for i in 1:n_tuples
-                cnt_i = cnt[i]
-                fnt_i = fnt[i]
-                cxnt = cnt_i.x
-                fxnt = fnt_i.x
-                fynt = fnt_i.y
-                a_up_bcs = a_bcs(FT, i)
-                Iaf1 = Operators.InterpolateC2F(; a_up_bcs...)
-                @. fynt =
-                    -(∇f(wvec(LBC(Iaf1(cxnt) * fx * fxnt * fxnt)))) +
-                    (fx * Iaf1(cxnt) * fxnt * (I0f(cz) * fy - I0f(cy) * fxnt)) +
-                    (fx * Iaf1(cxnt) * I0f(cϕ)) +
-                    fψ
-            end
-
-            @inbounds for i in 1:n_tuples
-                cnt_i = cnt[i]
-                fnt_i = fnt[i]
-                cxnt = cnt_i.x
-                fxnt = fnt_i.x
-                fynt = fnt_i.y
-                #! format: off
-                p_i = @allocated begin
-                    a_up_bcs = a_bcs(FT, i)
-                    Iaf2 = Operators.InterpolateC2F(; a_up_bcs...)
-                    # add extra parentheses so that we call +(+(a,b,c),d), as +(a,b,c,d) triggers allocations
-                    @. fynt =
-                        (-(∇f(wvec(LBC(Iaf2(cxnt) * fx * fxnt * fxnt)))) +
-                        (fx * Iaf2(cxnt) * fxnt * (I0f(cz) * fy - I0f(cy) * fxnt)) +
-                        (fx * Iaf2(cxnt) * I0f(cϕ))) +
-                        fψ
-                end
-                #! format: on
-                @test p_i == 0
-            end
-        end
-
-        alloc_test_nested_expressions_1()
-        alloc_test_nested_expressions_2()
-        alloc_test_nested_expressions_3()
-        alloc_test_nested_expressions_4()
-        alloc_test_nested_expressions_5()
-        alloc_test_nested_expressions_6()
-        alloc_test_nested_expressions_7()
-        alloc_test_nested_expressions_8()
-        alloc_test_nested_expressions_9()
-        alloc_test_nested_expressions_10()
-        alloc_test_nested_expressions_11()
-        alloc_test_nested_expressions_12()
-        alloc_test_nested_expressions_13(FT)
+function alloc_test_f2c_interp(cfield, ffield)
+    (; fx, fy, fz, fϕ, fψ) = ffield
+    (; cx, cy, cz, cϕ, cψ) = cfield
+    Ic = Operators.InterpolateF2C()
+    # Compile first
+    #! format: off
+    @. cfield.cz = cfield.cx * cfield.cy * Ic(ffield.fy) * Ic(ffield.fx) * cfield.cϕ * cfield.cψ
+    p = @allocated begin
+        @. cfield.cz = cfield.cx * cfield.cy * Ic(ffield.fy) * Ic(ffield.fx) * cfield.cϕ * cfield.cψ
     end
+    #! format: off
+    @test p == 0
+    @. cz = cx * cy * Ic(fy) * Ic(fx) * cϕ * cψ
+    p = @allocated begin
+        @. cz = cx * cy * Ic(fy) * Ic(fx) * cϕ * cψ
+    end
+    @test p == 0
+    closure() = @. cz = cx * cy * Ic(fy) * Ic(fx) * cϕ * cψ
+    closure()
+    p = @allocated begin
+        closure()
+    end
+    @test p == 0
+end
+
+function alloc_test_c2f_interp(cfield, ffield, If)
+    (;fx,fy,fz,fϕ,fψ) = ffield
+    (;cx,cy,cz,cϕ,cψ) = cfield
+    wvec = Geometry.WVector
+    # Compile first
+    #! format: off
+    @. ffield.fz = ffield.fx * ffield.fy * If(cfield.cy) * If(cfield.cx) * ffield.fϕ * ffield.fψ
+    p = @allocated begin
+        @. ffield.fz = ffield.fx * ffield.fy * If(cfield.cy) * If(cfield.cx) * ffield.fϕ * ffield.fψ
+    end
+    #! format: on
+    @test p == 0
+    @. fz = fx * fy * If(cy) * If(cx) * fϕ * fψ
+    p = @allocated begin
+        @. fz = fx * fy * If(cy) * If(cx) * fϕ * fψ
+    end
+    @test p == 0
+    fclosure() = @. fz = fx * fy * If(cy) * If(cx) * fϕ * fψ
+    fclosure()
+    p = @allocated begin
+        fclosure()
+    end
+    @test p == 0
+end
+
+function alloc_test_derivative(cfield, ffield, ∇c, ∇f)
+    (; fx, fy, fz, fϕ, fψ) = ffield
+    (; cx, cy, cz, cϕ, cψ) = cfield
+    ##### F2C
+    wvec = Geometry.WVector
+    # Compile first
+    #! format: off
+    @. cfield.cz =
+        cfield.cx * cfield.cy * ∇c(wvec(ffield.fy)) * ∇c(wvec(ffield.fx)) * cfield.cϕ * cfield.cψ
+    p = @allocated begin
+        @. cfield.cz = cfield.cx * cfield.cy * ∇c(wvec(ffield.fy)) * ∇c(wvec(ffield.fx)) * cfield.cϕ * cfield.cψ
+    end
+    #! format: on
+    @test p == 0
+    @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
+    p = @allocated begin
+        @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
+    end
+    @test p == 0
+    c∇closure() = @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
+    c∇closure()
+    p = @allocated begin
+        c∇closure()
+    end
+    @test_broken p == 0
+
+    ##### C2F
+    # wvec = Geometry.WVector # cannot re-define, otherwise many allocations
+
+    # Compile first
+    @. fz = fx * fy * ∇f(wvec(cy)) * ∇f(wvec(cx)) * fϕ * fψ
+    p = @allocated begin
+        @. fz = fx * fy * ∇f(wvec(cy)) * ∇f(wvec(cx)) * fϕ * fψ
+    end
+    @test p == 0
+end
+
+function alloc_test_redefined_operators(cfield, ffield)
+    (; fx, fy, fz, fϕ, fψ) = ffield
+    (; cx, cy, cz, cϕ, cψ) = cfield
+    ∇c = Operators.DivergenceF2C()
+    wvec = Geometry.WVector
+    # Compile first
+    @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
+    p = @allocated begin
+        @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
+    end
+    @test_broken p == 0
+    c∇closure1() = @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
+    c∇closure1()
+    p = @allocated begin
+        c∇closure1()
+    end
+    @test_broken p == 0
+
+    # Now simply repeat above:
+    ∇c = Operators.DivergenceF2C()
+    wvec = Geometry.WVector
+    # Compile first
+    @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
+    p = @allocated begin
+        @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
+    end
+    @test_broken p == 0
+    c∇closure2() = @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
+    c∇closure2()
+    p = @allocated begin
+        c∇closure2()
+    end
+    @test_broken p == 0
+end
+
+function alloc_test_operators_in_loops(cfield, ffield)
+    (; fx, fy, fz, fϕ, fψ) = ffield
+    (; cx, cy, cz, cϕ, cψ) = cfield
+    for i in 1:3
+        wvec = Geometry.WVector
+        bcval = i * 2
+        bcs = (;
+            bottom = Operators.SetValue(wvec(bcval)),
+            top = Operators.SetValue(wvec(bcval)),
+        )
+        ∇c = Operators.DivergenceF2C(; bcs...)
+        # Compile first
+        @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
+        p = @allocated begin
+            @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
+        end
+        @test p == 0
+        c∇closure() = @. cz = cx * cy * ∇c(wvec(fy)) * ∇c(wvec(fx)) * cϕ * cψ
+        c∇closure()
+        p = @allocated begin
+            c∇closure()
+        end
+        @test_broken p == 0
+    end
+end
+function alloc_test_nested_expressions_1(cfield, ffield)
+    (; fx, fy, fz, fϕ, fψ) = ffield
+    (; cx, cy, cz, cϕ, cψ) = cfield
+    ∇c = Operators.DivergenceF2C()
+    wvec = Geometry.WVector
+    LB = Operators.LeftBiasedC2F(; bottom = Operators.SetValue(1))
+    @. cz = cx * cy * ∇c(wvec(LB(cy))) * ∇c(wvec(LB(cx))) * cϕ * cψ # Compile first
+    p = @allocated begin
+        @. cz = cx * cy * ∇c(wvec(LB(cy))) * ∇c(wvec(LB(cx))) * cϕ * cψ
+    end
+    @test p == 0
+end
+
+function alloc_test_nested_expressions_2(cfield, ffield)
+    (; fx, fy, fz, fϕ, fψ) = ffield
+    (; cx, cy, cz, cϕ, cψ) = cfield
+    ∇c = Operators.DivergenceF2C()
+    wvec = Geometry.WVector
+    RB = Operators.RightBiasedC2F(; top = Operators.SetValue(1))
+    @. cz = cx * cy * ∇c(wvec(RB(cy))) * ∇c(wvec(RB(cx))) * cϕ * cψ # Compile first
+    p = @allocated begin
+        @. cz = cx * cy * ∇c(wvec(RB(cy))) * ∇c(wvec(RB(cx))) * cϕ * cψ
+    end
+    @test p == 0
+end
+
+function alloc_test_nested_expressions_3(cfield, ffield)
+    (; fx, fy, fz, fϕ, fψ) = ffield
+    (; cx, cy, cz, cϕ, cψ) = cfield
+    Ic = Operators.InterpolateF2C()
+    ∇c = Operators.DivergenceF2C()
+    wvec = Geometry.WVector
+    LB = Operators.LeftBiasedC2F(; bottom = Operators.SetValue(1))
+    #! format: off
+    @. cz = cx * cy * ∇c(wvec(LB(Ic(fy) * cx))) * ∇c(wvec(LB(Ic(fy) * cx))) * cϕ * cψ # Compile first
+    p = @allocated begin
+        @. cz = cx * cy * ∇c(wvec(LB(Ic(fy) * cx))) * ∇c(wvec(LB(Ic(fy) * cx))) * cϕ * cψ
+    end
+    #! format: on
+    @test p == 0
+end
+
+function alloc_test_nested_expressions_4(cfield, ffield)
+    (; fx, fy, fz, fϕ, fψ) = ffield
+    (; cx, cy, cz, cϕ, cψ) = cfield
+    wvec = Geometry.WVector
+    If = Operators.InterpolateC2F(;
+        bottom = Operators.SetValue(0),
+        top = Operators.SetValue(0),
+    )
+    ∇f = Operators.DivergenceC2F(;
+        bottom = Operators.SetValue(wvec(0)),
+        top = Operators.SetValue(wvec(0)),
+    )
+    LB = Operators.LeftBiasedF2C(; bottom = Operators.SetValue(1))
+    #! format: off
+    @. fz = fx * fy * ∇f(wvec(LB(If(cy) * fx))) * ∇f(wvec(LB(If(cy) * fx))) * fϕ * fψ # Compile first
+    p = @allocated begin
+        @. fz = fx * fy * ∇f(wvec(LB(If(cy) * fx))) * ∇f(wvec(LB(If(cy) * fx))) * fϕ * fψ
+    end
+    #! format: on
+    @test p == 0
+end
+
+function alloc_test_nested_expressions_5(cfield, ffield)
+    (; fx, fy, fz, fϕ, fψ) = ffield
+    (; cx, cy, cz, cϕ, cψ) = cfield
+    wvec = Geometry.WVector
+    If = Operators.InterpolateC2F(;
+        bottom = Operators.SetValue(0),
+        top = Operators.SetValue(0),
+    )
+    ∇c = Operators.DivergenceF2C()
+    #! format: off
+    @. cz = cx * cy * ∇c(wvec(If(cy) * fx)) * ∇c(wvec(If(cy) * fx)) * cϕ * cψ # Compile first
+    p = @allocated begin
+        @. cz = cx * cy * ∇c(wvec(If(cy) * fx)) * ∇c(wvec(If(cy) * fx)) * cϕ * cψ
+    end
+    #! format: off
+    @test p == 0
+end
+
+function alloc_test_nested_expressions_6(cfield, ffield)
+    (;fx,fy,fz,fϕ,fψ) = ffield
+    (;cx,cy,cz,cϕ,cψ) = cfield
+    wvec = Geometry.WVector
+    Ic = Operators.InterpolateF2C()
+    ∇f = Operators.DivergenceC2F(;
+        bottom = Operators.SetValue(wvec(0)),
+        top = Operators.SetValue(wvec(0)),
+    )
+    #! format: off
+    @. fz = fx * fy * ∇f(wvec(Ic(fy) * cx)) * ∇f(wvec(Ic(fy) * cx)) * fϕ * fψ # Compile first
+    p = @allocated begin
+        @. fz = fx * fy * ∇f(wvec(Ic(fy) * cx)) * ∇f(wvec(Ic(fy) * cx)) * fϕ * fψ
+    end
+    #! format: on
+    @test p == 0
+end
+
+function alloc_test_nested_expressions_7(cfield, ffield)
+    (; fx, fy, fz, fϕ, fψ) = ffield
+    (; cx, cy, cz, cϕ, cψ) = cfield
+    # similar to alloc_test_nested_expressions_8
+    Ic = Operators.InterpolateF2C()
+    @. cz = cx * cy * Ic(fy) * Ic(fy) * cϕ * cψ # Compile first
+    p = @allocated begin
+        @. cz = cx * cy * Ic(fy) * Ic(fy) * cϕ * cψ
+    end
+    @test p == 0
+end
+
+function alloc_test_nested_expressions_8(cfield, ffield)
+    (; fx, fy, fz, fϕ, fψ) = ffield
+    (; cx, cy, cz, cϕ, cψ) = cfield
+    wvec = Geometry.WVector
+    Ic = Operators.InterpolateF2C()
+    @. cz = cx * cy * abs(Ic(fy)) * abs(Ic(fy)) * cϕ * cψ # Compile first
+    p = @allocated begin
+        @. cz = cx * cy * abs(Ic(fy)) * abs(Ic(fy)) * cϕ * cψ
+    end
+    @test p == 0
+end
+
+function alloc_test_nested_expressions_9(cfield, ffield)
+    (; fx, fy, fz, fϕ, fψ) = ffield
+    (; cx, cy, cz, cϕ, cψ) = cfield
+    wvec = Geometry.WVector
+    Ic = Operators.InterpolateF2C()
+    @. cz = Int(cx < cy) * abs(Ic(fy)) * abs(Ic(fy)) * cϕ * cψ # Compile first
+    p = @allocated begin
+        @. cz = Int(cx < cy) * abs(Ic(fy)) * abs(Ic(fy)) * cϕ * cψ
+    end
+    @test p == 0
+end
+
+function alloc_test_nested_expressions_10(cfield, ffield)
+    (; fx, fy, fz, fϕ, fψ) = ffield
+    (; cx, cy, cz, cϕ, cψ) = cfield
+    Ic = Operators.InterpolateF2C()
+    @. cz = ifelse(cx < cy, abs(Ic(fy)) * abs(Ic(fy)) * cϕ * cψ, 0) # Compile first
+    p = @allocated begin
+        @. cz = ifelse(cx < cy, abs(Ic(fy)) * abs(Ic(fy)) * cϕ * cψ, 0)
+    end
+    @test p == 0
+end
+
+function alloc_test_nested_expressions_11(cfield, ffield)
+    (; fx, fy, fz, fϕ, fψ) = ffield
+    (; cx, cy, cz, cϕ, cψ) = cfield
+    If = Operators.InterpolateC2F(;
+        bottom = Operators.SetValue(0.0),
+        top = Operators.SetValue(0.0),
+    )
+    @. fz = fx * fy * abs(If(cy * cx)) * abs(If(cy * cx)) * fϕ * fψ # Compile first
+    p = @allocated begin
+        @. fz = fx * fy * abs(If(cy * cx)) * abs(If(cy * cx)) * fϕ * fψ
+    end
+    @test p == 0
+end
+
+function alloc_test_nested_expressions_12(cfield, ffield, ntcfield, ntffield)
+    (; fx, fy, fz, fϕ, fψ) = ffield
+    (; cx, cy, cz, cϕ, cψ) = cfield
+
+    Ic = Operators.InterpolateF2C()
+    cnt = ntcfield.nt
+    fnt = ntffield.nt
+
+    # Compile first
+    @inbounds for i in 1:n_tuples
+        cnt_i = cnt[i]
+        fnt_i = fnt[i]
+        cxnt = cnt_i.cx
+        fxnt = fnt_i.fx
+        cynt = cnt_i.cy
+        fynt = fnt_i.fy
+        cznt = cnt_i.cz
+        fznt = fnt_i.fz
+        cϕnt = cnt_i.cϕ
+        fϕnt = fnt_i.fϕ
+        cψnt = cnt_i.cψ
+        fψnt = fnt_i.fψ
+        @. cznt = cxnt * cynt * Ic(fynt) * Ic(fynt) * cϕnt * cψnt
+    end
+
+    @inbounds for i in 1:n_tuples
+        p_i = @allocated begin
+            cnt_i = cnt[i]
+            fnt_i = fnt[i]
+        end
+        @test p_i == 0
+        cxnt = cnt_i.cx
+        fxnt = fnt_i.fx
+        cynt = cnt_i.cy
+        fynt = fnt_i.fy
+        cznt = cnt_i.cz
+        fznt = fnt_i.fz
+        cϕnt = cnt_i.cϕ
+        fϕnt = fnt_i.fϕ
+        cψnt = cnt_i.cψ
+        fψnt = fnt_i.fψ
+        p = @allocated begin
+            @. cznt = cxnt * cynt * Ic(fynt) * Ic(fynt) * cϕnt * cψnt
+        end
+        @test p == 0
+    end
+end
+
+function alloc_test_nested_expressions_13(
+    cfield,
+    ffield,
+    ntcfield,
+    ntffield,
+    ::Type{FT},
+) where {FT}
+    (; fx, fy, fz, fϕ, fψ) = ffield
+    (; cx, cy, cz, cϕ, cψ) = cfield
+
+    Ic = Operators.InterpolateF2C()
+    cnt = ntcfield.nt
+    fnt = ntffield.nt
+    wvec = Geometry.WVector
+
+    adv_bcs = (;
+        bottom = Operators.SetValue(wvec(FT(0))),
+        top = Operators.SetValue(wvec(FT(0))),
+    )
+    LBC = Operators.LeftBiasedF2C(; bottom = Operators.SetValue(FT(0)))
+    zero_bcs =
+        (; bottom = Operators.SetValue(FT(0)), top = Operators.SetValue(FT(0)))
+    I0f = Operators.InterpolateC2F(; zero_bcs...)
+    ∇f = Operators.DivergenceC2F(; adv_bcs...)
+
+    # Compile first
+    @inbounds for i in 1:n_tuples
+        cnt_i = cnt[i]
+        fnt_i = fnt[i]
+        cxnt = cnt_i.cx
+        fxnt = fnt_i.fx
+        fynt = fnt_i.fy
+        a_up_bcs = a_bcs(FT, i)
+        Iaf1 = Operators.InterpolateC2F(; a_up_bcs...)
+        @. fynt =
+            -(∇f(wvec(LBC(Iaf1(cxnt) * fx * fxnt * fxnt)))) +
+            (fx * Iaf1(cxnt) * fxnt * (I0f(cz) * fy - I0f(cy) * fxnt)) +
+            (fx * Iaf1(cxnt) * I0f(cϕ)) +
+            fψ
+    end
+
+    @inbounds for i in 1:n_tuples
+        cnt_i = cnt[i]
+        fnt_i = fnt[i]
+        cxnt = cnt_i.cx
+        fxnt = fnt_i.fx
+        fynt = fnt_i.fy
+        #! format: off
+        p_i = @allocated begin
+            a_up_bcs = a_bcs(FT, i)
+            Iaf2 = Operators.InterpolateC2F(; a_up_bcs...)
+            # add extra parentheses so that we call +(+(a,b,c),d), as +(a,b,c,d) triggers allocations
+            @. fynt =
+                (-(∇f(wvec(LBC(Iaf2(cxnt) * fx * fxnt * fxnt)))) +
+                (fx * Iaf2(cxnt) * fxnt * (I0f(cz) * fy - I0f(cy) * fxnt)) +
+                (fx * Iaf2(cxnt) * I0f(cϕ))) +
+                fψ
+        end
+        #! format: on
+        @test p_i == 0
+    end
+end
+
+@testset "FD operator allocation tests" begin
+    FT = Float64
+    n_elems = 1000
+    domain = Domains.IntervalDomain(
+        Geometry.ZPoint{FT}(0.0),
+        Geometry.ZPoint{FT}(pi);
+        boundary_tags = (:bottom, :top),
+    )
+    mesh = Meshes.IntervalMesh(domain; nelems = n_elems)
+    cs = Spaces.CenterFiniteDifferenceSpace(mesh)
+    fs = Spaces.FaceFiniteDifferenceSpace(cs)
+    zc = getproperty(Fields.coordinate_field(cs), :z)
+    zf = getproperty(Fields.coordinate_field(fs), :z)
+    cfield_vars() =
+        (; cx = FT(0), cy = FT(0), cz = FT(0), cϕ = FT(0), cψ = FT(0))
+    ffield_vars() =
+        (; fx = FT(0), fy = FT(0), fz = FT(0), fϕ = FT(0), fψ = FT(0))
+    cntfield_vars() = (; nt = ntuple(i -> cfield_vars(), n_tuples))
+    fntfield_vars() = (; nt = ntuple(i -> ffield_vars(), n_tuples))
+    cfield = field_wrapper(cs, cfield_vars())
+    ffield = field_wrapper(fs, ffield_vars())
+    ntcfield = field_wrapper(cs, cntfield_vars())
+    ntffield = field_wrapper(fs, fntfield_vars())
+    wvec_glob = Geometry.WVector
+
+    alloc_test_f2c_interp(cfield, ffield)
+
+    alloc_test_c2f_interp(
+        cfield,
+        ffield,
+        Operators.InterpolateC2F(;
+            bottom = Operators.SetValue(0),
+            top = Operators.SetValue(0),
+        ),
+    )
+    alloc_test_c2f_interp(
+        cfield,
+        ffield,
+        Operators.InterpolateC2F(;
+            bottom = Operators.SetGradient(wvec_glob(0)),
+            top = Operators.SetGradient(wvec_glob(0)),
+        ),
+    )
+    alloc_test_c2f_interp(
+        cfield,
+        ffield,
+        Operators.InterpolateC2F(;
+            bottom = Operators.Extrapolate(),
+            top = Operators.Extrapolate(),
+        ),
+    )
+    alloc_test_c2f_interp(
+        cfield,
+        ffield,
+        Operators.LeftBiasedC2F(; bottom = Operators.SetValue(0)),
+    )
+    alloc_test_c2f_interp(
+        cfield,
+        ffield,
+        Operators.RightBiasedC2F(; top = Operators.SetValue(0)),
+    )
+
+    alloc_test_derivative(
+        cfield,
+        ffield,
+        Operators.DivergenceF2C(),
+        Operators.DivergenceC2F(;
+            bottom = Operators.SetValue(wvec_glob(0)),
+            top = Operators.SetValue(wvec_glob(0)),
+        ),
+    )
+    alloc_test_derivative(
+        cfield,
+        ffield,
+        Operators.DivergenceF2C(;
+            bottom = Operators.SetValue(wvec_glob(0)),
+            top = Operators.SetValue(wvec_glob(0)),
+        ),
+        Operators.DivergenceC2F(;
+            bottom = Operators.SetValue(wvec_glob(0)),
+            top = Operators.SetValue(wvec_glob(0)),
+        ),
+    )
+    alloc_test_derivative(
+        cfield,
+        ffield,
+        Operators.DivergenceF2C(;
+            bottom = Operators.Extrapolate(),
+            top = Operators.Extrapolate(),
+        ),
+        Operators.DivergenceC2F(;
+            bottom = Operators.SetDivergence(0),
+            top = Operators.SetDivergence(0),
+        ),
+    )
+
+    alloc_test_redefined_operators(cfield, ffield)
+    alloc_test_operators_in_loops(cfield, ffield)
+    alloc_test_nested_expressions_1(cfield, ffield)
+    alloc_test_nested_expressions_2(cfield, ffield)
+    alloc_test_nested_expressions_3(cfield, ffield)
+    alloc_test_nested_expressions_4(cfield, ffield)
+    alloc_test_nested_expressions_5(cfield, ffield)
+    alloc_test_nested_expressions_6(cfield, ffield)
+    alloc_test_nested_expressions_7(cfield, ffield)
+    alloc_test_nested_expressions_8(cfield, ffield)
+    alloc_test_nested_expressions_9(cfield, ffield)
+    alloc_test_nested_expressions_10(cfield, ffield)
+    alloc_test_nested_expressions_11(cfield, ffield)
+    alloc_test_nested_expressions_12(cfield, ffield, ntcfield, ntffield)
+    alloc_test_nested_expressions_13(cfield, ffield, ntcfield, ntffield, FT)
 end


### PR DESCRIPTION
This PR extends and fixes `Ref` broadcasting with StencilCoefs (#963), solution was basically the same as the one applied in #945. Closes #963.

I tried applying only `copyto!`, and only `apply_stencil!`, but that didn't work so I applied to all three methods (which does work).