### PR TITLE
CI: add memory in buildkite job

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -526,6 +526,7 @@ steps:
       - "examples/hybrid/box/output/bubble_3d_invariant_rhotheta/*"
     agents:
       config: cpu
+      slurm_mem: 20GB
       queue: central
       slurm_ntasks: 1
 


### PR DESCRIPTION
<!-- Provide a clear description of the content -->
This PR raises the memory for the buildkite `Rising Bubble 3D hybrid invariant (ρθ)` job (OOM behavior observed in dummy PR #991 )

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
