### PR TITLE
Conservation for bubble correction

### DIFF
--- a/src/Spaces/spectralelement.jl
+++ b/src/Spaces/spectralelement.jl
@@ -360,11 +360,11 @@ function SpectralElementSpace2D(
                             AIdx,
                         )
                         J = det(Geometry.components(∂u∂ξ))
-                        WJ = J * quad_weights[i] * quad_weights[j]
-                        # Modify WJ only for interior nodes
+                        # Modify J only for interior nodes
                         if i != 1 && j != 1 && i != Nq && j != Nq
-                            WJ *= 1 + interior_elem_area
+                            J *= (1 + interior_elem_area)
                         end
+                        WJ = J * quad_weights[i] * quad_weights[j]
                         # Finally allocate local geometry
                         local_geometry_slab[i, j] =
                             Geometry.LocalGeometry(u, J, WJ, ∂u∂ξ)


### PR DESCRIPTION
This PR addresses the bubble correction conservation issues that were noticed in ClimaAtmos. 

It modifies: 
- [x] The Jacobians in the `SpectralElementSpace2D` space constructor that were previously not updated for nonlinear elements
- [x] The `examples/sphere/limiters_advection.jl` example to check for conservation errors

Findings:
- [x] For the resolutions of our interest (e.g., `ne = 20`) the relative conservation error is of the order of magnitude of `eps(FT)` so this seems to be fine and as expected.

Related Issues: 
Will close #1063 

PR checks template:

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
