### PR TITLE
Add bench test for bycol broadcast fallback

### DIFF
--- a/test/Operators/finitedifference/column_benchmark.jl
+++ b/test/Operators/finitedifference/column_benchmark.jl
@@ -1,3 +1,7 @@
+#=
+julia --project=test
+using Revise; include(joinpath("test", "Operators", "finitedifference", "column_benchmark.jl"))
+=#
 include("column_benchmark_utils.jl")
 
 @testset "Benchmark operators" begin

--- a/test/Operators/finitedifference/column_benchmark_kernels.jl
+++ b/test/Operators/finitedifference/column_benchmark_kernels.jl
@@ -106,6 +106,28 @@ function op_divUpwind3rdOrderBiasedProductC2F!(c, f, bcs)
     return nothing
 end
 
+function op_broadcast_example0!(c, f, bcs)
+    Fields.bycolumn(axes(f.ᶠu³)) do colidx
+        CT3 = Geometry.Contravariant3Vector
+        @. f.ᶠu³[colidx] = f.ᶠu³[colidx] + f.ᶠu³[colidx]
+    end
+    return nothing
+end
+
+function op_broadcast_example1!(c, f, bcs)
+    Fields.bycolumn(axes(f.ᶠu³)) do colidx
+        CT3 = Geometry.Contravariant3Vector
+        @. f.ᶠu³[colidx] = f.ᶠuₕ³[colidx] + CT3(f.ᶠw[colidx])
+    end
+    return nothing
+end
+
+function op_broadcast_example2!(c, f, bcs)
+    CT3 = Geometry.Contravariant3Vector
+    @. f.ᶠu³ = f.ᶠuₕ³ + CT3(f.ᶠw)
+    return nothing
+end
+
 #=
 #####
 ##### Remaining TODOs


### PR DESCRIPTION
I took a look at the flame graph for the ClimaAtmos `longrun_aquaplanet_rhoe_equil_highres_allsky_ft64` job (the one that takes ~3 days to run) and found a pretty wide flame:

<img width="1350" alt="Screen Shot 2023-05-03 at 11 08 39 AM" src="https://user-images.githubusercontent.com/1880641/236006032-9c3fbb36-66dc-4489-b4da-91bea2d9ea6b.png">
which pointed to 

```julia
    Fields.bycolumn(axes(ᶜu)) do colidx
        @. ᶜu[colidx] = C123(ᶜuₕ[colidx]) + ᶜinterp(C123(ᶠw[colidx]))
        @. ᶠu³[colidx] = ᶠuₕ³[colidx] + CT3(ᶠw[colidx]) # <---------------------- this line
        compute_kinetic!(ᶜK[colidx], ᶜuₕ[colidx], ᶠw[colidx])
    end
```
Looking at this, it's actually not using `apply_stencil!` (being that it's not an operator), it's falling back on some bycolumn broadcasting which, for this particular expression, is very slow-- about 13 μs on my machine, as opposed to many other FD operators at about 200 ns. The baseline (roughly a `copyto!`) `bycolumn` operation takes ~400 ns.

This PR adds this example to the column benchmark in hopes to fix this issue.