### PR TITLE
remove broken annotations on tests

### DIFF
--- a/test/Operators/finitedifference/column.jl
+++ b/test/Operators/finitedifference/column.jl
@@ -26,28 +26,22 @@ device = ClimaComms.device()
         center_space = Spaces.CenterFiniteDifferenceSpace(topology)
         face_space = Spaces.FaceFiniteDifferenceSpace(center_space)
 
-        @test sum(ones(FT, center_space)) ≈ pi broken =
-            device isa ClimaComms.CUDADevice
-        @test sum(ones(FT, face_space)) ≈ pi broken =
-            device isa ClimaComms.CUDADevice
+        @test sum(ones(FT, center_space)) ≈ pi
+        @test sum(ones(FT, face_space)) ≈ pi
 
         centers = getproperty(Fields.coordinate_field(center_space), :z)
-        @test sum(sin.(centers)) ≈ FT(2.0) atol = 1e-2 broken =
-            device isa ClimaComms.CUDADevice
+        @test sum(sin.(centers)) ≈ FT(2.0) atol = 1e-2
 
         faces = getproperty(Fields.coordinate_field(face_space), :z)
-        @test sum(sin.(faces)) ≈ FT(2.0) atol = 1e-2 broken =
-            device isa ClimaComms.CUDADevice
+        @test sum(sin.(faces)) ≈ FT(2.0) atol = 1e-2
 
         ∇ᶜ = Operators.GradientF2C()
         ∂sin = Geometry.WVector.(∇ᶜ.(sin.(faces)))
-        @test ∂sin ≈ Geometry.WVector.(cos.(centers)) atol = 1e-2 broken =
-            device isa ClimaComms.CUDADevice
+        @test ∂sin ≈ Geometry.WVector.(cos.(centers)) atol = 1e-2
 
         divᶜ = Operators.DivergenceF2C()
         ∂sin = divᶜ.(Geometry.WVector.(sin.(faces)))
-        @test ∂sin ≈ cos.(centers) atol = 1e-2 broken =
-            device isa ClimaComms.CUDADevice
+        @test ∂sin ≈ cos.(centers) atol = 1e-2
 
         # Center -> Face operator
         # first order convergence at boundaries
@@ -56,24 +50,21 @@ device = ClimaComms.device()
             right = Operators.SetValue(FT(pi)),
         )
         ∂z = Geometry.WVector.(∇ᶠ.(centers))
-        @test ∂z ≈ Geometry.WVector.(ones(FT, face_space)) rtol = 10 * eps(FT) broken =
-            device isa ClimaComms.CUDADevice
+        @test ∂z ≈ Geometry.WVector.(ones(FT, face_space)) rtol = 10 * eps(FT)
 
         ∇ᶠ = Operators.GradientC2F(
             left = Operators.SetValue(FT(1)),
             right = Operators.SetValue(FT(-1)),
         )
         ∂cos = Geometry.WVector.(∇ᶠ.(cos.(centers)))
-        @test ∂cos ≈ Geometry.WVector.(.-sin.(faces)) atol = 1e-1 broken =
-            device isa ClimaComms.CUDADevice
+        @test ∂cos ≈ Geometry.WVector.(.-sin.(faces)) atol = 1e-1
 
         ∇ᶠ = Operators.GradientC2F(
             left = Operators.SetGradient(Geometry.WVector(FT(0))),
             right = Operators.SetGradient(Geometry.WVector(FT(0))),
         )
         ∂cos = Geometry.WVector.(∇ᶠ.(cos.(centers)))
-        @test ∂cos ≈ Geometry.WVector.(.-sin.(faces)) atol = 1e-2 broken =
-            device isa ClimaComms.CUDADevice
+        @test ∂cos ≈ Geometry.WVector.(.-sin.(faces)) atol = 1e-2
 
         # test that broadcasting into incorrect field space throws an error
         empty_centers = zeros(FT, center_space)


### PR DESCRIPTION
@sriharshakandala it looks like `sum` doesn't work on single columns:
```
julia> sum(ones(center_space))
ERROR: MethodError: no method matching mapreduce_cuda(::typeof(identity), ::typeof(+), ::ClimaCore.Fields.Field{ClimaCore.DataLayouts.VF{Float64, CUDA.CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}}, ClimaCore.Spaces.FiniteDifferenceSpace{ClimaCore.Spaces.CellCenter, ClimaCore.Topologies.IntervalTopology{ClimaComms.SingletonCommsContext{ClimaComms.CUDADevice}, ClimaCore.Meshes.IntervalMesh{ClimaCore.Domains.IntervalDomain{ClimaCore.Geometry.ZPoint{Float64}, Tuple{Symbol, Symbol}}, LinRange{ClimaCore.Geometry.ZPoint{Float64}, Int64}}, NamedTuple{(:left, :right), Tuple{Int64, Int64}}}, ClimaCore.Geometry.CartesianGlobalGeometry, ClimaCore.DataLayouts.VF{ClimaCore.Geometry.LocalGeometry{(3,), ClimaCore.Geometry.ZPoint{Float64}, Float64, SMatrix{1, 1, Float64, 1}}, CUDA.CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}}}}; weighting=true)
Stacktrace:
 [1] sum(field::ClimaCore.Fields.Field{ClimaCore.DataLayouts.VF{Float64, CUDA.CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}}, ClimaCore.Spaces.FiniteDifferenceSpace{ClimaCore.Spaces.CellCenter, ClimaCore.Topologies.IntervalTopology{ClimaComms.SingletonCommsContext{ClimaComms.CUDADevice}, ClimaCore.Meshes.IntervalMesh{ClimaCore.Domains.IntervalDomain{ClimaCore.Geometry.ZPoint{Float64}, Tuple{Symbol, Symbol}}, LinRange{ClimaCore.Geometry.ZPoint{Float64}, Int64}}, NamedTuple{(:left, :right), Tuple{Int64, Int64}}}, ClimaCore.Geometry.CartesianGlobalGeometry, ClimaCore.DataLayouts.VF{ClimaCore.Geometry.LocalGeometry{(3,), ClimaCore.Geometry.ZPoint{Float64}, Float64, SMatrix{1, 1, Float64, 1}}, CUDA.CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}}}}, #unused#::ClimaComms.CUDADevice)
   @ ClimaCore.Fields /central/home/spjbyrne/src/ClimaCore.jl/src/Fields/mapreduce_cuda.jl:5
 [2] sum(field::ClimaCore.Fields.Field{ClimaCore.DataLayouts.VF{Float64, CUDA.CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}}, ClimaCore.Spaces.FiniteDifferenceSpace{ClimaCore.Spaces.CellCenter, ClimaCore.Topologies.IntervalTopology{ClimaComms.SingletonCommsContext{ClimaComms.CUDADevice}, ClimaCore.Meshes.IntervalMesh{ClimaCore.Domains.IntervalDomain{ClimaCore.Geometry.ZPoint{Float64}, Tuple{Symbol, Symbol}}, LinRange{ClimaCore.Geometry.ZPoint{Float64}, Int64}}, NamedTuple{(:left, :right), Tuple{Int64, Int64}}}, ClimaCore.Geometry.CartesianGlobalGeometry, ClimaCore.DataLayouts.VF{ClimaCore.Geometry.LocalGeometry{(3,), ClimaCore.Geometry.ZPoint{Float64}, Float64, SMatrix{1, 1, Float64, 1}}, CUDA.CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}}}})
   @ ClimaCore.Fields /central/home/spjbyrne/src/ClimaCore.jl/src/Fields/mapreduce.jl:53
 [3] top-level scope
   @ REPL[17]:1
 [4] top-level scope
   @ ~/.julia/packages/CUDA/p5OVK/src/initialization.jl:171
SYSTEM (REPL): showing an error caused an error
ERROR: UndefVarError: T not defined
```

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
