### PR TITLE
add support for spatially dependent boundary conditions on GPU

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -435,6 +435,12 @@ steps:
         key: unit_hyb_ops_3d
         command: "julia --color=yes --check-bounds=yes --project=test test/Operators/hybrid/3d.jl"
 
+      - label: "Unit: hyb ops 3d CUDA"
+        key: unit_hyb_ops_3d_cuda
+        command: "julia --color=yes --check-bounds=yes --project=test test/Operators/hybrid/3d.jl"
+        agents:
+          slurm_gpus: 1
+
       - label: "Unit: remapping"
         key: unit_remapping
         command: "julia --color=yes --check-bounds=yes --project=test test/Operators/remapping.jl"

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -240,10 +240,15 @@ StencilBroadcasted{Style}(
 
 Adapt.adapt_structure(to, sbc::StencilBroadcasted{Style}) where {Style} =
     StencilBroadcasted{Style}(
-        sbc.op,
+        Adapt.adapt(to, sbc.op),
         Adapt.adapt(to, sbc.args),
         Adapt.adapt(to, sbc.axes),
     )
+
+function Adapt.adapt_structure(to, op::FiniteDifferenceOperator)
+    op
+end
+
 
 
 function Base.Broadcast.instantiate(sbc::StencilBroadcasted)
@@ -2689,6 +2694,15 @@ Base.@propagate_inbounds function stencil_right_boundary(
     @assert idx == right_center_boundary_idx(space)
     stencil_interior(op, loc, space, idx - 1, hidx, arg)
 end
+
+function Adapt.adapt_structure(to, op::DivergenceF2C)
+    DivergenceF2C(map(bc -> Adapt.adapt_structure(to, bc), op.bcs))
+end
+
+function Adapt.adapt_structure(to, bc::SetValue)
+    SetValue(Adapt.adapt_structure(to, bc.val))
+end
+
 
 """
     D = DivergenceC2F(;boundaryname=boundarycondition...)


### PR DESCRIPTION
Adapt spatially-varying boundary conditions for the GPU.

Fixes https://github.com/CliMA/ClimaAtmos.jl/issues/2192

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
