### PR TITLE
Better printing of objects

### DIFF
--- a/src/Meshes/cubedsphere.jl
+++ b/src/Meshes/cubedsphere.jl
@@ -77,18 +77,15 @@ sphere.
 struct NormalizedBilinearMap <: LocalElementMap end
 
 
-Base.show(io::IO, mesh::AbstractCubedSphere) = print(
-    io,
-    mesh.ne,
-    "×",
-    mesh.ne,
-    "×",
-    6,
-    "-element ",
-    nameof(typeof(mesh)),
-    " of ",
-    mesh.domain,
-)
+function Base.summary(io::IO, mesh::AbstractCubedSphere)
+    ne = mesh.ne
+    print(io, ne, "×", ne, "×", 6, "-element ", nameof(typeof(mesh)))
+end
+function Base.show(io::IO, mesh::AbstractCubedSphere)
+    summary(io, mesh)
+    print(io, " of ", mesh.domain)
+end
+
 
 domain(mesh::AbstractCubedSphere) = mesh.domain
 elements(mesh::AbstractCubedSphere) = CartesianIndices((mesh.ne, mesh.ne, 6))

--- a/src/Meshes/interval.jl
+++ b/src/Meshes/interval.jl
@@ -26,8 +26,12 @@ domain(mesh::IntervalMesh) = mesh.domain
 nelements(mesh::IntervalMesh) = length(mesh.faces) - 1
 elements(mesh::IntervalMesh) = Base.OneTo(nelements(mesh))
 
+function Base.summary(io::IO, mesh::IntervalMesh)
+    print(io, nelements(mesh), "-element IntervalMesh")
+end
 function Base.show(io::IO, mesh::IntervalMesh)
-    print(io, nelements(mesh), "-element IntervalMesh of ")
+    summary(io, mesh)
+    print(io, " of ")
     print(io, mesh.domain)
 end
 

--- a/src/Meshes/rectangle.jl
+++ b/src/Meshes/rectangle.jl
@@ -20,11 +20,17 @@ RectilinearMesh(domain::RectangleDomain, n1::Int, n2::Int) = RectilinearMesh(
     IntervalMesh(domain.interval2; nelems = n2),
 )
 
-function Base.show(io::IO, mesh::RectilinearMesh)
+function Base.summary(io::IO, mesh::RectilinearMesh)
     n1 = nelements(mesh.intervalmesh1)
     n2 = nelements(mesh.intervalmesh2)
-    print(io, n1, "×", n2, "-element RectilinearMesh of ", domain(mesh))
+    print(io, n1, "×", n2, "-element RectilinearMesh")
 end
+function Base.show(io::IO, mesh::RectilinearMesh)
+    summary(io, mesh)
+    print(io, " of ", domain(mesh))
+end
+
+
 domain(mesh::RectilinearMesh) =
     RectangleDomain(domain(mesh.intervalmesh1), domain(mesh.intervalmesh2))
 nelements(mesh::RectilinearMesh) =

--- a/src/Spaces/extruded.jl
+++ b/src/Spaces/extruded.jl
@@ -102,8 +102,24 @@ function Base.show(io::IO, space::ExtrudedFiniteDifferenceSpace)
         "FaceExtrudedFiniteDifferenceSpace",
         ":",
     )
-    println(iio, " "^(indent + 2), space.horizontal_space)
-    print(iio, " "^(indent + 2), space.vertical_topology)
+    print(iio, " "^(indent + 2), "context: ")
+    Topologies.print_context(iio, space.horizontal_space.topology.context)
+    println(iio)
+    println(iio, " "^(indent + 2), "horizontal:")
+    println(
+        iio,
+        " "^(indent + 4),
+        "mesh: ",
+        space.horizontal_space.topology.mesh,
+    )
+    println(
+        iio,
+        " "^(indent + 4),
+        "quadrature: ",
+        space.horizontal_space.quadrature_style,
+    )
+    println(iio, " "^(indent + 2), "vertical:")
+    print(iio, " "^(indent + 4), "mesh: ", space.vertical_topology.mesh)
 end
 local_geometry_data(space::CenterExtrudedFiniteDifferenceSpace) =
     space.center_local_geometry

--- a/src/Spaces/finitedifference.jl
+++ b/src/Spaces/finitedifference.jl
@@ -30,7 +30,10 @@ function Base.show(io::IO, space::FiniteDifferenceSpace)
         "FaceFiniteDifferenceSpace",
         ":",
     )
-    print(iio, " "^(indent + 2), Spaces.topology(space))
+    print(iio, " "^(indent + 2), "context: ")
+    Topologies.print_context(iio, space.topology.context)
+    println(iio)
+    print(iio, " "^(indent + 2), "mesh: ", space.topology.mesh)
 end
 
 function FiniteDifferenceSpace{S}(

--- a/src/Spaces/quadrature.jl
+++ b/src/Spaces/quadrature.jl
@@ -48,6 +48,9 @@ Gauss-Legendre-Lobatto quadrature using `Nq` quadrature points.
 """
 struct GLL{Nq} <: QuadratureStyle end
 
+Base.show(io::IO, ::GLL{Nq}) where {Nq} =
+    print(io, Nq, "-point Gauss-Legendre-Lobatto quadrature")
+
 @inline polynomial_degree(::GLL{Nq}) where {Nq} = Int(Nq - 1)
 @inline degrees_of_freedom(::GLL{Nq}) where {Nq} = Int(Nq)
 
@@ -62,6 +65,8 @@ end
 Gauss-Legendre quadrature using `Nq` quadrature points.
 """
 struct GL{Nq} <: QuadratureStyle end
+Base.show(io::IO, ::GL{Nq}) where {Nq} =
+    print(io, Nq, "-point Gauss-Legendre quadrature")
 
 @inline polynomial_degree(::GL{Nq}) where {Nq} = Int(Nq - 1)
 @inline degrees_of_freedom(::GL{Nq}) where {Nq} = Int(Nq)

--- a/src/Spaces/spectralelement.jl
+++ b/src/Spaces/spectralelement.jl
@@ -15,9 +15,12 @@ function Base.show(io::IO, space::AbstractSpectralElementSpace)
     println(io, nameof(typeof(space)), ":")
     if hasfield(typeof(space), :topology)
         # some reduced spaces (like slab space) do not have topology
-        println(iio, " "^(indent + 2), space.topology)
+        print(iio, " "^(indent + 2), "context: ")
+        Topologies.print_context(iio, space.topology.context)
+        println(iio)
+        println(iio, " "^(indent + 2), "mesh: ", space.topology.mesh)
     end
-    print(iio, " "^(indent + 2), space.quadrature_style)
+    print(iio, " "^(indent + 2), "quadrature: ", space.quadrature_style)
 end
 
 ClimaComms.device(space::AbstractSpectralElementSpace) =

--- a/src/Topologies/Topologies.jl
+++ b/src/Topologies/Topologies.jl
@@ -42,6 +42,37 @@ mesh in the horizontal domain.
 
 """
 abstract type AbstractTopology end
+
+function Base.summary(io::IO, topology::AbstractTopology)
+    print(io, nameof(typeof(topology)))
+end
+
+# TODO: move this to ClimaComms
+function print_device(io::IO, device::ClimaComms.AbstractDevice)
+    print(io, nameof(typeof(device)))
+end
+
+function print_context(io::IO, context::ClimaComms.SingletonCommsContext)
+    print(io, "SingletonCommsContext using ")
+    print_device(io, context.device)
+end
+
+function print_context(io::IO, context::ClimaComms.MPICommsContext)
+    if ClimaComms.MPI.Initialized()
+        print(
+            io,
+            "MPICommsContext with ",
+            ClimaComms.nprocs(context),
+            " processes",
+        )
+    else
+        print(io, "MPICommsContext (uninitialized)")
+    end
+    print(io, " using ")
+    print_device(io, context.device)
+end
+
+
 abstract type AbstractDistributedTopology <: AbstractTopology end
 
 coordinate_type(topology::AbstractTopology) = coordinate_type(domain(topology))

--- a/src/Topologies/interval.jl
+++ b/src/Topologies/interval.jl
@@ -49,8 +49,12 @@ IntervalTopology(mesh::Meshes.IntervalMesh) = IntervalTopology(
 
 isperiodic(topology::AbstractIntervalTopology) = isempty(topology.boundaries)
 
-function Base.show(io::IO, topology::AbstractIntervalTopology)
-    print(io, "IntervalTopology on ", Topologies.mesh(topology))
+function Base.show(io::IO, topology::IntervalTopology)
+    println(io, nameof(typeof(topology)))
+    print(io, "  context: ")
+    print_context(io, topology.context)
+    println(io)
+    print(io, "  mesh: ", topology.mesh)
 end
 
 function mesh(topology::AbstractIntervalTopology)

--- a/src/Topologies/topology2d.jl
+++ b/src/Topologies/topology2d.jl
@@ -127,6 +127,21 @@ ClimaComms.device(topology::Topology2D) = topology.context.device
 ClimaComms.array_type(topology::Topology2D) =
     ClimaComms.array_type(topology.context.device)
 
+function Base.show(io::IO, topology::Topology2D)
+    indent = get(io, :indent, 0)
+    println(io, nameof(typeof(topology)))
+    print(io, " "^(indent + 2), "context: ")
+    print_context(io, topology.context)
+    println(io)
+    println(io, " "^(indent + 2), "mesh: ", topology.mesh)
+    print(io, " "^(indent + 2), "elemorder: ")
+    if topology.elemorder isa CartesianIndices
+        print(io, topology.elemorder)
+    else
+        summary(io, topology.elemorder)
+    end
+end
+
 """
     spacefillingcurve(mesh::Meshes.AbstractCubedSphere)
 

--- a/test/Spaces/spaces.jl
+++ b/test/Spaces/spaces.jl
@@ -21,6 +21,12 @@ import ClimaCore.DataLayouts: IJFH, VF
 
     space = Spaces.SpectralElementSpace1D(topology, quad)
 
+    @test repr(space) === """
+    SpectralElementSpace1D:
+      context: SingletonCommsContext using CPUSingleThreaded
+      mesh: 1-element IntervalMesh of IntervalDomain: x ∈ [-3.0,5.0] (periodic)
+      quadrature: 4-point Gauss-Legendre-Lobatto quadrature"""
+
     coord_data = Spaces.coordinates_data(space)
     @test eltype(coord_data) == Geometry.XPoint{Float64}
 
@@ -99,17 +105,19 @@ end
         boundary_names = (:bottom, :top),
     )
     mesh = Meshes.IntervalMesh(domain; nelems = 1)
-    topology = Topologies.IntervalTopology(mesh)
+    topology = Topologies.IntervalTopology(context, mesh)
 
-    for Space in
-        [Spaces.CenterFiniteDifferenceSpace, Spaces.FaceFiniteDifferenceSpace]
-        space = Spaces.CenterFiniteDifferenceSpace(topology)
-        coord_data = Spaces.coordinates_data(space)
-        point_space = Spaces.level(space, 1)
-        @test point_space isa Spaces.PointSpace
-        @test Spaces.coordinates_data(point_space)[] ==
-              Spaces.level(coord_data, 1)[]
-    end
+    space = Spaces.CenterFiniteDifferenceSpace(topology)
+    @test repr(space) == """
+    CenterFiniteDifferenceSpace:
+      context: SingletonCommsContext using CPUSingleThreaded
+      mesh: 1-element IntervalMesh of IntervalDomain: z ∈ [0.0,5.0] (:bottom, :top)"""
+
+    coord_data = Spaces.coordinates_data(space)
+    point_space = Spaces.level(space, 1)
+    @test point_space isa Spaces.PointSpace
+    @test Spaces.coordinates_data(point_space)[] ==
+          Spaces.level(coord_data, 1)[]
 
     x_max = FT(0)
     y_max = FT(1)
@@ -155,6 +163,11 @@ end
     points, weights = Spaces.Quadratures.quadrature_points(FT, quad)
 
     space = Spaces.SpectralElementSpace2D(grid_topology, quad)
+    @test repr(space) == """
+    SpectralElementSpace2D:
+      context: SingletonCommsContext using CPUSingleThreaded
+      mesh: 1×1-element RectilinearMesh of RectangleDomain: x ∈ [-3.0,5.0] (periodic) × y ∈ [-2.0,8.0] (:south, :north)
+      quadrature: 4-point Gauss-Legendre-Lobatto quadrature"""
 
     coord_data = Spaces.coordinates_data(space)
     array = parent(coord_data)


### PR DESCRIPTION
Improves printing, of domains, meshes, topologies and spaces. 

Example
```
SpectralElementSpace2D:
  context: ClimaComms.SingletonCommsContext{ClimaComms.CPUDevice}(ClimaComms.CPUDevice())
  mesh: 4×8-element RectilinearMesh of RectangleDomain: x ∈ [-3.0,5.0] (:east, :west) × y ∈ [-2.0,8.0] (:south, :north)
  quadrature: 4-point Gauss-Legendre-Lobatto quadrature
```

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
