### PR TITLE
Store 1D SE differentiation matrix

### DIFF
--- a/src/Spaces/extruded.jl
+++ b/src/Spaces/extruded.jl
@@ -241,6 +241,7 @@ Base.@propagate_inbounds function level(
             horizontal_space.global_geometry,
             level(space.center_local_geometry, v),
             horizontal_space.dss_weights,
+            horizontal_space.differentiation_matrix,
         )
     elseif horizontal_space isa SpectralElementSpace2D
         SpectralElementSpace2D(
@@ -253,6 +254,7 @@ Base.@propagate_inbounds function level(
             horizontal_space.ghost_dss_weights,
             horizontal_space.internal_surface_geometry,
             horizontal_space.boundary_surface_geometries,
+            horizontal_space.differentiation_matrix,
         )
     else
         error("Unsupported horizontal space")
@@ -270,6 +272,7 @@ Base.@propagate_inbounds function level(
             horizontal_space.global_geometry,
             level(space.face_local_geometry, v.i + 1),
             horizontal_space.dss_weights,
+            horizontal_space.differentiation_matrix,
         )
     elseif horizontal_space isa SpectralElementSpace2D
         @inbounds SpectralElementSpace2D(
@@ -282,6 +285,7 @@ Base.@propagate_inbounds function level(
             horizontal_space.ghost_dss_weights,
             horizontal_space.internal_surface_geometry,
             horizontal_space.boundary_surface_geometries,
+            horizontal_space.differentiation_matrix,
         )
     else
         error("Unsupported horizontal space")

--- a/src/Spaces/spectralelement.jl
+++ b/src/Spaces/spectralelement.jl
@@ -86,12 +86,14 @@ struct SpectralElementSpace1D{
     GG <: Geometry.AbstractGlobalGeometry,
     LG,
     D,
+    DM,
 } <: AbstractSpectralElementSpace
     topology::T
     quadrature_style::Q
     global_geometry::GG
     local_geometry::LG
     dss_weights::D
+    differentiation_matrix::DM
 end
 
 function SpectralElementSpace1D(
@@ -149,6 +151,7 @@ function SpectralElementSpace1D(
         global_geometry,
         local_geometry,
         dss_weights,
+        Quadratures.differentiation_matrix(FT, quadrature_style),
     )
 end
 
@@ -174,6 +177,7 @@ struct SpectralElementSpace2D{
     D,
     IS,
     BS,
+    DM,
 } <: AbstractSpectralElementSpace
     topology::T
     quadrature_style::Q
@@ -184,6 +188,7 @@ struct SpectralElementSpace2D{
     ghost_dss_weights::D
     internal_surface_geometry::IS
     boundary_surface_geometries::BS
+    differentiation_matrix::DM
 end
 
 Adapt.adapt_structure(to, space::SpectralElementSpace2D) =
@@ -197,6 +202,7 @@ Adapt.adapt_structure(to, space::SpectralElementSpace2D) =
         Adapt.adapt(to, space.ghost_dss_weights),
         Adapt.adapt(to, space.internal_surface_geometry),
         Adapt.adapt(to, space.boundary_surface_geometries),
+        Adapt.adapt(to, space.differentiation_matrix),
     )
 
 
@@ -521,6 +527,7 @@ function SpectralElementSpace2D(
         dss_ghost_weights,
         internal_surface_geometry,
         boundary_surface_geometries,
+        DA(Quadratures.differentiation_matrix(FT, quadrature_style)),
     )
 end
 


### PR DESCRIPTION
Store 1D SE differentiation matrix to avoid recomputation in spectral element kernels

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
