### PR TITLE
Fix matrix multiplication at boundaries

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -513,6 +513,10 @@ steps:
         key: unit_field2arrays
         command: "julia --color=yes --check-bounds=yes --project=test test/MatrixFields/field2arrays.jl"
 
+      - label: "Unit: matrix multiplication at boundaries"
+        key: unit_matrix_multiplication_at_boundaries
+        command: "julia --color=yes --check-bounds=yes --project=test test/MatrixFields/matrix_multiplication_at_boundaries.jl"
+
       - label: "Unit: matrix field broadcasting (CPU)"
         key: unit_matrix_field_broadcasting_cpu
         command: "julia --color=yes --check-bounds=yes --project=test test/MatrixFields/matrix_field_broadcasting.jl"

--- a/docs/src/matrix_fields.md
+++ b/docs/src/matrix_fields.md
@@ -30,6 +30,7 @@ rmul_with_projection
 mul_return_type
 rmul_return_type
 matrix_shape
+column_axes
 ```
 
 ## Utilities

--- a/src/MatrixFields/MatrixFields.jl
+++ b/src/MatrixFields/MatrixFields.jl
@@ -68,10 +68,11 @@ const ColumnwiseBandMatrixField{V, S} = Fields.Field{
 function Base.show(io::IO, field::ColumnwiseBandMatrixField)
     print(io, eltype(field), "-valued Field")
     if eltype(eltype(field)) <: Number
+        shape = typeof(matrix_shape(field)).name.name
         if field isa Fields.FiniteDifferenceField
-            println(io, " that corresponds to the matrix")
+            println(io, " that corresponds to the $shape matrix")
         else
-            println(io, " whose first column corresponds to the matrix")
+            println(io, " whose first column corresponds to the $shape matrix")
         end
         column_field = Fields.column(field, 1, 1, 1)
         io = IOContext(io, :compact => true, :limit => true)

--- a/src/MatrixFields/field2arrays.jl
+++ b/src/MatrixFields/field2arrays.jl
@@ -94,7 +94,9 @@ all_columns(space::Spaces.ExtrudedFiniteDifferenceSpace) =
 #     Spaces.all_nodes(Spaces.horizontal_space(axes(field)))
 
 column_map(f::F, field) where {F} =
-    map((((i, j), h),) -> f(Spaces.column(field, i, j, h)), all_columns(field))
+    Iterators.map(all_columns(field)) do ((i, j), h)
+        f(Spaces.column(field, i, j, h))
+    end
 
 """
     field2arrays(field)
@@ -104,7 +106,7 @@ Converts a field defined on a `FiniteDifferenceSpace` or on an
 corresponds to a column of the field. This is done by calling
 `column_field2array` on each of the field's columns.
 """
-field2arrays(field) = column_map(column_field2array, field)
+field2arrays(field) = collect(column_map(column_field2array, field))
 
 """
     field2arrays_view(field)

--- a/src/MatrixFields/matrix_shape.jl
+++ b/src/MatrixFields/matrix_shape.jl
@@ -19,3 +19,24 @@ matrix_shape(matrix_field, matrix_space = axes(matrix_field)) = _matrix_shape(
 _matrix_shape(::Type{Int}, _) = Square()
 _matrix_shape(::Type{PlusHalf{Int}}, ::Spaces.CellCenter) = FaceToCenter()
 _matrix_shape(::Type{PlusHalf{Int}}, ::Spaces.CellFace) = CenterToFace()
+
+"""
+    column_axes(matrix_field, [matrix_space])
+
+Returns the space that corresponds to the columns of `matrix_field`, i.e., the
+`axes` of the `Field`s by which `matrix_field` can be multiplied. The
+`matrix_space`, on the other hand, is the space that corresponds to the rows of
+`matrix_field`. By default, `matrix_space` is set to `axes(matrix_field)`.
+"""
+column_axes(matrix_field, matrix_space = axes(matrix_field)) =
+    _column_axes(matrix_shape(matrix_field, matrix_space), matrix_space)
+
+_column_axes(::Square, space) = space
+_column_axes(::FaceToCenter, space) = Operators.reconstruct_placeholder_space(
+    Operators.FacePlaceholderSpace(),
+    space,
+)
+_column_axes(::CenterToFace, space) = Operators.reconstruct_placeholder_space(
+    Operators.CenterPlaceholderSpace(),
+    space,
+)

--- a/test/MatrixFields/field2arrays.jl
+++ b/test/MatrixFields/field2arrays.jl
@@ -70,7 +70,7 @@ import ClimaCore: Geometry, Domains, Meshes, Spaces, Fields, MatrixFields
     @test ᶜᶜmat_array_view == MatrixFields.column_field2array(ᶜᶜmat)
 
     @test MatrixFields.field2arrays(ᶜᶜmat) ==
-          (MatrixFields.column_field2array(ᶜᶜmat),)
+          [MatrixFields.column_field2array(ᶜᶜmat)]
 
     # Check for type instabilities.
     @test_opt MatrixFields.column_field2array(ᶜᶜmat)

--- a/test/MatrixFields/matrix_multiplication_at_boundaries.jl
+++ b/test/MatrixFields/matrix_multiplication_at_boundaries.jl
@@ -1,0 +1,70 @@
+include("matrix_field_test_utils.jl")
+
+# Replace all entries in matrix_field that are outside the matrix with NaNs.
+function nan_outside_entries!(matrix_field)
+    @assert !any(isnan, parent(matrix_field)) # Check that there are no NaNs.
+    nan_mask_field = copy(matrix_field)
+    for nan_mask_array_view in MatrixFields.field2arrays_view(nan_mask_field)
+        nan_mask_array_view .*= NaN
+    end
+    flip_nan_mask(nan_mask_entry, matrix_entry) =
+        isnan(nan_mask_entry) ? matrix_entry : NaN
+    @. matrix_field = map(flip_nan_mask, nan_mask_field, matrix_field)
+    @assert any(isnan, parent(matrix_field)) # Check that there are now NaNs.
+    return matrix_field
+end
+
+@testset "Matrix Multiplication At Boundaries" begin
+    FT = Float64
+    center_space, face_space = test_spaces(FT)
+
+    seed!(1) # ensures reproducibility
+    ᶜᶜmatrix_with_outside_entries =
+        random_field(TridiagonalMatrixRow{FT}, center_space)
+    ᶜᶠmatrix_with_outside_entries =
+        random_field(QuaddiagonalMatrixRow{FT}, center_space)
+    ᶠᶠmatrix_with_outside_entries =
+        random_field(TridiagonalMatrixRow{FT}, face_space)
+    ᶠᶜmatrix_with_outside_entries =
+        random_field(QuaddiagonalMatrixRow{FT}, face_space)
+    ᶜᶜmatrix_without_outside_entries =
+        random_field(DiagonalMatrixRow{FT}, center_space)
+    ᶜᶠmatrix_without_outside_entries =
+        random_field(BidiagonalMatrixRow{FT}, center_space)
+    ᶠᶠmatrix_without_outside_entries =
+        random_field(DiagonalMatrixRow{FT}, face_space)
+    # We can't have ᶠᶜmatrix_without_outside_entries because a CenterToFace
+    # matrix field will always store entries that are outside the matrix.
+
+    nan_outside_entries!(ᶜᶜmatrix_with_outside_entries)
+    nan_outside_entries!(ᶜᶠmatrix_with_outside_entries)
+    nan_outside_entries!(ᶠᶠmatrix_with_outside_entries)
+    nan_outside_entries!(ᶠᶜmatrix_with_outside_entries)
+
+    # Test all possible products of matrix fields that include outside entries.
+    # Ensure that ⋅ never makes use of the outside entries.
+    for (matrix_field1, matrix_field2) in (
+        (ᶜᶜmatrix_with_outside_entries, ᶜᶜmatrix_with_outside_entries),
+        (ᶜᶜmatrix_with_outside_entries, ᶜᶠmatrix_with_outside_entries),
+        (ᶜᶠmatrix_with_outside_entries, ᶠᶠmatrix_with_outside_entries),
+        (ᶜᶠmatrix_with_outside_entries, ᶠᶜmatrix_with_outside_entries),
+        (ᶠᶠmatrix_with_outside_entries, ᶠᶠmatrix_with_outside_entries),
+        (ᶠᶠmatrix_with_outside_entries, ᶠᶜmatrix_with_outside_entries),
+        (ᶠᶜmatrix_with_outside_entries, ᶜᶜmatrix_with_outside_entries),
+        (ᶠᶜmatrix_with_outside_entries, ᶜᶠmatrix_with_outside_entries),
+        (ᶜᶜmatrix_with_outside_entries, ᶜᶜmatrix_without_outside_entries),
+        (ᶜᶜmatrix_with_outside_entries, ᶜᶠmatrix_without_outside_entries),
+        (ᶜᶠmatrix_with_outside_entries, ᶠᶠmatrix_without_outside_entries),
+        (ᶠᶠmatrix_with_outside_entries, ᶠᶠmatrix_without_outside_entries),
+        (ᶠᶜmatrix_with_outside_entries, ᶜᶜmatrix_without_outside_entries),
+        (ᶠᶜmatrix_with_outside_entries, ᶜᶠmatrix_without_outside_entries),
+        (ᶜᶜmatrix_without_outside_entries, ᶜᶜmatrix_with_outside_entries),
+        (ᶜᶜmatrix_without_outside_entries, ᶜᶠmatrix_with_outside_entries),
+        (ᶜᶠmatrix_without_outside_entries, ᶠᶠmatrix_with_outside_entries),
+        (ᶜᶠmatrix_without_outside_entries, ᶠᶜmatrix_with_outside_entries),
+        (ᶠᶠmatrix_without_outside_entries, ᶠᶠmatrix_with_outside_entries),
+        (ᶠᶠmatrix_without_outside_entries, ᶠᶜmatrix_with_outside_entries),
+    )
+        @test !any(isnan, parent(@. matrix_field1 ⋅ matrix_field2))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,6 +77,7 @@ if !Sys.iswindows()
     @safetestset "MatrixFields - BandMatrixRow" begin @time include("MatrixFields/band_matrix_row.jl") end
     @safetestset "MatrixFields - rmul_with_projection" begin @time include("MatrixFields/rmul_with_projection.jl") end
     @safetestset "MatrixFields - field2arrays" begin @time include("MatrixFields/field2arrays.jl") end
+    @safetestset "MatrixFields - matrix multiplication at boundaries" begin @time include("MatrixFields/matrix_multiplication_at_boundaries.jl") end
     # now part of buildkite
     # @safetestset "MatrixFields - matrix field broadcasting" begin @time include("MatrixFields/matrix_field_broadcasting.jl") end
 


### PR DESCRIPTION
Peeled off from #1399. Fixes a bug in matrix-matrix multiplication (i.e., the `MultiplyColumnwiseBandMatrixField()` operator with two matrix fields as inputs) that was causing entries from outside the second input matrix to be used in the computation of entries outside the product matrix. These entries are used for padding, allowing us to store the nonzero entries of band matrices in `Field`s with rectangular parent arrays, so using them during the computation of matrix-matrix products leads to an unnecessary performance loss. Moreover, it breaks the assumption that these outside entries have no effect on program behavior.

In addition to fixing the bug, this PR
- Updates the documentation of `MultiplyColumnwiseBandMatrixField` to reflect the change.
- Adds a unit test which ensures that outside entries are never used during matrix-matrix multiplication.
- Simplifies some of the code for `MultiplyColumnwiseBandMatrixField`, making sure that it reflects the updated documentation as closely as possible.
- Introduces the `column_axes(matrix_field)` utility function, which can be used to obtain the space that corresponds to the columns of `matrix_field` (as opposed to `axes(matrix_field)`, which corresponds to the rows). This function simplifies the computation of interior/boundary indices during matrix multiplication.
- Fixes a type instability in `field2arrays` and updates the corresponding unit test. This also decreases the memory allocated by the new unit test for outside entries.
- Modifies the `show` method for matrix `Field`s so that it also displays the matrix shape.
