### PR TITLE
Add support for topography in `distributed_remapping`

### DIFF
--- a/src/Hypsography/Hypsography.jl
+++ b/src/Hypsography/Hypsography.jl
@@ -23,10 +23,10 @@ end
 
 Locate vertical levels using an exponential function between the surface field and the top
 of the domain, using the method of [Schar2002](@cite). This method is modified
-such no warping is applied above some user defined parameter 0 ≤ ηₕ < 1.0, where the lower and upper 
-bounds represent the domain bottom and top respectively. `s` governs the decay rate. 
-If the decay-scale is poorly specified (i.e., `s * zₜ` is lower than the maximum 
-surface elevation), a warning is thrown and `s` is adjusted such that it `szₜ > maximum(z_surface)`. 
+such no warping is applied above some user defined parameter 0 ≤ ηₕ < 1.0, where the lower and upper
+bounds represent the domain bottom and top respectively. `s` governs the decay rate.
+If the decay-scale is poorly specified (i.e., `s * zₜ` is lower than the maximum
+surface elevation), a warning is thrown and `s` is adjusted such that it `szₜ > maximum(z_surface)`.
 """
 struct SLEVEAdaption{F <: Fields.Field, FT <: Real} <: HypsographyAdaption
     # Union can be removed once deprecation removed.
@@ -201,15 +201,15 @@ end
 
 Option for 2nd order diffusive smoothing of generated terrain.
 Mutate (smooth) a given elevation profile `f` before assigning the surface
-elevation to the `HypsographyAdaption` type. A spectral second-order diffusion 
+elevation to the `HypsographyAdaption` type. A spectral second-order diffusion
 operator is applied with forward-Euler updates to generate
 profiles for each new iteration. Steps to generate smoothed terrain (
-represented as a ClimaCore Field) are as follows: 
+represented as a ClimaCore Field) are as follows:
 - Compute discrete elevation profile f
 - Compute diffuse_surface_elevation!(f, κ, iter). f is mutated.
 - Define `Hypsography.LinearAdaption(f)`
 - Define `ExtrudedFiniteDifferenceSpace` with new surface elevation.
-Default diffusion parameters are appropriate for spherical arrangements. 
+Default diffusion parameters are appropriate for spherical arrangements.
 For `zmax-zsfc` == 𝒪(10^4), κ == 𝒪(10^8), dt == 𝒪(10⁻¹).
 """
 function diffuse_surface_elevation!(

--- a/src/Remapping/Remapping.jl
+++ b/src/Remapping/Remapping.jl
@@ -4,7 +4,13 @@ using LinearAlgebra, StaticArrays
 
 import ClimaComms
 import ..DataLayouts,
-    ..Geometry, ..Spaces, ..Topologies, ..Meshes, ..Operators, ..Fields
+    ..Geometry,
+    ..Spaces,
+    ..Topologies,
+    ..Meshes,
+    ..Operators,
+    ..Fields,
+    ..Hypsography
 
 using ..RecursiveApply
 

--- a/src/Remapping/distributed_remapping.jl
+++ b/src/Remapping/distributed_remapping.jl
@@ -124,7 +124,6 @@ The `Remapper` is designed to not be tied to any particular `Field`. You can use
 `Remapper` for any `Field` as long as they are all defined on the same `topology`.
 
 `Remapper` is the main argument to the `interpolate` function.
-
 """
 function Remapper(target_hcoords, target_zcoords, space)
 
@@ -192,9 +191,18 @@ end
 
 
 """
-   interpolate(remapper, field)
+   interpolate(remapper, field; physical_z = false)
 
 Interpolate the given `field` as prescribed by `remapper`.
+
+
+Keyword arguments
+==================
+
+- `physical_z`: When `true`, interpolate to the physical z coordinates, taking into account
+                hypsography. If `false` (the default), interpolation will be based on the
+                reference z coordinate, i.e. will correspond to constant model levels.
+                `NaN`s are returned for values that are below the surface.
 
 Example
 ========
@@ -218,7 +226,11 @@ int2 = interpolate(remapper, field2)
 
 ```
 """
-function interpolate(remapper::Remapper, field::T) where {T <: Fields.Field}
+function interpolate(
+    remapper::Remapper,
+    field::T;
+    physical_z = false,
+) where {T <: Fields.Field}
 
     axes(field) == remapper.space ||
         error("Field is defined on a different space than remapper")
@@ -257,7 +269,8 @@ function interpolate(remapper::Remapper, field::T) where {T <: Fields.Field}
                     field,
                     remapper.target_zcoords,
                     weights,
-                    gidx,
+                    gidx;
+                    physical_z,
                 ) for (gidx, weights) in
                 zip(remapper.local_indices, remapper.interpolation_coeffs)
             )'


### PR DESCRIPTION
This PR adds a new mode to the `interpolate` function for distributed remapping, `interpolate_topography`. When `interpolate_topography` is `true`, the target `zcoords` are assumed to be with respect to the mean sea level as opposed to with respect to the surface. `zcoords` that are below the surface are filled with `NaN`s.

Closes #1488 
