### PR TITLE
Remove type constraint to permit field b.c. on curl operator

### DIFF
--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -245,7 +245,7 @@ end
 
 Set the curl at the boundary to be `val`.
 """
-struct SetCurl{S <: Geometry.ContravariantVector} <: BoundaryCondition
+struct SetCurl{S} <: BoundaryCondition
     val::S
 end
 

--- a/test/Operators/hybrid/2d.jl
+++ b/test/Operators/hybrid/2d.jl
@@ -547,6 +547,57 @@ end
     @test norm(curluw_diff) < norm(curluw_ref) * 1e-2
 end
 
+@testset "curl (field b.c.)" begin
+    hv_center_space, hv_face_space =
+        hvspace_2D(xlim = (-pi, pi), zlim = (-pi, pi))
+
+    ccoords = Fields.coordinate_field(hv_center_space)
+    fcoords = Fields.coordinate_field(hv_face_space)
+    fcoords_1 = Fields.level(fcoords, ClimaCore.Utilities.half)
+    curl_bcfield₁ = Geometry.Covariant1Vector.(0.0 .* fcoords_1.z)
+    curl_bcfield² = Geometry.Contravariant2Vector.(0.0 .* fcoords_1.z)
+
+    u =
+        Geometry.transform.(
+            Ref(Geometry.Covariant1Axis()),
+            Geometry.UVector.(sin.(ccoords.x .+ 2 .* ccoords.z)),
+        )
+    w =
+        Geometry.transform.(
+            Ref(Geometry.Covariant3Axis()),
+            Geometry.WVector.(cos.(3 .* fcoords.x .+ 4 .* fcoords.z)),
+        )
+
+    curl = Operators.Curl()
+    curlC2F = Operators.CurlC2F(
+        bottom = Operators.SetValue(curl_bcfield₁),
+        top = Operators.SetValue(Geometry.Covariant1Vector(0.0)),
+    )
+
+    curlu = curlC2F.(u)
+    curlw = curl.(w)
+    curluw = curlu .+ curlw
+    Spaces.weighted_dss!(curluw)
+
+    curlw_ref =
+        Geometry.Contravariant2Vector.(
+            3 .* sin.(3 .* fcoords.x .+ 4 .* fcoords.z),
+        )
+    curlu_ref =
+        Geometry.Contravariant2Vector.(2 .* cos.(fcoords.x .+ 2 .* fcoords.z))
+
+    curluw_ref = curlu_ref .+ curlw_ref
+
+    # TODO: make SetValue do reasonable things on Extruded spaces (#79)
+    zeroboundary = Operators.SetBoundaryOperator(
+        bottom = Operators.SetValue(curl_bcfield²),
+        top = Operators.SetValue(Geometry.Contravariant2Vector(0.0)),
+    )
+    curluw_diff = zeroboundary.(curluw .- curluw_ref)
+
+    @test norm(curluw_diff) < norm(curluw_ref) * 1e-2
+end
+
 
 @testset "curl-cross" begin
     hv_center_space, hv_face_space =


### PR DESCRIPTION
Currently, divergence and gradient operators support field b.c., curl does not due to a type constraint in the `finitedifference` boundary condition types. This PR removes the constraint and tests that the method works when the supplied boundary condition is a field. 
e.g. For reference, assigning a field b.c `fω¹_bc` where `fω¹_bc` is a Contravariant2Vector Field returns the following error. 
```
bottom = Operators.SetCurl(fω¹_bc)
ERROR: MethodError: no method matching ClimaCore.Operators.SetCurl(::ClimaCore.Fields.Field{ClimaCore.DataLayouts.IFH{Contravariant2Vector{Float64}, 5, SubArray{Float64, 3, Array{Float64, 4}, Tuple{Int64, Base.Slice{Base.OneTo{Int64}}, Base.Slice{Base.OneTo{Int64}}, Base.Slice{Base.OneTo{Int64}}}, true}}, ...
```
- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
