### PR TITLE
Add DeviceSide

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -180,6 +180,14 @@ steps:
         key: unit_spaces
         command: "julia --color=yes --check-bounds=yes --project=test test/Spaces/spaces.jl"
 
+      - label: "Unit: cuda spaces"
+        key: "gpu_cuda_spaces"
+        command:
+          - "julia --project -e 'using CUDA; CUDA.versioninfo()'"
+          - "srun julia --color=yes --check-bounds=yes --project=test test/Spaces/spaces.jl"
+        agents:
+          slurm_gpus: 1
+
       - label: "Unit: distributed cuda spaces"
         key: "gpu_distributed_extruded_cuda_spaces"
         command:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.11.4"
+version = "0.11.5"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/ClimaCore.jl
+++ b/src/ClimaCore.jl
@@ -4,6 +4,7 @@ using PkgVersion
 const VERSION = PkgVersion.@Version
 
 include("interface.jl")
+include("devices.jl")
 include("Utilities/Utilities.jl")
 include("RecursiveApply/RecursiveApply.jl")
 include("DataLayouts/DataLayouts.jl")

--- a/src/Fields/mapreduce_cuda.jl
+++ b/src/Fields/mapreduce_cuda.jl
@@ -89,6 +89,18 @@ function mapreduce_cuda(
     field::Field{V};
     weighting = false,
     opargs...,
+) where {S, V <: DataLayouts.DataF{S}}
+    data = Fields.field_values(field)
+    pdata = parent(data)
+    return DataLayouts.DataF{S}(Array(Array(f(pdata))[1, :]))
+end
+
+function mapreduce_cuda(
+    f,
+    op,
+    field::Field{V};
+    weighting = false,
+    opargs...,
 ) where {
     S,
     V <: Union{DataLayouts.VF{S}, DataLayouts.IJFH{S}, DataLayouts.VIJFH{S}},

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -8,6 +8,7 @@ import ..DataLayouts,
     ..Domains, ..Meshes, ..Topologies, ..Geometry, ..Quadratures
 import ..Utilities: PlusHalf, half
 import ..slab, ..column, ..level
+import ..DeviceSideDevice, ..DeviceSideContext
 
 using StaticArrays
 

--- a/src/Grids/spectralelement.jl
+++ b/src/Grids/spectralelement.jl
@@ -487,6 +487,9 @@ struct DeviceSpectralElementGrid2D{Q, GG, LG} <: AbstractSpectralElementGrid
     local_geometry::LG
 end
 
+ClimaComms.context(grid::DeviceSpectralElementGrid2D) = DeviceSideContext()
+ClimaComms.device(grid::DeviceSpectralElementGrid2D) = DeviceSideDevice()
+
 Adapt.adapt_structure(to, grid::SpectralElementGrid2D) =
     DeviceSpectralElementGrid2D(
         Adapt.adapt(to, grid.quadrature_style),

--- a/src/Spaces/Spaces.jl
+++ b/src/Spaces/Spaces.jl
@@ -23,6 +23,8 @@ import ..Utilities: PlusHalf, half
 import ..DataLayouts,
     ..Geometry, ..Domains, ..Meshes, ..Topologies, ..Grids, ..Quadratures
 
+import ..DeviceSideDevice, ..DeviceSideContext
+
 import ..Grids:
     Staggering,
     CellFace,

--- a/src/Spaces/finitedifference.jl
+++ b/src/Spaces/finitedifference.jl
@@ -153,12 +153,12 @@ Base.@propagate_inbounds function level(
     v::PlusHalf,
 )
     @inbounds local_geometry = level(local_geometry_data(space), v.i + 1)
-    PointSpace(local_geometry)
+    PointSpace(ClimaComms.context(space), local_geometry)
 end
 Base.@propagate_inbounds function level(
     space::CenterFiniteDifferenceSpace,
     v::Int,
 )
     local_geometry = level(local_geometry_data(space), v)
-    PointSpace(local_geometry)
+    PointSpace(ClimaComms.context(space), local_geometry)
 end

--- a/src/Spaces/pointspace.jl
+++ b/src/Spaces/pointspace.jl
@@ -7,21 +7,18 @@ local_geometry_data(space::AbstractPointSpace) = space.local_geometry
 
 A zero-dimensional space.
 """
-struct PointSpace{LG <: DataLayouts.Data0D} <: AbstractPointSpace
+struct PointSpace{
+    C <: ClimaComms.AbstractCommsContext,
+    LG <: DataLayouts.Data0D,
+} <: AbstractPointSpace
+    context::C
     local_geometry::LG
 end
 
-# not strictly correct, but it is needed for mapreduce
-ClimaComms.device(space::PointSpace) =
-    ClimaComms.device(ClimaComms.context(space))
-ClimaComms.context(space::PointSpace) =
-    ClimaComms.SingletonCommsContext(ClimaComms.CPUSingleThreaded())
+ClimaComms.device(space::PointSpace) = ClimaComms.device(space.context)
+ClimaComms.context(space::PointSpace) = space.context
 
-
-PointSpace(x::Geometry.LocalGeometry) =
-    PointSpace(ClimaComms.CPUSingleThreaded(), x)
-PointSpace(x::Geometry.AbstractPoint) =
-    PointSpace(ClimaComms.CPUSingleThreaded(), x)
+PointSpace(x::T) where {T} = PointSpace(ClimaComms.context(), x)
 
 function PointSpace(device::ClimaComms.AbstractDevice, x)
     context = ClimaComms.SingletonCommsContext(device)
@@ -36,12 +33,12 @@ function PointSpace(
     ArrayType = ClimaComms.array_type(ClimaComms.device(context))
     local_geometry_data = DataLayouts.DataF{LG}(Array{FT})
     local_geometry_data[] = local_geometry
-    return PointSpace(Adapt.adapt(ArrayType, local_geometry_data))
+    return PointSpace(context, Adapt.adapt(ArrayType, local_geometry_data))
 end
 
 
 Adapt.adapt_structure(to, space::PointSpace) =
-    PointSpace(Adapt.adapt(to, space.local_geometry))
+    PointSpace(DeviceSideContext(), Adapt.adapt(to, space.local_geometry))
 
 function PointSpace(
     context::ClimaComms.AbstractCommsContext,

--- a/src/Spaces/spectralelement.jl
+++ b/src/Spaces/spectralelement.jl
@@ -235,14 +235,14 @@ Base.@propagate_inbounds slab(space::AbstractSpectralElementSpace, h) =
 
 Base.@propagate_inbounds function column(space::SpectralElementSpace1D, i, h)
     local_geometry = column(local_geometry_data(space), i, h)
-    PointSpace(local_geometry)
+    PointSpace(ClimaComms.context(space), local_geometry)
 end
 Base.@propagate_inbounds column(space::SpectralElementSpace1D, i, j, h) =
     column(space, i, h)
 
 Base.@propagate_inbounds function column(space::SpectralElementSpace2D, i, j, h)
     local_geometry = column(local_geometry_data(space), i, j, h)
-    PointSpace(local_geometry)
+    PointSpace(ClimaComms.context(space), local_geometry)
 end
 
 function all_nodes(space::SpectralElementSpace2D)

--- a/src/Topologies/Topologies.jl
+++ b/src/Topologies/Topologies.jl
@@ -12,6 +12,7 @@ import ..Meshes: Meshes, domain, coordinates
 import ..DataLayouts
 import ..slab, ..column, ..level
 
+import ..DeviceSideDevice, ..DeviceSideContext
 
 using Memoize, WeakValueDicts
 

--- a/src/Topologies/interval.jl
+++ b/src/Topologies/interval.jl
@@ -23,6 +23,8 @@ end
 Adapt.adapt_structure(to, topology::IntervalTopology) =
     DeviceIntervalTopology(topology.boundaries)
 
+ClimaComms.context(topology::DeviceIntervalTopology) = DeviceSideContext()
+ClimaComms.device(topology::DeviceIntervalTopology) = DeviceSideDevice()
 
 ClimaComms.device(topology::IntervalTopology) = topology.context.device
 ClimaComms.array_type(topology::IntervalTopology) =

--- a/src/Topologies/topology2d.jl
+++ b/src/Topologies/topology2d.jl
@@ -113,9 +113,9 @@ mutable struct Topology2D{
     "neighbor process locations in neighbor_pids for each of the ghost vertices"
     ghost_vertex_neighbor_loc::Vector{Int}
     "offset array for `ghost_vertex_neighbor_loc`
-    a ragged array representation: for i = 1:length(ghost_vertex_gcidx), we have that 
+    a ragged array representation: for i = 1:length(ghost_vertex_gcidx), we have that
     for j = ghost_vertex_comm_idx_offset[i]:ghost_vertex_comm_idx_offset[i+1]-1
-    the ghost vertex ghost_vertex_gcidx[i] should get sent to 
+    the ghost vertex ghost_vertex_gcidx[i] should get sent to
     neighbor_pids[ghost_vertex_neighbor_loc[j]]"
     ghost_vertex_comm_idx_offset::Vector{Int}
     "representative local ghost vertex (idx, vert) for each unique ghost vertex"
@@ -124,7 +124,7 @@ mutable struct Topology2D{
     ghost_face_neighbor_loc::Vector{Int}
 end
 
-ClimaComms.device(topology::Topology2D) = topology.context.device
+ClimaComms.device(topology::Topology2D) = ClimaComms.device(topology.context)
 ClimaComms.array_type(topology::Topology2D) =
     ClimaComms.array_type(topology.context.device)
 

--- a/src/devices.jl
+++ b/src/devices.jl
@@ -1,0 +1,29 @@
+import ClimaComms
+
+# Sometimes, it is convenient to know whether something is running on a device or on its
+# host. We define new AbstractDevices and AbstractCommsContext to identify the case of a
+# function running on the device with data on the device.
+
+"""
+    DeviceSideDevice()
+
+This device represents data defined on the device side of an accelerator.
+
+The most common example is data defined on a GPU. DeviceSideDevice() is used for
+operations within the accelerator.
+"""
+struct DeviceSideDevice <: ClimaComms.AbstractDevice end
+
+
+"""
+    DeviceSideContext()
+
+Context associated to data defined on the device side of an accelerator.
+
+The most common example is data defined on a GPU. DeviceSideContext() is used for
+operations within the accelerator.
+"""
+struct DeviceSideContext <: ClimaComms.AbstractCommsContext end
+
+ClimaComms.context(::DeviceSideDevice) = DeviceSideContext()
+ClimaComms.device(::DeviceSideContext) = DeviceSideDevice()

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 AssociatedLegendrePolynomials = "2119f1ac-fb78-50f5-8cc0-dda848ebdb19"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,7 +109,7 @@ if !Sys.iswindows()
 end
 if "CUDA" in ARGS
     @safetestset "GPU - cuda" begin @time include("gpu/cuda.jl") end
-    @safetestset "GPU - data" begin @time include("test/DataLayouts/cuda.jl") end
+    @safetestset "GPU - data" begin @time include("DataLayouts/cuda.jl") end
     @safetestset "Spaces - serial CUDA DSS" begin @time include("Spaces/ddss1.jl") end
     @safetestset "Spaces - serial CUDA DSS on CubedSphere" begin @time include("Spaces/ddss1_cs.jl") end
     @safetestset "Operators - spectral element CUDA" begin @time include("Operators/spectralelement/rectilinear_cuda.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -110,6 +110,7 @@ end
 if "CUDA" in ARGS
     @safetestset "GPU - cuda" begin @time include("gpu/cuda.jl") end
     @safetestset "GPU - data" begin @time include("DataLayouts/cuda.jl") end
+    @safetestset "GPU - spaces" begin @time include("Spaces/spaces.jl") end
     @safetestset "Spaces - serial CUDA DSS" begin @time include("Spaces/ddss1.jl") end
     @safetestset "Spaces - serial CUDA DSS on CubedSphere" begin @time include("Spaces/ddss1_cs.jl") end
     @safetestset "Operators - spectral element CUDA" begin @time include("Operators/spectralelement/rectilinear_cuda.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -116,7 +116,7 @@ if "CUDA" in ARGS
     @safetestset "Operators - spectral element CUDA" begin @time include("Operators/spectralelement/rectilinear_cuda.jl") end
     @safetestset "Operators - finite difference CUDA" begin @time include("Operators/hybrid/cuda.jl") end
     @safetestset "Operators - extruded sphere space operators CUDA" begin @time include("Operators/hybrid/extruded_sphere_cuda.jl") end
-    @safetestset "Operators - extruded sphere space operators CUDA" begin @time include("Operators/hybrid/extruded_3dbox_cuda.jl") end
+    @safetestset "Operators - extruded 3dbox space operators CUDA" begin @time include("Operators/hybrid/extruded_3dbox_cuda.jl") end
     @safetestset "Fields - CUDA mapreduce" begin @time include("Fields/reduction_cuda.jl") end
 end
 


### PR DESCRIPTION
This PR implements a new `Device` that is used to identify structs that live on the GPU. 

`DeviceSideDevice` (and the associated `DeviceSideContext`) are singleton that are passed through `Adapt.adapt_structure` to those structs that are on the GPU.

With this change, I also added support for `mapreduce_cuda` for point spaces.