### PR TITLE
Remove tuplemap

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -227,7 +227,6 @@ Spaces.local_area
 
 ```@docs
 RecursiveApply
-RecursiveApply.tuplemap
 ```
 
 ## Fields

--- a/src/Fields/broadcast.jl
+++ b/src/Fields/broadcast.jl
@@ -78,7 +78,7 @@ function Base.showerror(io::IO, err::BroadcastInferenceError)
     print(io, "BroadcastInferenceError: cannot infer eltype.\n")
     bc = err.bc
     f = bc.f
-    eltypes = tuplemap(eltype, bc.args)
+    eltypes = map(eltype, bc.args)
     if !hasmethod(f, eltypes)
         print(io, "  function $(f) does not have a method for $(eltypes)")
     else

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -2913,7 +2913,7 @@ Compute the index of the leftmost point which uses only the interior stencil of 
     space = reconstruct_placeholder_space(axes(bc), parent_space)
     widths = _stencil_interior_width(bc)
     args_idx = _left_interior_window_idx_args(bc.args, space, loc)
-    args_idx_widths = tuplemap((arg, width) -> arg - width[1], args_idx, widths)
+    args_idx_widths = map((arg, width) -> arg - width[1], args_idx, widths)
     return max(
         max(args_idx_widths...),
         left_idx(space) + boundary_width(bc, loc),
@@ -2960,7 +2960,7 @@ end
     space = reconstruct_placeholder_space(axes(bc), parent_space)
     widths = _stencil_interior_width(bc)
     args_idx = _right_interior_window_idx_args(bc.args, space, loc)
-    args_widths = tuplemap((arg, width) -> arg - width[2], args_idx, widths)
+    args_widths = map((arg, width) -> arg - width[2], args_idx, widths)
     return min(min(args_widths...), right_idx(space) - boundary_width(bc, loc))
 end
 

--- a/src/Operators/spectralelement.jl
+++ b/src/Operators/spectralelement.jl
@@ -115,7 +115,7 @@ Base.Broadcast.broadcasted(
 ) = SpectralBroadcasted{SpectralStyle}(op, args)
 
 Base.eltype(sbc::SpectralBroadcasted) =
-    operator_return_eltype(sbc.op, tuplemap(eltype, sbc.args)...)
+    operator_return_eltype(sbc.op, map(eltype, sbc.args)...)
 
 function Base.Broadcast.instantiate(sbc::SpectralBroadcasted)
     op = sbc.op

--- a/src/RecursiveApply/RecursiveApply.jl
+++ b/src/RecursiveApply/RecursiveApply.jl
@@ -7,31 +7,7 @@ To extend to another type `T`, define `RecursiveApply.rmap(fn, args::T...)`
 """
 module RecursiveApply
 
-export ⊞, ⊠, ⊟, tuplemap
-
-"""
-    tuplemap(fn::Function, tup)
-
-A `map` impl for mapping function `fn` a tuple argument `tup`
-
-Currently just calls `Base.map` behind the scenes but is left
-stubbed out for potential specialization in the future.
-"""
-@inline function tuplemap(fn::F, tup::Tuple) where {F}
-    map(fn, tup)
-end
-
-"""
-    tuplemap(fn::Function, tup1, tup2)
-
-A `map` impl for mapping function `fn` over `tup1`, `tup2` tuple arguments.
-
-Currently just calls `Base.map` behind the scenes but is left
-stubbed out for potential specialization in the future.
-"""
-@inline function tuplemap(fn::F, tup1::Tuple, tup2::Tuple) where {F}
-    map(fn, tup1, tup2)
-end
+export ⊞, ⊠, ⊟
 
 """
     rmap(fn, X...)


### PR DESCRIPTION
This PR removes `tuplemap`, which was shown to improve inference in #1306. Perhaps we should just get rid of it?