### PR TITLE
Define one on AxisTensors

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -978,6 +978,7 @@ steps:
       TEST_NAME: "plane/inertial_gravity_wave"
     agents:
       config: cpu
+      slurm_mem: 20GB
       queue: central
       slurm_ntasks: 1
 

--- a/examples/hybrid/staggered_nonhydrostatic_model.jl
+++ b/examples/hybrid/staggered_nonhydrostatic_model.jl
@@ -272,11 +272,6 @@ end
 
 additional_tendency!(Yₜ, Y, p, t) = nothing
 
-# Allow one() to be called on vectors.
-Base.one(::T) where {T <: Geometry.AxisTensor} = one(T)
-Base.one(::Type{T}) where {T′, A, S, T <: Geometry.AxisTensor{T′, 1, A, S}} =
-    T(axes(T), S(one(T′)))
-
 function Wfact!(W, Y, p, dtγ, t)
     (; flags, dtγ_ref, ∂ᶜρₜ∂ᶠ𝕄, ∂ᶜ𝔼ₜ∂ᶠ𝕄, ∂ᶠ𝕄ₜ∂ᶜ𝔼, ∂ᶠ𝕄ₜ∂ᶜρ, ∂ᶠ𝕄ₜ∂ᶠ𝕄) = W
     ᶜρ = Y.c.ρ

--- a/src/Geometry/axistensors.jl
+++ b/src/Geometry/axistensors.jl
@@ -172,6 +172,11 @@ function Base.show(io::IO, a::AxisTensor{T, N, A, S}) where {T, N, A, S}
     )
 end
 
+# Allow one() to be called on vectors.
+Base.one(::T) where {T <: Geometry.AxisTensor} = one(T)
+Base.one(::Type{T}) where {T′, A, S, T <: Geometry.AxisTensor{T′, 1, A, S}} =
+    T(axes(T), S(one(T′)))
+
 """
     components(a::AxisTensor)
 

--- a/test/Operators/finitedifference/linsolve.jl
+++ b/test/Operators/finitedifference/linsolve.jl
@@ -67,11 +67,6 @@ include(
 jacobi_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :no_∂ᶜp∂ᶜK, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact);
 use_transform = false;
 
-# Allow one() to be called on vectors.
-Base.one(::T) where {T <: Geometry.AxisTensor} = one(T)
-Base.one(::Type{T}) where {T′, A, S, T <: Geometry.AxisTensor{T′, 1, A, S}} =
-    T(axes(T), S(one(T′)))
-
 Y = Fields.FieldVector(
     c = map(
         coord -> (

--- a/test/Operators/finitedifference/wfact.jl
+++ b/test/Operators/finitedifference/wfact.jl
@@ -49,12 +49,6 @@ QDT = Operators.StencilCoefs{-(1 + half), 1 + half, NTuple{4, FT}}
 ∂ᶜK∂ᶠw_data = similar(ᶜρ, BDT)
 ∂ᶜ𝔼ₜ∂ᶠ𝕄 = similar(ᶜρ, QDT)
 
-
-# Allow one() to be called on vectors.
-Base.one(::T) where {T <: Geometry.AxisTensor} = one(T)
-Base.one(::Type{T}) where {T′, A, S, T <: Geometry.AxisTensor{T′, 1, A, S}} =
-    T(axes(T), S(one(T′)))
-
 function wfact_test(∂ᶜ𝔼ₜ∂ᶠ𝕄, ∂ᶜK∂ᶠw_data, ᶜρe, ᶜρ, ᶜp, ᶠw)
 
     FT = eltype(ᶜρ)


### PR DESCRIPTION
This PR adds the `one` definition on `AxisTensor`s that we include in various places to the source code. Do we want to support this?