### PR TITLE
switch block dimension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.10.30"
+version = "0.10.31"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Operators/spectralelement.jl
+++ b/src/Operators/spectralelement.jl
@@ -273,15 +273,15 @@ function Base.copyto!(
     Nh = Topologies.nlocalelems(Spaces.topology(space))
     Nv = Spaces.nlevels(space)
 
-    @cuda threads = (Nq, Nq) blocks = (Nv, Nh) copyto_kernel!(out, sbc)
+    @cuda threads = (Nq, Nq) blocks = (Nh, Nv) copyto_kernel!(out, sbc)
     return out
 end
 
 function copyto_kernel!(out::Fields.SpectralElementField2D, sbc)
     i = threadIdx().x
     j = threadIdx().y
+    h = blockIdx().x
     v = nothing
-    h = blockIdx().y
     ij = CartesianIndex((i, j))
     slabidx = Fields.SlabIndex(v, h)
     result = get_node(sbc, ij, slabidx)


### PR DESCRIPTION
There is a limit of 65535 blocks in the y and z dimensions, which limited the number of elements we could use. Switching this to the x dimension should fix the problem: it has a limit of 2^31-1, and we are unlikely to have 65535 vertical levels.

Fixes https://github.com/CliMA/ClimaShallowWater.jl/issues/16

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
