### PR TITLE
Updated surface warp smoothing options

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -248,6 +248,12 @@ Fields.bycolumn
 Fields.Δz_field
 ```
 
+## Hypsography
+
+```@docs
+Hypsography.diffuse_surface_elevation!
+```
+
 ## Limiters
 
 The limiters supertype is


### PR DESCRIPTION
Optional surface diffusion over warped terrain. 
- [x] Update `src/Hypsography/Hypsography.jl`
- [x] Update unit-tests in `test/Spaces/terrain_warp.jl` (Integral, steady-state checks.)