### PR TITLE
Return nothing in cuda bycolumn

### DIFF
--- a/src/Fields/indices.jl
+++ b/src/Fields/indices.jl
@@ -144,6 +144,7 @@ bycolumn(
 
 function bycolumn(fn, space::AbstractSpace, ::ClimaComms.CUDADevice)
     fn(:)
+    return nothing
 end
 
 


### PR DESCRIPTION
This PR changes the cuda `bycolumn` to return `nothing`, like the other `bycolumn` methods.