### PR TITLE
Remove one job in allocs table

### DIFF
--- a/perf/allocs.jl
+++ b/perf/allocs.jl
@@ -20,7 +20,6 @@ dirs_to_monitor = [
 all_cases = [
     (joinpath(EXAMPLE_DIR, "sphere", "shallow_water.jl"), "barotropic_instability", ""),
     (joinpath(EXAMPLE_DIR, "hybrid", "plane", "bubble_2d_rhotheta.jl"), "", ""),
-    (joinpath(EXAMPLE_DIR, "hybrid", "driver.jl"), "", "sphere/baroclinic_wave_rhoe"),
 ]
 #! format: on
 


### PR DESCRIPTION
This PR removes the last allocation monitoring job in the allocation table script. Based on the last run, ClimaCore doesn't even show up on the list, so perhaps it's okay that we trim it to help with CI time

```
[ Info: sphere/baroclinic_wave_rhoe : 4 unique allocating sites, 54144 total bytes
┌─────────────────────────────────────────────────────────────────────┬─────────────┬───────────────┐
│ <file>:<line number>                                                │ Allocations │ Allocations % │
│                                                                     │   (bytes)   │    (xᵢ/∑x)    │
├─────────────────────────────────────────────────────────────────────┼─────────────┼───────────────┤
│ SciMLBase/gUcZ9/src/scimlfunctions.jl:1670                          │    27072    │      50       │
│ OrdinaryDiffEq/QXAKd/src/perform_step/rosenbrock_perform_step.jl:43 │    12032    │      22       │
│ OrdinaryDiffEq/QXAKd/src/perform_step/rosenbrock_perform_step.jl:69 │    9024     │      17       │
│ OrdinaryDiffEq/QXAKd/src/perform_step/rosenbrock_perform_step.jl:65 │    6016     │      11       │
└─────────────────────────────────────────────────────────────────────┴─────────────┴───────────────┘
```