### PR TITLE
Expand dz_field tests, add more coords support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.10.17"
+version = "0.10.18"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -147,6 +147,7 @@ Sketch of a 2DX hybrid discretization:
 
 ```@docs
 Spaces
+Spaces.Δz_data
 ```
 ### Finite Difference Spaces
 ClimaCore.jl supports staggered Finite Difference discretizations. Finite Differences
@@ -208,6 +209,7 @@ Fields.LinearAlgebra.norm(::Fields.Field)
 Fields.set!
 Fields.ColumnIndex
 Fields.bycolumn
+Fields.Δz_field
 ```
 
 ## Limiters

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -255,15 +255,17 @@ local_geometry_field(space::AbstractSpace) =
     Field(Spaces.local_geometry_data(space), space)
 local_geometry_field(field::Field) = local_geometry_field(axes(field))
 
+Base.@deprecate dz_field(space::AbstractSpace) Δz_field(space) false
+Base.@deprecate dz_field(field::Field) Δz_field(field) false
 
 """
-    dz_field(field::Field)
-    dz_field(space::AbstractSpace)
+    Δz_field(field::Field)
+    Δz_field(space::AbstractSpace)
 
 A `Field` containing the `Δz` values on the same space as the given field.
 """
-dz_field(field::Field) = dz_field(axes(field))
-dz_field(space::AbstractSpace) = Field(Spaces.dz_data(space), space)
+Δz_field(field::Field) = Δz_field(axes(field))
+Δz_field(space::AbstractSpace) = Field(Spaces.Δz_data(space), space)
 
 include("broadcast.jl")
 include("mapreduce.jl")

--- a/src/Geometry/axistensors.jl
+++ b/src/Geometry/axistensors.jl
@@ -54,6 +54,8 @@ coordinate_axis(::Type{<:Cartesian2Point}) = (2,)
 coordinate_axis(::Type{<:Cartesian3Point}) = (3,)
 
 coordinate_axis(::Type{<:Cartesian123Point}) = (1, 2, 3)
+coordinate_axis(::Type{<:LatLongZPoint}) = (1, 2, 3)
+coordinate_axis(::Type{<:Cartesian13Point}) = (1, 3)
 
 coordinate_axis(::Type{<:LatLongPoint}) = (1, 2)
 

--- a/src/Operators/integrals.jl
+++ b/src/Operators/integrals.jl
@@ -38,7 +38,7 @@ end
 
 function column_integral_definite(field::Fields.ColumnField)
     field_data = Fields.field_values(field)
-    Δz_data = Spaces.dz_data(axes(field))
+    Δz_data = Spaces.Δz_data(axes(field))
     Nv = Spaces.nlevels(axes(field))
     ∫field = zero(eltype(field))
     @inbounds for j in 1:Nv

--- a/src/Spaces/finitedifference.jl
+++ b/src/Spaces/finitedifference.jl
@@ -161,7 +161,12 @@ The index of the z-component of an abstract point
 in an `AxisTensor`.
 """
 z_component(::Type{<:Geometry.LatLongZPoint}) = 9
+z_component(::Type{<:Geometry.Cartesian3Point}) = 1
+z_component(::Type{<:Geometry.Cartesian13Point}) = 4
+z_component(::Type{<:Geometry.Cartesian123Point}) = 9
+z_component(::Type{<:Geometry.XYZPoint}) = 9
 z_component(::Type{<:Geometry.ZPoint}) = 1
+z_component(::Type{<:Geometry.XZPoint}) = 4
 
 """
     dz_data(space::AbstractSpace)

--- a/src/Spaces/finitedifference.jl
+++ b/src/Spaces/finitedifference.jl
@@ -153,30 +153,36 @@ local_geometry_data(space::CenterFiniteDifferenceSpace) =
 local_geometry_data(space::FaceFiniteDifferenceSpace) =
     space.face_local_geometry
 
+Base.@deprecate z_component(::Type{T}) where {T} Δz_metric_component(T) false
 
 """
-    z_component(::Type{<:Goemetry.AbstractPoint})
+    Δz_metric_component(::Type{<:Goemetry.AbstractPoint})
 
 The index of the z-component of an abstract point
 in an `AxisTensor`.
 """
-z_component(::Type{<:Geometry.LatLongZPoint}) = 9
-z_component(::Type{<:Geometry.Cartesian3Point}) = 1
-z_component(::Type{<:Geometry.Cartesian13Point}) = 4
-z_component(::Type{<:Geometry.Cartesian123Point}) = 9
-z_component(::Type{<:Geometry.XYZPoint}) = 9
-z_component(::Type{<:Geometry.ZPoint}) = 1
-z_component(::Type{<:Geometry.XZPoint}) = 4
+Δz_metric_component(::Type{<:Geometry.LatLongZPoint}) = 9
+Δz_metric_component(::Type{<:Geometry.Cartesian3Point}) = 1
+Δz_metric_component(::Type{<:Geometry.Cartesian13Point}) = 4
+Δz_metric_component(::Type{<:Geometry.Cartesian123Point}) = 9
+Δz_metric_component(::Type{<:Geometry.XYZPoint}) = 9
+Δz_metric_component(::Type{<:Geometry.ZPoint}) = 1
+Δz_metric_component(::Type{<:Geometry.XZPoint}) = 4
+
+Base.@deprecate dz_data(space::AbstractSpace) Δz_data(space) false
 
 """
-    dz_data(space::AbstractSpace)
+    Δz_data(space::AbstractSpace)
 
 A DataLayout containing the `Δz` on a given space `space`.
 """
-function dz_data(space::AbstractSpace)
+function Δz_data(space::AbstractSpace)
     lg = local_geometry_data(space)
     data_layout_type = eltype(lg.coordinates)
-    return getproperty(lg.∂x∂ξ.components.data, z_component(data_layout_type))
+    return getproperty(
+        lg.∂x∂ξ.components.data,
+        Δz_metric_component(data_layout_type),
+    )
 end
 
 function left_boundary_name(space::FiniteDifferenceSpace)

--- a/test/Fields/field.jl
+++ b/test/Fields/field.jl
@@ -476,6 +476,51 @@ Base.broadcastable(x::InferenceFoo) = Ref(x)
 
 end
 
+@testset "dz_field" begin
+    FT = Float64
+    x = FT(1)
+    y = FT(2)
+    z = FT(3)
+    lat, long = FT(4), FT(5)
+    x1 = FT(1)
+    x2 = FT(2)
+    x3 = FT(3)
+    coords = [
+        Geometry.ZPoint(z),
+        Geometry.XZPoint(x, z),
+        Geometry.XYZPoint(x, y, z),
+        Geometry.LatLongZPoint(lat, long, z),
+        Geometry.Cartesian3Point(x3),
+        Geometry.Cartesian13Point(x1, x3),
+        Geometry.Cartesian123Point(x1, x2, x3),
+    ]
+    all_components = [
+        SMatrix{1, 1, FT}(range(1, 1)...),
+        SMatrix{2, 2, FT}(range(1, 4)...),
+        SMatrix{3, 3, FT}(range(1, 9)...),
+        SMatrix{3, 3, FT}(range(1, 9)...),
+        SMatrix{1, 1, FT}(range(1, 1)...),
+        SMatrix{2, 2, FT}(range(1, 4)...),
+        SMatrix{3, 3, FT}(range(1, 9)...),
+    ]
+
+    expected_dzs = [1.0, 4.0, 9.0, 9.0, 1.0, 4.0, 9.0]
+
+    for (components, coord, expected_dz) in
+        zip(all_components, coords, expected_dzs)
+        CoordType = typeof(coord)
+        AIdx = Geometry.coordinate_axis(CoordType)
+        at = Geometry.AxisTensor(
+            (Geometry.LocalAxis{AIdx}(), Geometry.CovariantAxis{AIdx}()),
+            components,
+        )
+        local_geometry = Geometry.LocalGeometry(coord, FT(1.0), FT(1.0), at)
+        space = Spaces.PointSpace(local_geometry)
+        dz_computed = parent(Fields.dz_field(space))
+        @test length(dz_computed) == 1
+        @test dz_computed[1] == expected_dz
+    end
+end
 
 @testset "scalar assignment" begin
     domain_z = Domains.IntervalDomain(

--- a/test/Fields/field.jl
+++ b/test/Fields/field.jl
@@ -476,7 +476,7 @@ Base.broadcastable(x::InferenceFoo) = Ref(x)
 
 end
 
-@testset "dz_field" begin
+@testset "Δz_field" begin
     FT = Float64
     x = FT(1)
     y = FT(2)
@@ -516,7 +516,7 @@ end
         )
         local_geometry = Geometry.LocalGeometry(coord, FT(1.0), FT(1.0), at)
         space = Spaces.PointSpace(local_geometry)
-        dz_computed = parent(Fields.dz_field(space))
+        dz_computed = parent(Fields.Δz_field(space))
         @test length(dz_computed) == 1
         @test dz_computed[1] == expected_dz
     end
@@ -603,7 +603,7 @@ convergence_rate(err, Δh) =
 
             Y = FieldFromNamedTuple(space, (; y = FT(1)))
             zcf = Fields.coordinate_field(Y.y).z
-            Δz = Fields.dz_field(axes(zcf))
+            Δz = Fields.Δz_field(axes(zcf))
             Δz_col = Δz[Fields.ColumnIndex((1, 1), 1)]
             Δz_1 = parent(Δz_col)[1]
             key = (space, zelem)


### PR DESCRIPTION
This PR:
 - Expands `dz_field` tests
 - Adds `dz_field` support for more coords types

I've been running into situations in ClimaAtmos when unifying edmf and dycore radiation pieces where `z_component(::Type{<:Geometry.XZPoint}) = 4` is needed. I figured it would be better to just add support across the board.

It'd be good to confirm that I'm interpreting `coordinate_axis` correctly (which was needed for some of the tests).