### PR TITLE
Use Singleton context for serial plane examples.

### DIFF
--- a/examples/plane/limiters_advection.jl
+++ b/examples/plane/limiters_advection.jl
@@ -1,3 +1,4 @@
+using ClimaComms
 using LinearAlgebra
 
 import ClimaCore:
@@ -10,6 +11,8 @@ using ClimaTimeSteppers
 import Logging
 import TerminalLoggers
 Logging.global_logger(TerminalLoggers.TerminalLogger())
+
+const context = ClimaComms.SingletonCommsContext()
 
 """
     convergence_rate(err, Δh)
@@ -109,7 +112,7 @@ Nq = 4
 # h-refinement study loop
 for (k, ne) in enumerate(ne_seq)
     mesh = Meshes.RectilinearMesh(domain, ne, ne)
-    grid_topology = Topologies.Topology2D(mesh)
+    grid_topology = Topologies.DistributedTopology2D(context, mesh)
     quad = Spaces.Quadratures.GLL{Nq}()
     space = Spaces.SpectralElementSpace2D(grid_topology, quad)
 


### PR DESCRIPTION
Use Singleton communications context for serial plane examples.
This is a step towards merging 'Topology2D' and DistributedTopology2D structs.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
