### PR TITLE
Use Singleton context for serial Bickley jet examples

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -818,6 +818,7 @@ steps:
       FLOAT_TYPE: "Float64"
     agents:
       config: cpu
+      slurm_mem: 40GB
       queue: central
       slurm_ntasks: 1
 

--- a/examples/bickleyjet/bickleyjet_cg.jl
+++ b/examples/bickleyjet/bickleyjet_cg.jl
@@ -1,3 +1,4 @@
+using ClimaComms
 using LinearAlgebra
 
 import ClimaCore:
@@ -10,6 +11,7 @@ import Logging
 import TerminalLoggers
 Logging.global_logger(TerminalLoggers.TerminalLogger())
 
+const context = ClimaComms.SingletonCommsContext()
 
 const parameters = (
     ϵ = 0.1,  # perturbation size for initial condition
@@ -37,7 +39,7 @@ n1, n2 = 16, 16
 Nq = 4
 Nqh = 7
 mesh = Meshes.RectilinearMesh(domain, n1, n2)
-grid_topology = Topologies.Topology2D(mesh)
+grid_topology = Topologies.DistributedTopology2D(context, mesh)
 quad = Spaces.Quadratures.GLL{Nq}()
 space = Spaces.SpectralElementSpace2D(grid_topology, quad)
 

--- a/examples/bickleyjet/bickleyjet_cg_unsmesh.jl
+++ b/examples/bickleyjet/bickleyjet_cg_unsmesh.jl
@@ -1,3 +1,4 @@
+using ClimaComms
 using LinearAlgebra
 
 import ClimaCore:
@@ -9,6 +10,7 @@ using OrdinaryDiffEq: ODEProblem, solve, SSPRK33
 import Logging
 import TerminalLoggers
 Logging.global_logger(TerminalLoggers.TerminalLogger())
+const context = ClimaComms.SingletonCommsContext()
 
 FT = Float64
 const parameters = (
@@ -38,7 +40,7 @@ Nq = 4
 Nqh = 7
 
 mesh = Meshes.RectilinearMesh(domain, n1, n2)
-grid_topology = Topologies.Topology2D(mesh)
+grid_topology = Topologies.DistributedTopology2D(context, mesh)
 quad = Spaces.Quadratures.GLL{Nq}()
 space = Spaces.SpectralElementSpace2D(grid_topology, quad)
 

--- a/examples/bickleyjet/bickleyjet_dg.jl
+++ b/examples/bickleyjet/bickleyjet_dg.jl
@@ -1,3 +1,4 @@
+using ClimaComms
 using LinearAlgebra
 
 import ClimaCore:
@@ -17,6 +18,7 @@ using OrdinaryDiffEq: ODEProblem, solve, SSPRK33
 import Logging
 import TerminalLoggers
 Logging.global_logger(TerminalLoggers.TerminalLogger())
+const context = ClimaComms.SingletonCommsContext()
 
 const parameters = (
     ϵ = 0.1,  # perturbation size for initial condition
@@ -48,7 +50,7 @@ n1, n2 = 16, 16
 Nq = 4
 Nqh = 7
 mesh = Meshes.RectilinearMesh(domain, n1, n2)
-grid_topology = Topologies.Topology2D(mesh)
+grid_topology = Topologies.DistributedTopology2D(context, mesh)
 quad = Spaces.Quadratures.GLL{Nq}()
 space = Spaces.SpectralElementSpace2D(grid_topology, quad)
 


### PR DESCRIPTION
Use Singleton context for serial Bickley jet examples. 
This is a step towards merging 'Topology2D' and `DistributedTopology2D` structs.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
