### PR TITLE
Remove bubble warning

### DIFF
--- a/src/Spaces/spectralelement.jl
+++ b/src/Spaces/spectralelement.jl
@@ -275,7 +275,6 @@ function SpectralElementSpace2D(
 
     local_geometry = DataLayouts.IJFH{LG, Nq}(Array{FT}, nlelems)
     ghost_geometry = DataLayouts.IJFH{LG, Nq}(Array{FT}, ngelems)
-    bubble_warn = false
 
     quad_points, quad_weights =
         Quadratures.quadrature_points(FT, quadrature_style)
@@ -317,7 +316,6 @@ function SpectralElementSpace2D(
         # If enabled, apply bubble correction
         if enable_bubble
             if abs(elem_area - high_order_elem_area) ≤ eps(FT)
-                bubble_warn = true
                 for i in 1:Nq, j in 1:Nq
                     ξ = SVector(quad_points[i], quad_points[j])
                     u, ∂u∂ξ = compute_local_geometry(
@@ -406,9 +404,6 @@ function SpectralElementSpace2D(
                 end
             end
         end
-    end
-    if bubble_warn
-        @warn "The numerical and geometric areas of the element are equal. The bubble correction will not be performed."
     end
 
     # alternatively, we could do a ghost exchange here?


### PR DESCRIPTION
It was recently suggested that we remove the bubble correction [warning](https://github.com/CliMA/ClimaCore.jl/blob/main/src/Spaces/spectralelement.jl#L410-L412) since now it is used as default in the downstream repo (ClimaAtmos), so the user might not care about this warning.

This will close #1210 

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
