### PR TITLE
Define `parent_array_type` for ReshapedArray

### DIFF
--- a/src/DataLayouts/struct.jl
+++ b/src/DataLayouts/struct.jl
@@ -92,6 +92,10 @@ parent_array_type(::Type{<:MArray{S, T, N, L}}) where {S, T, N, L} =
 parent_array_type(::Type{<:SubArray{T, N, A}}) where {T, N, A} =
     parent_array_type(A)
 
+# ReshapedArray is needed for converting between arrays and fields for RRTMGP:
+parent_array_type(::Type{<:Base.ReshapedArray{T, N, P}}) where {T, N, P} =
+    parent_array_type(P)
+
 """
     promote_parent_array_type(::Type{<:AbstractArray}, ::Type{<:AbstractArray})
 


### PR DESCRIPTION
This PR defines `parent_array_type` for ReshapedArray, which is needed in RRTMGP to convert between fields and arrays. At the moment, ClimaAtmos pirates this method for this definition.