### PR TITLE
remove Perf Integrals (GPU) test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -787,13 +787,6 @@ steps:
         command:
           - "julia --color=yes --project=test test/Operators/integrals.jl"
 
-      - label: "Perf: Integrals (GPU)"
-        key: "gpu_integrals_perf"
-        command:
-          - "julia --color=yes --project=test test/Operators/integrals.jl"
-        agents:
-          slurm_gpus: 1
-
   - group: "Examples: Column"
     steps:
 


### PR DESCRIPTION
This is a frequent source of failures, and I'm not sure this test really is that useful (allocations for GPU kernels are a bit weird)

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
