### PR TITLE
Remove obsolete function

### DIFF
--- a/.github/workflows/ClimaCoreMakie.yml
+++ b/.github/workflows/ClimaCoreMakie.yml
@@ -8,11 +8,11 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
           version: '1.9'
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/ClimaCorePlots.yml
+++ b/.github/workflows/ClimaCorePlots.yml
@@ -8,11 +8,11 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
           version: '1.9'
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/ClimaCoreSpectra.yml
+++ b/.github/workflows/ClimaCoreSpectra.yml
@@ -8,11 +8,11 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
           version: '1.9'
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/ClimaCoreTempestRemap.yml
+++ b/.github/workflows/ClimaCoreTempestRemap.yml
@@ -8,11 +8,11 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
           version: '1.9'
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/ClimaCoreVTK.yml
+++ b/.github/workflows/ClimaCoreVTK.yml
@@ -8,11 +8,11 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
           version: '1.9'
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/CodeCov.yml
+++ b/.github/workflows/CodeCov.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2.2.0
+    - uses: actions/checkout@v4
 
     - name: Set up Julia
       uses: julia-actions/setup-julia@latest
@@ -29,7 +29,7 @@ jobs:
       if: success()
 
     - name: Submit coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         token: ${{secrets.CODECOV_TOKEN}}
       if: success()

--- a/.github/workflows/DocCleanup.yml
+++ b/.github/workflows/DocCleanup.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
 

--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -19,12 +19,12 @@ jobs:
     - uses: julia-actions/setup-julia@v1
       with:
         version: '1'
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: julia-actions/julia-buildpkg@v1
     - uses: julia-actions/julia-invalidations@v1
       id: invs_pr
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.repository.default_branch }}
     - uses: julia-actions/julia-buildpkg@v1

--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         access_token: ${{ github.token }}
 
-    - uses: actions/checkout@v2.2.0
+    - uses: actions/checkout@v4
 
     - uses: dorny/paths-filter@v2.9.1
       id: filter

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -28,7 +28,7 @@ jobs:
         access_token: ${{ github.token }}
 
     - name: Checkout
-      uses: actions/checkout@v2.2.0
+      uses: actions/checkout@v4
 
     - name: Set up Julia
       uses: julia-actions/setup-julia@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ jobs:
   docbuild:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
           version: 1.9

--- a/test/Operators/finitedifference/opt.jl
+++ b/test/Operators/finitedifference/opt.jl
@@ -225,9 +225,7 @@ end
             center_values = ones(FT, center_space)
             center_velocities = Geometry.WVector.(center_values)
 
-            filter18(@nospecialize(ft)) = ft !== typeof(Base.mapreduce_empty)
-            filter19(@nospecialize f) = f !== Base.mapreduce_empty
-            filter = VERSION ≤ v"1.9" ? filter18 : filter19
+            filter(@nospecialize f) = f !== Base.mapreduce_empty
 
             # face space operators
             @test_opt function_filter = filter sum(ones(FT, face_space))

--- a/test/Operators/hybrid/opt.jl
+++ b/test/Operators/hybrid/opt.jl
@@ -257,9 +257,7 @@ end
             center_values = ones(FT, center_space)
             center_velocities = Geometry.WVector.(center_values)
 
-            filter18(@nospecialize(ft)) = ft !== typeof(Base.mapreduce_empty)
-            filter19(@nospecialize f) = f !== Base.mapreduce_empty
-            filter = VERSION ≤ v"1.9" ? filter18 : filter19
+            filter(@nospecialize f) = f !== Base.mapreduce_empty
 
             # face space operators
             @test_opt function_filter = filter sum(ones(FT, face_space))

--- a/test/Operators/spectralelement/opt.jl
+++ b/test/Operators/spectralelement/opt.jl
@@ -106,9 +106,7 @@ end
 
 @static if @isdefined(var"@test_opt")
 
-    filter18(@nospecialize(ft)) = ft !== typeof(Base.mapreduce_empty)
-    filter19(@nospecialize f) = f !== Base.mapreduce_empty
-    filter = VERSION ≤ v"1.9" ? filter18 : filter19
+    filter(@nospecialize f) = f !== Base.mapreduce_empty
 
     function test_operators(field, vfield)
         @test_opt opt_Gradient(field)


### PR DESCRIPTION
`ClimaCore` now requires Julia 1.9, so the function `filter18` is no longer relevant.