### PR TITLE
Distr. regridding - local indices in LinearMap

### DIFF
--- a/lib/ClimaCoreTempestRemap/test/mpi_tests/online_remap.jl
+++ b/lib/ClimaCoreTempestRemap/test/mpi_tests/online_remap.jl
@@ -60,7 +60,7 @@ using Test
     field_i_singleton =
         MPI.bcast(field_i_singleton, root_pid, comms_ctx.mpicomm)
 
-    R = CCTR.generate_map(
+    R_distr = CCTR.generate_map(
         space_o_singleton,
         space_i_singleton,
         target_space_distr = space_o_distr,
@@ -68,15 +68,16 @@ using Test
 
     if ClimaComms.iamroot(comms_ctx)
         # remap without MPI (for testing comparison) and plot solution
+        R_singleton = CCTR.generate_map(space_o_singleton, space_i_singleton)
         field_o_singleton = Fields.zeros(space_o_singleton)
-        CCTR.remap!(field_o_singleton, R, field_i_singleton)
+        CCTR.remap!(field_o_singleton, R_singleton, field_i_singleton)
     end
 
     # setup and apply the remap using distributed approach
     field_o_distr = Fields.zeros(space_o_distr)
 
     # apply the remapping to field_i_singleton and store the result in field_o_distr
-    CCTR.remap!(field_o_distr, R, field_i_singleton)
+    CCTR.remap!(field_o_distr, R_distr, field_i_singleton)
 
     # compute analytical solution for comparison
     field_ref = sind.(Fields.coordinate_field(space_o_distr).long)

--- a/lib/ClimaCoreTempestRemap/test/online_remap.jl
+++ b/lib/ClimaCoreTempestRemap/test/online_remap.jl
@@ -22,9 +22,9 @@ function reshape_sparse_to_field!(field::Fields.Field, in_array::Array, R)
     f = 1
     for (n, row) in enumerate(R.row_indices)
         it, jt, et = (
-            view(R.target_idxs[1], n),
-            view(R.target_idxs[2], n),
-            view(R.target_idxs[3], n),
+            view(R.target_local_idxs[1], n),
+            view(R.target_local_idxs[2], n),
+            view(R.target_local_idxs[3], n),
         )
         for f in 1:Nf
             field_array[it, jt, f, et] .= in_array[row]


### PR DESCRIPTION
This PR stores local target indices in `LinearMap` instead of the unique indices used by TempestRemap. This will make the `remap!` function cleaner and isolate these internals to `generate_map`.

Note: This function includes one workaround which is not ideal but will be removed in the next implementation. On each process, the source indices, target indices, and weight vectors stored in `LinearMap` have to have the same length so that the values align in the correct positions to perform the multiplication in `remap!`. However, if each process only stored its local source/target indices, these vectors would be smaller than the weights. To get around this, I set the entire target index vector to 0 on each process and only filled in the correct values for local indices. In the next implementation, we will instead store only the local values of the indices and weights on each process.

Note 2: This implementation only works for remappings where the partitions of the source and target spaces are collocated. For non-aligned meshes, we'll need to implement the super-halo exchange for source data to get correct results.

This closes #1191.

## Quality assurance
Distribued remapping is compared against serial remapping (i.e. the previous implementation), as well as the analytical solution. The distributed and serial solutions are quantitatively found to have error of less than 10^-20, and are also compared visually in the following plots:

<img width="360" alt="regrid_source_data" src="https://user-images.githubusercontent.com/51397186/233468508-8ba368f7-254e-4c5b-97ef-125c619d5288.png">
<img width="360" alt="regrid_target_data_mpi" src="https://user-images.githubusercontent.com/51397186/233468531-03ef7ea5-5412-4abc-81fc-e339bb830836.png">
<img width="360" alt="regrid_target_data_serial" src="https://user-images.githubusercontent.com/51397186/233468544-17510286-0256-4324-88e2-759dbc0ef5a6.png">
<img width="360" alt="regrid_target_data_analytical" src="https://user-images.githubusercontent.com/51397186/233468561-1a4b1bdc-a06d-4d3a-bd3b-29e52c0057f1.png">

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
