### PR TITLE
fix CCTR ClimaCore compat

### DIFF
--- a/lib/ClimaCoreTempestRemap/Project.toml
+++ b/lib/ClimaCoreTempestRemap/Project.toml
@@ -14,7 +14,7 @@ TempestRemap_jll = "8573a8c5-1df0-515e-a024-abad257ee284"
 
 [compat]
 ClimaComms = "0.5"
-ClimaCore = "0.10.25, 0.11"
+ClimaCore = "0.11"
 Dates = "1"
 LinearAlgebra = "1"
 NCDatasets = "0.11, 0.12, 0.13"


### PR DESCRIPTION
<!-- Provide a clear description of the content -->
In ClimaCoreTempestRemap v0.3.11, the compat entry for ClimaCore is "0.10.25, 0.11", but it's only compatible with >=0.11 because it uses Spaces.staggering. 

We need to:
- [x] change compat to `ClimaCore = "0.11"`
- [x] update ClimaCoreTempestRemap v0.3.11 in JuliaRegistries https://github.com/JuliaRegistries/General/pull/95815

### QA
- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
