### PR TITLE
Refactor SchurComplementW for ClimaTimesteppers

### DIFF
--- a/test/Operators/finitedifference/linsolve.jl
+++ b/test/Operators/finitedifference/linsolve.jl
@@ -35,7 +35,7 @@ face_space = Spaces.FaceExtrudedFiniteDifferenceSpace(center_space)
 =#
 face_space = Spaces.FaceFiniteDifferenceSpace(center_space)
 
-function _linsolve!(x, A, b, update_matrix = false; kwargs...)
+function test_linsolve!(x, A, b, update_matrix = false; kwargs...)
 
     FT = Spaces.undertype(axes(x.c))
 
@@ -88,11 +88,11 @@ W = SchurComplementW(Y, use_transform, jacobi_flags)
 
 using JET
 using Test
-@time _linsolve!(Y, W, b)
-@time _linsolve!(Y, W, b)
+@time test_linsolve!(Y, W, b)
+@time test_linsolve!(Y, W, b)
 
 @testset "JET test for `apply` in linsolve! kernel" begin
-    @test_opt _linsolve!(Y, W, b)
+    @test_opt test_linsolve!(Y, W, b)
 end
 
 ClimaCore.Operators.allow_mismatched_fd_spaces() = false


### PR DESCRIPTION
This PR is a peel off from #1358.

This PR adds `temp1` and `temp2` to `SchurComplementW`, and defines
```julia
linsolve!(::Type{Val{:init}}, f, u0; kwargs...) = _linsolve!
_linsolve!(x, A, b, update_matrix = false; kwargs...) =
    LinearAlgebra.ldiv!(x, A, b)

# Function required by Krylov.jl (x and b can be AbstractVectors)
# See https://github.com/JuliaSmoothOptimizers/Krylov.jl/issues/605 for a
# related issue that requires the same workaround.
function LinearAlgebra.ldiv!(x, A::SchurComplementW, b)
    A.temp1 .= b
    LinearAlgebra.ldiv!(A.temp2, A, A.temp1)
    x .= A.temp2
end
```
and the original `_linsolve` contents are in
```julia
function LinearAlgebra.ldiv!(
    x::Fields.FieldVector,
    A::SchurComplementW,
    b::Fields.FieldVector,
)
```

(the pattern used in ClimaAtmos). It also renames `_linsolve!` to `test_linsolve!` to avoid a name collision in the test suite.

It's a much smaller PR than it appears, due to indenting.