### PR TITLE
Change Ref -> tuple in broadcasting CartesianVector

### DIFF
--- a/src/Fields/broadcast.jl
+++ b/src/Fields/broadcast.jl
@@ -419,7 +419,7 @@ function Base.Broadcast.broadcasted(
         fs,
         V,
         arg,
-        Ref(space.global_geometry),
+        tuple(space.global_geometry),
         local_geometry_field(space),
     )
 end

--- a/src/Operators/spectralelement.jl
+++ b/src/Operators/spectralelement.jl
@@ -313,6 +313,14 @@ Base.@propagate_inbounds function get_node(space, scalar, ij, slabidx)
     scalar[]
 end
 Base.@propagate_inbounds function get_node(
+    space,
+    scalar::Tuple{<:Any},
+    ij,
+    slabidx,
+)
+    scalar[1]
+end
+Base.@propagate_inbounds function get_node(
     parent_space,
     field::Fields.Field,
     ij::CartesianIndex{1},


### PR DESCRIPTION
This PR changes Ref -> tuple in broadcasting CartesianVector, since we were having allocation issues with `Ref`.