### PR TITLE
Limit GPU tests to use P100s

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -64,7 +64,7 @@ steps:
           - "julia --project -e 'using CUDA; CUDA.versioninfo()'"
           - "julia --color=yes --check-bounds=yes --project=test test/runtests.jl CUDA"
         agents:
-          slurm_gres: "gpu:1"
+          slurm_gres: "gpu:p100:1"
 
       - label: ":computer: test implicit_stencil Float32"
         key: "cpu_implicit_stencil_float32"


### PR DESCRIPTION
Until we can get the CUDA runtime on the cluster upgraded to 11.8, this will avoid hitting #1240.


- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
