### PR TITLE
Add and fix JET tests for DSS

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -856,6 +856,13 @@ steps:
         soft_fail:
           - exit_status: 1
 
+      - label: ":rocket: Spectral element operator benchmarks (extruded CPU Float64)"
+        key: "gpu_spectral_ops_bm_extruded_cpu_float64"
+        command:
+          - "julia --color=yes --project=test test/Operators/spectralelement/benchmark_ops.jl --device CPU --float-type Float64 --space-type ExtrudedFiniteDifferenceSpace"
+        soft_fail:
+          - exit_status: 1
+
       - label: ":rocket: Spectral element operator benchmarks"
         key: "gpu_spectral_ops_bm"
         command:

--- a/test/Operators/spectralelement/benchmark_kernels.jl
+++ b/test/Operators/spectralelement/benchmark_kernels.jl
@@ -97,7 +97,8 @@ kernel_spectral_u_cross_curl_u_array!(args) = kernel_copyto!(args)
 function kernel_spectral_u_cross_curl_u!(args)
     (; u, f, du) = args
     curl = Operators.Curl()
-    @. du = u × (f + curl(u))
+    CT12 = Geometry.Contravariant12Vector
+    @. du = CT12(u) × (f + curl(u))
     return
 end
 
@@ -120,5 +121,27 @@ function kernel_vector_dss!(args)
     Spaces.weighted_dss_start!(u, u_buffer)
     Spaces.weighted_dss_internal!(u, u_buffer)
     Spaces.weighted_dss_ghost!(u, u_buffer)
+    return
+end
+
+##### field dss!
+kernel_field_dss_array!(args) = kernel_copyto!(args)
+function kernel_field_dss!(args)
+    (; ϕψ_buffer) = args.buffers
+    (; ϕψ) = args
+    Spaces.weighted_dss_start!(ϕψ, ϕψ_buffer)
+    Spaces.weighted_dss_internal!(ϕψ, ϕψ_buffer)
+    Spaces.weighted_dss_ghost!(ϕψ, ϕψ_buffer)
+    return
+end
+
+##### ntuple_field dss!
+kernel_ntuple_field_dss_array!(args) = kernel_copyto!(args)
+function kernel_ntuple_field_dss!(args)
+    (; nt_ϕψ_buffer) = args.buffers
+    (; nt_ϕψ) = args
+    Spaces.weighted_dss_start!(nt_ϕψ, nt_ϕψ_buffer)
+    Spaces.weighted_dss_internal!(nt_ϕψ, nt_ϕψ_buffer)
+    Spaces.weighted_dss_ghost!(nt_ϕψ, nt_ϕψ_buffer)
     return
 end

--- a/test/Operators/spectralelement/benchmark_ops.jl
+++ b/test/Operators/spectralelement/benchmark_ops.jl
@@ -12,17 +12,17 @@ For interactive experimentation:
 using Revise; using ClimaCore
 include(joinpath(pkgdir(ClimaCore), "test", "Operators", "spectralelement", "benchmark_utils.jl"))
 include(joinpath(pkgdir(ClimaCore), "test", "Operators", "spectralelement", "benchmark_kernels.jl"))
-args = setup_kernel_args(["--device", "CUDA"]);
-device = args.device
-trial = benchmark_kernel!(args, kernel_spectral_div_grad!, device; silent=true);
-trial = benchmark_kernel_array!(args.arr_args, kernel_spectral_wdiv_array!, device; silent=true);
+kernel_args = setup_kernel_args(["--float-type", "Float64"]);
+device = kernel_args.device
+trial = benchmark_kernel!(kernel_args, kernel_spectral_div_grad!, device; silent=true);
+trial = benchmark_kernel_array!(kernel_args.arr_args, kernel_spectral_wdiv_array!, device; silent=true);
 show(stdout, MIME("text/plain"), trial);
 ```
 
 Notes:
 ```
 using CUDA
-CUDA.@profile kernel_spectral_div_grad!(args)
+CUDA.@profile kernel_spectral_div_grad!(kernel_args)
 ```
 =#
 import ClimaCore as CC
@@ -58,8 +58,8 @@ include(
 ##### Compare timings
 #####
 
-function benchmark_all(ARGS::Vector{String} = ARGS)
-    kernel_args = setup_kernel_args(ARGS)
+function benchmark_all(kernel_args = setup_kernel_args(ARGS))
+
     device = kernel_args.device
     #=
     # Run benchmarks for a single kernel with:
@@ -105,9 +105,35 @@ function benchmark_all(ARGS::Vector{String} = ARGS)
     for key in keys(bm)
         println("    best_times[:$key] = $(bm[key].t_mean_float)")
     end
-    return bm, kernel_args
+    return bm
 end
 
-bm, kernel_args = benchmark_all(ARGS);
+kernel_args = setup_kernel_args(ARGS);
+bm = benchmark_all(kernel_args);
 best_times = get_best_times(kernel_args);
 test_against_best_times(bm, best_times);
+
+using JET
+@testset "DSS performance" begin
+    kernel_scalar_dss!(kernel_args) # compile+test works
+    kernel_vector_dss!(kernel_args) # compile+test works
+    kernel_field_dss!(kernel_args) # compile+test works
+    kernel_ntuple_field_dss!(kernel_args) # compile+test works
+    # TODO: widen these tests to the GPU.
+    if kernel_args.device isa ClimaComms.CPUDevice
+        # Allocation tests
+        p = @allocated kernel_scalar_dss!(kernel_args)
+        @test p == 0
+        p = @allocated kernel_vector_dss!(kernel_args)
+        @test p == 0
+        p = @allocated kernel_field_dss!(kernel_args)
+        @test p == 0
+        p = @allocated kernel_ntuple_field_dss!(kernel_args)
+        @test p == 0
+        # Inference tests
+        JET.@test_opt kernel_scalar_dss!(kernel_args)
+        JET.@test_opt kernel_vector_dss!(kernel_args)
+        JET.@test_opt kernel_field_dss!(kernel_args)
+        JET.@test_opt kernel_ntuple_field_dss!(kernel_args)
+    end
+end

--- a/test/Operators/spectralelement/benchmark_utils.jl
+++ b/test/Operators/spectralelement/benchmark_utils.jl
@@ -105,13 +105,29 @@ function create_space(
     float_type = Float64,
     panel_size = 9,
     poly_nodes = 4,
+    z_elem = 10,
+    space_type,
 )
     earth_radius = float_type(6.37122e6)
-    domain = Domains.SphereDomain(earth_radius)
-    mesh = Meshes.EquiangularCubedSphere(domain, panel_size)
+    hdomain = Domains.SphereDomain(earth_radius)
+    hmesh = Meshes.EquiangularCubedSphere(hdomain, panel_size)
+    htopology = Topologies.Topology2D(context, hmesh)
     quad = Spaces.Quadratures.GLL{poly_nodes}()
-    topology = Topologies.Topology2D(context, mesh)
-    space = Spaces.SpectralElementSpace2D(topology, quad)
+    space = if space_type == "SpectralElementSpace2D"
+        Spaces.SpectralElementSpace2D(htopology, quad)
+    elseif space_type == "ExtrudedFiniteDifferenceSpace"
+        zlim = (0, 30e3)
+        vertdomain = Domains.IntervalDomain(
+            Geometry.ZPoint{float_type}(zlim[1]),
+            Geometry.ZPoint{float_type}(zlim[2]);
+            boundary_tags = (:bottom, :top),
+        )
+        vertmesh = Meshes.IntervalMesh(vertdomain, nelems = z_elem)
+        vtopology = Topologies.IntervalTopology(context, vertmesh)
+        vspace = Spaces.CenterFiniteDifferenceSpace(vtopology)
+        hspace = Spaces.SpectralElementSpace2D(htopology, quad)
+        Spaces.ExtrudedFiniteDifferenceSpace(hspace, vspace)
+    end
     return space
 end
 
@@ -134,6 +150,14 @@ function setup_kernel_args(ARGS::Vector{String} = ARGS)
         help = "Number of elements across each panel"
         arg_type = Int
         default = 8
+        "--z_elem"
+        help = "Number of vertical elements (for extruded spaces)"
+        arg_type = Int
+        default = 10
+        "--space-type"
+        help = "Space type [`SpectralElementSpace2D` (default) `ExtrudedFiniteDifferenceSpace`]"
+        arg_type = String
+        default = "SpectralElementSpace2D"
         "--poly-nodes"
         help = "Number of nodes in each dimension to use in the polynomial approximation. Polynomial degree = poly-nodes - 1."
         arg_type = Int
@@ -169,20 +193,36 @@ function setup_kernel_args(ARGS::Vector{String} = ARGS)
     float_type = args["float-type"]
     panel_size = args["panel-size"]
     poly_nodes = args["poly-nodes"]
-    space = create_space(context; float_type, panel_size, poly_nodes)
+    space_type = args["space-type"]
+    z_elem = args["z_elem"]
+    space = create_space(
+        context;
+        float_type,
+        panel_size,
+        poly_nodes,
+        space_type,
+        z_elem,
+    )
+    space_name = nameof(typeof(space))
     if ClimaComms.iamroot(context)
         nprocs = ClimaComms.nprocs(context)
-        @info "Setting up benchmark" device context float_type panel_size poly_nodes
+        @info "Setting up benchmark" device context float_type panel_size poly_nodes space_name
     end
 
     # Fields
     FT = float_type
     ϕ = zeros(space)
     ψ = zeros(space)
+    combine(ϕ, ψ) = (; ϕ, ψ)
+    combine_nt(ϕ, ψ) = ntuple(i -> (; ϕ, ψ), 2)
+    ϕψ = combine.(ϕ, ψ)
+    nt_ϕψ = combine_nt.(ϕ, ψ)
     u = initial_velocity(space)
     du = initial_velocity(space)
     ϕ_buffer = Spaces.create_dss_buffer(ϕ)
     u_buffer = Spaces.create_dss_buffer(u)
+    ϕψ_buffer = Spaces.create_dss_buffer(ϕψ)
+    nt_ϕψ_buffer = Spaces.create_dss_buffer(nt_ϕψ)
     f = @. Geometry.Contravariant3Vector(Geometry.WVector(ϕ))
 
     s = size(parent(ϕ))
@@ -193,8 +233,9 @@ function setup_kernel_args(ARGS::Vector{String} = ARGS)
         (; ϕ_arr = CUDA.fill(FT(1), s), ψ_arr = CUDA.fill(FT(2), s))
     end
 
-    kernel_args = (; ϕ, ψ, u, du, f)
-    buffers = (; u_buffer, ϕ_buffer) # cannot reside in CuArray kernels
+    kernel_args = (; ϕ, ψ, u, du, f, ϕψ, nt_ϕψ)
+    # buffers cannot reside in CuArray kernels
+    buffers = (; u_buffer, ϕ_buffer, ϕψ_buffer, nt_ϕψ_buffer)
 
     arr_args = (; array_kernel_args..., kernel_args..., device)
     return (; arr_args..., buffers, arr_args, float_type)


### PR DESCRIPTION
This PR adds and fixes JET tests for DSS.

This is actually also going to fix a bug: `map(zero, slab(perimeter_data, 1, 1)[1])` is not the correct eltype for ntuple fields + when there are ghost vertices, but our test suite does not cover this situation (until now).

Closes #1285, #1283.

I've added a TODO for widening the perf tests for the GPU. Right now, this fixes the CPU inference issues, and hooks in allocation tests.