### PR TITLE
Remove Topology2D from InputOutput source code.

### DIFF
--- a/src/InputOutput/readers.jl
+++ b/src/InputOutput/readers.jl
@@ -11,7 +11,7 @@ using ..Meshes:
     IntervalMesh,
     RectilinearMesh,
     EquiangularCubedSphere
-using ..Topologies: Topologies, IntervalTopology, Topology2D
+using ..Topologies: Topologies, IntervalTopology
 using ..Spaces:
     Spaces,
     Spaces.Quadratures,
@@ -294,15 +294,7 @@ function read_topology_new(reader::HDF5Reader, name::AbstractString)
             elemorder = Meshes.elements(mesh)
         end
 
-        if reader.context isa ClimaComms.SingletonCommsContext
-            return Topologies.Topology2D(mesh, elemorder)
-        else
-            return Topologies.DistributedTopology2D(
-                reader.context,
-                mesh,
-                elemorder,
-            )
-        end
+        return Topologies.DistributedTopology2D(reader.context, mesh, elemorder)
     else
         error("Unsupported type $type")
     end

--- a/src/InputOutput/writers.jl
+++ b/src/InputOutput/writers.jl
@@ -206,7 +206,6 @@ function write_new!(
 end
 
 # Topologies
-defaultname(::Topologies.Topology2D) = "2d"
 defaultname(::Topologies.DistributedTopology2D) = "2d"
 defaultname(topology::Topologies.IntervalTopology) = defaultname(topology.mesh)
 
@@ -224,28 +223,6 @@ function write_new!(
     group = create_group(writer.file, "topologies/$name")
     write_attribute(group, "type", "IntervalTopology")
     write_attribute(group, "mesh", meshname)
-    return name
-end
-
-"""
-    write_new!(writer, topology, name)
-
-Write `Topology2D` data to HDF5.
-"""
-function write_new!(
-    writer::HDF5Writer,
-    topology::Topologies.Topology2D,
-    name::AbstractString = defaultname(topology),
-)
-    @assert writer.context isa ClimaComms.SingletonCommsContext
-
-    group = create_group(writer.file, "topologies/$name")
-    write_attribute(group, "type", "Topology2D")
-    write_attribute(group, "mesh", write!(writer, topology.mesh))
-    if !(topology.elemorder isa CartesianIndices)
-        elemorder_matrix = reinterpret(reshape, Int, topology.elemorder)
-        write_dataset(group, "elemorder", elemorder_matrix)
-    end
     return name
 end
 


### PR DESCRIPTION
Remove Topology2D from InputOutput source code.
This is a step towards merging Topology2D and DistributedTopology2D structs.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
