### PR TITLE
disable forward-compatible driver

### DIFF
--- a/.buildkite/JuliaProject.toml
+++ b/.buildkite/JuliaProject.toml
@@ -1,7 +1,11 @@
 [extras]
 CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
+CUDA_Driver_jll = "4ee394cb-3365-5eb0-8335-949819d2adfc"
 HDF5_jll = "0234f1f7-429e-5d53-9886-15a909be8d59"
 MPIPreferences = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
+
+[preferences.CUDA_Driver_jll]
+compat = false
 
 [preferences.CUDA_Runtime_jll]
 version = "12.2"


### PR DESCRIPTION
Disables the forward-compatible CUDA driver (basically, it will insist that we always used the system one).

This appears to fix the segfaults we were seeing, and _may_ fix some of the other errors as well.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
