### PR TITLE
Fix enable_threading redefinition warning

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -14,7 +14,8 @@ and running julia with `julia --nthreads=N ...`
 This function is deprecated in version `0.10.42`.
 Please use the ClimaComms context for threading.
 """
-enable_threading() = false
+function enable_threading end
+
 Base.@deprecate enable_threading() deprecated_enable_threading() false
 deprecated_enable_threading() = false
 


### PR DESCRIPTION
I forgot that `@deprecate` defines the old method. This PR removes the old method to fix the redefinition warning.