### PR TITLE
Add compact syntax for overlapping multiple DSS calls

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.11.3"
+version = "0.11.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Topologies/dss.jl
+++ b/src/Topologies/dss.jl
@@ -9,11 +9,14 @@ $(DocStringExtensions.FIELDS)
 struct DSSBuffer{S, G, D, A, B, VI}
     "ClimaComms graph context for communication"
     graph_context::G
-    "Array for storing perimeter data"
+    """
+    Perimeter `DataLayout` object: typically a `VIFH{TT,Np}`, where `TT` is the
+    transformed type, and `Np` is the length of the perimeter
+    """
     perimeter_data::D
-    "send buffer"
+    "send buffer `AbstractVector{FT}`"
     send_data::A
-    "recv buffer"
+    "recv buffer `AbstractVector{FT}`"
     recv_data::A
     "indexing array for loading send buffer from `perimeter_data`"
     send_buf_idx::B
@@ -730,7 +733,7 @@ function dss_ghost!(
 end
 
 """
-    fill_send_buffer!(::ClimaComms.AbstractCPUDevice, dss_buffer::DSSBuffer)
+    fill_send_buffer!(::ClimaComms.AbstractCPUDevice, dss_buffer::DSSBuffer; synchronize=true)
 
 Loads the send buffer from `perimeter_data`. For unique ghost vertices, only data from the
 representative vertices which store result of "ghost local" DSS are loaded.
@@ -739,7 +742,8 @@ Part of [`ClimaCore.Spaces.weighted_dss!`](@ref).
 """
 function fill_send_buffer!(
     ::ClimaComms.AbstractCPUDevice,
-    dss_buffer::DSSBuffer,
+    dss_buffer::DSSBuffer;
+    synchronize = true,
 )
     (; perimeter_data, send_buf_idx, send_data) = dss_buffer
     (Np, _, _, Nv, nelems) = size(perimeter_data)

--- a/src/Topologies/dss_cuda.jl
+++ b/src/Topologies/dss_cuda.jl
@@ -419,7 +419,11 @@ function dss_local_ghost_kernel!(
     return nothing
 end
 
-function fill_send_buffer!(::ClimaComms.CUDADevice, dss_buffer::DSSBuffer)
+function fill_send_buffer!(
+    ::ClimaComms.CUDADevice,
+    dss_buffer::DSSBuffer;
+    synchronize = true,
+)
     (; perimeter_data, send_buf_idx, send_data) = dss_buffer
     pperimeter_data = parent(perimeter_data)
     (nlevels, nperimeter, nfid, nelems) = size(pperimeter_data)
@@ -432,7 +436,9 @@ function fill_send_buffer!(::ClimaComms.CUDADevice, dss_buffer::DSSBuffer)
             send_buf_idx,
             pperimeter_data,
         )
-        CUDA.synchronize(; blocking = true) # CUDA MPI uses a separate stream. This will synchronize across streams
+        if synchronize
+            CUDA.synchronize(; blocking = true) # CUDA MPI uses a separate stream. This will synchronize across streams
+        end
     end
     return nothing
 end

--- a/test/Spaces/ddss1_cs.jl
+++ b/test/Spaces/ddss1_cs.jl
@@ -123,8 +123,8 @@ end
     dss_buffer12 = Spaces.create_dss_buffer(y12)
     dss_buffer12_cpu = Spaces.create_dss_buffer(y12_cpu)
     # ensure physical velocity is continous across SE boundary for initial state
-    Spaces.weighted_dss!(y12, dss_buffer12)
-    Spaces.weighted_dss!(y12_cpu, dss_buffer12_cpu)
+    Spaces.weighted_dss!(y12 => dss_buffer12)
+    Spaces.weighted_dss!(y12_cpu => dss_buffer12_cpu)
 
     yinit12 = copy(y12)
     yinit12_cpu = copy(y12_cpu)


### PR DESCRIPTION
This addresses the multiple-sync issue we're seeing on GPUs, and also simplifies the interface considerably.

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
