### PR TITLE
Add 3D spectral element curl

### DIFF
--- a/benchmarks/3d/Project.toml
+++ b/benchmarks/3d/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
+ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"

--- a/benchmarks/3d/vector_laplacian.jl
+++ b/benchmarks/3d/vector_laplacian.jl
@@ -1,0 +1,73 @@
+
+using ClimaComms
+using ClimaCore:
+    Geometry, Domains, Meshes, Topologies, Spaces, Fields, Operators
+using CUDA, BenchmarkTools
+
+hdomain = Domains.SphereDomain(6.37122e6)
+hmesh = Meshes.EquiangularCubedSphere(hdomain, 30)
+htopology = Topologies.Topology2D(hmesh)
+hspace = Spaces.SpectralElementSpace2D(htopology, Spaces.Quadratures.GLL{4}())
+
+vdomain = Domains.IntervalDomain(
+    Geometry.ZPoint(0.0),
+    Geometry.ZPoint(10e3);
+    boundary_tags = (:bottom, :top),
+)
+vmesh = Meshes.IntervalMesh(vdomain; nelems = 45)
+vtopology = Topologies.IntervalTopology(
+    ClimaComms.SingletonCommsContext(ClimaComms.device()),
+    vmesh,
+)
+vspace = Spaces.CenterFiniteDifferenceSpace(vtopology)
+
+cspace = Spaces.ExtrudedFiniteDifferenceSpace(hspace, vspace)
+fspace = Spaces.FaceExtrudedFiniteDifferenceSpace(cspace)
+
+
+u = map(Fields.coordinate_field(cspace)) do coord
+    Geometry.Covariant123Vector(1.0, 1.0, 1.0)
+end
+temp_C123 = similar(u)
+ᶜ∇²u = similar(u)
+
+const C1 = Geometry.Covariant1Vector
+const C2 = Geometry.Covariant2Vector
+const C12 = Geometry.Covariant12Vector
+const C3 = Geometry.Covariant3Vector
+const C123 = Geometry.Covariant123Vector
+const CT1 = Geometry.Contravariant1Vector
+const CT2 = Geometry.Contravariant2Vector
+const CT12 = Geometry.Contravariant12Vector
+const CT3 = Geometry.Contravariant3Vector
+const CT123 = Geometry.Contravariant123Vector
+
+const divₕ = Operators.Divergence()
+const wdivₕ = Operators.WeakDivergence()
+const gradₕ = Operators.Gradient()
+const wgradₕ = Operators.WeakGradient()
+const curlₕ = Operators.Curl()
+const wcurlₕ = Operators.WeakCurl()
+
+
+function vector_laplacian!(ᶜ∇²u, u, temp_C123)
+    # current ClimaAtmos code
+    CUDA.@sync begin
+        @. ᶜ∇²u = C123(wgradₕ(divₕ(u)))
+        @. temp_C123 = C123(curlₕ(C12(u))) + C123(curlₕ(C3(u)))
+        @. ᶜ∇²u -= C123(wcurlₕ(C12(temp_C123))) + C123(wcurlₕ(C3(temp_C123)))
+    end
+    return nothing
+end
+
+@benchmark vector_laplacian!(ᶜ∇²u, u, temp_C123)
+
+function vector_laplacian_2!(ᶜ∇²u, u)
+    # current ClimaAtmos code
+    CUDA.@sync begin
+        @. ᶜ∇²u = C123(wgradₕ(divₕ(u))) - C123(wcurlₕ(C123(curlₕ(u))))
+    end
+    return nothing
+end
+
+@benchmark vector_laplacian_2!(ᶜ∇²u, u)

--- a/test/Operators/spectralelement/rectilinear.jl
+++ b/test/Operators/spectralelement/rectilinear.jl
@@ -340,3 +340,35 @@ end
         @test ∇⁴y_ref ≈ ∇⁴y rtol = 2e-2
     end
 end
+
+
+@testset "vector hyperdiffusion 3d" begin
+    for (topology, space, coords) in (grid_test_setup, ts_test_setup)
+        k = 2
+        l = 3
+
+        yₕ = @. Geometry.Covariant12Vector.(
+            Geometry.UVVector(sin(k * coords.x + l * coords.y), 0.0)
+        )
+        yᵥ = @. Geometry.Covariant3Vector.(
+            Geometry.WVector(sin(k * coords.x + l * coords.y))
+        )
+
+        curl = Operators.Curl()
+        wcurl = Operators.WeakCurl()
+
+        @test Geometry.Contravariant123Vector.(curl.(yₕ)) .+
+              Geometry.Contravariant123Vector.(curl.(yᵥ)) ≈
+              curl.(
+            Geometry.Covariant123Vector.(yₕ) .+
+            Geometry.Covariant123Vector.(yᵥ)
+        )
+        @test Geometry.Contravariant123Vector.(wcurl.(yₕ)) .+
+              Geometry.Contravariant123Vector.(wcurl.(yᵥ)) ≈
+              wcurl.(
+            Geometry.Covariant123Vector.(yₕ) .+
+            Geometry.Covariant123Vector.(yᵥ)
+        )
+
+    end
+end


### PR DESCRIPTION
This gives a significant performance boost to the vector laplacian operation in the hyperdiffusion, as we don't have to separate out the expressions.

```
julia> @benchmark vector_laplacian!(ᶜ∇²u, u, temp_C123)
BenchmarkTools.Trial: 92 samples with 1 evaluation.
 Range (min … max):  54.352 ms … 54.611 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     54.566 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   54.555 ms ± 47.949 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

julia> @benchmark vector_laplacian_2!(ᶜ∇²u, u)
BenchmarkTools.Trial: 180 samples with 1 evaluation.
 Range (min … max):  27.596 ms …  29.616 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     27.753 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   27.768 ms ± 186.883 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

```


- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
