### PR TITLE
ClimaCoreTempestRemap: add type parameters to names

### DIFF
--- a/lib/ClimaCoreTempestRemap/Project.toml
+++ b/lib/ClimaCoreTempestRemap/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCoreTempestRemap"
 uuid = "d934ef94-cdd4-4710-83d6-720549644b70"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.3.8"
+version = "0.3.9"
 
 [deps]
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"

--- a/lib/ClimaCoreTempestRemap/src/netcdf.jl
+++ b/lib/ClimaCoreTempestRemap/src/netcdf.jl
@@ -255,7 +255,7 @@ storing a field on `space`, along with any further dimensions specified in
 """
 function NCDatasets.defVar(
     nc::NCDataset,
-    name,
+    name::NCDatasets.SymbolOrString,
     T::DataType,
     space::Spaces.AbstractSpace,
     extradims = (),
@@ -276,7 +276,7 @@ returned.
 """
 function NCDatasets.defVar(
     nc::NCDataset,
-    name,
+    name::NCDatasets.SymbolOrString,
     field::Fields.Field,
     extradims = (),
 )


### PR DESCRIPTION
Latest release of ClimaCoreTempestRemap (v0.12.17) includes some changes to function signatures which triggers ambiguity warnings.

https://github.com/Alexander-Barth/NCDatasets.jl/commit/2b8e97adf572ef15e621601c444841cd36deeb96


- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
