### PR TITLE
Add comms context to vertical topology

### DIFF
--- a/src/Spaces/spectralelement.jl
+++ b/src/Spaces/spectralelement.jl
@@ -151,8 +151,12 @@ end
 
 nlevels(space::SpectralElementSpace1D) = 1
 
-const IntervalSpectralElementSpace1D =
-    SpectralElementSpace1D{<:Topologies.IntervalTopology{<:Meshes.IntervalMesh}}
+const IntervalSpectralElementSpace1D = SpectralElementSpace1D{
+    <:Topologies.IntervalTopology{
+        <:ClimaComms.AbstractCommsContext,
+        <:Meshes.IntervalMesh,
+    },
+}
 
 """
     SpectralElementSpace2D <: AbstractSpace


### PR DESCRIPTION
This PR adds the comms context to the vertical topology. This is a peel off from #1168.

Co-authored-by: @simonbyrne 