### PR TITLE
Test check bounds only when forced

### DIFF
--- a/test/Operators/finitedifference/column.jl
+++ b/test/Operators/finitedifference/column.jl
@@ -189,7 +189,12 @@ end
         ∂ = Operators.GradientF2C()
 
         # TODO: should we throw something else?
-        @test_throws BoundsError ∂.(w .* I.(θ))
+        are_boundschecks_forced = Base.JLOptions().check_bounds == 1
+        if are_boundschecks_forced
+            @test_throws BoundsError ∂.(w .* I.(θ))
+        else
+            @warn "Bounds check on BoundsError ∂.(w .* I.(θ)) not verified."
+        end
     end
 end
 


### PR DESCRIPTION
I've found many users find this unintuitive (e.g., [here](https://github.com/CliMA/ClimaCore.jl/issues/1196)), perhaps we can skip this test if bounds checks are not forced?

This will make

```julia
include("test/runtests.jl")
```
Pass with or without `--check-bounds=true`.