### PR TITLE
Add proposed new buffer to spectral element benchmarks

### DIFF
--- a/test/Operators/spectralelement/benchmark_utils.jl
+++ b/test/Operators/spectralelement/benchmark_utils.jl
@@ -234,13 +234,16 @@ end
 
 function test_against_best_times(bm, best_times)
     buffer = 1.4
+    new_buffer = 1
     pass(k) = bm[k].t_mean_float < best_times[k] * buffer
     intersect_keys = intersect(collect(keys(bm)), collect(keys(best_times)))
     if !all(k -> pass(k), intersect_keys)
         for k in keys(bm)
-            pass(k) ||
-                @error "$k failed: $(bm[k].t_mean_float) < $(best_times[k] * buffer)."
+            pass(k) && continue
+            @error "$k failed: $(bm[k].t_mean_float) < $(best_times[k] * buffer)."
+            new_buffer = max(new_buffer, bm[k].t_mean_float / best_times[k])
         end
+        @info "Proposed new buffer: $new_buffer"
         error("Spectral element CUDA operator benchmarks failed")
     else
         @info "Spectral element CUDA operator benchmarks passed 🎉"


### PR DESCRIPTION
This PR adds a proposed new buffer for when the spectral element benchmarks fail. This should help make updating the buffer a bit easier.