### PR TITLE
Move patch for AxisTensor component conversion from ClimaAtmos

### DIFF
--- a/src/Geometry/axistensors.jl
+++ b/src/Geometry/axistensors.jl
@@ -161,6 +161,10 @@ AxisTensor(axes::Tuple{Vararg{AbstractAxis}}, components) =
     components::AbstractArray{<:Any, N},
 ) where {N, A} = AxisTensor(A.instance, components)
 
+# conversion of components
+AxisTensor{T, N, A, S}(a::AxisTensor{<:Any, N, A, <:Any}) where {T, N, A, S} =
+    AxisTensor(axes(a), S(components(a)))
+Base.convert(::Type{T}, a::AxisTensor) where {T <: AxisTensor} = T(a)
 
 Base.axes(a::AxisTensor) = getfield(a, :axes)
 Base.axes(::Type{AxisTensor{T, N, A, S}}) where {T, N, A, S} = A.instance

--- a/test/Geometry/axistensors.jl
+++ b/test/Geometry/axistensors.jl
@@ -15,6 +15,10 @@ ClimaCore.Geometry.assert_exact_transform() = true
     f(x) = x.u₁ + x.u₂ + x.u₃
     @test_opt f(x)
 
+    ref = Ref(zero(x))
+    ref[] = Geometry.Covariant12Vector(1, 2) # Int components instead of Float64
+    @test ref[] == x
+
     M = Geometry.Axis2Tensor(
         (Geometry.Cartesian12Axis(), Geometry.Covariant12Axis()),
         [1.0 0.0; 0.5 2.0],


### PR DESCRIPTION
<!-- Provide a clear description of the content -->
This PR moves [a monkey patch for AxisTensor component conversion](https://github.com/CliMA/ClimaAtmos.jl/blob/16c2a66b6146a3229fc4a594e084c05b8a92151b/src/utils/abbreviations.jl#L79-L85) from ClimaAtmos to `axistensors.jl`. It also adds a unit test for the new functionality.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
