### PR TITLE
Fix dss inference

### DIFF
--- a/src/RecursiveApply/RecursiveApply.jl
+++ b/src/RecursiveApply/RecursiveApply.jl
@@ -40,7 +40,7 @@ Recursively apply `fn` to each element of `X`
 """
 rmap(fn::F, X) where {F} = fn(X)
 rmap(fn::F, X, Y) where {F} = fn(X, Y)
-rmap(fn::F, X::Tuple) where {F} = tuplemap(x -> rmap(fn, x), X)
+rmap(fn::F, X::Tuple) where {F} = map(x -> rmap(fn, x), X)
 rmap(fn, X::Tuple{}, Y::Tuple{}) = ()
 rmap(fn::F, X::Tuple, Y::Tuple) where {F} =
     (rmap(fn, first(X), first(Y)), rmap(fn, Base.tail(X), Base.tail(Y))...)
@@ -61,7 +61,7 @@ The return type of `rmap(fn, X::T)`.
 """
 rmaptype(fn::F, ::Type{T}) where {F, T} = fn(T)
 rmaptype(fn::F, ::Type{T}) where {F, T <: Tuple} =
-    Tuple{tuplemap(fn, tuple(T.parameters...))...}
+    Tuple{map(fn, tuple(T.parameters...))...}
 rmaptype(
     fn::F,
     ::Type{T},

--- a/test/Operators/spectralelement/benchmark_ops.jl
+++ b/test/Operators/spectralelement/benchmark_ops.jl
@@ -135,13 +135,13 @@ using JET
         p = @allocated kernel_ntuple_floats_dss!(kernel_args)
         @test p == 0
         p = @allocated kernel_complicated_field_dss!(kernel_args)
-        @test_broken p == 0
+        @test p == 0
         # Inference tests
         JET.@test_opt kernel_scalar_dss!(kernel_args)
         JET.@test_opt kernel_vector_dss!(kernel_args)
         JET.@test_opt kernel_field_dss!(kernel_args)
         JET.@test_opt kernel_ntuple_field_dss!(kernel_args)
         JET.@test_opt kernel_ntuple_floats_dss!(kernel_args)
-        # JET.@test_opt kernel_complicated_field_dss!(kernel_args) # failing
+        JET.@test_opt kernel_complicated_field_dss!(kernel_args)
     end
 end


### PR DESCRIPTION
This PR fixes dss inference for the complicated field (🎉) by removing the extra function call to `tuplemap`.

I remember we kept `tuplemap` around for some reason-- I think it was so that we could try forcing specialization when we wanted to. Being that it simply calls `map`, I'm wondering if we should just remove the extra function call altogether and delete the `tuplemap` function. Thoughts @simonbyrne?

Closes #1283.