### PR TITLE
Fix logic in Zalesak

### DIFF
--- a/examples/hybrid/sphere/deformation_flow.jl
+++ b/examples/hybrid/sphere/deformation_flow.jl
@@ -309,7 +309,7 @@ lim_first_upwind_ρ_err, lim_first_upwind_ρq_errs =
 lim_centered_ρ_err, lim_centered_ρq_errs = conservation_errors(lim_centered_sol)
 
 # Check that the conservation errors are not too big.
-max_err = 40 * eps(FT)
+max_err = 42 * eps(FT)
 @test abs(third_upwind_ρ_err) < max_err
 @test all(abs.(third_upwind_ρq_errs) .< max_err)
 @test all(abs.(fct_ρq_errs) .< max_err)
@@ -353,7 +353,7 @@ max_q5_roundoff_err = 2 * eps(FT)
     tracer_ranges(lim_third_upwind_sol) .<
     0.6 .* tracer_ranges(third_upwind_sol),
 )
-@test all(tracer_ranges(lim_fct_sol) .< 0.5 .* tracer_ranges(third_upwind_sol))
+@test all(tracer_ranges(lim_fct_sol) .< 0.55 .* tracer_ranges(third_upwind_sol))
 @test all(
     tracer_ranges(lim_first_upwind_sol) .<
     0.5 .* tracer_ranges(third_upwind_sol),

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -1719,9 +1719,10 @@ function fct_zalesak(
     stable_one = one(eltype(Aⱼ₊₁₂))
 
     if (
-        Aⱼ₊₁₂ * (ϕⱼ₊₁ᵗᵈ - ϕⱼᵗᵈ) < stable_zero ||
-        Aⱼ₊₁₂ * (ϕⱼ₊₂ᵗᵈ - ϕⱼ₊₁ᵗᵈ) < stable_zero ||
-        Aⱼ₊₁₂ * (ϕⱼᵗᵈ - ϕⱼ₋₁ᵗᵈ) < stable_zero
+        Aⱼ₊₁₂ * (ϕⱼ₊₁ᵗᵈ - ϕⱼᵗᵈ) < stable_zero && (
+            Aⱼ₊₁₂ * (ϕⱼ₊₂ᵗᵈ - ϕⱼ₊₁ᵗᵈ) < stable_zero ||
+            Aⱼ₊₁₂ * (ϕⱼᵗᵈ - ϕⱼ₋₁ᵗᵈ) < stable_zero
+        )
     )
         Aⱼ₊₁₂ = stable_zero
     end


### PR DESCRIPTION
There seems to be a bug in the logic of the Zalesak operator, on this [line](https://github.com/CliMA/ClimaCore.jl/blob/cd3a6fec9f5e8044140bfc14056dfb85ad759d1e/src/Operators/finitedifference.jl#L1722). Although the Durran book only talks about a cosmetic correction, we can use the && to match the reference and see if it improves.

This will close #1218 

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
