### PR TITLE
New runtests sketch

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -32,6 +32,8 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 TerminalLoggers = "5d786b92-1e48-4d6f-9151-6b4477ca9bed"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 Aqua = "0.8"

--- a/test/buildkite_yaml_struct.jl
+++ b/test/buildkite_yaml_struct.jl
@@ -1,0 +1,108 @@
+struct BuildkiteJob{C, L, K, E}
+    commands::C
+    label::L
+    key::K
+    env::E
+    function BuildkiteJob(dict::AbstractDict)
+        command = get(dict, "command", "")
+        if command isa AbstractString
+            command = BuildkiteCommand[BuildkiteCommand(command)]
+        elseif command isa AbstractArray
+            command = BuildkiteCommand.(command)
+        end
+        label = get(dict, "label", "")
+        key = get(dict, "key", "")
+        env = get(dict, "env", "")
+        t = typeof.((command, label, key, env))
+        return new{t...}(command, label, key, env)
+    end
+end
+
+struct BuildkiteCommand{C <: AbstractString}
+    command::C
+end
+
+Base.string(bkc::BuildkiteCommand) = bkc.command
+
+commands(j::BuildkiteJob) = j.commands
+
+get_file(bkc::BuildkiteCommand) = get_file(bkc.command)
+get_file(s::AbstractString) =
+    !occursin(".jl", s) ? "" : last(split(first(split(s, ".jl")), " ")) * ".jl"
+get_files(v::Vector{<:BuildkiteCommand}) =
+    filter(x -> !isempty(x), get_file.(string.(v)))
+get_files(j::BuildkiteJob) = get_files(commands(j))
+get_key(j::BuildkiteJob) = j.key
+get_label(j::BuildkiteJob) = j.label
+
+get_env(j::BuildkiteJob) = j.env
+keyword_match(j::BuildkiteJob, keywords) = any(
+    Base.Iterators.flatten(map(commands(j)) do cmd
+            map(x -> occursin(x, string(cmd)), keywords)
+        end),
+)
+function get_device(j::BuildkiteJob)
+    if keyword_match(j, ["gpu", "CUDADevice"])
+        return "GPU"
+    else
+        return "CPU"
+    end
+end
+function float_type(j::BuildkiteJob)
+    if keyword_match(j, ["Float64"])
+        return "Float64"
+    elseif keyword_match(j, ["Float32"])
+        return "Float32"
+    else
+        return ""
+    end
+end
+function get_context(j::BuildkiteJob)
+    if Pair("CLIMACOMMS_CONTEXT", "MPI") in get_env(j)
+        return "MPI"
+    else
+        return "Singleton"
+    end
+end
+
+function get_config(j::BuildkiteJob)
+    c = [get_device(j), float_type(j), get_context(j)]
+    filter!(x -> !isempty(x), c)
+    join(c, ", ")
+end
+
+function test_job(j::BuildkiteJob)
+    @eval Main begin
+        # Configure CL arguments
+        local env = get_env($j)
+        empty!(ARGS)
+        for (k, d) in get_env($j)
+            push!(ARGS, "--$k", "$d")
+        end
+
+        cl_args = string.($(j.commands))
+        for (k, d) in get_env($j)
+            push!(ARGS, "--$k", "$d")
+        end
+
+        # include()
+    end
+end
+
+using PrettyTables
+function tabulate_jobs(bkjs; verbose = false)
+    title = "Tests run in test/runtests.jl:"
+    test_names = get_label.(bkjs)
+    if verbose
+        test_env = get_env.(bkjs)
+        test_cmds = commands.(bkjs)
+        data = hcat(test_names, test_env, test_cmds)
+        header = ["Name", "env", "Commands"]
+    else
+        test_config = get_config.(bkjs)
+        test_files = get_files.(bkjs)
+        data = hcat(test_names, test_config, test_files)
+        header = ["Name", "config", "File"]
+    end
+    PrettyTables.pretty_table(data; title, header, alignment = :l, crop = :none)
+end

--- a/test/runtests_new.jl
+++ b/test/runtests_new.jl
@@ -1,0 +1,21 @@
+using Test
+using SafeTestsets
+using Base: operator_associativity
+import YAML
+
+include("yaml_helper.jl")
+include("buildkite_yaml_struct.jl")
+
+cc_dir = joinpath(@__DIR__, "..")
+yaml_file = joinpath(cc_dir, ".buildkite", "pipeline.yml")
+unit_tests = jobs_from_yaml(yaml_file)
+bkjs = BuildkiteJob.(unit_tests)
+
+# Avoid recursive inclusion:
+filter!(j -> any(x -> !occursin("test/runtests.jl", x), get_files(j)), bkjs)
+
+tabulate_jobs(bkjs; verbose = false)
+
+# for j in bkjs
+#     test_job(j)
+# end

--- a/test/yaml_helper.jl
+++ b/test/yaml_helper.jl
@@ -1,0 +1,12 @@
+function jobs_from_yaml(yaml_file; filter_name = nothing)
+    data = YAML.load_file(yaml_file)
+    steps = filter(x -> x isa Dict && haskey(x, "steps"), data["steps"])
+    i_unit_tests = findall(steps) do step
+        occursin("Unit: ", step["group"])
+    end
+    @assert i_unit_tests ≠ nothing "Unit tests not found"
+    unit_tests = collect(Iterators.flatten(map(i_unit_tests) do t
+        steps[t]["steps"]
+    end))
+    return unit_tests
+end


### PR DESCRIPTION
This is a proposal for the new `test/runtests.jl`.

Right now, there is a mismatch between what is run in buildkite vs `test/runtests.jl` vs `test_runtests_expensive.jl`. The latter two are run on GHA, but they don't run with the same environment variables / or CL arguments (xref: https://github.com/CliMA/ClimaCore.jl/pull/1321#issuecomment-1593728957).

This PR:
 - Defines a few helper structs in the test directory
 - Collects all unit tests from the buildkite yaml
 - Tabulates them
 - Runs them with the same environment variables / CL arguments (we can modify these appropriately if we, e.g.,  don't have the same resources)

Here's an output of what the [table](https://gist.github.com/charleskawczynski/4f3ce7590fb236a2e67d6ef50160dee3) looks like (which is printed before running tests in `test/runtests.jl`, for transparency). Since all of the tests and configs are collected into a list, we could even use Distributed.jl and `pmap` over the tests (perhaps the non-distributed tests, at least).

Remaining TODO in this PR, if people like this direction:
 - Sketch out how `test_job(:: BuildkiteJob)` should work