### PR TITLE
Use Singleton comms context for serial space tests.

### DIFF
--- a/test/Spaces/distributed/gather4.jl
+++ b/test/Spaces/distributed/gather4.jl
@@ -47,7 +47,8 @@ mesh = Meshes.RectilinearMesh(domain, n1, n2)
 
 grid_topology =
     Topologies.DistributedTopology2D(comms_ctx, mesh, Meshes.elements(mesh))
-global_grid_topology = Topologies.Topology2D(mesh)
+global_grid_topology =
+    Topologies.DistributedTopology2D(ClimaComms.SingletonCommsContext(), mesh)
 Nf = 4
 Nv = 1
 space = Spaces.SpectralElementSpace2D(grid_topology, quad)

--- a/test/Spaces/spaces.jl
+++ b/test/Spaces/spaces.jl
@@ -1,4 +1,5 @@
 using Test
+using ClimaComms
 using StaticArrays, IntervalSets, LinearAlgebra
 
 import ClimaCore: slab, Domains, Meshes, Topologies, Spaces, Fields
@@ -54,6 +55,7 @@ end
 
 @testset "finite difference space" begin
     FT = Float64
+    context = ClimaComms.SingletonCommsContext()
     domain = Domains.IntervalDomain(
         Geometry.ZPoint{FT}(0) .. Geometry.ZPoint{FT}(5),
         boundary_names = (:bottom, :top),
@@ -89,7 +91,7 @@ end
     hmesh = Meshes.RectilinearMesh(domain, x_elem, y_elem)
 
     quad = Spaces.Quadratures.GL{1}()
-    htopology = Topologies.Topology2D(hmesh)
+    htopology = Topologies.DistributedTopology2D(context, hmesh)
     hspace = Spaces.SpectralElementSpace2D(htopology, quad)
 
     @test collect(Spaces.unique_nodes(hspace)) ==
@@ -100,6 +102,7 @@ end
 
 @testset "1×1 domain space" begin
     FT = Float32
+    context = ClimaComms.SingletonCommsContext()
     domain = Domains.RectangleDomain(
         Geometry.XPoint{FT}(-3) .. Geometry.XPoint{FT}(5),
         Geometry.YPoint{FT}(-2) .. Geometry.YPoint{FT}(8),
@@ -108,7 +111,7 @@ end
         x2boundary = (:south, :north),
     )
     mesh = Meshes.RectilinearMesh(domain, 1, 1)
-    grid_topology = Topologies.Topology2D(mesh)
+    grid_topology = Topologies.DistributedTopology2D(context, mesh)
 
     quad = Spaces.Quadratures.GLL{4}()
     points, weights = Spaces.Quadratures.quadrature_points(FT, quad)
@@ -156,6 +159,7 @@ end
 end
 
 @testset "2D perimeter iterator on 2×2 rectangular mesh" begin
+    context = ClimaComms.SingletonCommsContext()
     domain = Domains.RectangleDomain(
         Domains.IntervalDomain(
             Geometry.XPoint(-2π),
@@ -172,7 +176,7 @@ end
     Nq = 5
     quad = Spaces.Quadratures.GLL{Nq}()
     mesh = Meshes.RectilinearMesh(domain, n1, n2)
-    grid_topology = Topologies.Topology2D(mesh)
+    grid_topology = Topologies.DistributedTopology2D(context, mesh)
     space = Spaces.SpectralElementSpace2D(grid_topology, quad)
     perimeter = Spaces.perimeter(space)
 
@@ -212,7 +216,7 @@ end
         x2boundary = (:south, :north),
     )
     mesh = Meshes.RectilinearMesh(domain, n1, n2)
-    grid_topology = Topologies.Topology2D(mesh)
+    grid_topology = Topologies.DistributedTopology2D(ClimaComms.SingletonCommsContext(), mesh)
 
     quad = Spaces.Quadratures.GLL{4}()
     points, weights = Spaces.Quadratures.quadrature_points(FT, quad)
@@ -292,7 +296,7 @@ end
         x2boundary = (:south, :north),
     )
     mesh = Meshes.RectilinearMesh(domain, n1, n2)
-    grid_topology = Topologies.Topology2D(mesh)
+    grid_topology = Topologies.DistributedTopology2D(ClimaComms.SingletonCommsContext(), mesh)
 
     quad = Spaces.Quadratures.GLL{Nij}()
     points, weights = Spaces.Quadratures.quadrature_points(FT, quad)

--- a/test/Spaces/sphere.jl
+++ b/test/Spaces/sphere.jl
@@ -1,16 +1,18 @@
 using LinearAlgebra, IntervalSets, UnPack
+using ClimaComms
 import ClimaCore: Domains, Topologies, Meshes, Spaces, Geometry, column
 
 using Test
 
 @testset "Sphere" begin
     FT = Float64
+    context = ClimaComms.SingletonCommsContext()
     radius = FT(3)
     ne = 4
     Nq = 4
     domain = Domains.SphereDomain(radius)
     mesh = Meshes.EquiangularCubedSphere(domain, ne)
-    topology = Topologies.Topology2D(mesh)
+    topology = Topologies.DistributedTopology2D(context, mesh)
     quad = Spaces.Quadratures.GLL{Nq}()
     space = Spaces.SpectralElementSpace2D(topology, quad)
 
@@ -37,6 +39,7 @@ end
 
 @testset "Volume of a spherical shell" begin
     FT = Float64
+    context = ClimaComms.SingletonCommsContext()
     radius = FT(128)
     zlim = (0, 1)
     helem = 4
@@ -53,7 +56,7 @@ end
 
     horzdomain = Domains.SphereDomain(radius)
     horzmesh = Meshes.EquiangularCubedSphere(horzdomain, helem)
-    horztopology = Topologies.Topology2D(horzmesh)
+    horztopology = Topologies.DistributedTopology2D(context, horzmesh)
     quad = Spaces.Quadratures.GLL{Nq}()
     horzspace = Spaces.SpectralElementSpace2D(horztopology, quad)
 

--- a/test/Spaces/terrain_warp.jl
+++ b/test/Spaces/terrain_warp.jl
@@ -1,4 +1,5 @@
 using Test
+using ClimaComms
 
 import ClimaCore:
     ClimaCore,
@@ -132,7 +133,10 @@ function warpedspace_3D(
     )
     horzdomain = Domains.RectangleDomain(xdomain, ydomain)
     horzmesh = Meshes.RectilinearMesh(horzdomain, xelem, yelem)
-    horztopology = Topologies.Topology2D(horzmesh)
+    horztopology = Topologies.DistributedTopology2D(
+        ClimaComms.SingletonCommsContext(),
+        horzmesh,
+    )
     quad = Spaces.Quadratures.GLL{npoly + 1}()
     hspace = Spaces.SpectralElementSpace2D(horztopology, quad)
 


### PR DESCRIPTION
Use Singleton comms context for serial space tests.
This is a step towards merging Topology2D and DistributedTopology2D structs.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
