### PR TITLE
Use Singleton context for serial shallow water examples.

### DIFF
--- a/examples/sphere/limiters_advection.jl
+++ b/examples/sphere/limiters_advection.jl
@@ -1,3 +1,4 @@
+using ClimaComms
 using LinearAlgebra
 
 import ClimaCore:
@@ -8,6 +9,8 @@ using OrdinaryDiffEq
 import Logging
 import TerminalLoggers
 Logging.global_logger(TerminalLoggers.TerminalLogger())
+
+const context = ClimaComms.SingletonCommsContext()
 
 """
     convergence_rate(err, Δh)
@@ -86,7 +89,7 @@ for (k, ne) in enumerate(ne_seq)
     # Set up space
     domain = Domains.SphereDomain(R)
     mesh = Meshes.EquiangularCubedSphere(domain, ne)
-    grid_topology = Topologies.Topology2D(mesh)
+    grid_topology = Topologies.DistributedTopology2D(context, mesh)
     quad = Spaces.Quadratures.GLL{Nq}()
     space = Spaces.SpectralElementSpace2D(grid_topology, quad)
 
@@ -259,7 +262,6 @@ linkfig(
     relpath(joinpath(path, "L1error.png"), joinpath(@__DIR__, "../..")),
     "L₁ error Vs Nₑ",
 )
-
 
 # L₂ error Vs number of elements
 Plots.png(

--- a/examples/sphere/shallow_water.jl
+++ b/examples/sphere/shallow_water.jl
@@ -1,3 +1,4 @@
+using ClimaComms
 usempi = get(ENV, "CLIMACORE_DISTRIBUTED", "") == "MPI"
 using LinearAlgebra
 using Colors
@@ -513,8 +514,8 @@ function shallow_water_driver(ARGS, usempi::Bool, ::Type{FT}) where {FT}
             println("running distributed simulation using $nprocs processes")
         end
     else
+        context = ClimaComms.SingletonCommsContext()
         global_logger(TerminalLoggers.TerminalLogger())
-        context = nothing
         println("running serial simulation")
     end
     # Test case specifications
@@ -544,13 +545,15 @@ function shallow_water_driver(ARGS, usempi::Bool, ::Type{FT}) where {FT}
     domain = Domains.SphereDomain(test.params.R)
     mesh = Meshes.EquiangularCubedSphere(domain, ne)
     quad = Spaces.Quadratures.GLL{Nq}()
+    grid_topology = Topologies.DistributedTopology2D(context, mesh)
     if usempi
-        grid_topology = Topologies.DistributedTopology2D(context, mesh)
-        global_grid_topology = Topologies.Topology2D(mesh)
+        global_grid_topology = Topologies.DistributedTopology2D(
+            ClimaComms.SingletonCommsContext(),
+            mesh,
+        )
         space = Spaces.SpectralElementSpace2D(grid_topology, quad)
         global_space = Spaces.SpectralElementSpace2D(global_grid_topology, quad)
     else
-        grid_topology = Topologies.Topology2D(mesh)
         global_space =
             space = Spaces.SpectralElementSpace2D(grid_topology, quad)
     end

--- a/examples/sphere/shallow_water_dss.jl
+++ b/examples/sphere/shallow_water_dss.jl
@@ -77,9 +77,7 @@ function shallow_water_dss_profiler(usempi::Bool, ::Type{FT}, npoly) where {FT}
         mesh,
         Topologies.spacefillingcurve(mesh),
     )
-    global_grid_topology = Topologies.Topology2D(mesh)
     space = Spaces.SpectralElementSpace2D(grid_topology, quad)
-    global_space = Spaces.SpectralElementSpace2D(global_grid_topology, quad)
     Y = set_initial_condition(space)
     ghost_buffer = usempi ? Spaces.create_ghost_buffer(Y) : nothing
     dss_buffer = Spaces.create_dss_buffer(Y)

--- a/examples/sphere/solidbody.jl
+++ b/examples/sphere/solidbody.jl
@@ -1,3 +1,4 @@
+using ClimaComms
 using LinearAlgebra
 
 import ClimaCore:
@@ -8,6 +9,8 @@ using OrdinaryDiffEq: ODEProblem, solve, SSPRK33
 import Logging
 import TerminalLoggers
 Logging.global_logger(TerminalLoggers.TerminalLogger())
+
+const context = ClimaComms.SingletonCommsContext()
 
 """
     convergence_rate(err, Δh)
@@ -76,7 +79,7 @@ Nq = 4
 for (k, ne) in enumerate(ne_seq)
     domain = Domains.SphereDomain(R)
     mesh = Meshes.EquiangularCubedSphere(domain, ne)
-    grid_topology = Topologies.Topology2D(mesh)
+    grid_topology = Topologies.DistributedTopology2D(context, mesh)
     quad = Spaces.Quadratures.GLL{Nq}()
     space = Spaces.SpectralElementSpace2D(grid_topology, quad)
 

--- a/src/Spaces/spectralelement.jl
+++ b/src/Spaces/spectralelement.jl
@@ -359,7 +359,13 @@ const RectilinearSpectralElementSpace2D =
     SpectralElementSpace2D{<:Topologies.Topology2D{<:Meshes.RectilinearMesh}}
 
 const CubedSphereSpectralElementSpace2D = SpectralElementSpace2D{
-    <:Topologies.Topology2D{<:Meshes.AbstractCubedSphere},
+    <:Union{
+        Topologies.Topology2D{<:Meshes.AbstractCubedSphere},
+        Topologies.DistributedTopology2D{
+            <:ClimaComms.AbstractCommsContext,
+            <:Meshes.AbstractCubedSphere,
+        },
+    },
 }
 
 function compute_local_geometry(


### PR DESCRIPTION
Use Singleton communications context for serial shallow water examples.
This is a step towards merging 'Topology2D' and DistributedTopology2D structs.

<!-- Provide a clear description of the content -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
