### PR TITLE
Properly deprecate `enable_threading`, bump patch version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.10.41"
+version = "0.10.42"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/DataLayouts/DataLayouts.jl
+++ b/src/DataLayouts/DataLayouts.jl
@@ -18,7 +18,7 @@ import Base: Base, @propagate_inbounds
 import StaticArrays: SOneTo, MArray, SArray
 import ClimaComms
 
-import ..enable_threading, ..slab, ..slab_args, ..column, ..column_args, ..level
+import ..slab, ..slab_args, ..column, ..column_args, ..level
 export slab, column, level, IJFH, IJF, IFH, IF, VF, VIJFH, VIFH, DataF
 
 include("struct.jl")

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -14,10 +14,9 @@ and running julia with `julia --nthreads=N ...`
 This function is deprecated in version `0.10.42`.
 Please use the ClimaComms context for threading.
 """
-function enable_threading()
-    @warn "Use ClimaComms context for threading"
-    return false
-end
+enable_threading() = false
+Base.@deprecate enable_threading() deprecated_enable_threading() false
+deprecated_enable_threading() = false
 
 """
     slab(data::AbstractData, h::Integer)


### PR DESCRIPTION
In #1315, I realized that throwing a warning in `enable_threading` could be bad if it's for some reason called many times. So, I'm changing it in this PR to a new "deprecated" function. This PR also bumps the patch version for a new release.