### PR TITLE
Rm broken column integrals, lower amb lim

### DIFF
--- a/src/Operators/integrals.jl
+++ b/src/Operators/integrals.jl
@@ -3,19 +3,6 @@
 #####
 
 """
-    column_integral_definite(field::Field)
-
-The definite vertical column integral of field `field`.
-"""
-column_integral_definite(field::Fields.CenterExtrudedFiniteDifferenceField) =
-    column_integral_definite(field, 1)
-column_integral_definite(field::Fields.FaceExtrudedFiniteDifferenceField) =
-    column_integral_definite(field, PlusHalf(1))
-
-column_integral_definite(field::Fields.Field, one_index::Union{Int, PlusHalf}) =
-    column_integral_definite(similar(level(field, one_index)), field)
-
-"""
     column_integral_definite!(col∫field::Field, field::Field)
 
 The definite vertical column integral, `col∫field`, of field `field`.

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -20,7 +20,7 @@ using Aqua
     # then please lower the limit based on the new number of ambiguities.
     # We're trying to drive this number down to zero to reduce latency.
     @info "Number of method ambiguities: $(length(ambs))"
-    @test length(ambs) ≤ 17
+    @test length(ambs) ≤ 10
 
     # returns a vector of all unbound args
     # ua = Aqua.detect_unbound_args_recursively(ClimaCore)


### PR DESCRIPTION
This PR:
 - Reduces the number of allowable method ambiguities to our current number of ambiguities (8)
 - Removes the broken, unused and untested `column_integral_definite`. It's broken because

```julia
column_integral_definite(field::Fields.Field, one_index::Union{Int, PlusHalf}) =
    column_integral_definite(similar(level(field, one_index)), field)
```
populates a temporary array (`similar(level(field, one_index))`) with the result, which users do not have access to, so it's a bug. Also, there's a method ambiguity between this method and the method that actually does all the work:


```julia
function column_integral_definite(field::Fields.ColumnField)
    field_data = Fields.field_values(field)
    Δz_data = Spaces.Δz_data(axes(field))
    Nv = Spaces.nlevels(axes(field))
    ∫field = zero(eltype(field))
    @inbounds for j in 1:Nv
        ∫field += field_data[j] * Δz_data[j]
    end
    return ∫field
end
```