### PR TITLE
Bubble correction: Fix robustness

### DIFF
--- a/src/Spaces/spectralelement.jl
+++ b/src/Spaces/spectralelement.jl
@@ -183,7 +183,7 @@ geometric and numerical areas of each element match.
 Let ``\\Delta A^e := A^e_{exact} - A^e_{approx}``, then, in
 the case of linear elements, we correct ``W_{i,j} J^e_{i,j}`` by:
 ```math
-\\widehat{W_{i,j} J^e}_{i,j} = W_{i,j} J^e_{i,j} / Nq^2 + \\Delta A^e * W_{i,j} / Nq^2 .
+\\widehat{W_{i,j} J^e}_{i,j} = W_{i,j} J^e_{i,j} + \\Delta A^e * W_{i,j} / Nq^2 .
 ```
 and the case of non linear elements, by
 ```math
@@ -245,7 +245,6 @@ function SpectralElementSpace2D(
         Quadratures.quadrature_points(FT, quadrature_style)
     high_order_quad_points, high_order_quad_weights =
         Quadratures.quadrature_points(FT, high_order_quadrature_style)
-    tot_area = zero(FT)
     for (lidx, elem) in enumerate(Topologies.localelems(topology))
         elem_area = zero(FT)
         high_order_elem_area = zero(FT)
@@ -307,7 +306,7 @@ function SpectralElementSpace2D(
                 # element so that geometric and numerical areas of each element match.
 
                 # Compute difference between geometric area of an element and its approximate numerical area
-                Δarea = abs(high_order_elem_area - elem_area)
+                Δarea = high_order_elem_area - elem_area
 
                 # Linear elements: Nq == 2 (SpectralElementSpace2D cannot have Nq < 2)
                 # Use uniform bubble correction
@@ -327,7 +326,6 @@ function SpectralElementSpace2D(
                         local_geometry_slab[i, j] =
                             Geometry.LocalGeometry(u, J, WJ, ∂u∂ξ)
                     end
-                    elem_area += Δarea
                 else # Higher-order elements: Use HOMME bubble correction for the interior nodes
                     for i in 2:(Nq - 1), j in 2:(Nq - 1)
                         ξ = SVector(quad_points[i], quad_points[j])
@@ -369,11 +367,9 @@ function SpectralElementSpace2D(
                         local_geometry_slab[i, j] =
                             Geometry.LocalGeometry(u, J, WJ, ∂u∂ξ)
                     end
-                    elem_area += Δarea
                 end
             end
         end
-        tot_area += elem_area # this matches the surface area in the test
     end
 
     # alternatively, we could do a ghost exchange here?

--- a/test/Spaces/sphere.jl
+++ b/test/Spaces/sphere.jl
@@ -56,51 +56,8 @@ end
 
     for FT in (Float64, Float32)
         # Reference rtols without bubble
-        no_bubble_rtols_f64 = (
-            FT(0.64),
-            FT(0.19),
-            FT(0.027),
-            FT(0.0049),
-            FT(0.0008),
-            FT(0.00014),
-            FT(2.4e-5),
-            FT(3.97e-6),
-            FT(6.77e-7),
-        )
-        no_bubble_rtols_f32 = (
-            FT(0.64f0),
-            FT(0.19f0),
-            FT(0.027f0),
-            FT(0.0049f0),
-            FT(0.0008f0),
-            FT(0.00014f0),
-            FT(2.4f-5),
-            FT(3.65f-6),
-            FT(4.05f-7),
-        )
-        # Reference rtols with bubble
-        bubble_rtols_f32 = (
-            FT(0.027),
-            FT(0.0008),
-            FT(2.4f-5),
-            FT(4.05f-7),
-            FT(1.35f-6),
-            FT(6.75f-8),
-            FT(1.08f-6),
-            FT(4.05f-7),
-            FT(6.75f-8),
-        )
-        bubble_rtols_f64 = (
-            FT(0.027),
-            FT(0.0008),
-            FT(2.33e-5),
-            FT(6.77e-7),
-            FT(1.98e-8),
-            FT(5.78e-10),
-            FT(1.7e-11),
-            FT(4.94e-13),
-            FT(1.53e-14),
-        )
+        rtols = [FT(35) * FT(0.5)^(FT(2.5) * Nq) for Nq in 2:10]
+
 
         for (k, Nq) in enumerate(2:10)
             context = ClimaComms.SingletonCommsContext()
@@ -112,27 +69,15 @@ end
             quad = Spaces.Quadratures.GLL{Nq}()
             no_bubble_space = Spaces.SpectralElementSpace2D(topology, quad)
             # check surface area
-            if FT == Float32
-                @test sum(ones(no_bubble_space)) ≈ FT(4pi * radius^2) rtol =
-                    no_bubble_rtols_f32[k]
-            else
-                @test sum(ones(no_bubble_space)) ≈ FT(4pi * radius^2) rtol =
-                    no_bubble_rtols_f64[k]
-            end
+            @test sum(ones(no_bubble_space)) ≈ FT(4pi * radius^2) rtol =
+                rtols[k]
 
             bubble_space = Spaces.SpectralElementSpace2D(
                 topology,
                 quad;
                 enable_bubble = true,
             )
-
-            if FT == Float32
-                @test sum(ones(bubble_space)) ≈ FT(4pi * radius^2) rtol =
-                    bubble_rtols_f32[k]
-            else
-                @test sum(ones(bubble_space)) ≈ FT(4pi * radius^2) rtol =
-                    bubble_rtols_f64[k]
-            end
+            @test sum(ones(bubble_space)) ≈ FT(4pi * radius^2) rtol = rtols[k]
         end
     end
 

--- a/test/Spaces/sphere.jl
+++ b/test/Spaces/sphere.jl
@@ -98,6 +98,8 @@ end
                 enable_bubble = true,
             )
 
+            @show FT
+            @show Nq
             @test sum(ones(bubble_space)) ≈ FT(4pi * radius^2) rtol =
                 no_bubble_rtols[k] broken = Nq == 2 || isodd(Nq)
         end


### PR DESCRIPTION
This is a PR to address issue #1093 

Will close #1093

For the linear case the fix proposed is to divide the delta area, `Δarea`, by `Nq^2` so that the corrected Jacobians are not "overcorrected". That is, instead of adding the entire `Δarea` that is an element-wide contribution we redistribute a node-wide contribution. This fixes the issue and in fact the `@test_broken` passes (showing the fix). 

For the nonlinear case, we remove the `abs` in the `Δarea` calculation.

Summary of changes:

- [x] For the linear case, divide the delta area, `Δarea`, by `Nq^2
- [x] Updated docstring 
- [x] For the nonlinear case, remove  `abs` in the `Δarea` calculation.
- [x] Update unit tests by removing the `@test_broken` and updating tolerances.

Template:
- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
