### PR TITLE
Add Base(-) for 1D X,Y,Z Points

### DIFF
--- a/src/Geometry/coordinates.jl
+++ b/src/Geometry/coordinates.jl
@@ -174,6 +174,8 @@ coordinate(pt::AbstractPoint, ax::Int) = _coordinate(pt, Val(ax))
 coordinate(pt::AbstractPoint, ax::Integer) = _coordinate(pt, Int(ax))
 
 # the following are needed for linranges to work correctly with coordinate values
+Base.:(-)(p1::T) where {T <: AbstractPoint} =
+    unionalltype(T)((-components(p1)...))
 Base.:(-)(p1::T, p2::T) where {T <: AbstractPoint} =
     unionalltype(T)((components(p1) - components(p2))...)
 Base.:(+)(p1::T, p2::T) where {T <: AbstractPoint} =

--- a/src/Geometry/coordinates.jl
+++ b/src/Geometry/coordinates.jl
@@ -173,11 +173,9 @@ coordinate_type(ptyp::Type{<:AbstractPoint}, ax::Integer) =
 coordinate(pt::AbstractPoint, ax::Int) = _coordinate(pt, Val(ax))
 coordinate(pt::AbstractPoint, ax::Integer) = _coordinate(pt, Int(ax))
 
-# TODO: we need to rationalize point operations with vectors
-#Base.:(-)(p1::T, p2::T) where {T <: AbstractPoint} =
-#    unionalltype(T)((components(p1) - components(p2))...)
-
 # the following are needed for linranges to work correctly with coordinate values
+Base.:(-)(p1::T, p2::T) where {T <: AbstractPoint} =
+    unionalltype(T)((components(p1) - components(p2))...)
 Base.:(+)(p1::T, p2::T) where {T <: AbstractPoint} =
     unionalltype(T)((components(p1) + components(p2))...)
 Base.:(*)(p::T, x::Number) where {T <: AbstractPoint} =

--- a/src/Meshes/interval.jl
+++ b/src/Meshes/interval.jl
@@ -159,7 +159,7 @@ function IntervalMesh(
     ]
 
     if reverse_mode
-        faces = map(f -> eltype(faces)(-f.z), faces)
+        faces = map(f -> eltype(faces)(-f), faces)
         faces[1] = faces[1] == -cmax ? cmax : faces[1]
         reverse!(faces)
     end

--- a/test/Geometry/geometry.jl
+++ b/test/Geometry/geometry.jl
@@ -601,6 +601,25 @@ end
     end
 end
 
+@testset "Opposite 1D X,Y,Z Points" begin
+    for FT in (Float32, Float64, BigFloat)
+        pt_x_1 = Geometry.XPoint(one(FT))
+        pt_x_2 = Geometry.XPoint(-one(FT))
+        pt_y_1 = Geometry.YPoint(one(FT))
+        pt_y_2 = Geometry.YPoint(-one(FT))
+        pt_z_1 = Geometry.ZPoint(one(FT))
+        pt_z_2 = Geometry.ZPoint(-one(FT))
+        # Check 1D geometry points
+        @test pt_x_1 ≈ -pt_x_2 rtol = 2eps()
+        @test pt_y_1 ≈ -pt_y_2 rtol = 2eps()
+        @test pt_z_1 ≈ -pt_z_2 rtol = 2eps()
+        # Check components
+        @test (pt_x_1).x ≈ -(pt_x_2).x rtol = 2eps()
+        @test (pt_y_1).y ≈ -(pt_y_2).y rtol = 2eps()
+        @test (pt_z_1).z ≈ -(pt_z_2).z rtol = 2eps()
+    end
+end
+
 @testset "Add and subtract 1D X,Y,Z Points" begin
     for FT in (Float32, Float64, BigFloat)
         pt_x_1 = Geometry.XPoint(one(FT))

--- a/test/Geometry/geometry.jl
+++ b/test/Geometry/geometry.jl
@@ -601,6 +601,31 @@ end
     end
 end
 
+@testset "Add and subtract 1D X,Y,Z Points" begin
+    for FT in (Float32, Float64, BigFloat)
+        pt_x_1 = Geometry.XPoint(one(FT))
+        pt_x_2 = Geometry.XPoint(FT(2))
+        pt_y_1 = Geometry.YPoint(one(FT))
+        pt_y_2 = Geometry.YPoint(FT(2))
+        pt_z_1 = Geometry.ZPoint(one(FT))
+        pt_z_2 = Geometry.ZPoint(FT(2))
+        # Check 1D geometry points
+        @test pt_x_1 + pt_x_2 ≈ Geometry.XPoint(FT(3)) rtol = 2eps()
+        @test pt_x_1 - pt_x_2 ≈ Geometry.XPoint(FT(-1)) rtol = 2eps()
+        @test pt_y_1 + pt_y_2 ≈ Geometry.YPoint(FT(3)) rtol = 2eps()
+        @test pt_y_1 - pt_y_2 ≈ Geometry.YPoint(FT(-1)) rtol = 2eps()
+        @test pt_z_1 + pt_z_2 ≈ Geometry.ZPoint(FT(3)) rtol = 2eps()
+        @test pt_z_1 - pt_z_2 ≈ Geometry.ZPoint(FT(-1)) rtol = 2eps()
+        # Check components
+        @test (pt_x_1 + pt_x_2).x ≈ FT(3) rtol = 2eps()
+        @test (pt_x_1 - pt_x_2).x ≈ FT(-1) rtol = 2eps()
+        @test (pt_y_1 + pt_y_2).y ≈ FT(3) rtol = 2eps()
+        @test (pt_y_1 - pt_y_2).y ≈ FT(-1) rtol = 2eps()
+        @test (pt_z_1 + pt_z_2).z ≈ FT(3) rtol = 2eps()
+        @test (pt_z_1 - pt_z_2).z ≈ FT(-1) rtol = 2eps()
+    end
+end
+
 @testset "1D ZPoint Euclidean distance" begin
     for FT in (Float32, Float64, BigFloat)
         pt_1 = Geometry.ZPoint(one(FT))


### PR DESCRIPTION
This will close #1006 

We currently have an inconsistent behavior between `+` and `-` for 1D X, Y, Z Points. 
This PR addresses this inconsistency and adds unit tests for testing both `+` and `-` between respective 1D Points. Plus, it adds an opposite unary operator for `-` 1D X, Y, Z Points.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
