### PR TITLE
Add operator_matrix to MatrixFields, along with tests and docs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -533,6 +533,17 @@ steps:
           slurm_gpus: 1
           slurm_mem: 40GB
 
+      - label: "Unit: operator matrices (CPU)"
+        key: unit_operator_matrices_cpu
+        command: "julia --color=yes --check-bounds=yes --project=test test/MatrixFields/operator_matrices.jl"
+
+      - label: "Unit: operator matrices (GPU)"
+        key: unit_operator_matrices_gpu
+        command: "julia --color=yes --project=test test/MatrixFields/operator_matrices.jl"
+        agents:
+          slurm_gpus: 1
+          slurm_mem: 40GB
+
   - group: "Unit: Hypsography"
     steps:
 

--- a/docs/src/matrix_fields.md
+++ b/docs/src/matrix_fields.md
@@ -20,6 +20,12 @@ BandMatrixRow
 MultiplyColumnwiseBandMatrixField
 ```
 
+## Operator Matrices
+
+```@docs
+operator_matrix
+```
+
 ## Internals
 
 ```@docs
@@ -31,6 +37,8 @@ mul_return_type
 rmul_return_type
 matrix_shape
 column_axes
+AbstractLazyOperator
+replace_lazy_operator
 ```
 
 ## Utilities

--- a/src/MatrixFields/MatrixFields.jl
+++ b/src/MatrixFields/MatrixFields.jl
@@ -48,10 +48,16 @@ export DiagonalMatrixRow,
     QuaddiagonalMatrixRow,
     PentadiagonalMatrixRow
 
+# Types that are teated as single values when using matrix fields.
+const SingleValue =
+    Union{Number, Geometry.AxisTensor, Geometry.AdjointAxisTensor}
+
 include("band_matrix_row.jl")
 include("rmul_with_projection.jl")
 include("matrix_shape.jl")
 include("matrix_multiplication.jl")
+include("lazy_operators.jl")
+include("operator_matrices.jl")
 include("field2arrays.jl")
 
 const ColumnwiseBandMatrixField{V, S} = Fields.Field{

--- a/src/MatrixFields/band_matrix_row.jl
+++ b/src/MatrixFields/band_matrix_row.jl
@@ -128,9 +128,9 @@ Base.:-(row1::BandMatrixRow, row2::UniformScaling) =
 Base.:-(row1::UniformScaling, row2::BandMatrixRow) =
     map(rsub, promote(row1, row2)...)
 
-Base.:*(row::BandMatrixRow, value::Number) =
+Base.:*(row::BandMatrixRow, value::SingleValue) =
     map(entry -> rmul(entry, value), row)
-Base.:*(value::Number, row::BandMatrixRow) =
+Base.:*(value::SingleValue, row::BandMatrixRow) =
     map(entry -> rmul(value, entry), row)
 
 Base.:/(row::BandMatrixRow, value::Number) =

--- a/src/MatrixFields/lazy_operators.jl
+++ b/src/MatrixFields/lazy_operators.jl
@@ -1,0 +1,121 @@
+"""
+    AbstractLazyOperator
+
+Supertype for "lazy operators", i.e., operators that can be called without any
+arguments by users, as long as they appear in broadcast expressions that contain
+at least one `Field`. If `lazy_op` is an `AbstractLazyOperator`, the expression
+`lazy_op.()` will internally be translated to `non_lazy_op.(fields...)`, as long
+as it appears in a broadcast expression with at least one `Field`. This
+translation is done by the function `replace_lazy_operator(space, lazy_op)`,
+which must be implemented by every subtype of `AbstractLazyOperator`.
+"""
+abstract type AbstractLazyOperator end
+
+struct LazyOperatorStyle <: Base.Broadcast.BroadcastStyle end
+
+Base.Broadcast.broadcasted(op::AbstractLazyOperator) =
+    Base.Broadcast.broadcasted(LazyOperatorStyle(), op)
+
+# Broadcasting over an AbstractLazyOperator and either a Ref, a Tuple, a Field,
+# an Operator, or another AbstractLazyOperator involves using LazyOperatorStyle.
+Base.Broadcast.BroadcastStyle(
+    ::LazyOperatorStyle,
+    ::Union{
+        Base.Broadcast.AbstractArrayStyle{0},
+        Base.Broadcast.Style{Tuple},
+        Fields.AbstractFieldStyle,
+        LazyOperatorStyle,
+    },
+) = LazyOperatorStyle()
+
+struct LazyOperatorBroadcasted{F, A} <:
+       Operators.OperatorBroadcasted{LazyOperatorStyle}
+    f::F
+    args::A
+end
+
+# TODO: This definition of Base.Broadcast.broadcasted results in 2 additional
+# method invalidations when using Julia 1.8.5. However, if we were to delete it,
+# we would also need to replace the following specializations on
+# LazyOperatorBroadcasted with specializations on Base.Broadcast.Broadcasted.
+# Specifically, we would need to modify Base.Broadcast.materialize so that it
+# specializes on Base.Broadcast.Broadcasted{LazyOperatorStyle}, and this would
+# result in 11 invalidations instead of 2.
+Base.Broadcast.broadcasted(::LazyOperatorStyle, f::F, args...) where {F} =
+    LazyOperatorBroadcasted(f, args)
+
+function Base.Broadcast.materialize(bc::LazyOperatorBroadcasted)
+    space = largest_space(bc)
+    isnothing(space) && error("Cannot materialize broadcast expression with \
+                               AbstractLazyOperator because it does not contain any Fields")
+    return Base.Broadcast.materialize(replace_lazy_operators(space, bc))
+end
+
+Base.Broadcast.materialize!(dest::Fields.Field, bc::LazyOperatorBroadcasted) =
+    Base.Broadcast.materialize!(dest, replace_lazy_operators(axes(dest), bc))
+
+replace_lazy_operators(_, arg) = arg
+replace_lazy_operators(space, bc::LazyOperatorBroadcasted) =
+    bc.f isa AbstractLazyOperator ? replace_lazy_operator(space, bc.f) :
+    Base.Broadcast.broadcasted(
+        bc.f,
+        replace_lazy_operators_args(space, bc.args...)...,
+    )
+
+replace_lazy_operators_args(_) = ()
+replace_lazy_operators_args(space, arg, args...) = (
+    replace_lazy_operators(space, arg),
+    replace_lazy_operators_args(space, args...)...,
+)
+
+"""
+    replace_lazy_operator(space, lazy_op)
+
+Generates an instance of `Base.AbstractBroadcasted` that corresponds to the
+expression `lazy_op.()`, where the broadcast in which this expression appears is
+being evaluated on the given `space`. Note that the staggering (`CellCenter` or
+`CellFace`) of this `space` depends on the specifics of the broadcast and is not
+predetermined.
+"""
+replace_lazy_operator(_, ::AbstractLazyOperator) =
+    error("Every subtype of AbstractLazyOperator must implement a method for
+           replace_lazy_operator(space, lazy_op)")
+
+largest_space(_) = nothing
+largest_space(field::Fields.Field) = axes(field)
+largest_space(bc::Base.AbstractBroadcasted) = largest_space_args(bc.args...)
+
+largest_space_args() = nothing
+largest_space_args(arg, args...) =
+    larger_space(largest_space(arg), largest_space_args(args...))
+
+larger_space(::Nothing, ::Nothing) = nothing
+larger_space(space1, ::Nothing) = space1
+larger_space(::Nothing, space2) = space2
+larger_space(space1::S, ::S) where {S} = space1 # Neither space is larger.
+larger_space(
+    space1::Spaces.FiniteDifferenceSpace,
+    ::Spaces.FiniteDifferenceSpace,
+) = space1 # The staggering does not matter here, so neither space is larger.
+larger_space(
+    space1::Spaces.ExtrudedFiniteDifferenceSpace,
+    ::Spaces.ExtrudedFiniteDifferenceSpace,
+) = space1 # The staggering does not matter here, so neither space is larger.
+larger_space(
+    space1::Spaces.ExtrudedFiniteDifferenceSpace,
+    ::Spaces.FiniteDifferenceSpace,
+) = space1 # The types indicate that space2 is a subspace of space1.
+larger_space(
+    ::Spaces.FiniteDifferenceSpace,
+    space2::Spaces.ExtrudedFiniteDifferenceSpace,
+) = space2 # The types indicate that space1 is a subspace of space2.
+larger_space(
+    space1::Spaces.ExtrudedFiniteDifferenceSpace,
+    ::Spaces.AbstractSpectralElementSpace,
+) = space1 # The types indicate that space2 is a subspace of space1.
+larger_space(
+    ::Spaces.AbstractSpectralElementSpace,
+    space2::Spaces.ExtrudedFiniteDifferenceSpace,
+) = space2 # The types indicate that space1 is a subspace of space2.
+larger_space(::S1, ::S2) where {S1, S2} =
+    error("Mismatched spaces ($(S1.name.name) and $(S2.name.name))")

--- a/src/MatrixFields/operator_matrices.jl
+++ b/src/MatrixFields/operator_matrices.jl
@@ -1,0 +1,932 @@
+# Note: This list must be kept up-to-date with finitedifference.jl.
+const OneArgFDOperatorWithCenterInput = Union{
+    Operators.InterpolateC2F,
+    Operators.LeftBiasedC2F,
+    Operators.RightBiasedC2F,
+    Operators.GradientC2F,
+    Operators.DivergenceC2F,
+    Operators.CurlC2F,
+}
+const OneArgFDOperatorWithFaceInput = Union{
+    Operators.InterpolateF2C,
+    Operators.LeftBiasedF2C,
+    Operators.RightBiasedF2C,
+    Operators.SetBoundaryOperator,
+    Operators.GradientF2C,
+    Operators.DivergenceF2C,
+}
+const TwoArgFDOperatorWithCenterInput = Union{
+    Operators.WeightedInterpolateC2F,
+    Operators.UpwindBiasedProductC2F,
+    Operators.Upwind3rdOrderBiasedProductC2F,
+    Operators.AdvectionC2C,
+    Operators.FluxCorrectionC2C,
+}
+const TwoArgFDOperatorWithFaceInput = Union{
+    Operators.WeightedInterpolateF2C,
+    Operators.AdvectionF2F,
+    Operators.FluxCorrectionF2F,
+}
+const ErroneousFDOperator = Union{
+    Operators.LeftBiased3rdOrderC2F,
+    Operators.LeftBiased3rdOrderF2C,
+    Operators.RightBiased3rdOrderC2F,
+    Operators.RightBiased3rdOrderF2C,
+}
+const NonlinearFDOperator = Union{Operators.FCTBorisBook, Operators.FCTZalesak}
+
+const OneArgFDOperator =
+    Union{OneArgFDOperatorWithCenterInput, OneArgFDOperatorWithFaceInput}
+const TwoArgFDOperator =
+    Union{TwoArgFDOperatorWithCenterInput, TwoArgFDOperatorWithFaceInput}
+
+const FDOperatorWithCenterInput =
+    Union{OneArgFDOperatorWithCenterInput, TwoArgFDOperatorWithCenterInput}
+const FDOperatorWithFaceInput =
+    Union{OneArgFDOperatorWithFaceInput, TwoArgFDOperatorWithFaceInput}
+
+operator_input_space(
+    ::FDOperatorWithCenterInput,
+    space::Spaces.FiniteDifferenceSpace,
+) = Spaces.CenterFiniteDifferenceSpace(space)
+operator_input_space(
+    ::FDOperatorWithCenterInput,
+    space::Spaces.ExtrudedFiniteDifferenceSpace,
+) = Spaces.CenterExtrudedFiniteDifferenceSpace(space)
+operator_input_space(
+    ::FDOperatorWithFaceInput,
+    space::Spaces.FiniteDifferenceSpace,
+) = Spaces.FaceFiniteDifferenceSpace(space)
+operator_input_space(
+    ::FDOperatorWithFaceInput,
+    space::Spaces.ExtrudedFiniteDifferenceSpace,
+) = Spaces.FaceExtrudedFiniteDifferenceSpace(space)
+
+has_affine_bc(op) = any(
+    bc ->
+        bc isa Union{
+            Operators.SetValue,
+            Operators.SetGradient,
+            Operators.SetDivergence,
+            Operators.SetCurl,
+        } && bc.val != rzero(typeof(bc.val)),
+    op.bcs,
+)
+
+uses_extrapolate(op) = any(bc -> bc isa Operators.Extrapolate, op.bcs)
+
+################################################################################
+
+struct FDOperatorMatrix{O <: Operators.FiniteDifferenceOperator} <:
+       Operators.FiniteDifferenceOperator
+    op::O
+end
+function FDOperatorMatrix(op::O) where {O}
+    has_affine_bc(op) &&
+        @warn "$(O.name.name) applies an affine transformation because of the \
+               boundary conditions it has been assigned; in order to be \
+               represented by an operator matrix, it must be converted into a \
+               linear operator, so its boundary conditions will be zeroed out"
+    return FDOperatorMatrix{O}(op)
+end
+
+struct LazyOneArgFDOperatorMatrix{O <: OneArgFDOperator} <: AbstractLazyOperator
+    op::O
+end
+
+# Since the operator matrix of a one-argument operator does not have any
+# arguments, we need to use a lazy operator to add an argument.
+replace_lazy_operator(space, lazy_op::LazyOneArgFDOperatorMatrix) =
+    Base.Broadcast.broadcasted(
+        FDOperatorMatrix(lazy_op.op),
+        Fields.local_geometry_field(operator_input_space(lazy_op.op, space)),
+    )
+
+# Since the operator matrix of a two-argument operator already has one argument,
+# we can modify Base.broadcasted to add a second argument.
+Base.Broadcast.broadcasted(
+    op_matrix::FDOperatorMatrix{<:TwoArgFDOperator},
+    arg,
+) = Base.Broadcast.broadcasted(
+    op_matrix,
+    arg,
+    Fields.local_geometry_field(operator_input_space(op_matrix.op, axes(arg))),
+)
+
+"""
+    operator_matrix(op)
+
+Constructs a new operator (or operator-like object) that generates the matrix
+applied by `op` to its final argument. If `op_matrix = operator_matrix(op)`,
+we can use the following identities:
+- When `op` takes one argument, `@. op(arg) == @. op_matrix() ⋅ arg`.
+- When `op` takes multiple arguments,
+    `@. op(args..., arg) == @. op_matrix(args...) ⋅ arg`.
+
+When `op` takes more than one argument, `operator_matrix(op)` constructs a
+`FiniteDifferenceOperator` that generates the operator matrix. When `op` only
+takes one argument, it instead constructs an `AbstractLazyOperator`, which is
+internally converted into a `FiniteDifferenceOperator` when used in a broadcast
+expression. Implementing `op_matrix` as a lazy operator allows us to add an
+argument to the expression `op_matrix.()`, and we then use this argument to
+infer the space and element type of the operator matrix.
+
+As an example, the `InterpolateF2C()` operator on a space with ``n`` cell
+centers applies an ``n \\times (n + 1)`` bidiagonal matrix:
+```math
+\\textrm{interp}(arg) = \\begin{bmatrix}
+    0.5 &     0.5 &       0 & \\cdots &       0 &       0 &       0 \\\\
+      0 &     0.5 &     0.5 & \\cdots &       0 &       0 &       0 \\\\
+      0 &       0 &     0.5 & \\cdots &       0 &       0 &       0 \\\\
+\\vdots & \\vdots & \\vdots & \\ddots & \\vdots & \\vdots & \\vdots \\\\
+      0 &       0 &       0 & \\cdots &     0.5 &     0.5 &       0 \\\\
+      0 &       0 &       0 & \\cdots &       0 &     0.5 &     0.5
+\\end{bmatrix} ⋅ arg
+```
+The `GradientF2C()` operator applies a similar matrix, but with different
+entries:
+```math
+\\textrm{grad}(arg) = \\begin{bmatrix}
+-\\textbf{e}^3 &  \\textbf{e}^3 &              0 & \\cdots &              0 &              0 &             0 \\\\
+             0 & -\\textbf{e}^3 &  \\textbf{e}^3 & \\cdots &              0 &              0 &             0 \\\\
+             0 &              0 & -\\textbf{e}^3 & \\cdots &              0 &              0 &             0 \\\\
+       \\vdots &        \\vdots &        \\vdots & \\ddots &        \\vdots &        \\vdots &       \\vdots \\\\
+             0 &              0 &              0 & \\cdots & -\\textbf{e}^3 &  \\textbf{e}^3 &             0 \\\\
+             0 &              0 &              0 & \\cdots &              0 & -\\textbf{e}^3 & \\textbf{e}^3
+\\end{bmatrix} ⋅ arg
+```
+The unit vector ``\\textbf{e}^3``, which can also be thought of as the
+differential along the third coordinate axis (``\\textrm{d}\\xi^3``), is
+implemented as a `Geometry.Covariant3Vector(1)`.
+
+Not all operators have well-defined operator matrices. For example, the operator
+`GradientC2F(; bottom = SetGradient(grad_b), top = SetGradient(grad_t))` applies
+an affine transformation:
+```math
+\\textrm{grad}(arg) = \\begin{bmatrix}
+grad_b \\\\ 0 \\\\ 0 \\\\ \\vdots \\\\ 0 \\\\ 0 \\\\ grad_t
+\\end{bmatrix} + \\begin{bmatrix}
+             0 &              0 &              0 & \\cdots &              0 &             0 \\\\
+-\\textbf{e}^3 &  \\textbf{e}^3 &              0 & \\cdots &              0 &             0 \\\\
+             0 & -\\textbf{e}^3 &  \\textbf{e}^3 & \\cdots &              0 &             0 \\\\
+       \\vdots &        \\vdots &        \\vdots & \\ddots &        \\vdots &       \\vdots \\\\
+             0 &              0 &              0 & \\cdots &  \\textbf{e}^3 &             0 \\\\
+             0 &              0 &              0 & \\cdots & -\\textbf{e}^3 & \\textbf{e}^3 \\\\
+             0 &              0 &              0 & \\cdots &              0 &             0
+\\end{bmatrix} ⋅ arg
+```
+However, this simplifies to a linear transformation when ``grad_b`` and
+``grad_t`` are both 0:
+```math
+\\textrm{grad}(arg) = \\begin{bmatrix}
+             0 &              0 &              0 & \\cdots &              0 &             0 \\\\
+-\\textbf{e}^3 &  \\textbf{e}^3 &              0 & \\cdots &              0 &             0 \\\\
+             0 & -\\textbf{e}^3 &  \\textbf{e}^3 & \\cdots &              0 &             0 \\\\
+       \\vdots &        \\vdots &        \\vdots & \\ddots &        \\vdots &       \\vdots \\\\
+             0 &              0 &              0 & \\cdots &  \\textbf{e}^3 &             0 \\\\
+             0 &              0 &              0 & \\cdots & -\\textbf{e}^3 & \\textbf{e}^3 \\\\
+             0 &              0 &              0 & \\cdots &              0 &             0
+\\end{bmatrix} ⋅ arg
+```
+In general, when `op` has nonzero boundary conditions that make it apply an
+affine transformation, `operator_matrix(op)` will print out a warning and zero
+out the boundary conditions before computing the operator matrix.
+
+In addition to affine transformations, there are also some operators that apply
+nonlinear transformations to their arguments; that is, transformations which
+cannot be accurately approximated without using more terms of the form
+```math
+\\textrm{op}(\\textbf{0}) +
+\\textrm{op}'(\\textbf{0}) ⋅ arg +
+\\textrm{op}''(\\textbf{0}) ⋅ arg ⋅ arg +
+\\ldots.
+```
+When `op` is such an operator, `operator_matrix(op)` will throw an error. In the
+future, we may want to modify `operator_matrix(op)` so that it will instead
+return ``\\textrm{op}'(\\textbf{0})``, where ``\\textbf{0} ={} ```zero.(arg)`.
+"""
+operator_matrix(op::OneArgFDOperator) = LazyOneArgFDOperatorMatrix(op)
+operator_matrix(op::TwoArgFDOperator) = FDOperatorMatrix(op)
+operator_matrix(::O) where {O <: ErroneousFDOperator} = error(
+    "$(O.name.name) always throws an AssertionError when it is used, so its \
+     operator matrix has not been implemented",
+)
+operator_matrix(::O) where {O <: NonlinearFDOperator} = error(
+    "$(O.name.name) applies a nonlinear transformation to its argument, so it \
+     cannot be represented by a matrix",
+)
+operator_matrix(::O) where {O <: Operators.AbstractOperator} =
+    error("operator_matrix has not been defined for $(O.name.name)")
+
+################################################################################
+
+Operators.has_boundary(
+    op_matrix::FDOperatorMatrix,
+    lbw::Operators.LeftBoundaryWindow{name},
+) where {name} = Operators.has_boundary(op_matrix.op, lbw)
+Operators.has_boundary(
+    op_matrix::FDOperatorMatrix,
+    rbw::Operators.RightBoundaryWindow{name},
+) where {name} = Operators.has_boundary(op_matrix.op, rbw)
+
+Operators.get_boundary(
+    op_matrix::FDOperatorMatrix,
+    lbw::Operators.LeftBoundaryWindow{name},
+) where {name} = Operators.get_boundary(op_matrix.op, lbw)
+Operators.get_boundary(
+    op_matrix::FDOperatorMatrix,
+    rbw::Operators.RightBoundaryWindow{name},
+) where {name} = Operators.get_boundary(op_matrix.op, rbw)
+
+Operators.stencil_interior_width(op_matrix::FDOperatorMatrix, args...) =
+    Operators.stencil_interior_width(op_matrix.op, args...)
+
+Operators.left_interior_idx(
+    space::Spaces.AbstractSpace,
+    op_matrix::FDOperatorMatrix,
+    bc::Operators.AbstractBoundaryCondition,
+    args...,
+) = Operators.left_interior_idx(space, op_matrix.op, bc, args...)
+
+Operators.right_interior_idx(
+    space::Spaces.AbstractSpace,
+    op_matrix::FDOperatorMatrix,
+    bc::Operators.AbstractBoundaryCondition,
+    args...,
+) = Operators.right_interior_idx(space, op_matrix.op, bc, args...)
+
+Operators.return_space(op_matrix::FDOperatorMatrix, spaces...) =
+    Operators.return_space(op_matrix.op, spaces...)
+
+function Operators.return_eltype(op_matrix::FDOperatorMatrix, args...)
+    args′ = args[1:(end - 1)]
+    FT = Geometry.undertype(eltype(args[end]))
+    return op_matrix_row_type(op_matrix.op, FT, args′...)
+end
+
+Base.@propagate_inbounds function Operators.stencil_interior(
+    op_matrix::FDOperatorMatrix,
+    loc,
+    space,
+    idx,
+    hidx,
+    args...,
+)
+    args′ = args[1:(end - 1)]
+    row = op_matrix_interior_row(op_matrix.op, space, loc, idx, hidx, args′...)
+    return convert(Operators.return_eltype(op_matrix, args...), row)
+end
+
+Base.@propagate_inbounds function Operators.stencil_left_boundary(
+    op_matrix::FDOperatorMatrix,
+    bc::Operators.AbstractBoundaryCondition,
+    loc,
+    space,
+    idx,
+    hidx,
+    args...,
+)
+    args′ = args[1:(end - 1)]
+    row = op_matrix_first_row(op_matrix.op, bc, space, loc, idx, hidx, args′...)
+    return convert(Operators.return_eltype(op_matrix, args...), row)
+end
+
+Base.@propagate_inbounds function Operators.stencil_right_boundary(
+    op_matrix::FDOperatorMatrix,
+    bc::Operators.AbstractBoundaryCondition,
+    loc,
+    space,
+    idx,
+    hidx,
+    args...,
+)
+    args′ = args[1:(end - 1)]
+    row = op_matrix_last_row(op_matrix.op, bc, space, loc, idx, hidx, args′...)
+    return convert(Operators.return_eltype(op_matrix, args...), row)
+end
+
+# Simplified methods for when the operator matrix only depends on FT.
+op_matrix_row_type(op, ::Type{FT}, args...) where {FT} =
+    typeof(op_matrix_interior_row(op, FT))
+op_matrix_interior_row(op, space, loc, idx, hidx, args...) =
+    op_matrix_interior_row(op, Spaces.undertype(space))
+op_matrix_first_row(op, bc, space, loc, idx, hidx, args...) =
+    op_matrix_first_row(op, bc, Spaces.undertype(space))
+op_matrix_last_row(op, bc, space, loc, idx, hidx, args...) =
+    op_matrix_last_row(op, bc, Spaces.undertype(space))
+
+################################################################################
+
+# Additional aliases for CenterToFace or FaceToCenter matrix rows
+const LowerEmptyMatrixRow = BandMatrixRow{-1 + half, 0}
+const UpperEmptyMatrixRow = BandMatrixRow{half, 0}
+const LowerDiagonalMatrixRow = BandMatrixRow{-1 + half, 1}    # -0.5
+const UpperDiagonalMatrixRow = BandMatrixRow{half, 1}         #  0.5
+const LowerBidiagonalMatrixRow = BandMatrixRow{-2 + half, 2}  # -1.5, -0.5
+const UpperBidiagonalMatrixRow = BandMatrixRow{half, 2}       #  0.5,  1.5
+const LowerTridiagonalMatrixRow = BandMatrixRow{-2 + half, 3} # -1.5, -0.5, 0.5
+const UpperTridiagonalMatrixRow = BandMatrixRow{-1 + half, 3} # -0.5,  0.5, 1.5
+
+# Additional aliases for Square matrix rows
+const LowerBidiagonalSquareMatrixRow = BandMatrixRow{-1, 2} # -1, 0
+const UpperBidiagonalSquareMatrixRow = BandMatrixRow{0, 2}  #  0, 1
+
+const C3{T} = Geometry.Covariant3Vector{T}
+const CT3{T} = Geometry.Contravariant3Vector{T}
+const CT12_CT12{T} = Geometry.Axis2Tensor{
+    T,
+    Tuple{Geometry.Contravariant12Axis, Geometry.Contravariant12Axis},
+    SMatrix{2, 2, T, 4},
+}
+
+# Levi-Civita symbol in 2D
+const εⁱʲ = Geometry.AxisTensor(
+    (Geometry.Contravariant12Axis(), Geometry.Contravariant12Axis()),
+    SMatrix{2, 2}(0, 1, -1, 0),
+)
+
+Base.@propagate_inbounds ct3_data(velocity, space, loc, idx, hidx) =
+    Geometry.contravariant3(
+        Operators.getidx(space, velocity, loc, idx, hidx),
+        Geometry.LocalGeometry(space, idx, hidx),
+    )
+
+################################################################################
+
+op_matrix_interior_row(
+    ::Union{Operators.InterpolateC2F, Operators.InterpolateF2C},
+    ::Type{FT},
+) where {FT} = BidiagonalMatrixRow(FT(1), FT(1)) / 2
+op_matrix_first_row(
+    ::Operators.InterpolateC2F,
+    ::Operators.SetValue,
+    ::Type{FT},
+) where {FT} = UpperDiagonalMatrixRow(FT(0))
+op_matrix_last_row(
+    ::Operators.InterpolateC2F,
+    ::Operators.SetValue,
+    ::Type{FT},
+) where {FT} = LowerDiagonalMatrixRow(FT(0))
+op_matrix_first_row(
+    ::Operators.InterpolateC2F,
+    ::Operators.SetGradient,
+    ::Type{FT},
+) where {FT} = UpperDiagonalMatrixRow(FT(1))
+op_matrix_last_row(
+    ::Operators.InterpolateC2F,
+    ::Operators.SetGradient,
+    ::Type{FT},
+) where {FT} = LowerDiagonalMatrixRow(FT(1))
+op_matrix_first_row(
+    ::Operators.InterpolateC2F,
+    ::Operators.Extrapolate,
+    ::Type{FT},
+) where {FT} = UpperDiagonalMatrixRow(FT(1))
+op_matrix_last_row(
+    ::Operators.InterpolateC2F,
+    ::Operators.Extrapolate,
+    ::Type{FT},
+) where {FT} = LowerDiagonalMatrixRow(FT(1))
+
+op_matrix_interior_row(
+    ::Union{Operators.LeftBiasedC2F, Operators.LeftBiasedF2C},
+    ::Type{FT},
+) where {FT} = LowerDiagonalMatrixRow(FT(1))
+op_matrix_first_row(
+    ::Operators.LeftBiasedC2F,
+    ::Operators.SetValue,
+    ::Type{FT},
+) where {FT} = LowerEmptyMatrixRow()
+op_matrix_first_row(
+    ::Operators.LeftBiasedF2C,
+    ::Operators.SetValue,
+    ::Type{FT},
+) where {FT} = LowerDiagonalMatrixRow(FT(0))
+
+op_matrix_interior_row(
+    ::Union{Operators.RightBiasedC2F, Operators.RightBiasedF2C},
+    ::Type{FT},
+) where {FT} = UpperDiagonalMatrixRow(FT(1))
+op_matrix_last_row(
+    ::Operators.RightBiasedC2F,
+    ::Operators.SetValue,
+    ::Type{FT},
+) where {FT} = UpperEmptyMatrixRow()
+op_matrix_last_row(
+    ::Operators.RightBiasedF2C,
+    ::Operators.SetValue,
+    ::Type{FT},
+) where {FT} = UpperDiagonalMatrixRow(FT(0))
+
+op_matrix_row_type(
+    ::Operators.WeightedInterpolationOperator,
+    ::Type{FT},
+    weight,
+) where {FT} = BidiagonalMatrixRow{eltype(weight)}
+Base.@propagate_inbounds function op_matrix_interior_row(
+    ::Operators.WeightedInterpolationOperator,
+    space,
+    loc,
+    idx,
+    hidx,
+    weight,
+)
+    w⁻ = Operators.getidx(space, weight, loc, idx - half, hidx)
+    w⁺ = Operators.getidx(space, weight, loc, idx + half, hidx)
+    denominator = radd(w⁻, w⁺)
+    return BidiagonalMatrixRow(rdiv(w⁻, denominator), rdiv(w⁺, denominator))
+end
+op_matrix_first_row(
+    ::Operators.WeightedInterpolateC2F,
+    ::Operators.SetValue,
+    ::Type{FT},
+) where {FT} = UpperDiagonalMatrixRow(FT(0))
+op_matrix_last_row(
+    ::Operators.WeightedInterpolateC2F,
+    ::Operators.SetValue,
+    ::Type{FT},
+) where {FT} = LowerDiagonalMatrixRow(FT(0))
+op_matrix_first_row(
+    ::Operators.WeightedInterpolateC2F,
+    ::Operators.SetGradient,
+    ::Type{FT},
+) where {FT} = UpperDiagonalMatrixRow(FT(1))
+op_matrix_last_row(
+    ::Operators.WeightedInterpolateC2F,
+    ::Operators.SetGradient,
+    ::Type{FT},
+) where {FT} = LowerDiagonalMatrixRow(FT(1))
+op_matrix_first_row(
+    ::Operators.WeightedInterpolateC2F,
+    ::Operators.Extrapolate,
+    ::Type{FT},
+) where {FT} = UpperDiagonalMatrixRow(FT(1))
+op_matrix_last_row(
+    ::Operators.WeightedInterpolateC2F,
+    ::Operators.Extrapolate,
+    ::Type{FT},
+) where {FT} = LowerDiagonalMatrixRow(FT(1))
+
+op_matrix_row_type(
+    op::Operators.UpwindBiasedProductC2F,
+    ::Type{FT},
+    _,
+) where {FT} =
+    uses_extrapolate(op) ? QuaddiagonalMatrixRow{CT3{FT}} :
+    BidiagonalMatrixRow{CT3{FT}}
+Base.@propagate_inbounds function op_matrix_interior_row(
+    ::Operators.UpwindBiasedProductC2F,
+    space,
+    loc,
+    idx,
+    hidx,
+    velocity,
+)
+    v³ = CT3(ct3_data(velocity, space, loc, idx, hidx))
+    av³ = CT3(abs(v³.u³))
+    return BidiagonalMatrixRow(v³ + av³, v³ - av³) / 2
+end
+Base.@propagate_inbounds function op_matrix_first_row(
+    ::Operators.UpwindBiasedProductC2F,
+    ::Operators.SetValue,
+    space,
+    loc,
+    idx,
+    hidx,
+    velocity,
+)
+    v³ = CT3(ct3_data(velocity, space, loc, idx, hidx))
+    av³ = CT3(abs(v³.u³))
+    return UpperDiagonalMatrixRow(v³ - av³) / 2
+end
+Base.@propagate_inbounds function op_matrix_last_row(
+    ::Operators.UpwindBiasedProductC2F,
+    ::Operators.SetValue,
+    space,
+    loc,
+    idx,
+    hidx,
+    velocity,
+)
+    v³ = CT3(ct3_data(velocity, space, loc, idx, hidx))
+    av³ = CT3(abs(v³.u³))
+    return LowerDiagonalMatrixRow(v³ + av³) / 2
+end
+Base.@propagate_inbounds function op_matrix_first_row(
+    ::Operators.UpwindBiasedProductC2F,
+    ::Operators.Extrapolate,
+    space,
+    loc,
+    idx,
+    hidx,
+    velocity,
+)
+    v³ = CT3(ct3_data(velocity, space, loc, idx + 1, hidx))
+    av³ = CT3(abs(v³.u³))
+    return UpperBidiagonalMatrixRow(v³ + av³, v³ - av³) / 2
+end
+Base.@propagate_inbounds function op_matrix_last_row(
+    ::Operators.UpwindBiasedProductC2F,
+    ::Operators.Extrapolate,
+    space,
+    loc,
+    idx,
+    hidx,
+    velocity,
+)
+    v³ = CT3(ct3_data(velocity, space, loc, idx - 1, hidx))
+    av³ = CT3(abs(v³.u³))
+    return LowerBidiagonalMatrixRow(v³ + av³, v³ - av³) / 2
+end
+
+op_matrix_row_type(
+    ::Operators.Upwind3rdOrderBiasedProductC2F,
+    ::Type{FT},
+    _,
+) where {FT} = QuaddiagonalMatrixRow{CT3{FT}}
+Base.@propagate_inbounds function op_matrix_interior_row(
+    ::Operators.Upwind3rdOrderBiasedProductC2F,
+    space,
+    loc,
+    idx,
+    hidx,
+    velocity,
+)
+    v³ = CT3(ct3_data(velocity, space, loc, idx, hidx))
+    av³ = CT3(abs(v³.u³))
+    return QuaddiagonalMatrixRow(-v³ - av³, 7v³ + 3av³, 7v³ - 3av³, -v³ + av³) /
+           12
+end
+Base.@propagate_inbounds function op_matrix_first_row(
+    ::Operators.Upwind3rdOrderBiasedProductC2F,
+    ::Operators.FirstOrderOneSided,
+    space,
+    loc,
+    idx,
+    hidx,
+    velocity,
+)
+    v³ = CT3(ct3_data(velocity, space, loc, idx, hidx))
+    av³ = CT3(abs(v³.u³))
+    return UpperTridiagonalMatrixRow(8v³ + 4av³, 5v³ - 5av³, -v³ + av³) / 12
+end
+Base.@propagate_inbounds function op_matrix_last_row(
+    ::Operators.Upwind3rdOrderBiasedProductC2F,
+    ::Operators.FirstOrderOneSided,
+    space,
+    loc,
+    idx,
+    hidx,
+    velocity,
+)
+    v³ = CT3(ct3_data(velocity, space, loc, idx, hidx))
+    av³ = CT3(abs(v³.u³))
+    return LowerTridiagonalMatrixRow(-v³ - av³, 5v³ + 5av³, 8v³ - 4av³) / 12
+end
+Base.@propagate_inbounds function op_matrix_first_row(
+    ::Operators.Upwind3rdOrderBiasedProductC2F,
+    ::Operators.ThirdOrderOneSided,
+    space,
+    loc,
+    idx,
+    hidx,
+    velocity,
+)
+    v³ = CT3(ct3_data(velocity, space, loc, idx, hidx))
+    return UpperTridiagonalMatrixRow(4v³, 10v³, -2v³) / 12
+end
+Base.@propagate_inbounds function op_matrix_last_row(
+    ::Operators.Upwind3rdOrderBiasedProductC2F,
+    ::Operators.ThirdOrderOneSided,
+    space,
+    loc,
+    idx,
+    hidx,
+    velocity,
+)
+    v³ = CT3(ct3_data(velocity, space, loc, idx, hidx))
+    return LowerTridiagonalMatrixRow(-2v³, 10v³, 4v³) / 12
+end
+
+op_matrix_row_type(::Operators.AdvectionOperator, ::Type{FT}, _) where {FT} =
+    TridiagonalMatrixRow{FT}
+Base.@propagate_inbounds function op_matrix_interior_row(
+    ::Operators.AdvectionC2C,
+    space,
+    loc,
+    idx,
+    hidx,
+    velocity,
+)
+    v³⁻_data = ct3_data(velocity, space, loc, idx - half, hidx)
+    v³⁺_data = ct3_data(velocity, space, loc, idx + half, hidx)
+    return TridiagonalMatrixRow(-v³⁻_data, v³⁻_data - v³⁺_data, v³⁺_data) / 2
+end
+Base.@propagate_inbounds function op_matrix_first_row(
+    ::Operators.AdvectionC2C,
+    ::Operators.SetValue,
+    space,
+    loc,
+    idx,
+    hidx,
+    velocity,
+)
+    v³⁻_data = ct3_data(velocity, space, loc, idx - half, hidx)
+    v³⁺_data = ct3_data(velocity, space, loc, idx + half, hidx)
+    return UpperBidiagonalSquareMatrixRow(2v³⁻_data - v³⁺_data, v³⁺_data) / 2
+end
+Base.@propagate_inbounds function op_matrix_last_row(
+    ::Operators.AdvectionC2C,
+    ::Operators.SetValue,
+    space,
+    loc,
+    idx,
+    hidx,
+    velocity,
+)
+    v³⁻_data = ct3_data(velocity, space, loc, idx - half, hidx)
+    v³⁺_data = ct3_data(velocity, space, loc, idx + half, hidx)
+    return LowerBidiagonalSquareMatrixRow(-v³⁻_data, v³⁻_data - 2v³⁺_data) / 2
+end
+Base.@propagate_inbounds function op_matrix_first_row(
+    ::Operators.AdvectionC2C,
+    ::Operators.Extrapolate,
+    space,
+    loc,
+    idx,
+    hidx,
+    velocity,
+)
+    v³⁺_data = ct3_data(velocity, space, loc, idx + half, hidx)
+    return UpperBidiagonalSquareMatrixRow(-v³⁺_data, v³⁺_data)
+end
+Base.@propagate_inbounds function op_matrix_last_row(
+    ::Operators.AdvectionC2C,
+    ::Operators.Extrapolate,
+    space,
+    loc,
+    idx,
+    hidx,
+    velocity,
+)
+    v³⁻_data = ct3_data(velocity, space, loc, idx - half, hidx)
+    return LowerBidiagonalSquareMatrixRow(-v³⁻_data, v³⁻_data)
+end
+Base.@propagate_inbounds function op_matrix_interior_row(
+    ::Operators.AdvectionF2F,
+    space,
+    loc,
+    idx,
+    hidx,
+    velocity,
+)
+    FT = Spaces.undertype(space)
+    v³_data = ct3_data(velocity, space, loc, idx, hidx)
+    return TridiagonalMatrixRow(-v³_data, FT(0), v³_data) / 2
+end
+Base.@propagate_inbounds function op_matrix_interior_row(
+    ::Union{Operators.FluxCorrectionC2C, Operators.FluxCorrectionF2F},
+    space,
+    loc,
+    idx,
+    hidx,
+    velocity,
+)
+    av³⁻_data = abs(ct3_data(velocity, space, loc, idx - half, hidx))
+    av³⁺_data = abs(ct3_data(velocity, space, loc, idx + half, hidx))
+    return TridiagonalMatrixRow(av³⁻_data, -av³⁻_data - av³⁺_data, av³⁺_data)
+end
+Base.@propagate_inbounds function op_matrix_first_row(
+    ::Union{Operators.FluxCorrectionC2C, Operators.FluxCorrectionF2F},
+    ::Operators.Extrapolate,
+    space,
+    loc,
+    idx,
+    hidx,
+    velocity,
+)
+    av³⁺_data = abs(ct3_data(velocity, space, loc, idx + half, hidx))
+    return UpperBidiagonalSquareMatrixRow(-av³⁺_data, av³⁺_data)
+end
+Base.@propagate_inbounds function op_matrix_last_row(
+    ::Union{Operators.FluxCorrectionC2C, Operators.FluxCorrectionF2F},
+    ::Operators.Extrapolate,
+    space,
+    loc,
+    idx,
+    hidx,
+    velocity,
+)
+    av³⁻_data = abs(ct3_data(velocity, space, loc, idx - half, hidx))
+    return LowerBidiagonalSquareMatrixRow(av³⁻_data, -av³⁻_data)
+end
+
+op_matrix_interior_row(::Operators.SetBoundaryOperator, ::Type{FT}) where {FT} =
+    DiagonalMatrixRow(FT(1))
+op_matrix_first_row(
+    ::Operators.SetBoundaryOperator,
+    ::Operators.SetValue,
+    ::Type{FT},
+) where {FT} = DiagonalMatrixRow(FT(0))
+op_matrix_last_row(
+    ::Operators.SetBoundaryOperator,
+    ::Operators.SetValue,
+    ::Type{FT},
+) where {FT} = DiagonalMatrixRow(FT(0))
+
+op_matrix_row_type(op::Operators.GradientOperator, ::Type{FT}) where {FT} =
+    uses_extrapolate(op) ? QuaddiagonalMatrixRow{C3{FT}} :
+    BidiagonalMatrixRow{C3{FT}}
+op_matrix_interior_row(::Operators.GradientOperator, ::Type{FT}) where {FT} =
+    BidiagonalMatrixRow(-C3(FT(1)), C3(FT(1)))
+op_matrix_first_row(
+    ::Operators.GradientC2F,
+    ::Operators.SetValue,
+    ::Type{FT},
+) where {FT} = UpperDiagonalMatrixRow(C3(FT(2)))
+op_matrix_last_row(
+    ::Operators.GradientC2F,
+    ::Operators.SetValue,
+    ::Type{FT},
+) where {FT} = LowerDiagonalMatrixRow(-C3(FT(2)))
+op_matrix_first_row(
+    ::Operators.GradientC2F,
+    ::Operators.SetGradient,
+    ::Type{FT},
+) where {FT} = UpperDiagonalMatrixRow(C3(FT(0)))
+op_matrix_last_row(
+    ::Operators.GradientC2F,
+    ::Operators.SetGradient,
+    ::Type{FT},
+) where {FT} = LowerDiagonalMatrixRow(C3(FT(0)))
+op_matrix_first_row(
+    ::Operators.GradientF2C,
+    ::Operators.SetValue,
+    ::Type{FT},
+) where {FT} = BidiagonalMatrixRow(C3(FT(0)), C3(FT(1)))
+op_matrix_last_row(
+    ::Operators.GradientF2C,
+    ::Operators.SetValue,
+    ::Type{FT},
+) where {FT} = BidiagonalMatrixRow(-C3(FT(1)), C3(FT(0)))
+op_matrix_first_row(
+    ::Operators.GradientF2C,
+    ::Operators.Extrapolate,
+    ::Type{FT},
+) where {FT} = UpperTridiagonalMatrixRow(C3(FT(0)), -C3(FT(1)), C3(FT(1)))
+op_matrix_last_row(
+    ::Operators.GradientF2C,
+    ::Operators.Extrapolate,
+    ::Type{FT},
+) where {FT} = LowerTridiagonalMatrixRow(-C3(FT(1)), C3(FT(1)), C3(FT(0)))
+
+op_matrix_row_type(op::Operators.DivergenceOperator, ::Type{FT}) where {FT} =
+    uses_extrapolate(op) ? QuaddiagonalMatrixRow{Adjoint{FT, C3{FT}}} :
+    BidiagonalMatrixRow{Adjoint{FT, C3{FT}}}
+Base.@propagate_inbounds function op_matrix_interior_row(
+    op::Operators.DivergenceOperator,
+    space,
+    loc,
+    idx,
+    hidx,
+)
+    invJ = Geometry.LocalGeometry(space, idx, hidx).invJ
+    J⁻ = Geometry.LocalGeometry(space, idx - half, hidx).J
+    J⁺ = Geometry.LocalGeometry(space, idx + half, hidx).J
+    return BidiagonalMatrixRow(-C3(J⁻)', C3(J⁺)') * invJ
+end
+Base.@propagate_inbounds function op_matrix_first_row(
+    ::Operators.DivergenceC2F,
+    ::Operators.SetValue,
+    space,
+    loc,
+    idx,
+    hidx,
+)
+    invJ = Geometry.LocalGeometry(space, idx, hidx).invJ
+    J⁺ = Geometry.LocalGeometry(space, idx + half, hidx).J
+    return UpperDiagonalMatrixRow(C3(J⁺)') * 2invJ
+end
+Base.@propagate_inbounds function op_matrix_last_row(
+    ::Operators.DivergenceC2F,
+    ::Operators.SetValue,
+    space,
+    loc,
+    idx,
+    hidx,
+)
+    invJ = Geometry.LocalGeometry(space, idx, hidx).invJ
+    J⁻ = Geometry.LocalGeometry(space, idx - half, hidx).J
+    return LowerDiagonalMatrixRow(-C3(J⁻)') * 2invJ
+end
+op_matrix_first_row(
+    ::Operators.DivergenceC2F,
+    ::Operators.SetDivergence,
+    ::Type{FT},
+) where {FT} = UpperDiagonalMatrixRow(C3(FT(0))')
+op_matrix_last_row(
+    ::Operators.DivergenceC2F,
+    ::Operators.SetDivergence,
+    ::Type{FT},
+) where {FT} = LowerDiagonalMatrixRow(C3(FT(0))')
+Base.@propagate_inbounds function op_matrix_first_row(
+    ::Operators.DivergenceF2C,
+    ::Operators.SetValue,
+    space,
+    loc,
+    idx,
+    hidx,
+)
+    FT = Spaces.undertype(space)
+    invJ = Geometry.LocalGeometry(space, idx, hidx).invJ
+    J⁺ = Geometry.LocalGeometry(space, idx + half, hidx).J
+    return BidiagonalMatrixRow(C3(FT(0))', C3(J⁺)') * invJ
+end
+Base.@propagate_inbounds function op_matrix_last_row(
+    ::Operators.DivergenceF2C,
+    ::Operators.SetValue,
+    space,
+    loc,
+    idx,
+    hidx,
+)
+    FT = Spaces.undertype(space)
+    invJ = Geometry.LocalGeometry(space, idx, hidx).invJ
+    J⁻ = Geometry.LocalGeometry(space, idx - half, hidx).J
+    return BidiagonalMatrixRow(-C3(J⁻)', C3(FT(0))') * invJ
+end
+Base.@propagate_inbounds function op_matrix_first_row(
+    ::Operators.DivergenceF2C,
+    ::Operators.Extrapolate,
+    space,
+    loc,
+    idx,
+    hidx,
+)
+    FT = Spaces.undertype(space)
+    invJ = Geometry.LocalGeometry(space, idx + 1, hidx).invJ
+    J⁻ = Geometry.LocalGeometry(space, idx + 1 - half, hidx).J
+    J⁺ = Geometry.LocalGeometry(space, idx + 1 + half, hidx).J
+    return UpperTridiagonalMatrixRow(C3(FT(0))', -C3(J⁻)', C3(J⁺)') * invJ
+end
+Base.@propagate_inbounds function op_matrix_last_row(
+    ::Operators.DivergenceF2C,
+    ::Operators.Extrapolate,
+    space,
+    loc,
+    idx,
+    hidx,
+)
+    FT = Spaces.undertype(space)
+    invJ = Geometry.LocalGeometry(space, idx - 1, hidx).invJ
+    J⁻ = Geometry.LocalGeometry(space, idx - 1 - half, hidx).J
+    J⁺ = Geometry.LocalGeometry(space, idx - 1 + half, hidx).J
+    return LowerTridiagonalMatrixRow(-C3(J⁻)', C3(J⁺)', C3(FT(0))') * invJ
+end
+
+op_matrix_row_type(
+    ::Operators.CurlFiniteDifferenceOperator,
+    ::Type{FT},
+) where {FT} = BidiagonalMatrixRow{CT12_CT12{FT}}
+Base.@propagate_inbounds function op_matrix_interior_row(
+    ::Operators.CurlFiniteDifferenceOperator,
+    space,
+    loc,
+    idx,
+    hidx,
+)
+    invJ = Geometry.LocalGeometry(space, idx, hidx).invJ
+    return BidiagonalMatrixRow(-εⁱʲ, εⁱʲ) * invJ
+end
+Base.@propagate_inbounds function op_matrix_first_row(
+    ::Operators.CurlC2F,
+    ::Operators.SetValue,
+    space,
+    loc,
+    idx,
+    hidx,
+)
+    invJ = Geometry.LocalGeometry(space, idx, hidx).invJ
+    return UpperDiagonalMatrixRow(εⁱʲ) * 2invJ
+end
+Base.@propagate_inbounds function op_matrix_last_row(
+    ::Operators.CurlC2F,
+    ::Operators.SetValue,
+    space,
+    loc,
+    idx,
+    hidx,
+)
+    invJ = Geometry.LocalGeometry(space, idx, hidx).invJ
+    return LowerDiagonalMatrixRow(-εⁱʲ) * 2invJ
+end
+op_matrix_first_row(
+    ::Operators.CurlC2F,
+    ::Operators.SetCurl,
+    ::Type{FT},
+) where {FT} = UpperDiagonalMatrixRow(zero(CT12_CT12{FT}))
+op_matrix_last_row(
+    ::Operators.CurlC2F,
+    ::Operators.SetCurl,
+    ::Type{FT},
+) where {FT} = LowerDiagonalMatrixRow(zero(CT12_CT12{FT}))

--- a/src/MatrixFields/rmul_with_projection.jl
+++ b/src/MatrixFields/rmul_with_projection.jl
@@ -1,6 +1,3 @@
-const SingleValue =
-    Union{Number, Geometry.AxisTensor, Geometry.AdjointAxisTensor}
-
 """
     mul_with_projection(x, y, lg)
 

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -2418,7 +2418,7 @@ Base.@propagate_inbounds function stencil_left_boundary(
 )
     @assert idx == left_center_boundary_idx(space)
     Geometry.project(
-        Geometery.Covariant3Axis(),
+        Geometry.Covariant3Axis(),
         stencil_interior(op, loc, space, idx + 1, hidx, arg),
         Geometry.LocalGeometry(space, idx, hidx),
     )
@@ -3326,7 +3326,12 @@ Base.@propagate_inbounds function setidx!(
 end
 
 function Base.Broadcast.broadcasted(op::FiniteDifferenceOperator, args...)
-    Base.Broadcast.broadcasted(StencilStyle(), op, args...)
+    args′ = map(Base.Broadcast.broadcastable, args)
+    style = Base.Broadcast.result_style(
+        StencilStyle(),
+        Base.Broadcast.combine_styles(args′...),
+    )
+    Base.Broadcast.broadcasted(style, op, args′...)
 end
 
 function Base.Broadcast.broadcasted(

--- a/src/Operators/spectralelement.jl
+++ b/src/Operators/spectralelement.jl
@@ -105,8 +105,14 @@ Adapt.adapt_structure(to, sbc::SpectralBroadcasted{Style}) where {Style} =
 return_space(::SpectralElementOperator, space) = space
 
 
-Base.Broadcast.broadcasted(op::SpectralElementOperator, args...) =
-    Base.Broadcast.broadcasted(SpectralStyle(), op, args...)
+function Base.Broadcast.broadcasted(op::SpectralElementOperator, args...)
+    args′ = map(Base.Broadcast.broadcastable, args)
+    style = Base.Broadcast.result_style(
+        SpectralStyle(),
+        Base.Broadcast.combine_styles(args′...),
+    )
+    Base.Broadcast.broadcasted(style, op, args′...)
+end
 
 Base.Broadcast.broadcasted(
     ::SpectralStyle,

--- a/src/RecursiveApply/RecursiveApply.jl
+++ b/src/RecursiveApply/RecursiveApply.jl
@@ -98,6 +98,7 @@ rmaptype(
 Recursively apply `promote_type` to the input types.
 """
 rpromote_type(Ts...) = reduce((T1, T2) -> rmaptype(promote_type, T1, T2), Ts)
+rpromote_type() = Union{}
 
 """
     rzero(T)

--- a/test/MatrixFields/matrix_field_test_utils.jl
+++ b/test/MatrixFields/matrix_field_test_utils.jl
@@ -60,8 +60,12 @@ function test_field_broadcast(;
         end
 
         result = get_result()
+        result_copy = copy(result)
         time = @benchmark set_result!(result)
         time_rounded = round(time; sigdigits = 2)
+
+        # Test that set_result! sets the same value as get_result.
+        @test result == result_copy
 
         if isnothing(ref_set_result!)
             @info "$test_name:\n\tTime = $time_rounded s (reference \
@@ -127,8 +131,12 @@ function test_field_broadcast_against_array_reference(;
         end
 
         result = get_result()
+        result_copy = copy(result)
         time = @benchmark set_result!(result)
         time_rounded = round(time; sigdigits = 2)
+
+        # Test that set_result! sets the same value as get_result.
+        @test result == result_copy
 
         ref_result = similar(result)
         temp_value_fields = map(similar, get_temp_value_fields())

--- a/test/MatrixFields/operator_matrices.jl
+++ b/test/MatrixFields/operator_matrices.jl
@@ -1,0 +1,382 @@
+import LinearAlgebra: I
+
+import ClimaCore.RecursiveApply: rzero
+import ClimaCore.Operators:
+    SetValue,
+    SetGradient,
+    SetDivergence,
+    SetCurl,
+    Extrapolate,
+    FirstOrderOneSided,
+    ThirdOrderOneSided,
+    InterpolateC2F,
+    InterpolateF2C,
+    LeftBiasedC2F,
+    LeftBiasedF2C,
+    RightBiasedC2F,
+    RightBiasedF2C,
+    WeightedInterpolateC2F,
+    WeightedInterpolateF2C,
+    UpwindBiasedProductC2F,
+    Upwind3rdOrderBiasedProductC2F,
+    FCTBorisBook,
+    FCTZalesak,
+    AdvectionC2C,
+    AdvectionF2F,
+    FluxCorrectionC2C,
+    FluxCorrectionF2F,
+    SetBoundaryOperator,
+    GradientC2F,
+    GradientF2C,
+    DivergenceC2F,
+    DivergenceF2C,
+    CurlC2F,
+    return_eltype
+
+include("matrix_field_test_utils.jl")
+
+apply_op_matrix(::Nothing, op_matrix, arg) = @. op_matrix() ⋅ arg
+apply_op_matrix(boundary_op, op_matrix, arg) = @. boundary_op(op_matrix() ⋅ arg)
+apply_op_matrix(::Nothing, op_matrix, arg1, arg2) = @. op_matrix(arg1) ⋅ arg2
+apply_op_matrix(boundary_op, op_matrix, arg1, arg2) =
+    @. boundary_op(op_matrix(arg1) ⋅ arg2)
+
+apply_op_matrix!(result, ::Nothing, op_matrix, arg) =
+    @. result = op_matrix() ⋅ arg
+apply_op_matrix!(result, boundary_op, op_matrix, arg) =
+    @. result = boundary_op(op_matrix() ⋅ arg)
+apply_op_matrix!(result, ::Nothing, op_matrix, arg1, arg2) =
+    @. result = op_matrix(arg1) ⋅ arg2
+apply_op_matrix!(result, boundary_op, op_matrix, arg1, arg2) =
+    @. result = boundary_op(op_matrix(arg1) ⋅ arg2)
+
+apply_op!(result, ::Nothing, op, args...) = @. result = op(args...)
+apply_op!(result, boundary_op, op, args...) =
+    @. result = boundary_op(op(args...))
+
+function test_op_matrix(
+    ::Type{Op},
+    ::Type{BC},
+    args,
+    requires_boundary_values = false,
+) where {Op, BC}
+    FT = Spaces.undertype(axes(args[end]))
+
+    # Use zeroed-out boundary conditions to avoid affine operator warnings.
+    op_bc = if BC <: SetValue
+        BC(rzero(eltype(args[end])))
+    elseif BC <: SetGradient
+        BC(zero(Geometry.Covariant3Vector{FT}))
+    elseif BC <: SetDivergence
+        BC(zero(FT))
+    elseif BC <: SetCurl
+        BC(zero(Geometry.Contravariant12Vector{FT}))
+    else
+        BC()
+    end
+
+    op = if BC <: Nothing
+        Op()
+    elseif Op <: Union{LeftBiasedC2F, LeftBiasedF2C}
+        Op(; bottom = op_bc)
+    elseif Op <: Union{RightBiasedC2F, RightBiasedF2C}
+        Op(; top = op_bc)
+    else
+        Op(; bottom = op_bc, top = op_bc)
+    end
+    op_matrix = MatrixFields.operator_matrix(op)
+
+    # This boundary condition doesn't matter, since it's applied after the
+    # operator. It is zeroed out for simplicity, but it does not need to be.
+    boundary_op = if requires_boundary_values
+        boundary_op_bc = SetValue(rzero(return_eltype(op, args...)))
+        SetBoundaryOperator(; bottom = boundary_op_bc, top = boundary_op_bc)
+    else
+        nothing
+    end
+
+    test_field_broadcast(;
+        test_name = "operator matrix of $Op ($(BC <: Nothing ? "no BCs" : BC))",
+        get_result = () -> apply_op_matrix(boundary_op, op_matrix, args...),
+        set_result! = result ->
+            apply_op_matrix!(result, boundary_op, op_matrix, args...),
+        ref_set_result! = result -> apply_op!(result, boundary_op, op, args...),
+        time_ratio_limit = 50, # Extrapolating operator matrices are very slow.
+    )
+end
+
+@testset "operator_matrix Unit Tests" begin
+    FT = Float64
+    center_space, face_space = test_spaces(FT)
+
+    seed!(1) # ensures reproducibility
+    ᶜscalar = random_field(FT, center_space)
+    ᶠscalar = random_field(FT, face_space)
+    ᶜnested = random_field(NestedType{FT}, center_space)
+    ᶠnested = random_field(NestedType{FT}, face_space)
+    ᶜuvw = random_field(Geometry.UVWVector{FT}, center_space)
+    ᶠuvw = random_field(Geometry.UVWVector{FT}, face_space)
+    ᶜc12 = random_field(Geometry.Covariant12Vector{FT}, center_space)
+
+    # For each operator, test the operator matrix for every possible boundary
+    # condition, and use the most generic possible inputs. The nested inputs can
+    # be replaced with any nested or scalar type, and the UVW inputs can be
+    # replaced with any vector type.
+    # Note: Even though the UpwindBiasedProduct and Gradient operators should
+    # work with nested inputs, they currently throw errors unless they are given
+    # scalar inputs because of bugs in their return_eltype methods.
+    # Note: The Curl operator currently only works with C12, C1, or C2 inputs.
+    test_op_matrix(InterpolateC2F, Nothing, (ᶜnested,), true)
+    test_op_matrix(InterpolateC2F, SetValue, (ᶜnested,))
+    test_op_matrix(InterpolateC2F, SetGradient, (ᶜnested,))
+    test_op_matrix(InterpolateC2F, Extrapolate, (ᶜnested,))
+    test_op_matrix(InterpolateF2C, Nothing, (ᶠnested,))
+    test_op_matrix(LeftBiasedC2F, Nothing, (ᶜnested,), true)
+    test_op_matrix(LeftBiasedC2F, SetValue, (ᶜnested,))
+    test_op_matrix(LeftBiasedF2C, Nothing, (ᶠnested,))
+    test_op_matrix(LeftBiasedF2C, SetValue, (ᶠnested,))
+    test_op_matrix(RightBiasedC2F, Nothing, (ᶜnested,), true)
+    test_op_matrix(RightBiasedC2F, SetValue, (ᶜnested,))
+    test_op_matrix(RightBiasedF2C, Nothing, (ᶠnested,))
+    test_op_matrix(RightBiasedF2C, SetValue, (ᶠnested,))
+    test_op_matrix(WeightedInterpolateC2F, Nothing, (ᶜscalar, ᶜnested), true)
+    test_op_matrix(WeightedInterpolateC2F, SetValue, (ᶜscalar, ᶜnested))
+    test_op_matrix(WeightedInterpolateC2F, SetGradient, (ᶜscalar, ᶜnested))
+    test_op_matrix(WeightedInterpolateC2F, Extrapolate, (ᶜscalar, ᶜnested))
+    test_op_matrix(WeightedInterpolateF2C, Nothing, (ᶠscalar, ᶠnested))
+    test_op_matrix(UpwindBiasedProductC2F, Nothing, (ᶠuvw, ᶜscalar), true)
+    test_op_matrix(UpwindBiasedProductC2F, SetValue, (ᶠuvw, ᶜscalar))
+    test_op_matrix(UpwindBiasedProductC2F, Extrapolate, (ᶠuvw, ᶜscalar))
+    test_op_matrix(
+        Upwind3rdOrderBiasedProductC2F,
+        FirstOrderOneSided,
+        (ᶠuvw, ᶜscalar),
+        true,
+    )
+    test_op_matrix(
+        Upwind3rdOrderBiasedProductC2F,
+        ThirdOrderOneSided,
+        (ᶠuvw, ᶜscalar),
+        true,
+    )
+    test_op_matrix(AdvectionC2C, SetValue, (ᶠuvw, ᶜnested))
+    test_op_matrix(AdvectionC2C, Extrapolate, (ᶠuvw, ᶜnested))
+    test_op_matrix(AdvectionF2F, Nothing, (ᶠuvw, ᶠnested), true)
+    test_op_matrix(FluxCorrectionC2C, Extrapolate, (ᶠuvw, ᶜnested))
+    test_op_matrix(FluxCorrectionF2F, Extrapolate, (ᶜuvw, ᶠnested))
+    test_op_matrix(SetBoundaryOperator, SetValue, (ᶠnested,))
+    test_op_matrix(GradientC2F, Nothing, (ᶜscalar,), true)
+    test_op_matrix(GradientC2F, SetValue, (ᶜscalar,))
+    test_op_matrix(GradientC2F, SetGradient, (ᶜscalar,))
+    test_op_matrix(GradientF2C, Nothing, (ᶠscalar,))
+    test_op_matrix(GradientF2C, SetValue, (ᶠscalar,))
+    test_op_matrix(GradientF2C, Extrapolate, (ᶠscalar,))
+    test_op_matrix(DivergenceC2F, Nothing, (ᶜuvw,), true)
+    test_op_matrix(DivergenceC2F, SetValue, (ᶜuvw,))
+    test_op_matrix(DivergenceC2F, SetDivergence, (ᶜuvw,))
+    test_op_matrix(DivergenceF2C, Nothing, (ᶠuvw,))
+    test_op_matrix(DivergenceF2C, SetValue, (ᶠuvw,))
+    test_op_matrix(DivergenceF2C, Extrapolate, (ᶠuvw,))
+    test_op_matrix(CurlC2F, Nothing, (ᶜc12,), true)
+    test_op_matrix(CurlC2F, SetValue, (ᶜc12,))
+    test_op_matrix(CurlC2F, SetCurl, (ᶜc12,))
+
+    @test_throws "nonlinear" MatrixFields.operator_matrix(FCTBorisBook())
+    @test_throws "nonlinear" MatrixFields.operator_matrix(FCTZalesak())
+end
+
+@testset "Operator Matrix Broadcasting" begin
+    FT = Float64
+    center_space, face_space = test_spaces(FT)
+
+    seed!(1) # ensures reproducibility
+    ᶜscalar = random_field(FT, center_space)
+    ᶠscalar = random_field(FT, face_space)
+    ᶜnested = random_field(NestedType{FT}, center_space)
+    ᶠuvw = random_field(Geometry.UVWVector{FT}, face_space)
+    c12_a = rand(Geometry.Covariant12Vector{FT})
+    c12_b = rand(Geometry.Covariant12Vector{FT})
+
+    set_scalar_values =
+        (; bottom = SetValue(zero(FT)), top = SetValue(zero(FT)))
+    nested_zero = rzero(NestedType{FT})
+    set_nested_values =
+        (; bottom = SetValue(nested_zero), top = SetValue(nested_zero))
+    c12_zero = zero(Geometry.Covariant12Vector{FT})
+    set_c12_values = (; bottom = SetValue(c12_zero), top = SetValue(c12_zero))
+    extrapolate = (; bottom = Extrapolate(), top = Extrapolate())
+
+    ᶠinterp = InterpolateC2F(; set_nested_values...)
+    ᶜlbias = LeftBiasedF2C()
+    ᶠrbias = RightBiasedC2F(; set_nested_values.top)
+    ᶜwinterp = WeightedInterpolateF2C()
+    ᶠupwind = UpwindBiasedProductC2F(; set_scalar_values...)
+    ᶜadvect = AdvectionC2C(; extrapolate...)
+    ᶜflux_correct = FluxCorrectionC2C(; extrapolate...)
+    ᶠgrad = GradientC2F(; set_scalar_values...)
+    ᶜdiv = DivergenceF2C()
+    ᶠcurl = CurlC2F(; set_c12_values...)
+    ᶠinterp_matrix = MatrixFields.operator_matrix(ᶠinterp)
+    ᶜlbias_matrix = MatrixFields.operator_matrix(ᶜlbias)
+    ᶠrbias_matrix = MatrixFields.operator_matrix(ᶠrbias)
+    ᶜwinterp_matrix = MatrixFields.operator_matrix(ᶜwinterp)
+    ᶠupwind_matrix = MatrixFields.operator_matrix(ᶠupwind)
+    ᶜadvect_matrix = MatrixFields.operator_matrix(ᶜadvect)
+    ᶜflux_correct_matrix = MatrixFields.operator_matrix(ᶜflux_correct)
+    ᶠgrad_matrix = MatrixFields.operator_matrix(ᶠgrad)
+    ᶜdiv_matrix = MatrixFields.operator_matrix(ᶜdiv)
+    ᶠcurl_matrix = MatrixFields.operator_matrix(ᶠcurl)
+
+    @test_throws "does not contain any Fields" @. ᶜlbias_matrix() ⋅
+                                                  ᶠinterp_matrix()
+
+    ᶜ0 = @. zero(ᶜscalar)
+    ᶜ1 = @. one(ᶜscalar)
+    ᶠ1 = @. one(ᶠscalar)
+    for get_result in (
+        () -> (@. ᶜlbias_matrix() ⋅ ᶠinterp_matrix() + DiagonalMatrixRow(ᶜ0)),
+        () -> (@. DiagonalMatrixRow(ᶜ0) + ᶜlbias_matrix() ⋅ ᶠinterp_matrix()),
+        () -> (@. ᶜlbias_matrix() ⋅ ᶠinterp_matrix() ⋅ DiagonalMatrixRow(ᶜ1)),
+        () -> (@. ᶜlbias_matrix() ⋅ DiagonalMatrixRow(ᶠ1) ⋅ ᶠinterp_matrix()),
+        () -> (@. DiagonalMatrixRow(ᶜ1) ⋅ ᶜlbias_matrix() ⋅ ᶠinterp_matrix()),
+    )
+        test_field_broadcast(;
+            test_name = "product of two lazy operator matrices",
+            get_result,
+            set_result! = result ->
+                (@. result = ᶜlbias_matrix() ⋅ ᶠinterp_matrix()),
+        )
+    end
+
+    test_field_broadcast(;
+        test_name = "product of six operator matrices",
+        get_result = () ->
+            (@. ᶜflux_correct_matrix(ᶠuvw) ⋅ ᶜadvect_matrix(ᶠuvw) ⋅
+                ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠrbias_matrix() ⋅ ᶜlbias_matrix() ⋅
+                ᶠinterp_matrix()),
+        set_result! = result -> (@. result =
+            ᶜflux_correct_matrix(ᶠuvw) ⋅ ᶜadvect_matrix(ᶠuvw) ⋅
+            ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠrbias_matrix() ⋅ ᶜlbias_matrix() ⋅
+            ᶠinterp_matrix()),
+    )
+
+    test_field_broadcast(;
+        test_name = "applying six operators to a nested field using operator \
+                     matrices",
+        get_result = () ->
+            (@. ᶜflux_correct_matrix(ᶠuvw) ⋅ ᶜadvect_matrix(ᶠuvw) ⋅
+                ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠrbias_matrix() ⋅ ᶜlbias_matrix() ⋅
+                ᶠinterp_matrix() ⋅ ᶜnested),
+        set_result! = result -> (@. result =
+            ᶜflux_correct_matrix(ᶠuvw) ⋅ ᶜadvect_matrix(ᶠuvw) ⋅
+            ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠrbias_matrix() ⋅ ᶜlbias_matrix() ⋅
+            ᶠinterp_matrix() ⋅ ᶜnested),
+        ref_set_result! = result -> (@. result = ᶜflux_correct(
+            ᶠuvw,
+            ᶜadvect(ᶠuvw, ᶜwinterp(ᶠscalar, ᶠrbias(ᶜlbias(ᶠinterp(ᶜnested))))),
+        )),
+    )
+
+    test_field_broadcast(;
+        test_name = "applying six operators to a nested field using operator \
+                     matrices, but with forced right associativity",
+        get_result = () -> (@. ᶜflux_correct_matrix(ᶠuvw) ⋅ (
+            ᶜadvect_matrix(ᶠuvw) ⋅ (
+                ᶜwinterp_matrix(ᶠscalar) ⋅ (
+                    ᶠrbias_matrix() ⋅
+                    (ᶜlbias_matrix() ⋅ (ᶠinterp_matrix() ⋅ ᶜnested))
+                )
+            )
+        )),
+        set_result! = result -> (@. result =
+            ᶜflux_correct_matrix(ᶠuvw) ⋅ (
+                ᶜadvect_matrix(ᶠuvw) ⋅ (
+                    ᶜwinterp_matrix(ᶠscalar) ⋅ (
+                        ᶠrbias_matrix() ⋅
+                        (ᶜlbias_matrix() ⋅ (ᶠinterp_matrix() ⋅ ᶜnested))
+                    )
+                )
+            )),
+        ref_set_result! = result -> (@. result = ᶜflux_correct(
+            ᶠuvw,
+            ᶜadvect(ᶠuvw, ᶜwinterp(ᶠscalar, ᶠrbias(ᶜlbias(ᶠinterp(ᶜnested))))),
+        )),
+        time_ratio_limit = 20, # This case's ref function is fast on Buildkite.
+        test_broken_with_cuda = true, # TODO: Fix this.
+    )
+
+    # TODO: For some reason, we need to compile and run @test_opt on several
+    # simpler broadcast expressions before we can run the remaining two test
+    # cases. As of Julia 1.8.5, the tests fail if we skip this step. Is this a
+    # false positive, a compiler issue, or a sign that the code can be improved?
+    for get_result in (
+        () -> (@. (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠcurl_matrix() *
+            (c12_a,) +
+            (DiagonalMatrixRow(ᶜdiv(ᶠuvw)) - ᶜadvect_matrix(ᶠuvw)) / 5),
+        () -> (@. ᶜdiv_matrix() ⋅ DiagonalMatrixRow(ᶠscalar) ⋅ ᶠgrad_matrix() ⋅
+            (
+            (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠcurl_matrix() * (c12_a,) +
+            (DiagonalMatrixRow(ᶜdiv(ᶠuvw)) - ᶜadvect_matrix(ᶠuvw)) / 5
+        )),
+    )
+        get_result()
+        @test_opt ignored_modules = ignore_cuda get_result()
+    end
+
+    test_field_broadcast(;
+        test_name = "non-trivial combination of operator matrices and other \
+                     matrix fields",
+        get_result = () -> (@. ᶠupwind_matrix(ᶠuvw) ⋅ (
+            ᶜdiv_matrix() ⋅ DiagonalMatrixRow(ᶠscalar) ⋅ ᶠgrad_matrix() ⋅
+            (
+                (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠcurl_matrix() *
+                (c12_a,) +
+                (DiagonalMatrixRow(ᶜdiv(ᶠuvw)) - ᶜadvect_matrix(ᶠuvw)) / 5
+            ) - (2I,)
+        )),
+        set_result! = result -> (@. result =
+            ᶠupwind_matrix(ᶠuvw) ⋅ (
+                ᶜdiv_matrix() ⋅ DiagonalMatrixRow(ᶠscalar) ⋅ ᶠgrad_matrix() ⋅ (
+                    (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠcurl_matrix() *
+                    (c12_a,) +
+                    (DiagonalMatrixRow(ᶜdiv(ᶠuvw)) - ᶜadvect_matrix(ᶠuvw)) / 5
+                ) - (2I,)
+            )),
+    )
+
+    # TODO: This case's reference function takes too long to compile on both
+    # CPUs and GPUs (more than half an hour), as of Julia 1.9. This might be
+    # happening because of excessive inlining---aside from ⋅, all other finite
+    # difference operators use @propagate_inbounds. So, the reference function
+    # is currently disabled, although the test does pass when it is enabled.
+    test_field_broadcast(;
+        test_name = "applying a non-trivial sequence of operations to a scalar \
+                     field using operator matrices and other matrix fields",
+        get_result = () -> (@. ᶠupwind_matrix(ᶠuvw) ⋅ (
+            ᶜdiv_matrix() ⋅ DiagonalMatrixRow(ᶠscalar) ⋅ ᶠgrad_matrix() ⋅
+            (
+                (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠcurl_matrix() *
+                (c12_a,) +
+                (DiagonalMatrixRow(ᶜdiv(ᶠuvw)) - ᶜadvect_matrix(ᶠuvw)) / 5
+            ) - (2I,)
+        ) ⋅ ᶜscalar),
+        set_result! = result -> (@. result =
+            ᶠupwind_matrix(ᶠuvw) ⋅ (
+                ᶜdiv_matrix() ⋅ DiagonalMatrixRow(ᶠscalar) ⋅ ᶠgrad_matrix() ⋅ (
+                    (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠcurl_matrix() *
+                    (c12_a,) +
+                    (DiagonalMatrixRow(ᶜdiv(ᶠuvw)) - ᶜadvect_matrix(ᶠuvw)) / 5
+                ) - (2I,)
+            ) ⋅ ᶜscalar),
+        # ref_set_result! = result -> (@. result = ᶠupwind(
+        #     ᶠuvw,
+        #     ᶜdiv(
+        #         ᶠscalar * ᶠgrad(
+        #             (c12_b',) * ᶜwinterp(ᶠscalar, ᶠcurl((c12_a,) * ᶜscalar)) +
+        #             (ᶜdiv(ᶠuvw) * ᶜscalar - ᶜadvect(ᶠuvw, ᶜscalar)) / 5,
+        #         ),
+        #     ) - 2 * ᶜscalar,
+        # )),
+        # max_eps_error_limit = 20, # This case's roundoff error is large.
+    )
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,6 +80,7 @@ if !Sys.iswindows()
     @safetestset "MatrixFields - matrix multiplication at boundaries" begin @time include("MatrixFields/matrix_multiplication_at_boundaries.jl") end
     # now part of buildkite
     # @safetestset "MatrixFields - matrix field broadcasting" begin @time include("MatrixFields/matrix_field_broadcasting.jl") end
+    # @safetestset "MatrixFields - operator matrices" begin @time include("MatrixFields/operator_matrices.jl") end
 
     @safetestset "Hypsography - 2d" begin @time include("Hypsography/2d.jl") end
     @safetestset "Hypsography - 3d sphere" begin @time include("Hypsography/3dsphere.jl") end


### PR DESCRIPTION
## Purpose

Second PR of #1230. Refactors what is currently in `src/operators/operator2stencil.jl`.

## Content

- Adds the function `operator_matrix(op)`, which will replace `Operator2Stencil(op)`. This function has a detailed docstring and throws descriptive errors for operators without well-defined operator matrices.
- Improves the usability of operator matrices. With this new interface, users will no longer need to specify intermediate fields to compute operator matrices. For example, with our pre-existing code, the matrix of the interpolation operator (a bidiagonal matrix whose entries are `-1/2` and `+1/2`) needs to be computed with `@. matrix_field = interp_matrix(ones_field)`, where `ones_field` is a field filled with the number `1` that is used to infer the space and entry type of the matrix. Now, this matrix can just be computed with `@. matrix_field = interp_matrix()`. In order to make this work, `interp_matrix` is now defined as a "lazy operator". When a broadcast expression containing lazy operators is evaluated, each lazy operator is replaced with an actual operator, and it is given one or more fields as input arguments. In this case, `interp_matrix` is given the local geometry field as an input argument, and this field is used to infer the space and entry type of the operator matrix.
- This usability improvement slightly changes the computation of derivative matrices. With our pre-existing code, `@. op(func(field))` is equivalent to `@. op_matrix(ones_field) ⋅ func(field)`, and the derivative of this expression with respect to `field` can be specified as `@. op_matrix(func'(field))`, where `func'` is the derivative of the point-wise function `func`. With this new interface, `@. op(func(field))` is equivalent to `@. op_matrix() ⋅ func(field)`, and the derivative can be specified as `@. op_matrix() ⋅ DiagonalMatrixRow(func'(field))`. Similarly, the derivative of `@. op2(func2(op1(func1(field))))` with respect to `field` is `op2_matrix(func2'(op1(func1(field)))) ⋅ op1_matrix(func1'(field))` with our pre-existing code and `op2_matrix() ⋅ DiagonalMatrixRow(func2'(op1(func1(field)))) ⋅ op1_matrix() ⋅ DiagonalMatrixRow(func1'(field))` with the new interface. Although the new interface leads to longer derivative expressions, those expressions are more similar to how the chain rule is usually written out, and they can be debugged/analyzed more incrementally.
- Adds support for computing operator matrices of multi-argument operators. For example, if `op` is the `Upwind3rdOrderBiasedProductC2F` operator, then `@. op(velocity_field, tracer_field)` is equivalent to `@. op_matrix(velocity_field) ⋅ tracer_field`. The implementation is similar to that of single-argument operators, except that it does not require the use of "lazy operators" (since there is already a field being passed to the operator matrix, the local geometry field can be obtained from that field during the evaluation of `Base.Broadcast.broadcasted`).
- Adds support for computing operator matrices of operators with `Extrapolate` boundary conditions. These boundary conditions cause the matrices to have larger bandwidths than other boundary conditions.
- Tests the `operator_matrix` function with every valid combination of finite difference operators and boundary conditions. The tests check for correctness, type stability, and lack of allocations. The tests are run on both CPUs and GPUs. In addition, the tests print out how the performance of `@. op_matrix() ⋅ field` compares to the performance of `@. op(field)`; the two expressions are similarly fast on GPUs (between `-70%` and `+40%` relative change in speed), though the operator matrix expressions tend to be slower on CPUs.
- Tests a few more complicated broadcast expressions involving products and linear combinations of operator matrices. These tests indicate that operator matrices are similarly performant to regular matrix fields.
- Modifies `test_field_broadcast` so that it also tests whether `get_result` generates the same result as `set_result!`.
- Modifies the `*` method for `BandMatrixRow` so that matrix fields can be scaled by vectors/covectors in addition to numbers. This simplifies a few of the complicated broadcast tests.
- Fixes a typo (`Geometery`) in the method of `stencil_left_boundary` for `GradientF2C`.
- Adds a missing method to `rpromote_type` that was preventing empty matrix rows from being constructed.
- Modifies the `Base.Broadcast.broadcasted` method for `FiniteDifferenceOperator` and `SpectralElementOperator` so that lazy operators can work correctly (the original versions of these methods would always overwrite the `LazyOperatorStyle` with `StencilStyle` or `SpectralStyle`, respectively).
- Unfortunately, this PR also adds 2 method invalidations. These are due to a new definition of `broadcasted` for lazy operators:
    ```
    Base.Broadcast.broadcasted(::LazyOperatorStyle, f::F, args...) where {F} =
        LazyOperatorBroadcasted(f, args)
    ```
    As explained in an accompanying code comment, removing this method requires modifying several other method definitions, and one of these modifications adds 11 invalidations. So, there doesn't seem to be a good way to avoid these 2 invalidations.