### PR TITLE
Make docs strict

### DIFF
--- a/.dev/Manifest.toml
+++ b/.dev/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.8.5"
+julia_version = "1.9.2"
 manifest_format = "2.0"
 project_hash = "30b405be1c677184b7703a9bfb3d2100029ccad0"
 
@@ -27,15 +27,19 @@ uuid = "a80b9123-70ca-4bc0-993e-6e3bcb318db6"
 version = "0.8.12"
 
 [[deps.Compat]]
-deps = ["Dates", "LinearAlgebra", "UUIDs"]
+deps = ["UUIDs"]
 git-tree-sha1 = "7a60c856b9fa189eb34f5f8a6f6b5529b7942957"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
 version = "4.6.1"
+weakdeps = ["Dates", "LinearAlgebra"]
+
+    [deps.Compat.extensions]
+    CompatLinearAlgebraExt = "LinearAlgebra"
 
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.0.1+0"
+version = "1.0.5+0"
 
 [[deps.Crayons]]
 git-tree-sha1 = "249fe38abf76d48563e2f4556bebd215aa317e15"
@@ -104,7 +108,7 @@ version = "1.10.2+0"
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [[deps.LinearAlgebra]]
-deps = ["Libdl", "libblastrampoline_jll"]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[deps.Logging]]
@@ -117,14 +121,14 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.0+0"
+version = "2.28.2+0"
 
 [[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2022.2.1"
+version = "2022.10.11"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
@@ -133,7 +137,7 @@ version = "1.2.0"
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.20+0"
+version = "0.3.21+4"
 
 [[deps.OrderedCollections]]
 git-tree-sha1 = "d321bf2de576bf25ec4d3e4360faca399afca282"
@@ -147,9 +151,9 @@ uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 version = "2.7.1"
 
 [[deps.Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.8.0"
+version = "1.9.2"
 
 [[deps.PrecompileTools]]
 deps = ["Preferences"]
@@ -188,12 +192,12 @@ uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 [[deps.TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
-version = "1.0.0"
+version = "1.0.3"
 
 [[deps.Tar]]
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
-version = "1.10.1"
+version = "1.10.0"
 
 [[deps.Tokenize]]
 git-tree-sha1 = "90538bf898832b6ebd900fa40f223e695970e3a5"
@@ -215,12 +219,12 @@ uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.12+3"
+version = "1.2.13+0"
 
 [[deps.libblastrampoline_jll]]
-deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
+deps = ["Artifacts", "Libdl"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
-version = "5.1.1+0"
+version = "5.8.0+0"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -56,7 +56,7 @@ withenv("GKSwstype" => "nul") do
     Documenter.makedocs(
         bib,
         sitename = "ClimaCore.jl",
-        strict = [:example_block],
+        strict = true,
         format = format,
         checkdocs = :exports,
         clean = true,

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -209,14 +209,18 @@ Spaces.Quadratures.orthonormal_poly
 
 ```@docs
 Spaces.dss_transform
+Spaces.dss_transform!
+Spaces.dss_untransform!
 Spaces.dss_untransform
 Spaces.dss_local_vertices!
 Spaces.dss_local!
 Spaces.dss_local_ghost!
 Spaces.dss_ghost!
 Spaces.create_dss_buffer
+Spaces.fill_send_buffer!
 Spaces.DSSBuffer
 Spaces.create_ghost_buffer
+Spaces.load_from_recv_buffer!
 Spaces.weighted_dss_start!
 Spaces.weighted_dss_internal!
 Spaces.weighted_dss_ghost!
@@ -305,11 +309,23 @@ InputOutput.read_mesh
 InputOutput.read_topology
 InputOutput.read_space
 InputOutput.read_field
+InputOutput.defaultname
 ```
 
 ## Remapping
 
 ```@docs
 Remapping.interpolate_array
+```
+
+## ClimaCoreMakie
+
+```@meta
+CurrentModule = ClimaCoreMakie
+```
+
+```@docs
+ClimaCoreMakie.fieldheatmap
+ClimaCoreMakie.fieldcontourf
 ```
 

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -6,7 +6,7 @@
 
 ### Flux Limiters advection
 
-The 2D Cartesian advection/transport example in [`examples/plane/limiters_advection.jl`](https://github.com/CliMA/ClimaCore.jl/tree/main/examples/plane/limiters_advection.jl) demonstrates the application of flux limiters in the horizontal direction, namely [`QuasiMonotoneLimiter`](https://clima.github.io/ClimaCore.jl/previews/PR729/api/#ClimaCore.Limiters.QuasiMonotoneLimiter), in a 2D Cartesian domain.
+The 2D Cartesian advection/transport example in [`examples/plane/limiters_advection.jl`](https://github.com/CliMA/ClimaCore.jl/tree/main/examples/plane/limiters_advection.jl) demonstrates the application of flux limiters in the horizontal direction, namely [`QuasiMonotoneLimiter`](https://clima.github.io/ClimaCore.jl/stable/api/#ClimaCore.Limiters.QuasiMonotoneLimiter), in a 2D Cartesian domain.
 
 #### Equations and discretizations
 
@@ -64,7 +64,7 @@ Because this is a purely 2D problem, there is no staggered vertical discretizati
 - ``wD`` is the [discrete horizontal weak spectral divergence](https://clima.github.io/ClimaCore.jl/stable/operators/#ClimaCore.Operators.WeakDivergence), called `wdiv` in the example code.
 - ``G`` is the [discrete horizontal strong spectral gradient](https://clima.github.io/ClimaCore.jl/stable/operators/#ClimaCore.Operators.Gradient), called `grad` in the example code.
 
-To discretize the hyperdiffusion operator, ``g(\rho, q) = - \nu_4 [\nabla^4 (\rho q)]``, in the horizontal direction, we compose the horizontal weak divergence, ``wD``, and the horizontal gradient operator, ``G_h``, twice, with an intermediate call to [`weighted_dss!`](@ref) between the two compositions, as in ``[g_2(\rho, g) \circ DSS(\rho, q) \circ g_1(\rho, q)]``, with:
+To discretize the hyperdiffusion operator, ``g(\rho, q) = - \nu_4 [\nabla^4 (\rho q)]``, in the horizontal direction, we compose the horizontal weak divergence, ``wD``, and the horizontal gradient operator, ``G_h``, twice, with an intermediate call to [`weighted_dss!`](https://clima.github.io/ClimaCore.jl/stable/api/#ClimaCore.Spaces.weighted_dss!) between the two compositions, as in ``[g_2(\rho, g) \circ DSS(\rho, q) \circ g_1(\rho, q)]``, with:
 - ``g_1(\rho, q) = wD(G_h(q))``
 - ``DSS(\rho, q) = DSS(g_1(\rho q))``
 - ``g_2(\rho, q) = -\nu_4 wD(\rho G_h(\rho q))``
@@ -101,7 +101,7 @@ Because this is a fully 2D problem, the application of limiters does not affect 
 
 ### Flux Limiters advection
 
-The 3D Cartesian advection/transport example in [`examples/hybrid/box/limiters_advection.jl`](https://github.com/CliMA/ClimaCore.jl/tree/main/examples/hybrid/box/limiters_advection.jl) demonstrates the application of flux limiters in the horizontal direction, namely [`QuasiMonotoneLimiter`](https://clima.github.io/ClimaCore.jl/previews/PR729/api/#ClimaCore.Limiters.QuasiMonotoneLimiter), in a hybrid Cartesian domain. It also demonstrates the usage of the high-order upwinding scheme in the vertical direction, called [`Upwind3rdOrderBiasedProductC2F`](@ref).
+The 3D Cartesian advection/transport example in [`examples/hybrid/box/limiters_advection.jl`](https://github.com/CliMA/ClimaCore.jl/tree/main/examples/hybrid/box/limiters_advection.jl) demonstrates the application of flux limiters in the horizontal direction, namely [`QuasiMonotoneLimiter`](https://clima.github.io/ClimaCore.jl/stable/api/#ClimaCore.Limiters.QuasiMonotoneLimiter), in a hybrid Cartesian domain. It also demonstrates the usage of the high-order upwinding scheme in the vertical direction, called [`Upwind3rdOrderBiasedProductC2F`](https://clima.github.io/ClimaCore.jl/stable/operators/#ClimaCore.Operators.Upwind3rdOrderBiasedProductC2F).
 
 #### Equations and discretizations
 
@@ -177,7 +177,7 @@ We make use of the following operators
   - This example uses advective fluxes equal to zero at the top and bottom boundaries.
 - ``G_h`` is the [discrete horizontal spectral gradient](https://clima.github.io/ClimaCore.jl/stable/operators/#ClimaCore.Operators.Gradient), called `hgrad` in the example code.
 
-To discretize the hyperdiffusion operator, ``g(\rho, q) = - \nu_4 [\nabla^4 (\rho q)]``, in the horizontal direction, we compose the horizontal weak divergence, ``wD_h``, and the horizontal gradient operator, ``G_h``, twice, with an intermediate call to [`weighted_dss!`](@ref) between the two compositions, as in ``[g_2(\rho, g) \circ DSS(\rho, q) \circ g_1(\rho, q)]``, with:
+To discretize the hyperdiffusion operator, ``g(\rho, q) = - \nu_4 [\nabla^4 (\rho q)]``, in the horizontal direction, we compose the horizontal weak divergence, ``wD_h``, and the horizontal gradient operator, ``G_h``, twice, with an intermediate call to [`weighted_dss!`](https://clima.github.io/ClimaCore.jl/stable/api/#ClimaCore.Spaces.weighted_dss!) between the two compositions, as in ``[g_2(\rho, g) \circ DSS(\rho, q) \circ g_1(\rho, q)]``, with:
 - ``g_1(\rho, q) = wD_h(G_h(q))``
 - ``DSS(\rho, q) = DSS(g_1(\rho q))``
 - ``g_2(\rho, q) = -\nu_4 wD_h(\rho G_h(\rho q))``
@@ -230,7 +230,7 @@ Because this is a Cartesian 3D problem, the application of limiters does not aff
 
 ### Flux Limiters advection
 
-The 2D sphere advection/transport example in [`examples/sphere/limiters_advection.jl`](https://github.com/CliMA/ClimaCore.jl/tree/main/examples/sphere/limiters_advection.jl) demonstrates the application of flux limiters in the horizontal direction, namely [`QuasiMonotoneLimiter`](https://clima.github.io/ClimaCore.jl/previews/PR729/api/#ClimaCore.Limiters.QuasiMonotoneLimiter), in a 2D spherical domain.
+The 2D sphere advection/transport example in [`examples/sphere/limiters_advection.jl`](https://github.com/CliMA/ClimaCore.jl/tree/main/examples/sphere/limiters_advection.jl) demonstrates the application of flux limiters in the horizontal direction, namely [`QuasiMonotoneLimiter`](https://clima.github.io/ClimaCore.jl/stable/api/#ClimaCore.Limiters.QuasiMonotoneLimiter), in a 2D spherical domain.
 
 #### Equations and discretizations
 
@@ -288,7 +288,7 @@ Because this is a purely 2D problem, there is no staggered vertical discretizati
 - ``wD`` is the [discrete horizontal weak spectral divergence](https://clima.github.io/ClimaCore.jl/stable/operators/#ClimaCore.Operators.WeakDivergence), called `wdiv` in the example code.
 - ``G`` is the [discrete horizontal strong spectral gradient](https://clima.github.io/ClimaCore.jl/stable/operators/#ClimaCore.Operators.Gradient), called `grad` in the example code.
 
-To discretize the hyperdiffusion operator, ``g(\rho, q) = - \nu_4 [\nabla^4 (\rho q)]``, in the horizontal direction, we compose the horizontal weak divergence, ``wD``, and the horizontal gradient operator, ``G_h``, twice, with an intermediate call to [`weighted_dss!`](@ref) between the two compositions, as in ``[g_2(\rho, g) \circ DSS(\rho, q) \circ g_1(\rho, q)]``, with:
+To discretize the hyperdiffusion operator, ``g(\rho, q) = - \nu_4 [\nabla^4 (\rho q)]``, in the horizontal direction, we compose the horizontal weak divergence, ``wD``, and the horizontal gradient operator, ``G_h``, twice, with an intermediate call to [`weighted_dss!`](https://clima.github.io/ClimaCore.jl/stable/api/#ClimaCore.Spaces.weighted_dss!) between the two compositions, as in ``[g_2(\rho, g) \circ DSS(\rho, q) \circ g_1(\rho, q)]``, with:
 - ``g_1(\rho, q) = wD(G_h(q))``
 - ``DSS(\rho, q) = DSS(g_1(\rho q))``
 - ``g_2(\rho, q) = -\nu_4 wD(\rho G_h(\rho q))``
@@ -401,7 +401,7 @@ Because this is a purely 2D problem, there is no staggered vertical discretizati
 - ``wCurl`` is the [discrete weak curl](https://clima.github.io/ClimaCore.jl/stable/operators/#ClimaCore.Operators.WeakCurl), called `wcurl` in the example code.
 
 
-To discretize the hyperdiffusion operator, ``g(h, \boldsymbol{u}) = - \nu_4 [\nabla^4 (h, \boldsymbol{u})]``, in the horizontal direction, we compose the weak divergence, ``wD``, and the gradient operator, ``G``, twice, with an intermediate call to [`weighted_dss!`](@ref) between the two compositions, as in ``[g_2(h, \boldsymbol{u}) \circ DSS(h, \boldsymbol{u}) \circ g_1(h, \boldsymbol{u})]``. Moreover, when ``g(h, \boldsymbol{u}) = - \nu_4 [\nabla^4 (h)]``, i.e., the operator is applied to a scalar field only, it is discretized composing the following operations:
+To discretize the hyperdiffusion operator, ``g(h, \boldsymbol{u}) = - \nu_4 [\nabla^4 (h, \boldsymbol{u})]``, in the horizontal direction, we compose the weak divergence, ``wD``, and the gradient operator, ``G``, twice, with an intermediate call to [`weighted_dss!`](https://clima.github.io/ClimaCore.jl/stable/api/#ClimaCore.Spaces.weighted_dss!) between the two compositions, as in ``[g_2(h, \boldsymbol{u}) \circ DSS(h, \boldsymbol{u}) \circ g_1(h, \boldsymbol{u})]``. Moreover, when ``g(h, \boldsymbol{u}) = - \nu_4 [\nabla^4 (h)]``, i.e., the operator is applied to a scalar field only, it is discretized composing the following operations:
 - ``g_1(h) = wD(G(h))``
 - ``DSS(g_1(h))``
 - ``g_2(h) = -\nu_4 wD(G(h))``
@@ -428,7 +428,7 @@ This suite of examples contains five different test cases:
 
 ### Deformation Flow with Flux Limiters
 
-The 3D sphere advection/transport example in [`examples/hybrid/sphere/deformation_flow.jl`](https://github.com/CliMA/ClimaCore.jl/tree/main/examples/hybrid/sphere/deformation_flow.jl) demonstrates the application of flux limiters in the horziontal direction, namely [`QuasiMonotoneLimiter`](https://clima.github.io/ClimaCore.jl/previews/PR729/api/#ClimaCore.Limiters.QuasiMonotoneLimiter), in a hybrid 3D spherical domain. It also demonstrates the usage of the flux-corrected transport in the vertical direction; by default, it uses `FCTZalesak`.
+The 3D sphere advection/transport example in [`examples/hybrid/sphere/deformation_flow.jl`](https://github.com/CliMA/ClimaCore.jl/tree/main/examples/hybrid/sphere/deformation_flow.jl) demonstrates the application of flux limiters in the horziontal direction, namely [`QuasiMonotoneLimiter`](https://clima.github.io/ClimaCore.jl/stable/api/#ClimaCore.Limiters.QuasiMonotoneLimiter), in a hybrid 3D spherical domain. It also demonstrates the usage of the flux-corrected transport in the vertical direction; by default, it uses `FCTZalesak`.
 
 #### Equations and discretizations
 
@@ -505,7 +505,7 @@ We make use of the following operators
   - This example uses advective fluxes equal to zero at the top and bottom boundaries.
 - ``G_h`` is the [discrete horizontal spectral gradient](https://clima.github.io/ClimaCore.jl/stable/operators/#ClimaCore.Operators.Gradient), called `hgrad` in the example code.
 
-To discretize the hyperdiffusion operator for each tracer concentration, ``g(\rho, q_i) = - \nu_4 [\nabla^4 (\rho q_i)]``, in the horizontal direction, we compose the horizontal weak divergence, ``wD_h``, and the horizontal gradient operator, ``G_h``, twice, with an intermediate call to [`weighted_dss!`](@ref) between the two compositions, as in ``[g_2(\rho, g) \circ DSS(\rho, q) \circ g_1(\rho, q_i)]``, with:
+To discretize the hyperdiffusion operator for each tracer concentration, ``g(\rho, q_i) = - \nu_4 [\nabla^4 (\rho q_i)]``, in the horizontal direction, we compose the horizontal weak divergence, ``wD_h``, and the horizontal gradient operator, ``G_h``, twice, with an intermediate call to [`weighted_dss!`](https://clima.github.io/ClimaCore.jl/stable/api/#ClimaCore.Spaces.weighted_dss!) between the two compositions, as in ``[g_2(\rho, g) \circ DSS(\rho, q) \circ g_1(\rho, q_i)]``, with:
 - ``g_1(\rho, q_i) = wD_h(G_h(q_i))``
 - ``DSS(\rho, q_i) = DSS(g_1(\rho q_i))``
 - ``g_2(\rho, q_i) = -\nu_4 wD_h(\rho G_h(\rho q_i))``

--- a/lib/ClimaCoreTempestRemap/src/wrappers.jl
+++ b/lib/ClimaCoreTempestRemap/src/wrappers.jl
@@ -37,8 +37,8 @@ end
 """
     overlap_mesh(outfile::AbstractString, meshfile_a::AbstractString, meshfile_b::AbstractString; verbose=false)
 
-Create the overlap mesh of `meshfile_a` and `meshfile_b` and write it to `outfile`. All
-files should be in Exodus format.
+Create the overlap mesh of `meshfile_a` and `meshfile_b` and
+write it to `outfile`. All files should be in Exodus format.
 
 Set `verbose=true` to print information.
 
@@ -82,8 +82,8 @@ end
     )
 
 Create a file `weightfile` in SCRIP format containing the remapping weights from
-`meshfile_in` to `meshfile_out`, where `overlap_meshfile` is constructed via
-[`overlap_meshfile(meshfile_overlap, meshfile_in, meshfile_out)`](@ref).
+`meshfile_in` to `meshfile_out`, where `meshfile_overlap` is constructed via
+[`overlap_mesh`](@ref).
 
 Keyword arguments are passed as command-line options. These include:
 - `in_type` / `out_type`: the type of the input and output mesh:

--- a/src/InputOutput/writers.jl
+++ b/src/InputOutput/writers.jl
@@ -94,6 +94,12 @@ function write!(writer::HDF5Writer, obj, name = defaultname(obj))
 end
 
 # Domains
+"""
+    defaultname(obj)
+
+Default name of object for InputOutput writers.
+"""
+function defaultname end
 defaultname(::Domains.SphereDomain) = "sphere"
 function defaultname(domain::Domains.IntervalDomain)
     Domains.coordinate_type(domain) <: Geometry.XPoint && return "x-interval"


### PR DESCRIPTION
This PR makes the docs strict and fixes the remaining broken docs. One more thing we could do is delete some of the previews (cc @simonbyrne), there are many, many, of them based on the docbuild log. Closes #1418