### PR TITLE
Use rmul over rdiv

### DIFF
--- a/examples/hybrid/plane/inertial_gravity_wave.jl
+++ b/examples/hybrid/plane/inertial_gravity_wave.jl
@@ -61,7 +61,7 @@ horizontal_mesh = periodic_line_mesh(; x_max, x_elem = x_elem)
 
 # Additional values required for driver
 # dt may need tweaking for is_small_scale = false
-dt = is_small_scale ? FT(1.5) : FT(20)
+dt = is_small_scale ? FT(1.25) : FT(20)
 t_end = is_small_scale ? FT(60 * 60 * 0.5) : FT(60 * 60 * 8)
 dt_save_to_sol = t_end / (animation_duration * fps)
 ode_algorithm = CTS.SSP333

--- a/src/Geometry/localgeometry.jl
+++ b/src/Geometry/localgeometry.jl
@@ -21,21 +21,28 @@ struct LocalGeometry{I, C <: AbstractPoint, FT, S}
     gⁱʲ::Axis2Tensor{FT, Tuple{ContravariantAxis{I}, ContravariantAxis{I}}, S}
     "Covariant metric tensor (gᵢⱼ), transforms contravariant to covariant vector components"
     gᵢⱼ::Axis2Tensor{FT, Tuple{CovariantAxis{I}, CovariantAxis{I}}, S}
-end
-
-@inline function LocalGeometry(coordinates, J, WJ, ∂x∂ξ)
-    ∂ξ∂x = inv(∂x∂ξ)
-    return LocalGeometry(
+    @inline function LocalGeometry(
         coordinates,
         J,
         WJ,
-        inv(J),
-        ∂x∂ξ,
-        ∂ξ∂x,
-        ∂ξ∂x * ∂ξ∂x',
-        ∂x∂ξ' * ∂x∂ξ,
-    )
+        ∂x∂ξ::Axis2Tensor{FT, Tuple{LocalAxis{I}, CovariantAxis{I}}, S},
+    ) where {FT, I, S}
+        ∂ξ∂x = inv(∂x∂ξ)
+        C = typeof(coordinates)
+        Jinv = inv(J)
+        return new{I, C, FT, S}(
+            coordinates,
+            J,
+            WJ,
+            Jinv,
+            ∂x∂ξ,
+            ∂ξ∂x,
+            ∂ξ∂x * ∂ξ∂x',
+            ∂x∂ξ' * ∂x∂ξ,
+        )
+    end
 end
+
 
 """
     SurfaceGeometry

--- a/test/Spaces/spaces.jl
+++ b/test/Spaces/spaces.jl
@@ -138,7 +138,7 @@ end
     @test Spaces.coordinates_data(point_space)[] ==
           Spaces.level(coord_data, 1)[]
 
-    x_max = FT(0)
+    x_max = FT(1)
     y_max = FT(1)
     x_elem = 2
     y_elem = 2


### PR DESCRIPTION
A wise man once told me "division is much more expensive than multiplication". This PR converts some `rdiv`s `rmul`s in a bunch of places.

Checks off a box in https://github.com/CliMA/ClimaAtmos.jl/issues/635