### PR TITLE
Use Singleton comms context for serial Operators tests.

### DIFF
--- a/test/Operators/finitedifference/column_benchmark_utils.jl
+++ b/test/Operators/finitedifference/column_benchmark_utils.jl
@@ -1,5 +1,6 @@
 #! format: off
 using Test
+using ClimaComms
 using StaticArrays, IntervalSets, LinearAlgebra
 import BenchmarkTools
 import StatsBase
@@ -39,7 +40,7 @@ function get_spaces(z_elems, ::Type{FT}) where {FT}
     )
     h_domain = Domains.RectangleDomain(x_domain, y_domain)
     h_mesh = Meshes.RectilinearMesh(h_domain, #=x_elem=# 1, #=y_elem=# 1)
-    topology = Topologies.Topology2D(h_mesh)
+    topology = Topologies.DistributedTopology2D(ClimaComms.SingletonCommsContext(), h_mesh)
     h_space = Spaces.SpectralElementSpace2D(topology, quad)
 
     z_domain = Domains.IntervalDomain(

--- a/test/Operators/finitedifference/implicit_stencils.jl
+++ b/test/Operators/finitedifference/implicit_stencils.jl
@@ -1,4 +1,5 @@
 using Test
+using ClimaComms
 using Random: seed!
 
 using ClimaCore: Geometry, Domains, Meshes, Topologies, Spaces, Fields
@@ -63,7 +64,10 @@ Operators.Operator2Stencil(op::CurriedTwoArgOperator) =
 
     hdomain = Domains.SphereDomain(radius)
     hmesh = Meshes.EquiangularCubedSphere(hdomain, helem)
-    htopology = Topologies.Topology2D(hmesh)
+    htopology = Topologies.DistributedTopology2D(
+        ClimaComms.SingletonCommsContext(),
+        hmesh,
+    )
     quad = Spaces.Quadratures.GLL{npoly + 1}()
     hspace = Spaces.SpectralElementSpace2D(htopology, quad)
 

--- a/test/Operators/finitedifference/linsolve.jl
+++ b/test/Operators/finitedifference/linsolve.jl
@@ -1,4 +1,5 @@
 using Test
+using ClimaComms
 
 import ClimaCore
 # To avoid JET failures in the error message
@@ -14,7 +15,8 @@ velem = 4
 
 hdomain = Domains.SphereDomain(radius)
 hmesh = Meshes.EquiangularCubedSphere(hdomain, helem)
-htopology = Topologies.Topology2D(hmesh)
+htopology =
+    Topologies.DistributedTopology2D(ClimaComms.SingletonCommsContext(), hmesh)
 quad = Spaces.Quadratures.GLL{npoly + 1}()
 hspace = Spaces.SpectralElementSpace2D(htopology, quad)
 

--- a/test/Operators/finitedifference/opt_implicit_stencils.jl
+++ b/test/Operators/finitedifference/opt_implicit_stencils.jl
@@ -1,4 +1,5 @@
 using Test
+using ClimaComms
 using Random: seed!
 
 using ClimaCore: Geometry, Domains, Meshes, Topologies, Spaces, Fields
@@ -27,7 +28,7 @@ Operators.Operator2Stencil(op::CurriedTwoArgOperator) =
 
     hdomain = Domains.SphereDomain(radius)
     hmesh = Meshes.EquiangularCubedSphere(hdomain, helem)
-    htopology = Topologies.Topology2D(hmesh)
+    htopology = Topologies.DistributedTopology2D(ClimaComms.SingletonCommsContext(), hmesh)
     quad = Spaces.Quadratures.GLL{npoly + 1}()
     hspace = Spaces.SpectralElementSpace2D(htopology, quad)
 

--- a/test/Operators/finitedifference/wfact.jl
+++ b/test/Operators/finitedifference/wfact.jl
@@ -1,4 +1,5 @@
 using Test
+using ClimaComms
 
 import ClimaCore
 # To avoid JET failures in the error message
@@ -18,7 +19,8 @@ velem = 4
 
 hdomain = Domains.SphereDomain(radius)
 hmesh = Meshes.EquiangularCubedSphere(hdomain, helem)
-htopology = Topologies.Topology2D(hmesh)
+htopology =
+    Topologies.DistributedTopology2D(ClimaComms.SingletonCommsContext(), hmesh)
 quad = Spaces.Quadratures.GLL{npoly + 1}()
 hspace = Spaces.SpectralElementSpace2D(htopology, quad)
 

--- a/test/Operators/hybrid/3d.jl
+++ b/test/Operators/hybrid/3d.jl
@@ -1,4 +1,5 @@
 using Test
+using ClimaComms
 using StaticArrays, IntervalSets, LinearAlgebra
 
 import ClimaCore:
@@ -29,7 +30,10 @@ import ClimaCore.DataLayouts: level
 
     horzdomain = Domains.SphereDomain(30.0)
     horzmesh = Meshes.EquiangularCubedSphere(horzdomain, 4)
-    horztopology = Topologies.Topology2D(horzmesh)
+    horztopology = Topologies.DistributedTopology2D(
+        ClimaComms.SingletonCommsContext(),
+        horzmesh,
+    )
     quad = Spaces.Quadratures.GLL{3 + 1}()
     horzspace = Spaces.SpectralElementSpace2D(horztopology, quad)
 
@@ -67,7 +71,10 @@ function hvspace_3D(
         x2periodic = true,
     )
     horzmesh = Meshes.RectilinearMesh(horzdomain, xelem, yelem)
-    horztopology = Topologies.Topology2D(horzmesh)
+    horztopology = Topologies.DistributedTopology2D(
+        ClimaComms.SingletonCommsContext(),
+        horzmesh,
+    )
 
     quad = Spaces.Quadratures.GLL{npoly + 1}()
     horzspace = Spaces.SpectralElementSpace2D(horztopology, quad)

--- a/test/Operators/hybrid/dss_opt.jl
+++ b/test/Operators/hybrid/dss_opt.jl
@@ -1,4 +1,5 @@
 using Test, JET
+using ClimaComms
 using StaticArrays, IntervalSets, LinearAlgebra
 
 import ClimaCore
@@ -30,7 +31,10 @@ vert_center_space = Spaces.CenterFiniteDifferenceSpace(vertmesh)
 
 horzdomain = Domains.SphereDomain(30.0)
 horzmesh = Meshes.EquiangularCubedSphere(horzdomain, 4)
-horztopology = Topologies.Topology2D(horzmesh)
+horztopology = Topologies.DistributedTopology2D(
+    ClimaComms.SingletonCommsContext(),
+    horzmesh,
+)
 quad = Spaces.Quadratures.GLL{5}()
 horzspace = Spaces.SpectralElementSpace2D(horztopology, quad)
 

--- a/test/Operators/hybrid/opt.jl
+++ b/test/Operators/hybrid/opt.jl
@@ -1,4 +1,5 @@
 using Test
+using ClimaComms
 using JET
 
 using IntervalSets
@@ -225,7 +226,10 @@ function hspace2d(FT)
     Nq = 3
     quad = Spaces.Quadratures.GLL{Nq}()
     hmesh = Meshes.RectilinearMesh(hdomain, 3, 3)
-    htopology = Topologies.Topology2D(hmesh)
+    htopology = Topologies.DistributedTopology2D(
+        ClimaComms.SingletonCommsContext(),
+        hmesh,
+    )
     return Spaces.SpectralElementSpace2D(htopology, quad)
 end
 

--- a/test/Operators/remapping.jl
+++ b/test/Operators/remapping.jl
@@ -1,8 +1,9 @@
 using Test
+using ClimaComms
 using ClimaCore:
     Domains, Meshes, Topologies, Geometry, Operators, Spaces, Fields
 using ClimaCore.Operators: local_weights, LinearRemap, remap, remap!
-using ClimaCore.Topologies: Topology2D
+using ClimaCore.Topologies: DistributedTopology2D
 using ClimaCore.Spaces: AbstractSpace, Quadratures
 using ClimaCore.DataLayouts: IJFH
 using IntervalSets, LinearAlgebra, SparseArrays
@@ -25,7 +26,10 @@ function make_space(
 )
     nq == 1 ? (quad = Quadratures.GL{1}()) : (quad = Quadratures.GLL{nq}())
     mesh = Meshes.RectilinearMesh(domain, nxelems, nyelems)
-    topology = Topologies.Topology2D(mesh)
+    topology = Topologies.DistributedTopology2D(
+        ClimaComms.SingletonCommsContext(),
+        mesh,
+    )
     space = Spaces.SpectralElementSpace2D(topology, quad)
     return space
 end

--- a/test/Operators/spectralelement/diffusion2d.jl
+++ b/test/Operators/spectralelement/diffusion2d.jl
@@ -1,4 +1,5 @@
 using Test
+using ClimaComms
 using StaticArrays, IntervalSets
 import ClimaCore.DataLayouts: IJFH
 import ClimaCore:
@@ -24,7 +25,10 @@ using OrdinaryDiffEq
     )
 
     mesh = Meshes.RectilinearMesh(domain, 10, 10)
-    grid_topology = Topologies.Topology2D(mesh)
+    grid_topology = Topologies.DistributedTopology2D(
+        ClimaComms.SingletonCommsContext(),
+        mesh,
+    )
 
     Nq = 6
     quad = Spaces.Quadratures.GLL{Nq}()

--- a/test/Operators/spectralelement/opt.jl
+++ b/test/Operators/spectralelement/opt.jl
@@ -1,5 +1,6 @@
 using Test
 using JET
+using ClimaComms
 using LinearAlgebra, IntervalSets
 
 import ClimaCore:
@@ -138,7 +139,10 @@ end
             quad = Spaces.Quadratures.GLL{Nq}()
             mesh = Meshes.RectilinearMesh(domain, 3, 3)
 
-            topology = Topologies.Topology2D(mesh)
+            topology = Topologies.DistributedTopology2D(
+                ClimaComms.SingletonCommsContext(),
+                mesh,
+            )
             space = Spaces.SpectralElementSpace2D(topology, quad)
 
             coords = Fields.coordinate_field(space)
@@ -192,7 +196,10 @@ end
 
             horzdomain = Domains.RectangleDomain(xdomain, ydomain)
             horzmesh = Meshes.RectilinearMesh(horzdomain, xelem, yelem)
-            horztopology = Topologies.Topology2D(horzmesh)
+            horztopology = Topologies.DistributedTopology2D(
+                ClimaComms.SingletonCommsContext(),
+                horzmesh,
+            )
 
             quad = Spaces.Quadratures.GLL{npoly + 1}()
             horzspace = Spaces.SpectralElementSpace2D(horztopology, quad)

--- a/test/Operators/spectralelement/rectilinear.jl
+++ b/test/Operators/spectralelement/rectilinear.jl
@@ -1,5 +1,6 @@
 using Test
 using StaticArrays
+using ClimaComms
 import ClimaCore.DataLayouts: IJFH, VF
 import ClimaCore:
     Geometry, Fields, Domains, Topologies, Meshes, Spaces, Operators
@@ -17,12 +18,18 @@ Nq = 5
 quad = Spaces.Quadratures.GLL{Nq}()
 
 grid_mesh = Meshes.RectilinearMesh(domain, 17, 16)
-grid_topology = Topologies.Topology2D(grid_mesh)
+grid_topology = Topologies.DistributedTopology2D(
+    ClimaComms.SingletonCommsContext(),
+    grid_mesh,
+)
 grid_space = Spaces.SpectralElementSpace2D(grid_topology, quad)
 grid_coords = Fields.coordinate_field(grid_space)
 
 ts_mesh = Meshes.RectilinearMesh(domain, 17, 16)
-ts_topology = Topologies.Topology2D(ts_mesh)
+ts_topology = Topologies.DistributedTopology2D(
+    ClimaComms.SingletonCommsContext(),
+    ts_mesh,
+)
 ts_space = Spaces.SpectralElementSpace2D(ts_topology, quad)
 ts_coords = Fields.coordinate_field(ts_space)
 

--- a/test/Operators/spectralelement/sphere_curl.jl
+++ b/test/Operators/spectralelement/sphere_curl.jl
@@ -1,4 +1,5 @@
 using Test
+using ClimaComms
 using StaticArrays, IntervalSets
 import ClimaCore.DataLayouts: IJFH
 import ClimaCore:
@@ -18,7 +19,10 @@ wcurl = Operators.WeakCurl()
     Nq = 6
 
     mesh = Meshes.EquiangularCubedSphere(domain, Ne)
-    grid_topology = Topologies.Topology2D(mesh)
+    grid_topology = Topologies.DistributedTopology2D(
+        ClimaComms.SingletonCommsContext(),
+        mesh,
+    )
 
     quad = Spaces.Quadratures.GLL{Nq}()
     space = Spaces.SpectralElementSpace2D(grid_topology, quad)
@@ -71,7 +75,10 @@ convergence_rate(err, Δh) =
 
         for (Ie, Ne) in enumerate(Nes)
             mesh = Meshes.EquiangularCubedSphere(domain, Ne)
-            grid_topology = Topologies.Topology2D(mesh)
+            grid_topology = Topologies.DistributedTopology2D(
+                ClimaComms.SingletonCommsContext(),
+                mesh,
+            )
 
             quad = Spaces.Quadratures.GLL{Nq}()
             space = Spaces.SpectralElementSpace2D(grid_topology, quad)

--- a/test/Operators/spectralelement/sphere_diffusion.jl
+++ b/test/Operators/spectralelement/sphere_diffusion.jl
@@ -1,5 +1,6 @@
 using Test
 using StaticArrays, IntervalSets
+using ClimaComms
 import ClimaCore.DataLayouts: IJFH
 import ClimaCore:
     Fields, Domains, Meshes, Topologies, Spaces, Operators, Geometry
@@ -22,7 +23,10 @@ using StaticArrays, IntervalSets, LinearAlgebra
     Nq = 4
     domain = Domains.SphereDomain(R)
     mesh = Meshes.EquiangularCubedSphere(domain, ne)
-    grid_topology = Topologies.Topology2D(mesh)
+    grid_topology = Topologies.DistributedTopology2D(
+        ClimaComms.SingletonCommsContext(),
+        mesh,
+    )
     quad = Spaces.Quadratures.GLL{Nq}()
     space = Spaces.SpectralElementSpace2D(grid_topology, quad)
 

--- a/test/Operators/spectralelement/sphere_diffusion_vec.jl
+++ b/test/Operators/spectralelement/sphere_diffusion_vec.jl
@@ -1,4 +1,5 @@
 using Test
+using ClimaComms
 using StaticArrays, IntervalSets
 import ClimaCore.DataLayouts: IJFH
 import ClimaCore:
@@ -34,7 +35,10 @@ end
     radius = FT(1)
     domain = Domains.SphereDomain(radius)
     mesh = Meshes.EquiangularCubedSphere(domain, Ne)
-    grid_topology = Topologies.Topology2D(mesh)
+    grid_topology = Topologies.DistributedTopology2D(
+        ClimaComms.SingletonCommsContext(),
+        mesh,
+    )
 
     quad = Spaces.Quadratures.GLL{Nq}()
     space = Spaces.SpectralElementSpace2D(grid_topology, quad)
@@ -77,7 +81,10 @@ convergence_rate(err, Δh) =
 
         for (Ie, Ne) in enumerate(Nes)
             mesh = Meshes.EquiangularCubedSphere(domain, Ne)
-            grid_topology = Topologies.Topology2D(mesh)
+            grid_topology = Topologies.DistributedTopology2D(
+                ClimaComms.SingletonCommsContext(),
+                mesh,
+            )
 
             quad = Spaces.Quadratures.GLL{Nq}()
             space = Spaces.SpectralElementSpace2D(grid_topology, quad)

--- a/test/Operators/spectralelement/sphere_divergence.jl
+++ b/test/Operators/spectralelement/sphere_divergence.jl
@@ -1,4 +1,5 @@
 using Test
+using ClimaComms
 using StaticArrays, IntervalSets
 import ClimaCore.DataLayouts: IJFH
 import ClimaCore:
@@ -18,7 +19,10 @@ wdiv = Operators.WeakDivergence()
     Nq = 6
 
     mesh = Meshes.EquiangularCubedSphere(domain, Ne)
-    grid_topology = Topologies.Topology2D(mesh)
+    grid_topology = Topologies.DistributedTopology2D(
+        ClimaComms.SingletonCommsContext(),
+        mesh,
+    )
 
     quad = Spaces.Quadratures.GLL{Nq}()
     space = Spaces.SpectralElementSpace2D(grid_topology, quad)
@@ -67,7 +71,10 @@ convergence_rate(err, Δh) =
 
         for (Ie, Ne) in enumerate(Nes)
             mesh = Meshes.EquiangularCubedSphere(domain, Ne)
-            grid_topology = Topologies.Topology2D(mesh)
+            grid_topology = Topologies.DistributedTopology2D(
+                ClimaComms.SingletonCommsContext(),
+                mesh,
+            )
 
             quad = Spaces.Quadratures.GLL{Nq}()
             space = Spaces.SpectralElementSpace2D(grid_topology, quad)

--- a/test/Operators/spectralelement/sphere_geometry.jl
+++ b/test/Operators/spectralelement/sphere_geometry.jl
@@ -1,4 +1,5 @@
 using LinearAlgebra, IntervalSets, UnPack
+using ClimaComms
 import ClimaCore:
     Domains, Topologies, Meshes, Spaces, Geometry, Operators, Fields
 
@@ -26,7 +27,10 @@ end
 
         domain = Domains.SphereDomain(radius)
         mesh = Meshes.EquiangularCubedSphere(domain, Ne)
-        grid_topology = Topologies.Topology2D(mesh)
+        grid_topology = Topologies.DistributedTopology2D(
+            ClimaComms.SingletonCommsContext(),
+            mesh,
+        )
         quad = Spaces.Quadratures.GLL{Nq}()
         space = Spaces.SpectralElementSpace2D(grid_topology, quad)
 

--- a/test/Operators/spectralelement/sphere_geometry_distributed.jl
+++ b/test/Operators/spectralelement/sphere_geometry_distributed.jl
@@ -50,7 +50,10 @@ end
         quad = Spaces.Quadratures.GLL{Nq}()
         space = Spaces.SpectralElementSpace2D(grid_topology, quad)
         # for comparison with serial results
-        grid_topology_serial = Topologies.Topology2D(mesh)
+        grid_topology_serial = Topologies.DistributedTopology2D(
+            ClimaComms.SingletonCommsContext(),
+            mesh,
+        )
         space_serial = Spaces.SpectralElementSpace2D(grid_topology_serial, quad)
 
         surface_area = sum(ones(space))

--- a/test/Operators/spectralelement/sphere_gradient.jl
+++ b/test/Operators/spectralelement/sphere_gradient.jl
@@ -1,4 +1,5 @@
 using Test
+using ClimaComms
 using StaticArrays, IntervalSets
 import ClimaCore.DataLayouts: IJFH
 import ClimaCore:
@@ -18,7 +19,10 @@ wgrad = Operators.WeakGradient()
     Nq = 6
 
     mesh = Meshes.EquiangularCubedSphere(domain, Ne)
-    grid_topology = Topologies.Topology2D(mesh)
+    grid_topology = Topologies.DistributedTopology2D(
+        ClimaComms.SingletonCommsContext(),
+        mesh,
+    )
 
     quad = Spaces.Quadratures.GLL{Nq}()
     space = Spaces.SpectralElementSpace2D(grid_topology, quad)
@@ -66,7 +70,10 @@ convergence_rate(err, Δh) =
 
         for (Ie, Ne) in enumerate(Nes)
             mesh = Meshes.EquiangularCubedSphere(domain, Ne)
-            grid_topology = Topologies.Topology2D(mesh)
+            grid_topology = Topologies.DistributedTopology2D(
+                ClimaComms.SingletonCommsContext(),
+                mesh,
+            )
 
             quad = Spaces.Quadratures.GLL{Nq}()
             space = Spaces.SpectralElementSpace2D(grid_topology, quad)

--- a/test/Operators/spectralelement/sphere_hyperdiffusion.jl
+++ b/test/Operators/spectralelement/sphere_hyperdiffusion.jl
@@ -1,4 +1,5 @@
 using Test
+using ClimaComms
 using StaticArrays, IntervalSets
 import ClimaCore.DataLayouts: IJFH
 import ClimaCore:
@@ -23,7 +24,10 @@ include("sphere_sphericalharmonics.jl")
 
     Ne = 16
     mesh = Meshes.EquiangularCubedSphere(domain, Ne)
-    grid_topology = Topologies.Topology2D(mesh)
+    grid_topology = Topologies.DistributedTopology2D(
+        ClimaComms.SingletonCommsContext(),
+        mesh,
+    )
 
     Nq = 6
     quad = Spaces.Quadratures.GLL{Nq}()

--- a/test/Operators/spectralelement/sphere_hyperdiffusion_vec.jl
+++ b/test/Operators/spectralelement/sphere_hyperdiffusion_vec.jl
@@ -1,4 +1,5 @@
 using Test
+using ClimaComms
 using StaticArrays, IntervalSets
 import ClimaCore.DataLayouts: IJFH
 import ClimaCore:
@@ -40,7 +41,10 @@ end
     radius = FT(1)
     domain = Domains.SphereDomain(radius)
     mesh = Meshes.EquiangularCubedSphere(domain, Ne)
-    grid_topology = Topologies.Topology2D(mesh)
+    grid_topology = Topologies.DistributedTopology2D(
+        ClimaComms.SingletonCommsContext(),
+        mesh,
+    )
 
     quad = Spaces.Quadratures.GLL{Nq}()
     space = Spaces.SpectralElementSpace2D(grid_topology, quad)
@@ -83,7 +87,10 @@ convergence_rate(err, Δh) =
 
         for (Ie, Ne) in enumerate(Nes)
             mesh = Meshes.EquiangularCubedSphere(domain, Ne)
-            grid_topology = Topologies.Topology2D(mesh)
+            grid_topology = Topologies.DistributedTopology2D(
+                ClimaComms.SingletonCommsContext(),
+                mesh,
+            )
 
             quad = Spaces.Quadratures.GLL{Nq}()
             space = Spaces.SpectralElementSpace2D(grid_topology, quad)


### PR DESCRIPTION
Use Singleton comms context for serial Operators tests.
This is a step towards merging Topology2D and DistributedTopology2D structs.

<!-- Provide a clear description of the content -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
