### PR TITLE
Deformation flow example: add different upwinding modes

### DIFF
--- a/examples/hybrid/sphere/deformation_flow.jl
+++ b/examples/hybrid/sphere/deformation_flow.jl
@@ -146,27 +146,27 @@ function vertical_tendency!(Yₜ, Y, cache, t)
         if isnothing(fct_op)
             @. ρqₜ_n -= vdivf2c(ᶠwinterp(ᶜJ, Y.c.ρ) * face_uᵥ * Ic2f(q_n))
         elseif fct_op == upwind1
-            @. ρqₜ_n -= vdivf2c(Ic2f(Y.c.ρ) * upwind1(face_uᵥ, q_n))
+            @. ρqₜ_n -= vdivf2c(ᶠwinterp(ᶜJ, Y.c.ρ) * upwind1(face_uᵥ, q_n))
         elseif fct_op == upwind3
-            @. ρqₜ_n -= vdivf2c(Ic2f(Y.c.ρ) * upwind3(face_uᵥ, q_n))
+            @. ρqₜ_n -= vdivf2c(ᶠwinterp(ᶜJ, Y.c.ρ) * upwind3(face_uᵥ, q_n))
         elseif fct_op == FCTBorisBook
             @. ρqₜ_n -= vdivf2c(
-                Ic2f(Y.c.ρ) * (
+                ᶠwinterp(ᶜJ, Y.c.ρ) * (
                     upwind1(face_uᵥ, q_n) + FCTBorisBook(
                         upwind3(face_uᵥ, q_n) - upwind1(face_uᵥ, q_n),
                         q_n / dt -
-                        vdivf2c(Ic2f(Y.c.ρ) * upwind1(face_uᵥ, q_n)) / Y.c.ρ,
+                        vdivf2c(ᶠwinterp(ᶜJ, Y.c.ρ) * upwind1(face_uᵥ, q_n)) / Y.c.ρ,
                     )
                 ),
             )
         elseif fct_op == FCTZalesak
             @. ρqₜ_n -= vdivf2c(
-                Ic2f(Y.c.ρ) * (
+                ᶠwinterp(ᶜJ, Y.c.ρ) * (
                     upwind1(face_uᵥ, q_n) + FCTZalesak(
                         upwind3(face_uᵥ, q_n) - upwind1(face_uᵥ, q_n),
                         q_n / dt,
                         q_n / dt -
-                        vdivf2c(Ic2f(Y.c.ρ) * upwind1(face_uᵥ, q_n)) / Y.c.ρ,
+                        vdivf2c(ᶠwinterp(ᶜJ, Y.c.ρ) * upwind1(face_uᵥ, q_n)) / Y.c.ρ,
                     )
                 ),
             )


### PR DESCRIPTION
This quick PR adds two different upwinding modes to our deformation flow example: centered diff and first-order upwinding, for comparison of behaviors. This is part of the investigation of first-order upwinding in ClimaAtmos. It was recommended to me to use this example.

It also renamed the existing reference solution to specify that it was third-order upwinding.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
