### PR TITLE
Inline copyto_slab

### DIFF
--- a/src/Operators/spectralelement.jl
+++ b/src/Operators/spectralelement.jl
@@ -196,7 +196,8 @@ function Base.copyto!(
     },
 )
     Fields.byslab(axes(out)) do slabidx
-        copyto_slab!(out, sbc, slabidx)
+        Base.@_inline_meta
+        @inbounds copyto_slab!(out, sbc, slabidx)
     end
     return out
 end
@@ -207,7 +208,7 @@ end
 
 Copy the slab indexed by `slabidx` from `bc` to `out`.
 """
-function copyto_slab!(out, bc, slabidx)
+@inline function copyto_slab!(out, bc, slabidx)
     space = axes(out)
     QS = Spaces.quadrature_style(space)
     Nq = Quadratures.degrees_of_freedom(QS)


### PR DESCRIPTION
Running

```julia
import ClimaShallowWater as CSW
import OrdinaryDiffEq as ODE
using BenchmarkTools
integrator = CSW.setup_integrator(["--output-nsteps", "0"])
trial = BenchmarkTools.@benchmark ODE.step!($integrator)
show(stdout, MIME("text/plain"), trial)
```

in ClimaShallowWater yields:


ClimaCore Main branch:
```julia
julia> include("perf/benchmark.jl")
[ Info: Precompiling ClimaShallowWater [77cbd926-740a-4734-9de9-4655503a1911]
┌ Info: Setting up experiment
│   device = ClimaComms.CPU()
│   context = ClimaComms.SingletonCommsContext{ClimaComms.CPU}(ClimaComms.CPU())
│   testcase = ClimaShallowWater.SteadyStateTest(ClimaShallowWater.SphericalParameters(6.37122e6, 7.292e-5, 9.80616, 0.0015, 0.0), 38.61068276698372, 2998.1154702758267)
│   float_type = Float64
│   panel_size = 8
│   poly_nodes = 4
│   time_step = 360.0
│   time_end = 172800.0
│   approx_resolution = 384185.2320888938
└   D₄ = 1.458434484260881e16
BenchmarkTools.Trial: 524 samples with 1 evaluation.
 Range (min … max):  9.264 ms …  11.551 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     9.435 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   9.544 ms ± 319.555 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▃▃▆██▇▆▅▅▅▄▂▂▂▂▂▁ ▁                                          
  ███████████████████▇▇▇▇▆▆▆▆▆▆▄▇▄▄▆▆▁▄▁▄▄▄▆▄▄▆▁▁▄▄▇▆▁▆▁▄▄▆▁▄ █
  9.26 ms      Histogram: log(frequency) by time      10.8 ms <

 Memory estimate: 48 bytes, allocs estimate: 6.
```

This PR:
```julia
julia> include("perf/benchmark.jl")
[ Info: Precompiling ClimaShallowWater [77cbd926-740a-4734-9de9-4655503a1911]
┌ Info: Setting up experiment
│   device = ClimaComms.CPU()
│   context = ClimaComms.SingletonCommsContext{ClimaComms.CPU}(ClimaComms.CPU())
│   testcase = ClimaShallowWater.SteadyStateTest(ClimaShallowWater.SphericalParameters(6.37122e6, 7.292e-5, 9.80616, 0.0015, 0.0), 38.61068276698372, 2998.1154702758267)
│   float_type = Float64
│   panel_size = 8
│   poly_nodes = 4
│   time_step = 360.0
│   time_end = 172800.0
│   approx_resolution = 384185.2320888938
└   D₄ = 1.458434484260881e16
BenchmarkTools.Trial: 622 samples with 1 evaluation.
 Range (min … max):  7.839 ms …   9.307 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     7.933 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   8.043 ms ± 288.004 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▂█▇ ▁                                                        
  ███▇██▆▆▅▄▅▄▄▄▃▄▃▃▃▂▂▂▂▂▁▂▂▃▁▂▂▂▁▂▂▁▁▁▂▂▂▃▁▂▁▂▂▂▂▂▂▃▂▂▂▂▂▂▂ ▃
  7.84 ms         Histogram: frequency by time        9.11 ms <

 Memory estimate: 48 bytes, allocs estimate: 6.
```


The difference is also apparent in the flame graph.