### PR TITLE
Fix type-casting allocations in broadcasting

### DIFF
--- a/src/Fields/broadcast.jl
+++ b/src/Fields/broadcast.jl
@@ -301,6 +301,8 @@ Base.Broadcast.broadcasted(
     ::Val{n},
 ) where {n} = Base.Broadcast.broadcasted(x -> Base.literal_pow(^, x, Val(n)), f)
 
+Base.Broadcast.broadcasted(::Type{T}, x::Number) where {T <: Number} = x
+
 # Specialize handling of +, *, muladd, so that we can support broadcasting over NamedTuple element types
 # Required for ODE solvers
 

--- a/test/Fields/field.jl
+++ b/test/Fields/field.jl
@@ -140,7 +140,7 @@ end
 
         ifelse_broadcast_allocating(a, b, c)
         p_allocated = @allocated ifelse_broadcast_allocating(a, b, c)
-        @test_broken p_allocated == 0
+        @test p_allocated == 0
 
         ifelse_broadcast_or(a, b, c)
         p_allocated = @allocated ifelse_broadcast_or(a, b, c)


### PR DESCRIPTION
Closes #1355 and #1097.

I'm not thrilled that this is basically type piracy, but it does fix the allocations. It's actually a bit surprising to me that a simple definition doesn't exist in Base.

This should fix the GPU moisture issue in ClimaAtmos (among other isbits errors and allocations).