### PR TITLE
Remove `CLIMACOMMS_CONTEXT` if cxt is specified

### DIFF
--- a/examples/bickleyjet/bickleyjet_cg_invariant_hypervisc.jl
+++ b/examples/bickleyjet/bickleyjet_cg_invariant_hypervisc.jl
@@ -13,10 +13,9 @@ import ClimaCore:
 using OrdinaryDiffEq: ODEProblem, solve, SSPRK33
 
 using Logging
-#ENV["CLIMACOMMS_CONTEXT"] = "MPI" # TODO: remove before merging
-usempi = get(ENV, "CLIMACOMMS_CONTEXT", "") == "MPI"
+const context = ClimaComms.context()
+usempi = context isa ClimaComms.MPICommsContext
 if usempi
-    const context = ClimaComms.MPICommsContext()
     const pid, nprocs = ClimaComms.init(context)
     const iamroot = ClimaComms.iamroot(context)
     iamroot && println("running distributed simulation using $nprocs processes")
@@ -28,7 +27,6 @@ if usempi
         global_logger(prev_logger)
     end
 else
-    const context = ClimaComms.SingletonCommsContext()
     import TerminalLoggers
     global_logger(TerminalLoggers.TerminalLogger())
 end

--- a/examples/hybrid/hybrid3dcs_dss.jl
+++ b/examples/hybrid/hybrid3dcs_dss.jl
@@ -1,6 +1,4 @@
-ENV["CLIMACOMMS_CONTEXT"] = "MPI"
 ENV["TEST_NAME"] = "sphere/baroclinic_wave_rhoe"
-usempi = true
 using LinearAlgebra
 using Colors
 using JLD2
@@ -46,7 +44,6 @@ end
 
 
 function hybrid3dcubedsphere_dss_profiler(
-    usempi::Bool,
     ::Type{FT},
     resolution,
     npoly,
@@ -231,4 +228,4 @@ function hybrid3dcubedsphere_dss_profiler(
     return nothing
 end
 
-hybrid3dcubedsphere_dss_profiler(usempi, FT, resolution, npoly)
+hybrid3dcubedsphere_dss_profiler(FT, resolution, npoly)

--- a/examples/sphere/shallow_water_dss.jl
+++ b/examples/sphere/shallow_water_dss.jl
@@ -1,5 +1,3 @@
-ENV["CLIMACOMMS_CONTEXT"] = "MPI"
-usempi = true
 npoly = parse(Int, get(ARGS, 1, 4))
 FT = get(ARGS, 2, Float64) == "Float64" ? Float64 : Float32
 using LinearAlgebra
@@ -19,9 +17,7 @@ import ClimaCore:
     DataLayouts
 
 using Logging
-if usempi
-    using ClimaComms
-end
+using ClimaComms
 
 set_initial_condition(space) =
     map(Fields.local_geometry_field(space)) do local_geometry
@@ -49,7 +45,7 @@ function weighted_dss_full!(Y, ghost_buffer)
     return nothing
 end
 
-function shallow_water_dss_profiler(usempi::Bool, ::Type{FT}, npoly) where {FT}
+function shallow_water_dss_profiler(::Type{FT}, npoly) where {FT}
     context = ClimaComms.MPICommsContext()
     pid, nprocs = ClimaComms.init(context)
     iamroot = ClimaComms.iamroot(context)
@@ -213,4 +209,4 @@ function shallow_water_dss_profiler(usempi::Bool, ::Type{FT}, npoly) where {FT}
     return nothing
 end
 
-shallow_water_dss_profiler(usempi, FT, npoly)
+shallow_water_dss_profiler(FT, npoly)

--- a/test/Operators/spectralelement/sphere_geometry_distributed.jl
+++ b/test/Operators/spectralelement/sphere_geometry_distributed.jl
@@ -1,4 +1,3 @@
-ENV["CLIMACOMMS_CONTEXT"] = "MPI"
 using LinearAlgebra, IntervalSets, UnPack
 import ClimaCore:
     Domains, Topologies, Meshes, Spaces, Geometry, Operators, Fields

--- a/test/Spaces/distributed/ddss_setup.jl
+++ b/test/Spaces/distributed/ddss_setup.jl
@@ -8,7 +8,6 @@ using ClimaComms
 const context = ClimaComms.MPICommsContext()
 const pid, nprocs = ClimaComms.init(context)
 
-ENV["CLIMACOMMS_CONTEXT"] = "MPI"
 # log output only from root process
 logger_stream = ClimaComms.iamroot(context) ? stderr : devnull
 prev_logger = global_logger(ConsoleLogger(logger_stream, Logging.Info))

--- a/test/Spaces/distributed/gather4.jl
+++ b/test/Spaces/distributed/gather4.jl
@@ -13,8 +13,6 @@ import ClimaCore:
 
 using Logging
 
-ENV["CLIMACOMMS_CONTEXT"] = "MPI"
-
 using ClimaComms
 const comms_ctx = ClimaComms.MPICommsContext()
 const pid, nprocs = ClimaComms.init(comms_ctx)

--- a/test/Spaces/distributed_cuda/ddss2.jl
+++ b/test/Spaces/distributed_cuda/ddss2.jl
@@ -7,8 +7,6 @@ import ClimaCore:
 using ClimaComms
 using CUDA
 
-ENV["CLIMACOMMS_CONTEXT"] = "MPI"
-
 # initializing MPI
 const device = ClimaComms.device()
 const context = ClimaComms.MPICommsContext(device)

--- a/test/Spaces/distributed_cuda/ddss3.jl
+++ b/test/Spaces/distributed_cuda/ddss3.jl
@@ -7,8 +7,6 @@ import ClimaCore:
 using ClimaComms
 using CUDA
 
-ENV["CLIMACOMMS_CONTEXT"] = "MPI"
-
 # initializing MPI
 const device = ClimaComms.device()
 const context = ClimaComms.MPICommsContext(device)

--- a/test/Spaces/distributed_cuda/ddss4.jl
+++ b/test/Spaces/distributed_cuda/ddss4.jl
@@ -7,8 +7,6 @@ import ClimaCore:
 using ClimaComms
 using CUDA
 
-ENV["CLIMACOMMS_CONTEXT"] = "MPI"
-
 # initializing MPI
 const device = ClimaComms.device()
 const context = ClimaComms.MPICommsContext(device)


### PR DESCRIPTION
This is another peel off from #1289. I've skipped the driver, again, to reduce the diff. These changes were already approved in #1289.