### PR TITLE
Fix FT scope for some examples

### DIFF
--- a/examples/column/bb_fct_advection.jl
+++ b/examples/column/bb_fct_advection.jl
@@ -38,6 +38,7 @@ end
 
 function tendency!(yₜ, y, parameters, t)
     (; w, Δt) = parameters
+    FT = Spaces.undertype(axes(y.q))
     divf2c = Operators.DivergenceF2C(
         bottom = Operators.SetValue(Geometry.WVector(FT(0))),
         top = Operators.SetValue(Geometry.WVector(FT(0))),
@@ -91,13 +92,14 @@ for (i, stretch_fn) in enumerate(stretch_fns)
     cent_space = Spaces.CenterFiniteDifferenceSpace(mesh)
     face_space = Spaces.FaceFiniteDifferenceSpace(cent_space)
     z = Fields.coordinate_field(cent_space).z
+    O = ones(FT, face_space)
 
     # Initial condition
     q_init = pulse.(z, 0.0, z₀, zₕ, z₁)
     y = Fields.FieldVector(q = q_init)
 
     # Unitary, constant advective velocity
-    w = Geometry.WVector.(speed .* ones(FT, face_space))
+    w = Geometry.WVector.(speed .* O)
 
     # Solve the ODE
     parameters = (; w, Δt)

--- a/examples/column/fct_advection.jl
+++ b/examples/column/fct_advection.jl
@@ -94,9 +94,10 @@ for (i, stretch_fn) in enumerate(stretch_fns)
     cs = Spaces.CenterFiniteDifferenceSpace(mesh)
     fs = Spaces.FaceFiniteDifferenceSpace(cs)
     zc = Fields.coordinate_field(cs)
+    O = ones(FT, fs)
 
     # Unitary, constant advective velocity
-    w = Geometry.WVector.(speed .* ones(FT, fs))
+    w = Geometry.WVector.(speed .* O)
 
     # Initial condition
     y0 = pulse.(zc, 0.0, z₀, zₕ, z₁)

--- a/examples/column/zalesak_fct_advection.jl
+++ b/examples/column/zalesak_fct_advection.jl
@@ -38,6 +38,7 @@ end
 
 function tendency!(yₜ, y, parameters, t)
     (; w, Δt) = parameters
+    FT = Spaces.undertype(axes(y.q))
     divf2c = Operators.DivergenceF2C(
         bottom = Operators.SetValue(Geometry.WVector(FT(0))),
         top = Operators.SetValue(Geometry.WVector(FT(0))),
@@ -92,13 +93,14 @@ for (i, stretch_fn) in enumerate(stretch_fns)
     cent_space = Spaces.CenterFiniteDifferenceSpace(mesh)
     face_space = Spaces.FaceFiniteDifferenceSpace(cent_space)
     z = Fields.coordinate_field(cent_space).z
+    O = ones(FT, face_space)
 
     # Initial condition
     q_init = pulse.(z, 0.0, z₀, zₕ, z₁)
     y = Fields.FieldVector(q = q_init)
 
     # Unitary, constant advective velocity
-    w = Geometry.WVector.(speed .* ones(FT, face_space))
+    w = Geometry.WVector.(speed .* O)
 
     # Solve the ODE
     parameters = (; w, Δt)

--- a/examples/hybrid/box/limiters_advection.jl
+++ b/examples/hybrid/box/limiters_advection.jl
@@ -172,6 +172,7 @@ end
 
 function vertical_tendency!(yₜ, y, cache, t)
     (; face_u) = cache
+    FT = Spaces.undertype(axes(y.ρ))
     Ic2f = Operators.InterpolateC2F()
     vdivf2c = Operators.DivergenceF2C(
         top = Operators.SetValue(Geometry.Contravariant3Vector(FT(0))),

--- a/lib/ClimaCoreSpectra/test/gcm_visual_test.jl
+++ b/lib/ClimaCoreSpectra/test/gcm_visual_test.jl
@@ -14,7 +14,7 @@ using FFTW
 # Adapted from: https://github.com/CliMA/ClimateMachine.jl/blob/master/test/Common/Spectra/spherical_helper_test.jl
 include(joinpath(@__DIR__, "spherical_helper.jl"))
 
-FT = Float64
+const FT = Float64
 # -- TEST 1: power_spectrum_1d
 n_gauss_lats = 32
 


### PR DESCRIPTION
This PR fixes accessing a non-constant `FT` defined in global scope, in a few examples / tests.