### PR TITLE
Fix dss_transform ambiguity aqua test

### DIFF
--- a/src/Spaces/dss_transform.jl
+++ b/src/Spaces/dss_transform.jl
@@ -69,6 +69,11 @@ end
     weight,
 ) where {T, N} = arg * weight
 @inline dss_transform(
+    arg::Geometry.AxisTensor{T, N, <:Tuple{}},
+    local_geometry::Geometry.LocalGeometry,
+    weight,
+) where {T, N} = arg * weight
+@inline dss_transform(
     arg::Geometry.LocalVector,
     local_geometry::Geometry.LocalGeometry,
     weight,

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -20,7 +20,7 @@ using Aqua
     # then please lower the limit based on the new number of ambiguities.
     # We're trying to drive this number down to zero to reduce latency.
     @info "Number of method ambiguities: $(length(ambs))"
-    @test length(ambs) ≤ 16
+    @test length(ambs) ≤ 15
 
     # returns a vector of all unbound args
     # ua = Aqua.detect_unbound_args_recursively(ClimaCore)


### PR DESCRIPTION
This PR fixes a method ambiguity for `dss_transform`-- perhaps not too important, but 🤷🏻.