### PR TITLE
Reverse stretched mesh for land model

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1035,5 +1035,6 @@ steps:
       - "julia --color=yes --project=perf perf/invalidations.jl"
     agents:
       config: cpu
+      slurm_mem: 20GB
       queue: central
       slurm_ntasks: 1

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -88,6 +88,7 @@ Meshes.NormalizedBilinearMap
 ```@docs
 Meshes.Uniform
 Meshes.ExponentialStretching
+Meshes.GeneralizedExponentialStretching
 ```
 
 ### Interfaces

--- a/src/Meshes/interval.jl
+++ b/src/Meshes/interval.jl
@@ -83,7 +83,7 @@ function monotonic_check(faces)
     if !(monotonic_incr || monotonic_decr)
         error(
             string(
-                "Faces in vertical mesh are not increasing monotonically. ",
+                "Faces in vertical mesh are not increasing or decreasing monotonically. ",
                 "We need to have dz_bottom <= z_max / z_elem and dz_top >= z_max / z_elem.",
             ),
         )
@@ -115,7 +115,7 @@ end
 
 
 """
-    ExponentialStretching(H)
+    ExponentialStretching(H::FT)
 
 Apply exponential stretching to the domain when constructing elements. `H` is
 the scale height (a typical atmospheric scale height `H ≈ 7.5`km).
@@ -126,7 +126,13 @@ For an interval ``[z_0,z_1]``, this makes the elements uniformally spaced in
 \\zeta = \\frac{1 - e^{-\\eta/h}}{1-e^{-1/h}},
 ```
 where ``\\eta = \\frac{z - z_0}{z_1-z_0}``, and ``h = \\frac{H}{z_1-z_0}`` is
-the non-dimensional scale height.
+the non-dimensional scale height. If `reverse_mode` is `true`, the smallest
+element is at the top, and the largest at the bottom (this is typical for land
+model configurations).
+
+Then, the user can define a stretched mesh via
+
+    ClimaCore.Meshes.IntervalMesh(interval_domain, ExponentialStretching(H); nelems::Int, reverse_mode = false)
 """
 struct ExponentialStretching{FT} <: StretchingRule
     H::FT
@@ -136,6 +142,7 @@ function IntervalMesh(
     domain::IntervalDomain{CT},
     stretch::ExponentialStretching{FT};
     nelems::Int,
+    reverse_mode::Bool = false,
 ) where {CT <: Geometry.Abstract1DPoint{FT}} where {FT}
     if nelems < 1
         throw(ArgumentError("`nelems` must be ≥ 1"))
@@ -144,19 +151,36 @@ function IntervalMesh(
     cmax = Geometry.component(domain.coord_max, 1)
     R = cmax - cmin
     h = stretch.H / R
-    η(ζ) = ζ == 1 ? ζ : -h * log1p((expm1(-1 / h)) * ζ)
-    faces =
-        [CT(cmin + R * η(ζ)) for ζ in range(FT(0), FT(1); length = nelems + 1)]
+
+    η(ζ) = ζ == 1 ? ζ : (-h) * log1p((expm1(-1 / h)) * ζ)
+    faces = [
+        CT(reverse_mode ? cmax + R * η(ζ) : cmin + R * η(ζ)) for
+        ζ in range(FT(0), FT(1); length = nelems + 1)
+    ]
+
+    if reverse_mode
+        faces = map(f -> eltype(faces)(-f.z), faces)
+        faces[1] = faces[1] == -cmax ? cmax : faces[1]
+        reverse!(faces)
+    end
     monotonic_check(faces)
     IntervalMesh(domain, faces)
 end
 
 """
-    GeneralizedExponentialStretching(dz_bottom, dz_top)
+    GeneralizedExponentialStretching(dz_bottom::FT, dz_top::FT)
 
 Apply a generalized form of exponential stretching to the domain when constructing elements.
-`dz_bottom` and `dz_top` are target element grid spacings at surface and at the top of the
-vertical column domain (m).
+`dz_bottom` and `dz_top` are target element grid spacings at the bottom and at the top of the
+vertical column domain (m). In typical atmosphere configurations, `dz_bottom` is the smallest
+grid spacing and `dz_top` the largest one. On the other hand, for typical land configurations,
+`dz_bottom` is the largest grid spacing and `dz_top` the smallest one.
+
+For land configurations, use `reverse_mode` = `true` (default value `false`).
+
+Then, the user can define a generalized stretched mesh via
+
+    ClimaCore.Meshes.IntervalMesh(interval_domain, GeneralizedExponentialStretching(dz_bottom, dz_top); nelems::Int, reverse_mode = false)
 """
 struct GeneralizedExponentialStretching{FT} <: StretchingRule
     dz_bottom::FT
@@ -167,34 +191,48 @@ function IntervalMesh(
     domain::IntervalDomain{CT},
     stretch::GeneralizedExponentialStretching{FT};
     nelems::Int,
+    reverse_mode::Bool = false,
 ) where {CT <: Geometry.Abstract1DPoint{FT}} where {FT}
     if nelems ≤ 1
         throw(ArgumentError("`nelems` must be ≥ 2"))
     end
+
     dz_bottom, dz_top = stretch.dz_bottom, stretch.dz_top
-    if !(dz_bottom ≤ dz_top)
+    if !(dz_bottom ≤ dz_top) && !reverse_mode
         throw(ArgumentError("dz_bottom must be ≤ dz_top"))
     end
-    # surface coord height value
+
+    if !(dz_bottom ≥ dz_top) && reverse_mode
+        throw(ArgumentError("dz_top must be ≤ dz_bottom"))
+    end
+
+    # bottom coord height value, always min, for both atmos and land, since z-axis does not change
     z_bottom = Geometry.component(domain.coord_min, 1)
-    # top coord height value
+    # top coord height value, always max, for both atmos and land, since z-axis does not change
     z_top = Geometry.component(domain.coord_max, 1)
+    # but in case of reverse_mode, we temporarily swap them together with dz_bottom and dz_top
+    # so that the following root solve algorithm does not need to change
+    if reverse_mode
+        z_bottom, z_top = Geometry.component(domain.coord_max, 1),
+        -Geometry.component(domain.coord_min, 1)
+        dz_top, dz_bottom = dz_bottom, dz_top
+    end
 
     # define the inverse σ⁻¹ exponential stretching function
-    exp_stretch(ζ, h) = -h * log(1 - (1 - exp(-1 / h)) * ζ)
+    exp_stretch(ζ, h) = ζ == 1 ? ζ : -h * log(1 - (1 - exp(-1 / h)) * ζ)
 
-    # nondimensional vertical coordinate ([0.0, 1.0])
+    # nondimensional vertical coordinate (]0.0, 1.0])
     ζ_n = LinRange(one(FT), nelems, nelems) / nelems
 
-    # find surface height variation
-    find_surface(h) = dz_bottom - z_top * exp_stretch(ζ_n[1], h)
+    # find bottom height variation
+    find_bottom(h) = dz_bottom - z_top * exp_stretch(ζ_n[1], h)
     # we use linearization
-    # h_bottom ≈ -dz_bottom / z_top / log(1 - 1/nelems)
+    # h_bottom ≈ -dz_bottom / (z_top - z_bottom) / log(1 - 1/nelems)
     # to approx bracket the lower / upper bounds of root sol
-    guess₋ = -dz_bottom / z_top / log(1 - FT(1 / (nelems - 1)))
-    guess₊ = -dz_bottom / z_top / log(1 - FT(1 / (nelems + 1)))
+    guess₋ = -dz_bottom / (z_top - z_bottom) / log(1 - FT(1 / (nelems - 1)))
+    guess₊ = -dz_bottom / (z_top - z_bottom) / log(1 - FT(1 / (nelems + 1)))
     h_bottom_sol = RootSolvers.find_zero(
-        find_surface,
+        find_bottom,
         RootSolvers.SecantMethod(guess₋, guess₊),
         RootSolvers.CompactSolution(),
         RootSolvers.ResidualTolerance(FT(1e-3)),
@@ -234,6 +272,11 @@ function IntervalMesh(
 
     # add the bottom level
     faces = [z_bottom; faces...]
+    if reverse_mode
+        reverse!(faces)
+        faces = map(f -> eltype(faces)(-f), faces)
+        faces[end] = faces[end] == -z_bottom ? z_bottom : faces[1]
+    end
     monotonic_check(faces)
     IntervalMesh(domain, CT.(faces))
 end

--- a/test/Meshes/interval.jl
+++ b/test/Meshes/interval.jl
@@ -7,24 +7,35 @@ function unit_intervalmesh(;
     stretching = nothing,
     nelems = 20,
     periodic = false,
+    reverse_mode = false,
 )
     if periodic
         dom = ClimaCore.Domains.IntervalDomain(
+            reverse_mode ? ClimaCore.Geometry.ZPoint(-1.0) :
             ClimaCore.Geometry.ZPoint(0.0),
+            reverse_mode ? ClimaCore.Geometry.ZPoint(0.0) :
             ClimaCore.Geometry.ZPoint(1.0);
             periodic = true,
         )
     else
         dom = ClimaCore.Domains.IntervalDomain(
+            reverse_mode ? ClimaCore.Geometry.ZPoint(-1.0) :
             ClimaCore.Geometry.ZPoint(0.0),
+            reverse_mode ? ClimaCore.Geometry.ZPoint(0.0) :
             ClimaCore.Geometry.ZPoint(1.0),
             boundary_names = (:left, :right),
         )
     end
     if stretching !== nothing
-        return ClimaCore.Meshes.IntervalMesh(dom, stretching, nelems = nelems)
+        return dom,
+        ClimaCore.Meshes.IntervalMesh(
+            dom,
+            stretching,
+            nelems = nelems,
+            reverse_mode = reverse_mode,
+        )
     else
-        return ClimaCore.Meshes.IntervalMesh(dom, nelems = nelems)
+        return dom, ClimaCore.Meshes.IntervalMesh(dom, nelems = nelems)
     end
 end
 
@@ -33,12 +44,12 @@ end
         @test_throws ArgumentError unit_intervalmesh(nelems = nelems)
     end
     for nelems in (1, 3)
-        mesh = unit_intervalmesh(nelems = nelems)
+        dom, mesh = unit_intervalmesh(nelems = nelems)
         @test length(mesh.faces) == nelems + 1 # number of faces is +1 elements
         @test Meshes.nelements(mesh) == nelems
         @test Meshes.elements(mesh) == UnitRange(1, nelems)
     end
-    mesh = unit_intervalmesh(nelems = 2)
+    dom, mesh = unit_intervalmesh(nelems = 2)
     @test Meshes.domain(mesh) isa Domains.IntervalDomain
     @test Meshes.is_boundary_face(mesh, 1, 1) == true
     @test Meshes.boundary_face_name(mesh, 1, 1) == :left
@@ -65,12 +76,12 @@ end
         )
     end
     for nelems in (1, 3)
-        mesh = unit_intervalmesh(nelems = nelems, periodic = true)
+        dom, mesh = unit_intervalmesh(nelems = nelems, periodic = true)
         @test length(mesh.faces) == nelems + 1 # number of faces is +1 elements
         @test Meshes.nelements(mesh) == nelems
         @test Meshes.elements(mesh) == UnitRange(1, nelems)
     end
-    mesh = unit_intervalmesh(nelems = 2, periodic = true)
+    dom, mesh = unit_intervalmesh(nelems = 2, periodic = true)
     @test Meshes.domain(mesh) isa Domains.IntervalDomain
     @test Meshes.is_boundary_face(mesh, 1, 1) == false
     @test Meshes.boundary_face_name(mesh, 1, 1) == nothing
@@ -89,23 +100,27 @@ end
 end
 
 @testset "IntervalMesh ExponentialStretching" begin
+    FT = Float64
     @test_throws ArgumentError unit_intervalmesh(
         stretching = Meshes.ExponentialStretching(0.25),
         nelems = 0,
     )
-    mesh = unit_intervalmesh(
+    dom, mesh = unit_intervalmesh(
         stretching = Meshes.ExponentialStretching(0.25),
         nelems = 1,
     )
     @test Meshes.coordinates(mesh, 1, 1) == Geometry.ZPoint(0.0)
     @test Meshes.coordinates(mesh, 1, 2) ≈ Geometry.ZPoint(1.0)
     # approx equal to gcm ref profile height fraction given the vert domain
-    # ~7.5 km of 45 km vertical domain extent
+    # height of 45 km and scale height of ~7.5 km
     # we normalize to unit length for easy comparison
-    mesh = unit_intervalmesh(
-        stretching = Meshes.ExponentialStretching(7.5 / 45.0),
-        nelems = 10,
+    H = 7.5 / 45.0
+    nelems = 10
+    dom, mesh = unit_intervalmesh(
+        stretching = Meshes.ExponentialStretching(H),
+        nelems = nelems,
     )
+    # check against a reference profile
     ref_profile = [
         Geometry.ZPoint(0.0),
         Geometry.ZPoint(0.017514189444930356),
@@ -123,6 +138,77 @@ end
     for eidx in Meshes.nelements(mesh)
         @test Meshes.coordinates(mesh, eidx, 1) == ref_profile[eidx]
         @test Meshes.coordinates(mesh, eidx, 2) == ref_profile[eidx + 1]
+    end
+    # check, without a reference profile, that the inverse transformation gives us equispaced points
+    cmin = Geometry.component(dom.coord_min, 1)
+    cmax = Geometry.component(dom.coord_max, 1)
+    R = cmax - cmin
+    h = H / R
+    ζ(η, h) = (-expm1(-η / h)) / (-expm1(-1 / h))
+    face_values = [mesh.faces[f].z for f in 1:length(mesh.faces)]
+    inverse_faces = [ζ(η, h) for η in face_values]
+    for idx in eachindex(inverse_faces)
+        @test inverse_faces[idx] ==
+              range(FT(0), FT(1); length = nelems + 1)[idx]
+    end
+end
+
+@testset "IntervalMesh ExponentialStretching reverse" begin
+    FT = Float64
+    @test_throws ArgumentError unit_intervalmesh(
+        stretching = Meshes.ExponentialStretching(0.25),
+        nelems = 0,
+        reverse_mode = true,
+    )
+    dom, mesh = unit_intervalmesh(
+        stretching = Meshes.ExponentialStretching(0.25),
+        nelems = 1,
+        reverse_mode = true,
+    )
+    @test Meshes.coordinates(mesh, 1, 1) == Geometry.ZPoint(-1.0)
+    @test Meshes.coordinates(mesh, 1, 2) ≈ Geometry.ZPoint(0.0)
+    # approx equal to gcm ref profile height fraction given the vert domain
+    # height of 45 km and scale height of ~7.5 km
+    # we normalize to unit length for easy comparison
+    H = 7.5 / 45.0
+    nelems = 10
+    reverse_mode = true
+    dom, mesh = unit_intervalmesh(
+        stretching = Meshes.ExponentialStretching(7.5 / 45.0),
+        nelems = nelems,
+        reverse_mode = reverse_mode,
+    )
+    # check against a reference profile
+    ref_profile = [
+        Geometry.ZPoint(-1.0000000000000000),
+        Geometry.ZPoint(-0.3800869206593279),
+        Geometry.ZPoint(-0.2665952891528509),
+        Geometry.ZPoint(-0.1997009518240897),
+        Geometry.ZPoint(-0.15209658312699387),
+        Geometry.ZPoint(-0.11511191590370247),
+        Geometry.ZPoint(-0.08486241436551151),
+        Geometry.ZPoint(-0.05926886424040023),
+        Geometry.ZPoint(-0.03708734253289887),
+        Geometry.ZPoint(-0.017514189444930356),
+        Geometry.ZPoint(0.0),
+    ]
+    @test Meshes.coordinates(mesh, 1, 1) == ref_profile[1]
+    for eidx in Meshes.nelements(mesh)
+        @test Meshes.coordinates(mesh, eidx, 1) == ref_profile[eidx]
+        @test Meshes.coordinates(mesh, eidx, 2) == ref_profile[eidx + 1]
+    end
+    # check, without a reference profile, that the inverse transformation gives us equispaced points
+    cmin = Geometry.component(dom.coord_min, 1)
+    cmax = Geometry.component(dom.coord_max, 1)
+    R = cmax - cmin
+    h = H / R
+    ζ(η, h) = (-expm1(-η / h)) / (-expm1(-1 / h))
+    face_values = [-mesh.faces[f].z for f in 1:length(mesh.faces)]
+    reverse!(face_values)
+    inverse_faces = [ζ(η, h) for η in face_values]
+    for idx in eachindex(inverse_faces)
+        @test inverse_faces[idx] ==
+              range(FT(0), FT(1); length = nelems + 1)[idx]
     end
 end
 
@@ -143,21 +229,60 @@ end
         nelems = 1,
     )
     # test a gcm like configuration
-    # 45 km vertical domain height Δzₛ = 20m, Δzₜ = 7km
-    mesh = unit_intervalmesh(
+    dom, mesh = unit_intervalmesh(
         stretching = Meshes.GeneralizedExponentialStretching(
             0.02 / 45.0,
             7.0 / 45.0,
         ),
         nelems = 45, # 46 face levels
     )
-    # test the mesh coordinates are eqv to Δzₛ
+    # test the mesh coordinates are eqv to dz_bottom
     @test Meshes.coordinates(mesh, 1, 1) == Geometry.ZPoint(0.0)
     @test Meshes.coordinates(mesh, 1, 2) ≈ Geometry.ZPoint(0.02 / 45.0)
 
-    # test the face element distance at the top of the domain is Δzₜ
+    # test the face element distance at the top of the domain is dz_top
     fₑ₋₁ = Geometry.component(Meshes.coordinates(mesh, 45, 1), 1)
     fₑ = Geometry.component(Meshes.coordinates(mesh, 45, 2), 1)
     # a residual tol of ~1e-1 or 1e-2 is fine for typical use cases
     @test fₑ - fₑ₋₁ ≈ 7.0 / 45.0 rtol = 1e-2
+end
+
+
+@testset "IntervalMesh GeneralizedExponentialStretching reverse" begin
+    # use normalized GCM profile heights (7.5km)
+    @test_throws ArgumentError unit_intervalmesh(
+        stretching = Meshes.GeneralizedExponentialStretching(
+            7.0 / 45.0,
+            0.02 / 45.0,
+        ),
+        nelems = 0,
+        reverse_mode = true,
+    )
+    @test_throws ArgumentError unit_intervalmesh(
+        stretching = Meshes.GeneralizedExponentialStretching(
+            7.0 / 45.0,
+            0.02 / 45.0,
+        ),
+        nelems = 1,
+        reverse_mode = true,
+    )
+    # test a gcm like configuration, for land
+    nelems = 45
+    dom, mesh = unit_intervalmesh(
+        stretching = Meshes.GeneralizedExponentialStretching(
+            7.0 / 45.0,
+            0.02 / 45.0,
+        ),
+        nelems = nelems, # 46 face levels
+        reverse_mode = true,
+    )
+    # test the mesh coordinates are eqv to dz_bottom
+    @test Meshes.coordinates(mesh, 1, 1) == Geometry.ZPoint(-1.0)
+    # test the face element distance at the top of the domain is dz_top
+    @test Meshes.coordinates(mesh, 1, nelems) ≈
+          Geometry.ZPoint(-Geometry.ZPoint(0.02 / 45.0).z)
+    fₑ₋₁ = Geometry.component(Meshes.coordinates(mesh, nelems, 1), 1)
+    fₑ = Geometry.component(Meshes.coordinates(mesh, nelems, 2), 1)
+    # a residual tol of ~1e-1 or 1e-2 is fine for typical use cases
+    @test fₑ - fₑ₋₁ ≈ 0.02 / 45.0 rtol = 1e-2
 end


### PR DESCRIPTION
This will close #995

This PR adds a new command line argument for the creation of a stretched mesh, both with `ExponentialStretching` and `GeneralizedExponentialStretching` stretching types. 

To activate the reverse mode for land models, the user will have to pass a boolean flag (`false` by default, to reflect the existing mode for atmos configurations) to the stretching mode function. The new interface will look like: 

```stretching = Meshes.ExponentialStretching(H; reverse_mode)```

and 

```stretching = Meshes.GeneralizedExponentialStretching(dz_bottom, dz_top; reverse_mode)```

In addition to the new feature and new unit tests, this PR improves existing documentation and tests. In the `ExponentialStretching` unit tests, we were originally only checking the generated mesh faces against a reference profile. I left these checks and added checks without a reference profile, so that we effectively check that the transformation (and its inverse) give us the desired behavior. 

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
