### PR TITLE
Add SLEVE coordinate option

### DIFF
--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -146,6 +146,19 @@
   doi = {10.1006/jcph.1996.0047}
 }
 
+@article{Schar2002,
+      author = {Christoph Schär and Daniel Leuenberger and Oliver Fuhrer and Daniel Lüthi and Claude Girard"},
+      title = {A New Terrain-Following Vertical Coordinate Formulation for Atmospheric Prediction Models"},
+      journal = {Monthly Weather Review},
+      year = {2002},
+      publisher = {American Meteorological Society},
+      address = {Boston MA, USA},
+      volume = {130},
+      number = {10},
+      doi = {https://doi.org/10.1175/1520-0493(2002)130<2459:ANTFVC>2.0.CO;2},
+      pages= {2459 - 2480},
+}
+
 @article{Taylor2010,
   title={A compatible and conservative spectral element method on unstructured grids},
   author={Taylor, Mark A and Fournier, Aim\'{e}},

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -250,6 +250,8 @@ Fields.Δz_field
 ## Hypsography
 
 ```@docs
+Hypsography.LinearAdaption
+Hypsography.SLEVEAdaption
 Hypsography.diffuse_surface_elevation!
 ```
 


### PR DESCRIPTION
Adds exponential decay of vertical levels, with specified decay-scale, and relaxation strength parameters. Follows Clima Design docs eq. (3.5). 
- [x] Code
- [x] Unit-test
- [x] Docs
Linked issue: https://github.com/CliMA/ClimaAtmos.jl/issues/1774

**Example:** 

- Plots show cell-center values of `z` coordinate in a test space with uniform vertical stretching.

**_Default Linear_**
<img width="300" alt="GCS_Linear" src="https://github.com/CliMA/ClimaCore.jl/assets/43710045/6927fb01-8c81-448b-a223-2b99c74fcf9c">

**_Optional SLEVE_**
<img width="300" alt="SLEVE_Schar_et_al" src="https://github.com/CliMA/ClimaCore.jl/assets/43710045/d53a72b0-7fcb-4294-aa0a-fb21042b4485">

