### PR TITLE
add curl methods for plane config

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -395,6 +395,10 @@ steps:
         key: unit_sphere_hyperdiffusion_vec
         command: "julia --color=yes --check-bounds=yes --project=test test/Operators/spectralelement/sphere_hyperdiffusion_vec.jl"
 
+      - label: "Unit: spec ops plane"
+        key: unit_spec_ops_plane
+        command: "julia --color=yes --check-bounds=yes --project=test test/Operators/spectralelement/plane.jl"
+
       - label: "Unit: column"
         key: unit_column
         command: "julia --color=yes --check-bounds=yes --project=test test/Operators/finitedifference/column.jl"

--- a/src/Geometry/conversions.jl
+++ b/src/Geometry/conversions.jl
@@ -588,12 +588,23 @@ Curl is only defined for `CovariantVector`` field input types.
     ::Val{(1, 2)},
     ::Type{Covariant123Vector{FT}},
 ) where {FT} = Contravariant123Vector{FT}
+
+
 @inline curl_result_type(::Val{(1,)}, ::Type{Covariant1Vector{FT}}) where {FT} =
-    Contravariant1Vector{FT}
+    Contravariant1Vector{FT} # not strictly correct: should be a zero Vector
 @inline curl_result_type(::Val{(1,)}, ::Type{Covariant2Vector{FT}}) where {FT} =
     Contravariant3Vector{FT}
 @inline curl_result_type(::Val{(1,)}, ::Type{Covariant3Vector{FT}}) where {FT} =
     Contravariant2Vector{FT}
+@inline curl_result_type(
+    ::Val{(1,)},
+    ::Type{Covariant13Vector{FT}},
+) where {FT} = Contravariant2Vector{FT}
+@inline curl_result_type(
+    ::Val{(1,)},
+    ::Type{Covariant123Vector{FT}},
+) where {FT} = Contravariant23Vector{FT}
+
 @inline curl_result_type(
     ::Val{(3,)},
     ::Type{Covariant12Vector{FT}},

--- a/src/Operators/spectralelement.jl
+++ b/src/Operators/spectralelement.jl
@@ -1392,6 +1392,31 @@ function apply_operator(op::Curl{(1,)}, space, slabidx, arg)
                 out[ii] = out[ii] ⊞ Geometry.Contravariant2Vector(⊟(D₁v₃))
             end
         end
+    elseif RT <: Geometry.Contravariant3Vector
+        @inbounds for i in 1:Nq
+            ij = CartesianIndex((i,))
+            local_geometry = get_local_geometry(space, ij, slabidx)
+            v = get_node(space, arg, ij, slabidx)
+            v₂ = Geometry.covariant2(v, local_geometry)
+            for ii in 1:Nq
+                D₁v₂ = D[ii, i] ⊠ v₂
+                out[ii] = out[ii] ⊞ Geometry.Contravariant3Vector(D₁v₂)
+            end
+        end
+    elseif RT <: Geometry.Contravariant23Vector
+        @inbounds for i in 1:Nq
+            ij = CartesianIndex((i,))
+            local_geometry = get_local_geometry(space, ij, slabidx)
+            v = get_node(space, arg, ij, slabidx)
+            v₂ = Geometry.covariant2(v, local_geometry)
+            v₃ = Geometry.covariant3(v, local_geometry)
+            for ii in 1:Nq
+                D₁v₃ = D[ii, i] ⊠ v₃
+                D₁v₂ = D[ii, i] ⊠ v₂
+                out[ii] =
+                    out[ii] ⊞ Geometry.Contravariant23Vector(⊟(D₁v₃), D₁v₂)
+            end
+        end
     else
         error("invalid return type: $RT")
     end
@@ -1663,7 +1688,34 @@ function apply_operator(op::WeakCurl{(1,)}, space, slabidx, arg)
             Wv₃ = W ⊠ Geometry.covariant3(v, local_geometry)
             for ii in 1:Nq
                 Dᵀ₁Wv₃ = D[i, ii] ⊠ Wv₃
-                out[ii] = out[ii] ⊞ Geometry.Contravariant2Vector(⊟(Dᵀ₁Wv₃))
+                out[ii] = out[ii] ⊞ Geometry.Contravariant2Vector(Dᵀ₁Wv₃)
+            end
+        end
+    elseif RT <: Geometry.Contravariant3Vector
+        @inbounds for i in 1:Nq
+            ij = CartesianIndex((i,))
+            local_geometry = get_local_geometry(space, ij, slabidx)
+            v = get_node(space, arg, ij, slabidx)
+            W = local_geometry.WJ / local_geometry.J
+            Wv₂ = W ⊠ Geometry.covariant2(v, local_geometry)
+            for ii in 1:Nq
+                Dᵀ₁Wv₂ = D[i, ii] ⊠ Wv₂
+                out[ii] = out[ii] ⊞ Geometry.Contravariant3Vector(⊟(Dᵀ₁Wv₂))
+            end
+        end
+    elseif RT <: Geometry.Contravariant23Vector
+        @inbounds for i in 1:Nq
+            ij = CartesianIndex((i,))
+            local_geometry = get_local_geometry(space, ij, slabidx)
+            v = get_node(space, arg, ij, slabidx)
+            W = local_geometry.WJ / local_geometry.J
+            Wv₃ = W ⊠ Geometry.covariant3(v, local_geometry)
+            Wv₂ = W ⊠ Geometry.covariant2(v, local_geometry)
+            for ii in 1:Nq
+                Dᵀ₁Wv₃ = D[i, ii] ⊠ Wv₃
+                Dᵀ₁Wv₂ = D[i, ii] ⊠ Wv₂
+                out[ii] =
+                    out[ii] ⊞ Geometry.Contravariant23Vector(Dᵀ₁Wv₃, ⊟(Dᵀ₁Wv₂))
             end
         end
     else

--- a/test/Operators/spectralelement/plane.jl
+++ b/test/Operators/spectralelement/plane.jl
@@ -1,0 +1,51 @@
+using Test
+using StaticArrays
+using ClimaComms
+import ClimaCore.DataLayouts: IJFH, VF
+import ClimaCore:
+    Geometry, Fields, Domains, Topologies, Meshes, Spaces, Operators
+using LinearAlgebra, IntervalSets
+
+FT = Float64
+hdomain = Domains.IntervalDomain(
+    Geometry.XPoint{FT}(-pi) .. Geometry.XPoint{FT}(pi),
+    periodic = true,
+)
+
+Nq = 5
+quad = Spaces.Quadratures.GLL{Nq}()
+device = ClimaComms.CPUSingleThreaded()
+hmesh = Meshes.IntervalMesh(hdomain, nelems = 16)
+htopology =
+    Topologies.IntervalTopology(ClimaComms.SingletonCommsContext(device), hmesh)
+hspace = Spaces.SpectralElementSpace1D(htopology, quad)
+
+vdomain = Domains.IntervalDomain(
+    Geometry.ZPoint{FT}(-pi),
+    Geometry.ZPoint{FT}(pi);
+    boundary_tags = (:bottom, :top),
+)
+vmesh = Meshes.IntervalMesh(vdomain, nelems = 16)
+vtopology =
+    Topologies.IntervalTopology(ClimaComms.SingletonCommsContext(device), vmesh)
+vspace = Spaces.CenterFiniteDifferenceSpace(vtopology)
+
+cspace = Spaces.ExtrudedFiniteDifferenceSpace(hspace, vspace)
+
+curl = Operators.Curl()
+
+w = map(
+    coord -> Geometry.WVector(coord.x + coord.z),
+    Fields.coordinate_field(cspace),
+)
+@test curl.(Geometry.Covariant3Vector.(w)) ≈ map(
+    coord -> Geometry.Contravariant2Vector(-1.0),
+    Fields.coordinate_field(cspace),
+)
+
+v = map(
+    coord -> Geometry.Covariant2Vector(coord.x + coord.z),
+    Fields.coordinate_field(cspace),
+)
+@test Geometry.WVector.(curl.(Geometry.Covariant2Vector.(v))) ≈
+      map(coord -> Geometry.WVector(1.0), Fields.coordinate_field(cspace))


### PR DESCRIPTION
These are currently missing, needed for https://github.com/CliMA/ClimaAtmos.jl/pull/2006


- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
