### PR TITLE
Fix _array_type for FieldVectors

### DIFF
--- a/src/Fields/fieldvector.jl
+++ b/src/Fields/fieldvector.jl
@@ -282,5 +282,5 @@ ClimaComms.array_type(x::FieldVector) = _array_type(x)
 
 @inline _array_type(x::FieldVector, pns::Tuple) = promote_type(
     _array_type(getproperty(x, first(pns))),
-    _array_type(x, Base.tail(pns))...,
+    _array_type(x, Base.tail(pns)),
 )

--- a/test/Fields/field.jl
+++ b/test/Fields/field.jl
@@ -164,6 +164,8 @@ end
     xcenters = Fields.coordinate_field(space).x
     y = Fields.FieldVector(x = xcenters)
     @test ClimaComms.array_type(y) == Array
+    y = Fields.FieldVector(x = xcenters, y = xcenters)
+    @test ClimaComms.array_type(y) == Array
 end
 
 @testset "FieldVector basetype replacement and deepcopy" begin


### PR DESCRIPTION
This PR fixes `_array_type` for FieldVectors.