### PR TITLE
Pass `persistent` argument

### DIFF
--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -385,12 +385,12 @@ Spaces.create_ghost_buffer(field::Field) = Spaces.create_dss_buffer(field)
 
 Create a buffer for communicating neighbour information of `field`.
 """
-function Spaces.create_dss_buffer(field::Field)
+function Spaces.create_dss_buffer(field::Field, ispersistent = true)
     space = axes(field)
     hspace =
         space isa Spaces.ExtrudedFiniteDifferenceSpace ?
         space.horizontal_space : space
-    Spaces.create_dss_buffer(field_values(field), hspace)
+    Spaces.create_dss_buffer(field_values(field), hspace, ispersistent)
 end
 # Add definitions for backward compatibility
 Spaces.weighted_dss2!(

--- a/src/Spaces/dss.jl
+++ b/src/Spaces/dss.jl
@@ -42,13 +42,21 @@ Creates a [`DSSBuffer`](@ref) for the field data corresponding to `data`
 function create_dss_buffer(
     data::Union{DataLayouts.IJFH{S, Nij}, DataLayouts.VIJFH{S, Nij}},
     hspace::AbstractSpectralElementSpace,
+    ispersistent = true,
 ) where {S, Nij}
     @assert hspace.quadrature_style isa Spaces.Quadratures.GLL "DSS2 is only compatible with GLL quadrature"
     topology = hspace.topology
     local_geometry = local_geometry_data(hspace)
     local_weights = hspace.local_dss_weights
     perimeter = Spaces.perimeter(hspace)
-    create_dss_buffer(data, topology, perimeter, local_geometry, local_weights)
+    create_dss_buffer(
+        data,
+        topology,
+        perimeter,
+        local_geometry,
+        local_weights,
+        ispersistent,
+    )
 end
 
 function create_dss_buffer(
@@ -57,6 +65,7 @@ function create_dss_buffer(
     perimeter,
     local_geometry = nothing,
     local_weights = nothing,
+    ispersistent = true,
 ) where {S, Nij}
     context =
         topology isa Topologies.Topology2D ? topology.context :
@@ -95,7 +104,7 @@ function create_dss_buffer(
             recv_data,
             buffer_lengths,
             neighbor_pids,
-            persistent = true,
+            persistent = ispersistent,
         )
         send_buf_idx, recv_buf_idx =
             Topologies.compute_ghost_send_recv_idx(topology, Nij)
@@ -179,7 +188,8 @@ function create_dss_buffer(
     )
 end
 
-create_dss_buffer(data::DataLayouts.AbstractData, hspace) = nothing
+create_dss_buffer(data::DataLayouts.AbstractData, hspace, ispersistent = true) =
+    nothing
 
 """
     function weighted_dss!(


### PR DESCRIPTION
Enable user to choose between persistent and non-persistent MPI communication for DSS.

<!-- Provide a clear description of the content -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
