### PR TITLE
Add inbounds to slab indices

### DIFF
--- a/src/Fields/indices.jl
+++ b/src/Fields/indices.jl
@@ -137,18 +137,22 @@ struct SlabIndex{VIdx, HIdx}
 end
 
 
-Base.getindex(field::Field, slabidx::SlabIndex) = slab(field, slabidx)
+Base.@propagate_inbounds Base.getindex(field::Field, slabidx::SlabIndex) =
+    slab(field, slabidx)
 
-function slab(field::SpectralElementField, slabidx::SlabIndex{Nothing})
+Base.@propagate_inbounds function slab(
+    field::SpectralElementField,
+    slabidx::SlabIndex{Nothing},
+)
     slab(field, slabidx.h)
 end
-function slab(
+Base.@propagate_inbounds function slab(
     field::CenterExtrudedFiniteDifferenceField,
     slabidx::SlabIndex{Int},
 )
     slab(field, slabidx.v, slabidx.h)
 end
-function slab(
+Base.@propagate_inbounds function slab(
     field::FaceExtrudedFiniteDifferenceField,
     slabidx::SlabIndex{PlusHalf{Int}},
 )
@@ -157,25 +161,29 @@ end
 
 function byslab(fn, space::Spaces.AbstractSpectralElementSpace)
     Nh = Topologies.nlocalelems(space.topology)::Int
-    for h in 1:Nh
+    @inbounds for h in 1:Nh
         fn(SlabIndex(nothing, h))
     end
 end
 function byslab(fn, space::Spaces.CenterExtrudedFiniteDifferenceSpace)
     Nh = Topologies.nlocalelems(Spaces.topology(space))
     Nv = Spaces.nlevels(space)
-    for h in 1:Nh
-        for v in 1:Nv
-            fn(SlabIndex(v, h))
+    @inbounds begin
+        for h in 1:Nh
+            for v in 1:Nv
+                fn(SlabIndex(v, h))
+            end
         end
     end
 end
 function byslab(fn, space::Spaces.FaceExtrudedFiniteDifferenceSpace)
     Nh = Topologies.nlocalelems(Spaces.topology(space))
     Nv = Spaces.nlevels(space)
-    for h in 1:Nh
-        for v in 1:Nv
-            fn(SlabIndex(v - half, h))
+    @inbounds begin
+        for h in 1:Nh
+            for v in 1:Nv
+                fn(SlabIndex(v - half, h))
+            end
         end
     end
 end


### PR DESCRIPTION
This PR adds some `@inbounds` to the `byslab` operators. The div benchmark goes from 120 um to 105 um on my machine.

I found this in the ClimaAtmos long runs allocation job [here](https://buildkite.com/clima/climaatmos-longruns/builds/948#0187cb66-93ee-4254-a3a4-c6a43e3ff8fe/141-208). I'm hoping that this fixes the allocations