### PR TITLE
option for deep atmosphere

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -285,6 +285,7 @@ Fields.Δz_field
 Hypsography.LinearAdaption
 Hypsography.SLEVEAdaption
 Hypsography.diffuse_surface_elevation!
+Hypsography.ref_z_to_physical_z
 ```
 
 ## Limiters

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -285,7 +285,6 @@ Fields.Δz_field
 Hypsography.LinearAdaption
 Hypsography.SLEVEAdaption
 Hypsography.diffuse_surface_elevation!
-Hypsography.ref_z_to_physical_z
 ```
 
 ## Limiters

--- a/examples/hybrid/plane/topo_agnesi_nh.jl
+++ b/examples/hybrid/plane/topo_agnesi_nh.jl
@@ -69,12 +69,11 @@ function hvspace_2D(
     quad = Quadratures.GLL{npoly + 1}()
     horzspace = Spaces.SpectralElementSpace1D(horztopology, quad)
 
-    z_surface = warp_fn.(Fields.coordinate_field(horzspace))
+    z_surface = Geometry.ZPoint.(warp_fn.(Fields.coordinate_field(horzspace)))
     hv_face_space = Spaces.ExtrudedFiniteDifferenceSpace(
         horzspace,
         vert_face_space,
-        Hypsography.LinearAdaption(),
-        z_surface,
+        Hypsography.LinearAdaption(z_surface),
     )
     hv_center_space = Spaces.CenterExtrudedFiniteDifferenceSpace(hv_face_space)
     return (hv_center_space, hv_face_space)

--- a/examples/hybrid/plane/topo_schar_nh.jl
+++ b/examples/hybrid/plane/topo_schar_nh.jl
@@ -92,12 +92,11 @@ function hvspace_2D(
     quad = Quadratures.GLL{npoly + 1}()
     horzspace = Spaces.SpectralElementSpace1D(horztopology, quad)
 
-    z_surface = warp_fn.(Fields.coordinate_field(horzspace))
+    z_surface = Geometry.ZPoint.(warp_fn.(Fields.coordinate_field(horzspace)))
     hv_face_space = Spaces.ExtrudedFiniteDifferenceSpace(
         horzspace,
         vert_face_space,
-        Hypsography.LinearAdaption(),
-        z_surface,
+        Hypsography.LinearAdaption(z_surface),
     )
     hv_center_space = Spaces.CenterExtrudedFiniteDifferenceSpace(hv_face_space)
     return (hv_center_space, hv_face_space)

--- a/examples/hybrid/sphere/deformation_flow.jl
+++ b/examples/hybrid/sphere/deformation_flow.jl
@@ -221,12 +221,15 @@ function run_deformation_flow(use_limiter, fct_op)
         zd = z - z_c
 
         centers = (
-            Geometry.LatLongZPoint(ϕ_c, λ_c1, FT(0)),
-            Geometry.LatLongZPoint(ϕ_c, λ_c2, FT(0)),
+            Geometry.LatLongZPoint(ϕ_c, λ_c1, z),
+            Geometry.LatLongZPoint(ϕ_c, λ_c2, z),
         )
-        horz_geometry = Spaces.global_geometry(horz_space)
         rds = map(centers) do center
-            Geometry.great_circle_distance(coord, center, horz_geometry)
+            Geometry.great_circle_distance(
+                coord,
+                center,
+                Spaces.global_geometry(cent_space),
+            )
         end
         ds = @. min(1, (rds / R_t)^2 + (zd / Z_t)^2) # scaled distance functions
 

--- a/src/DataLayouts/broadcast.jl
+++ b/src/DataLayouts/broadcast.jl
@@ -234,8 +234,8 @@ end
 function Base.similar(
     bc::Union{IJFH{<:Any, Nij, A}, Broadcast.Broadcasted{IJFHStyle{Nij, A}}},
     ::Type{Eltype},
+    (_, _, _, _, Nh) = size(bc),
 ) where {Nij, A, Eltype}
-    _, _, _, _, Nh = size(bc)
     PA = parent_array_type(A)
     array = similar(PA, (Nij, Nij, typesize(eltype(A), Eltype), Nh))
     return IJFH{Eltype, Nij}(array)
@@ -244,8 +244,8 @@ end
 function Base.similar(
     bc::Union{IFH{<:Any, Ni, A}, Broadcast.Broadcasted{IFHStyle{Ni, A}}},
     ::Type{Eltype},
+    (_, _, _, _, Nh) = size(bc),
 ) where {Ni, A, Eltype}
-    _, _, _, _, Nh = size(bc)
     PA = parent_array_type(A)
     array = similar(PA, (Ni, typesize(eltype(A), Eltype), Nh))
     return IFH{Eltype, Ni}(array)
@@ -272,8 +272,8 @@ end
 function Base.similar(
     bc::Union{VF{<:Any, A}, Broadcast.Broadcasted{VFStyle{A}}},
     ::Type{Eltype},
+    (_, _, _, Nv, _) = size(bc),
 ) where {A, Eltype}
-    _, _, _, Nv, _ = size(bc)
     PA = parent_array_type(A)
     array = similar(PA, (Nv, typesize(eltype(A), Eltype)))
     return VF{Eltype}(array)
@@ -282,8 +282,8 @@ end
 function Base.similar(
     bc::Union{VIFH{<:Any, Ni, A}, Broadcast.Broadcasted{VIFHStyle{Ni, A}}},
     ::Type{Eltype},
+    (_, _, _, Nv, Nh) = size(bc),
 ) where {Ni, A, Eltype}
-    _, _, _, Nv, Nh = size(bc)
     PA = parent_array_type(A)
     array = similar(PA, (Nv, Ni, typesize(eltype(A), Eltype), Nh))
     return VIFH{Eltype, Ni}(array)
@@ -292,8 +292,8 @@ end
 function Base.similar(
     bc::Union{VIJFH{<:Any, Nij, A}, Broadcast.Broadcasted{VIJFHStyle{Nij, A}}},
     ::Type{Eltype},
+    (_, _, _, Nv, Nh) = size(bc),
 ) where {Nij, A, Eltype}
-    _, _, _, Nv, Nh = size(bc)
     PA = parent_array_type(A)
     array = similar(PA, (Nv, Nij, Nij, typesize(eltype(A), Eltype), Nh))
     return VIJFH{Eltype, Nij}(array)

--- a/src/Geometry/globalgeometry.jl
+++ b/src/Geometry/globalgeometry.jl
@@ -274,7 +274,6 @@ function LocalVector(
     G' * u
 end
 
-
 function product_geometry(
     horizontal_local_geometry::Geometry.LocalGeometry,
     vertical_local_geometry::Geometry.LocalGeometry,
@@ -286,18 +285,28 @@ function product_geometry(
     )
     J = horizontal_local_geometry.J * vertical_local_geometry.J
     WJ = horizontal_local_geometry.WJ * vertical_local_geometry.WJ
-    if global_geometry isa DeepSphericalGlobalGeometry
-        r = global_geometry.radius
-        z = vertical_local_geometry.coordinates.z
-        ∂x∂ξ = blockmat(
-            horizontal_local_geometry.∂x∂ξ .* ((r + z) / r),
-            vertical_local_geometry.∂x∂ξ,
-        )
-    else
-        ∂x∂ξ = blockmat(
-            horizontal_local_geometry.∂x∂ξ,
-            vertical_local_geometry.∂x∂ξ,
-        )
-    end
+    ∂x∂ξ =
+        blockmat(horizontal_local_geometry.∂x∂ξ, vertical_local_geometry.∂x∂ξ)
+    return Geometry.LocalGeometry(coordinates, J, WJ, ∂x∂ξ)
+end
+function product_geometry(
+    horizontal_local_geometry::Geometry.LocalGeometry,
+    vertical_local_geometry::Geometry.LocalGeometry,
+    global_geometry::DeepSphericalGlobalGeometry,
+)
+    r = global_geometry.radius
+    z = vertical_local_geometry.coordinates.z
+    scale = ((r + z) / r)
+
+    coordinates = Geometry.product_coordinates(
+        horizontal_local_geometry.coordinates,
+        vertical_local_geometry.coordinates,
+    )
+    J = scale^2 * horizontal_local_geometry.J * vertical_local_geometry.J
+    WJ = scale^2 * horizontal_local_geometry.WJ * vertical_local_geometry.WJ
+    ∂x∂ξ = blockmat(
+        scale * horizontal_local_geometry.∂x∂ξ,
+        vertical_local_geometry.∂x∂ξ,
+    )
     return Geometry.LocalGeometry(coordinates, J, WJ, ∂x∂ξ)
 end

--- a/src/Geometry/globalgeometry.jl
+++ b/src/Geometry/globalgeometry.jl
@@ -278,6 +278,7 @@ function product_geometry(
     horizontal_local_geometry::Geometry.LocalGeometry,
     vertical_local_geometry::Geometry.LocalGeometry,
     global_geometry::AbstractGlobalGeometry,
+    ∇z = nothing,
 )
     coordinates = Geometry.product_coordinates(
         horizontal_local_geometry.coordinates,
@@ -285,14 +286,18 @@ function product_geometry(
     )
     J = horizontal_local_geometry.J * vertical_local_geometry.J
     WJ = horizontal_local_geometry.WJ * vertical_local_geometry.WJ
-    ∂x∂ξ =
-        blockmat(horizontal_local_geometry.∂x∂ξ, vertical_local_geometry.∂x∂ξ)
+    ∂x∂ξ = blockmat(
+        horizontal_local_geometry.∂x∂ξ,
+        vertical_local_geometry.∂x∂ξ,
+        ∇z,
+    )
     return Geometry.LocalGeometry(coordinates, J, WJ, ∂x∂ξ)
 end
 function product_geometry(
     horizontal_local_geometry::Geometry.LocalGeometry,
     vertical_local_geometry::Geometry.LocalGeometry,
     global_geometry::DeepSphericalGlobalGeometry,
+    ∇z = nothing,
 )
     r = global_geometry.radius
     z = vertical_local_geometry.coordinates.z
@@ -307,6 +312,7 @@ function product_geometry(
     ∂x∂ξ = blockmat(
         scale * horizontal_local_geometry.∂x∂ξ,
         vertical_local_geometry.∂x∂ξ,
+        ∇z,
     )
     return Geometry.LocalGeometry(coordinates, J, WJ, ∂x∂ξ)
 end

--- a/src/Geometry/localgeometry.jl
+++ b/src/Geometry/localgeometry.jl
@@ -122,18 +122,3 @@ function blockmat(
         ),
     )
 end
-
-function product_geometry(
-    horizontal_local_geometry::Geometry.LocalGeometry,
-    vertical_local_geometry::Geometry.LocalGeometry,
-)
-    coordinates = Geometry.product_coordinates(
-        horizontal_local_geometry.coordinates,
-        vertical_local_geometry.coordinates,
-    )
-    J = horizontal_local_geometry.J * vertical_local_geometry.J
-    WJ = horizontal_local_geometry.WJ * vertical_local_geometry.WJ
-    ∂x∂ξ =
-        blockmat(horizontal_local_geometry.∂x∂ξ, vertical_local_geometry.∂x∂ξ)
-    return Geometry.LocalGeometry(coordinates, J, WJ, ∂x∂ξ)
-end

--- a/src/Geometry/localgeometry.jl
+++ b/src/Geometry/localgeometry.jl
@@ -74,7 +74,7 @@ function blockmat(
     Geometry.AxisTensor(
         (Geometry.UWAxis(), Geometry.Covariant13Axis()),
         @SMatrix [
-            A[1, 1] zero(FT);
+            A[1, 1] zero(FT)
             zero(FT) B[1, 1]
         ]
     )
@@ -102,7 +102,7 @@ function blockmat(
     Geometry.AxisTensor(
         (Geometry.UWAxis(), Geometry.Covariant13Axis()),
         @SMatrix [
-            A[1, 1] zero(FT);
+            A[1, 1] zero(FT)
             C[1, 1] B[1, 1]
         ]
     )
@@ -124,8 +124,8 @@ function blockmat(
     B = Geometry.components(b)
     Geometry.AxisTensor(
         (Geometry.VWAxis(), Geometry.Covariant23Axis()),
-        @SMatrix[
-            A[1, 1] zero(FT);
+        @SMatrix [
+            A[1, 1] zero(FT)
             zero(FT) B[1, 1]
         ]
     )
@@ -152,8 +152,8 @@ function blockmat(
     C = Geometry.components(c)
     Geometry.AxisTensor(
         (Geometry.VWAxis(), Geometry.Covariant23Axis()),
-        @SMatrix[
-            A[1, 1] zero(FT);
+        @SMatrix [
+            A[1, 1] zero(FT)
             C[1, 1] B[1, 1]
         ]
     )
@@ -175,8 +175,8 @@ function blockmat(
     Geometry.AxisTensor(
         (Geometry.UVWAxis(), Geometry.Covariant123Axis()),
         @SMatrix [
-            A[1, 1] A[1, 2] zero(FT);
-            A[2, 1] A[2, 2] zero(FT);
+            A[1, 1] A[1, 2] zero(FT)
+            A[2, 1] A[2, 2] zero(FT)
             zero(FT) zero(FT) B[1, 1]
         ]
     )
@@ -204,8 +204,8 @@ function blockmat(
     Geometry.AxisTensor(
         (Geometry.UVWAxis(), Geometry.Covariant123Axis()),
         @SMatrix [
-            A[1, 1] A[1, 2] zero(FT);
-            A[2, 1] A[2, 2] zero(FT);
+            A[1, 1] A[1, 2] zero(FT)
+            A[2, 1] A[2, 2] zero(FT)
             C[1, 1] C[1, 2] B[1, 1]
         ]
     )

--- a/src/Geometry/localgeometry.jl
+++ b/src/Geometry/localgeometry.jl
@@ -68,6 +68,7 @@ function blockmat(
         Tuple{Geometry.WAxis, Geometry.Covariant3Axis},
         SMatrix{1, 1, FT, 1},
     },
+    c::Nothing = nothing,
 ) where {FT}
     A = Geometry.components(a)
     B = Geometry.components(b)
@@ -119,6 +120,7 @@ function blockmat(
         Tuple{Geometry.WAxis, Geometry.Covariant3Axis},
         SMatrix{1, 1, FT, 1},
     },
+    c::Nothing = nothing,
 ) where {FT}
     A = Geometry.components(a)
     B = Geometry.components(b)
@@ -169,6 +171,7 @@ function blockmat(
         Tuple{Geometry.WAxis, Geometry.Covariant3Axis},
         SMatrix{1, 1, FT, 1},
     },
+    c::Nothing = nothing,
 ) where {FT}
     A = Geometry.components(a)
     B = Geometry.components(b)

--- a/src/Geometry/localgeometry.jl
+++ b/src/Geometry/localgeometry.jl
@@ -52,7 +52,11 @@ end
 undertype(::Type{LocalGeometry{I, C, FT, S}}) where {I, C, FT, S} = FT
 undertype(::Type{SurfaceGeometry{FT, N}}) where {FT, N} = FT
 
+"""
+    blockmat(m11, m22[, m12])
 
+Construct an `Axis2Tensor` from sub-blocks
+"""
 function blockmat(
     a::Geometry.Axis2Tensor{
         FT,
@@ -69,7 +73,38 @@ function blockmat(
     B = Geometry.components(b)
     Geometry.AxisTensor(
         (Geometry.UWAxis(), Geometry.Covariant13Axis()),
-        SMatrix{2, 2}(A[1, 1], zero(FT), zero(FT), B[1, 1]),
+        @SMatrix [
+            A[1, 1] zero(FT);
+            zero(FT) B[1, 1]
+        ]
+    )
+end
+function blockmat(
+    a::Geometry.Axis2Tensor{
+        FT,
+        Tuple{Geometry.UAxis, Geometry.Covariant1Axis},
+        SMatrix{1, 1, FT, 1},
+    },
+    b::Geometry.Axis2Tensor{
+        FT,
+        Tuple{Geometry.WAxis, Geometry.Covariant3Axis},
+        SMatrix{1, 1, FT, 1},
+    },
+    c::Geometry.Axis2Tensor{
+        FT,
+        Tuple{Geometry.WAxis, Geometry.Covariant1Axis},
+        SMatrix{1, 1, FT, 1},
+    },
+) where {FT}
+    A = Geometry.components(a)
+    B = Geometry.components(b)
+    C = Geometry.components(c)
+    Geometry.AxisTensor(
+        (Geometry.UWAxis(), Geometry.Covariant13Axis()),
+        @SMatrix [
+            A[1, 1] zero(FT);
+            C[1, 1] B[1, 1]
+        ]
     )
 end
 
@@ -89,10 +124,40 @@ function blockmat(
     B = Geometry.components(b)
     Geometry.AxisTensor(
         (Geometry.VWAxis(), Geometry.Covariant23Axis()),
-        SMatrix{2, 2}(A[1, 1], zero(FT), zero(FT), B[1, 1]),
+        @SMatrix[
+            A[1, 1] zero(FT);
+            zero(FT) B[1, 1]
+        ]
     )
 end
-
+function blockmat(
+    a::Geometry.Axis2Tensor{
+        FT,
+        Tuple{Geometry.VAxis, Geometry.Covariant2Axis},
+        SMatrix{1, 1, FT, 1},
+    },
+    b::Geometry.Axis2Tensor{
+        FT,
+        Tuple{Geometry.WAxis, Geometry.Covariant3Axis},
+        SMatrix{1, 1, FT, 1},
+    },
+    c::Geometry.Axis2Tensor{
+        FT,
+        Tuple{Geometry.WAxis, Geometry.Covariant2Axis},
+        SMatrix{1, 1, FT, 1},
+    },
+) where {FT}
+    A = Geometry.components(a)
+    B = Geometry.components(b)
+    C = Geometry.components(c)
+    Geometry.AxisTensor(
+        (Geometry.VWAxis(), Geometry.Covariant23Axis()),
+        @SMatrix[
+            A[1, 1] zero(FT);
+            C[1, 1] B[1, 1]
+        ]
+    )
+end
 function blockmat(
     a::Geometry.Axis2Tensor{
         FT,
@@ -109,16 +174,39 @@ function blockmat(
     B = Geometry.components(b)
     Geometry.AxisTensor(
         (Geometry.UVWAxis(), Geometry.Covariant123Axis()),
-        SMatrix{3, 3}(
-            A[1, 1],
-            A[2, 1],
-            zero(FT),
-            A[1, 2],
-            A[2, 2],
-            zero(FT),
-            zero(FT),
-            zero(FT),
-            B[1, 1],
-        ),
+        @SMatrix [
+            A[1, 1] A[1, 2] zero(FT);
+            A[2, 1] A[2, 2] zero(FT);
+            zero(FT) zero(FT) B[1, 1]
+        ]
+    )
+end
+function blockmat(
+    a::Geometry.Axis2Tensor{
+        FT,
+        Tuple{Geometry.UVAxis, Geometry.Covariant12Axis},
+        SMatrix{2, 2, FT, 4},
+    },
+    b::Geometry.Axis2Tensor{
+        FT,
+        Tuple{Geometry.WAxis, Geometry.Covariant3Axis},
+        SMatrix{1, 1, FT, 1},
+    },
+    c::Geometry.Axis2Tensor{
+        FT,
+        Tuple{Geometry.WAxis, Geometry.Covariant12Axis},
+        SMatrix{1, 2, FT, 2},
+    },
+) where {FT}
+    A = Geometry.components(a)
+    B = Geometry.components(b)
+    C = Geometry.components(c)
+    Geometry.AxisTensor(
+        (Geometry.UVWAxis(), Geometry.Covariant123Axis()),
+        @SMatrix [
+            A[1, 1] A[1, 2] zero(FT);
+            A[2, 1] A[2, 2] zero(FT);
+            C[1, 1] C[1, 2] B[1, 1]
+        ]
     )
 end

--- a/src/Grids/extruded.jl
+++ b/src/Grids/extruded.jl
@@ -58,7 +58,8 @@ function ExtrudedFiniteDifferenceGrid(
         _ExtrudedFiniteDifferenceGrid(
             horizontal_grid,
             vertical_grid,
-            hypsography,
+            hypsography;
+            deep,
         )
     end
 end
@@ -68,7 +69,7 @@ function _ExtrudedFiniteDifferenceGrid(
     horizontal_grid::Union{SpectralElementGrid1D, SpectralElementGrid2D},
     vertical_grid::FiniteDifferenceGrid,
     hypsography::Flat;
-    deep = false,
+    deep::Bool,
 )
     if horizontal_grid.global_geometry isa Geometry.SphericalGlobalGeometry
         radius = horizontal_grid.global_geometry.radius

--- a/src/Grids/finitedifference.jl
+++ b/src/Grids/finitedifference.jl
@@ -49,28 +49,39 @@ end
 
 function _FiniteDifferenceGrid(topology::Topologies.IntervalTopology)
     global_geometry = Geometry.CartesianGlobalGeometry()
-    mesh = topology.mesh
-    CT = Meshes.coordinate_type(mesh)
-    AIdx = Geometry.coordinate_axis(CT)
-    # TODO: FD operators  hardcoded to work over the 3-axis, need to generalize
-    # similar to spectral operators
-    @assert AIdx == (3,) "FiniteDifference operations only work over the 3-axis (ZPoint) domain"
-    FT = eltype(CT)
     ArrayType = ClimaComms.array_type(topology)
     face_coordinates = collect(mesh.faces)
+    # construct on CPU, adapt to GPU
+    center_local_geometry, face_local_geometry = fd_geometry_data(
+        face_coordinates;
+        periodic = Topologies.isperiodic(topology),
+    )
+    return FiniteDifferenceGrid(
+        topology,
+        global_geometry,
+        Adapt.adapt(ArrayType, center_local_geometry),
+        Adapt.adapt(ArrayType, face_local_geometry),
+    )
+end
+
+function fd_geometry_data(
+    face_coordinates::AbstractVector{Geometry.ZPoint{FT}};
+    periodic,
+) where {FT}
+    AIdx == (3,)
+    CT = Geometry.ZPoint{FT}
     LG = Geometry.LocalGeometry{AIdx, CT, FT, SMatrix{1, 1, FT, 1}}
-    nface = length(face_coordinates) - Topologies.isperiodic(topology)
+
+    nface = length(face_coordinates) - periodic
     ncent = length(face_coordinates) - 1
-    # contstruct on CPU, copy to device at end
     center_local_geometry = DataLayouts.VF{LG}(Array{FT}, ncent)
     face_local_geometry = DataLayouts.VF{LG}(Array{FT}, nface)
+
     for i in 1:ncent
         # centers
         coord⁻ = Geometry.component(face_coordinates[i], 1)
         coord⁺ = Geometry.component(face_coordinates[i + 1], 1)
-        # at the moment we use a "discrete Jacobian"
-        # ideally we should use the continuous quantity via the derivative of the warp function
-        # could we just define this then as deriv on the mesh element coordinates?
+        # use a "discrete Jacobian"
         coord = (coord⁺ + coord⁻) / 2
         Δcoord = coord⁺ - coord⁻
         J = Δcoord
@@ -86,11 +97,12 @@ function _FiniteDifferenceGrid(topology::Topologies.IntervalTopology)
             ),
         )
     end
+
     for i in 1:nface
         coord = Geometry.component(face_coordinates[i], 1)
         if i == 1
             # bottom face
-            if Topologies.isperiodic(topology)
+            if periodic
                 Δcoord⁺ =
                     Geometry.component(face_coordinates[2], 1) -
                     Geometry.component(face_coordinates[1], 1)
@@ -104,7 +116,8 @@ function _FiniteDifferenceGrid(topology::Topologies.IntervalTopology)
                 J = coord⁺ - coord
                 WJ = J / 2
             end
-        elseif !Topologies.isperiodic(topology) && i == nface
+        elseif i == ncent + 1
+            @assert !periodic
             # top face
             coord⁻ = Geometry.component(face_coordinates[i - 1], 1)
             J = coord - coord⁻
@@ -116,7 +129,6 @@ function _FiniteDifferenceGrid(topology::Topologies.IntervalTopology)
             WJ = J
         end
         ∂x∂ξ = SMatrix{1, 1}(J)
-        ∂ξ∂x = SMatrix{1, 1}(inv(J))
         face_local_geometry[i] = Geometry.LocalGeometry(
             CT(coord),
             J,
@@ -127,12 +139,7 @@ function _FiniteDifferenceGrid(topology::Topologies.IntervalTopology)
             ),
         )
     end
-    return FiniteDifferenceGrid(
-        topology,
-        global_geometry,
-        Adapt.adapt(ArrayType, center_local_geometry),
-        Adapt.adapt(ArrayType, face_local_geometry),
-    )
+    return (center_local_geometry, face_local_geometry)
 end
 
 

--- a/src/Grids/finitedifference.jl
+++ b/src/Grids/finitedifference.jl
@@ -79,7 +79,7 @@ function fd_geometry_data(
     periodic,
 ) where {FT}
     CT = Geometry.ZPoint{FT}
-    AIdx == (3,)
+    AIdx = (3,)
     LG = Geometry.LocalGeometry{AIdx, CT, FT, SMatrix{1, 1, FT, 1}}
     (Ni, Nj, Nk, Nv, Nh) = size(face_coordinates)
     Nv_face = Nv - periodic

--- a/src/Hypsography/Hypsography.jl
+++ b/src/Hypsography/Hypsography.jl
@@ -29,9 +29,9 @@ Convert reference `z`s to physical `z`s as prescribed by the given adaption.
 """
 function ref_z_to_physical_z(
     ::Flat,
-    z_ref::ZPoint,
-    z_surfac::ZPoint,
-    z_top::ZPoint,
+    z_ref::Geometry.ZPoint,
+    z_surfac::Geometry.ZPoint,
+    z_top::Geometry.ZPoint,
 )
     return z_ref
 end
@@ -59,9 +59,9 @@ end
 
 function ref_z_to_physical_z(
     ::LinearAdaption,
-    z_ref::ZPoint,
-    z_surface::ZPoint,
-    z_top::ZPoint,
+    z_ref::Geometry.ZPoint,
+    z_surface::Geometry.ZPoint,
+    z_top::Geometry.ZPoint,
 )
     Geometry.ZPoint(z_ref.z + (1 - z_ref.z / z_top.z) * z_surface.z)
 end

--- a/src/Hypsography/Hypsography.jl
+++ b/src/Hypsography/Hypsography.jl
@@ -128,7 +128,8 @@ function _ExtrudedFiniteDifferenceGrid(
     vertical_domain = Topologies.domain(vertical_grid)
     z_top = vertical_domain.coord_max
 
-    face_z = ref_z_to_physical_z.(Ref(adaption), face_z_ref, z_surface, z_top)
+    face_z =
+        ref_z_to_physical_z.(Ref(adaption), face_z_ref, z_surface, Ref(z_top))
 
     return _ExtrudedFiniteDifferenceGrid(
         horizontal_grid,

--- a/src/Hypsography/Hypsography.jl
+++ b/src/Hypsography/Hypsography.jl
@@ -12,6 +12,7 @@ import ..Geometry,
     ..Fields,
     ..Operators
 import ..Spaces: ExtrudedFiniteDifferenceSpace
+import ClimaCore.Utilities: half
 
 import ..Grids:
     _ExtrudedFiniteDifferenceGrid,
@@ -30,13 +31,11 @@ Convert reference `z`s to physical `z`s as prescribed by the given adaption.
 function ref_z_to_physical_z(
     ::Flat,
     z_ref::Geometry.ZPoint,
-    z_surfac::Geometry.ZPoint,
+    z_surface::Geometry.ZPoint,
     z_top::Geometry.ZPoint,
 )
     return z_ref
 end
-
-
 
 """
     LinearAdaption(surface::Field)

--- a/src/Hypsography/Hypsography.jl
+++ b/src/Hypsography/Hypsography.jl
@@ -2,7 +2,13 @@ module Hypsography
 
 import ..slab, ..column
 import ..Geometry,
-    ..Domains, ..Topologies, ..Grids, ..Spaces, ..Fields, ..Operators
+    ..DataLayouts,
+    ..Domains,
+    ..Topologies,
+    ..Grids,
+    ..Spaces,
+    ..Fields,
+    ..Operators
 import ..Spaces: ExtrudedFiniteDifferenceSpace
 
 import ..Grids:
@@ -20,10 +26,45 @@ using StaticArrays, LinearAlgebra
 Locate the levels by linear interpolation between the surface field and the top
 of the domain, using the method of [GalChen1975](@cite).
 """
-struct LinearAdaption{F <: Union{Fields.Field, Nothing}} <: HypsographyAdaption
-    # Union can be removed once deprecation removed.
+struct LinearAdaption{F <: Fields.Field} <: HypsographyAdaption
     surface::F
+    function LinearAdaption(surface::Fields.Field)
+        if eltype(surface) <: Real
+            @warn "`LinearAdaptation`: `surface` argument scalar field has been deprecated. Use a field `ZPoint`s."
+            surface = Geometry.ZPoint.(surface)
+        end
+        new{typeof(surface)}(surface)
+    end
 end
+
+# this method is invoked by the ExtrudedFiniteDifferenceGrid constructor
+function _ExtrudedFiniteDifferenceGrid(
+    horizontal_grid::Grids.AbstractGrid,
+    vertical_grid::Grids.FiniteDifferenceGrid,
+    adaption::LinearAdaption,
+    global_geometry::Geometry.AbstractGlobalGeometry,
+)
+    @assert Spaces.grid(axes(adaption.surface)) == horizontal_grid
+    z_surface = Fields.field_values(adaption.surface)
+
+    face_z_ref =
+        Grids.local_geometry_data(vertical_grid, Grids.CellFace()).coordinates
+    vertical_domain = Topologies.domain(vertical_grid)
+    z_top = vertical_domain.coord_max
+
+    face_z = @. Geometry.ZPoint(
+        face_z_ref.z + (1 - face_z_ref.z / z_top.z) * z_surface.z,
+    )
+
+    return _ExtrudedFiniteDifferenceGrid(
+        horizontal_grid,
+        vertical_grid,
+        adaption,
+        global_geometry,
+        face_z,
+    )
+end
+
 
 """
     SLEVEAdaption(surface::Field, ηₕ::FT, s::FT)
@@ -36,168 +77,131 @@ If the decay-scale is poorly specified (i.e., `s * zₜ` is lower than the maxim
 surface elevation), a warning is thrown and `s` is adjusted such that it `szₜ > maximum(z_surface)`.
 """
 struct SLEVEAdaption{F <: Fields.Field, FT <: Real} <: HypsographyAdaption
-    # Union can be removed once deprecation removed.
     surface::F
     ηₕ::FT
     s::FT
+    function SLEVEAdaption(
+        surface::Fields.Field,
+        ηₕ::FT,
+        s::FT,
+    ) where {FT <: Real}
+        @assert 0 <= ηₕ <= 1
+        @assert s >= 0
+        if eltype(surface) <: Real
+            @warn "`SLEVEAdaption`: `surface` argument scalar field has been deprecated. Use a field `ZPoint`s."
+            surface = Geometry.ZPoint.(surface)
+        end
+        new{typeof(surface), FT}(surface, ηₕ, s)
+    end
 end
 
-# deprecated in 0.10.12
-LinearAdaption() = LinearAdaption(nothing)
-
-@deprecate(
-    ExtrudedFiniteDifferenceSpace(
-        horizontal_space::Spaces.AbstractSpace,
-        vertical_space::Spaces.FiniteDifferenceSpace,
-        adaption::LinearAdaption{Nothing},
-        z_surface::Fields.Field,
-    ),
-    ExtrudedFiniteDifferenceSpace(
-        horizontal_space,
-        vertical_space,
-        LinearAdaption(z_surface),
-    ),
-    false
+function _ExtrudedFiniteDifferenceGrid(
+    horizontal_grid::Grids.AbstractGrid,
+    vertical_grid::Grids.FiniteDifferenceGrid,
+    adaption::SLEVEAdaption,
+    global_geometry::Geometry.AbstractGlobalGeometry,
 )
+    @assert Spaces.grid(axes(adaption.surface)) == horizontal_grid
+    z_surface = Fields.field_values(adaption.surface)
 
-# linear coordinates
+    face_z_ref =
+        Grids.local_geometry_data(vertical_grid, Grids.CellFace()).coordinates
+    vertical_domain = Topologies.domain(vertical_grid)
+    z_top = vertical_domain.coord_max
+
+    (; ηₕ, s) = adaption
+
+    η = @. face_z_ref.z ./ z_top.z
+    if s * z_top.z <= maximum(z_surface.z)
+        @warn "Decay scale (s*z_top = $(s*z_top)) must be higher than max surface elevation (max(z_surface) = $(maximum(z_surface))). Returning s = FT(0.8). Scale height is therefore s=$(0.8 * z_top) m."
+        s = 0.8
+    end
+    face_z = @. ifelse(
+        η <= ηₕ,
+        η * z_top + z_surface * (sinh((ηₕ - η) / s / ηₕ)) / (sinh(1 / s)),
+        η * z_top,
+    )
+
+    return _ExtrudedFiniteDifferenceGrid(
+        horizontal_grid,
+        vertical_grid,
+        adaption,
+        global_geometry,
+        face_z,
+    )
+end
+
+# generic hypsography constructor, uses computed face_z points
 function _ExtrudedFiniteDifferenceGrid(
     horizontal_grid::Grids.AbstractGrid,
     vertical_grid::Grids.FiniteDifferenceGrid,
     adaption::HypsographyAdaption,
-)
-    if adaption isa LinearAdaption
-        if isnothing(adaption.surface)
-            error("LinearAdaption requires a Field argument")
-        end
-        if axes(adaption.surface).grid !== horizontal_grid
-            error("Terrain must be defined on the horizontal space")
-        end
-    end
-
-    # construct initial flat space, then mutate
-    ref_grid = Grids.ExtrudedFiniteDifferenceGrid(
+    global_geometry::Geometry.AbstractGlobalGeometry,
+    face_z::DataLayouts.AbstractData{Geometry.ZPoint{FT}},
+) where {FT}
+    # construct the "flat" grid
+    # avoid cached constructor so that it gets cleaned up automatically
+    flat_grid = _ExtrudedFiniteDifferenceGrid(
         horizontal_grid,
         vertical_grid,
         Flat(),
+        global_geometry,
     )
-    face_ref_space = Spaces.FaceExtrudedFiniteDifferenceSpace(ref_grid)
-    face_ref_coords = Spaces.coordinates_data(face_ref_space)
-    coord_type = eltype(face_ref_coords)
-    z_ref = face_ref_coords.z
+    center_flat_space = Spaces.space(flat_grid, Grids.CellCenter())
+    face_flat_space = Spaces.space(flat_grid, Grids.CellFace())
 
-    vertical_domain = Topologies.domain(vertical_grid)
-    z_top = vertical_domain.coord_max.z
+    # compute the "z-only local geometry" based on face z coords
+    ArrayType = ClimaComms.array_type(horizontal_grid.topology)
+    # currently only works on Arrays
+    (center_z_local_geometry, face_z_local_geometry) = Grids.fd_geometry_data(
+        Adapt.adapt(Array, face_z);
+        periodic = Topologies.isperiodic(vertical_grid.topology),
+    )
 
+    center_z_local_geometry = Adapt.adapt(ArrayType, center_z_local_geometry)
+    face_z_local_geometry = Adapt.adapt(ArrayType, face_z_local_geometry)
+
+    # compute ∇Z at face and centers
     grad = Operators.Gradient()
-    z_surface = Fields.field_values(adaption.surface)
 
-    FT = eltype(z_surface)
-
-    # TODO: Function dispatch
-    if adaption isa LinearAdaption
-        fZ_data = @. z_ref + (1 - z_ref / z_top) * z_surface
-        fZ = Fields.Field(fZ_data, face_ref_space)
-    elseif adaption isa SLEVEAdaption
-        ηₕ = adaption.ηₕ
-        s = adaption.s
-        @assert FT(0) <= ηₕ <= FT(1)
-        @assert s >= FT(0)
-        η = @. z_ref ./ z_top
-        if s * z_top <= maximum(z_surface)
-            @warn "Decay scale (s*z_top = $(s*z_top)) must be higher than max surface elevation (max(z_surface) = $(maximum(z_surface))). Returning s = FT(0.8). Scale height is therefore s=$(0.8 * z_top) m."
-            s = @. FT(8 / 10)
-        end
-        fZ_data = @. ifelse(
-            η <= ηₕ,
-            η * z_top + z_surface * (sinh((ηₕ - η) / s / ηₕ)) / (sinh(1 / s)),
-            η * z_top,
+    center_∇Z_field =
+        grad.(
+            Fields.Field(
+                center_z_local_geometry,
+                center_flat_space,
+            ).coordinates.z
         )
-        fZ = Fields.Field(fZ_data, face_ref_space)
-    end
+    Spaces.weighted_dss!(center_∇Z_field)
 
-    # Take the horizontal gradient for the Z surface field
-    # for computing updated ∂x∂ξ₃₁, ∂x∂ξ₃₂ terms
-    grad = Operators.Gradient()
-    If2c = Operators.InterpolateF2C()
+    face_∇Z_field =
+        grad.(
+            Fields.Field(face_z_local_geometry, face_flat_space).coordinates.z
+        )
+    Spaces.weighted_dss!(face_∇Z_field)
 
-    # DSS the horizontal gradient of Z surface field to force
-    # deriv continuity along horizontal element boundaries
-    f∇Z = grad.(fZ)
-    Spaces.weighted_dss!(f∇Z)
-
-    # Interpolate horizontal gradient surface field to centers
-    # used to compute ∂x∂ξ₃₃ (Δz) metric term
-    cZ = If2c.(fZ)
-
-    # DSS the interpolated horizontal gradients as well
-    c∇Z = If2c.(f∇Z)
-    Spaces.weighted_dss!(c∇Z)
-
-    face_local_geometry = copy(ref_grid.face_local_geometry)
-    center_local_geometry = copy(ref_grid.center_local_geometry)
-
-    Ni, Nj, _, Nv, Nh = size(center_local_geometry)
-    for h in 1:Nh, j in 1:Nj, i in 1:Ni
-        face_column = column(face_local_geometry, i, j, h)
-        fZ_column = column(Fields.field_values(fZ), i, j, h)
-        f∇Z_column = column(Fields.field_values(f∇Z), i, j, h)
-        center_column = column(center_local_geometry, i, j, h)
-        cZ_column = column(Fields.field_values(cZ), i, j, h)
-        c∇Z_column = column(Fields.field_values(c∇Z), i, j, h)
-
-        # update face metrics
-        for v in 1:(Nv + 1)
-            local_geom = face_column[v]
-            coord = if coord_type <: Geometry.Abstract2DPoint
-                c1 = Geometry.components(local_geom.coordinates)[1]
-                coord_type(c1, fZ_column[v])
-            elseif coord_type <: Geometry.Abstract3DPoint
-                c1 = Geometry.components(local_geom.coordinates)[1]
-                c2 = Geometry.components(local_geom.coordinates)[2]
-                coord_type(c1, c2, fZ_column[v])
-            end
-            Δz = if v == 1
-                # if this is the domain min face level compute the metric
-                # extrapolating from the bottom face level of the domain
-                2 * (cZ_column[v] - fZ_column[v])
-            elseif v == Nv + 1
-                # if this is the domain max face level compute the metric
-                # extrapolating from the top face level of the domain
-                2 * (fZ_column[v] - cZ_column[v - 1])
-            else
-                cZ_column[v] - cZ_column[v - 1]
-            end
-            ∂x∂ξ = reconstruct_metric(local_geom.∂x∂ξ, f∇Z_column[v], Δz)
-            W = local_geom.WJ / local_geom.J
-            J = det(Geometry.components(∂x∂ξ))
-            face_column[v] = Geometry.LocalGeometry(coord, J, W * J, ∂x∂ξ)
-        end
-
-        # update center metrics
-        for v in 1:Nv
-            local_geom = center_column[v]
-            coord = if coord_type <: Geometry.Abstract2DPoint
-                c1 = Geometry.components(local_geom.coordinates)[1]
-                coord_type(c1, cZ_column[v])
-            elseif coord_type <: Geometry.Abstract3DPoint
-                c1 = Geometry.components(local_geom.coordinates)[1]
-                c2 = Geometry.components(local_geom.coordinates)[2]
-                coord_type(c1, c2, cZ_column[v])
-            end
-            Δz = fZ_column[v + 1] - fZ_column[v]
-            ∂x∂ξ = reconstruct_metric(local_geom.∂x∂ξ, c∇Z_column[v], Δz)
-            W = local_geom.WJ / local_geom.J
-            J = det(Geometry.components(∂x∂ξ))
-            center_column[v] = Geometry.LocalGeometry(coord, J, W * J, ∂x∂ξ)
-        end
-    end
+    # construct full local geometry
+    center_local_geometry =
+        Geometry.product_geometry.(
+            horizontal_grid.local_geometry,
+            center_z_local_geometry,
+            Ref(global_geometry),
+            Ref(Geometry.WVector(1)) .*
+            adjoint.(Fields.field_values(center_∇Z_field)),
+        )
+    face_local_geometry =
+        Geometry.product_geometry.(
+            horizontal_grid.local_geometry,
+            face_z_local_geometry,
+            Ref(global_geometry),
+            Ref(Geometry.WVector(1)) .*
+            adjoint.(Fields.field_values(face_∇Z_field)),
+        )
 
     return ExtrudedFiniteDifferenceGrid(
         horizontal_grid,
         vertical_grid,
         adaption,
-        ref_grid.global_geometry,
+        global_geometry,
         center_local_geometry,
         face_local_geometry,
     )

--- a/src/Hypsography/Hypsography.jl
+++ b/src/Hypsography/Hypsography.jl
@@ -1,5 +1,7 @@
 module Hypsography
 
+import ClimaComms, Adapt
+
 import ..slab, ..column
 import ..Geometry,
     ..DataLayouts,

--- a/src/InputOutput/readers.jl
+++ b/src/InputOutput/readers.jl
@@ -344,7 +344,14 @@ function read_grid_new(reader, name)
             hypsography = Grids.Flat()
         elseif hypsography_type == "LinearAdaption"
             hypsography = Hypsography.LinearAdaption(
-                read_field(reader, attrs(group)["hypsography_surface"]),
+                read_field(reader, attrs(group)["hypsography_surface"]).surface,
+            )
+        elseif hypsography_type == "SLEVEAdaption"
+            # Store hyps object for general use ?
+            hypsography = Hypsography.SLEVEAdaption(
+                read_field(reader, attrs(group)["hypsography_obj"]).surface,
+                read_field(reader, attrs(group)["hypsography_obj"]).ηₕ,
+                read_field(reader, attrs(group)["hypsography_obj"]).s,
             )
         else
             error("Unsupported hypsography type $hypsography_type")

--- a/src/InputOutput/readers.jl
+++ b/src/InputOutput/readers.jl
@@ -344,14 +344,14 @@ function read_grid_new(reader, name)
             hypsography = Grids.Flat()
         elseif hypsography_type == "LinearAdaption"
             hypsography = Hypsography.LinearAdaption(
-                read_field(reader, attrs(group)["hypsography_surface"]).surface,
+                read_field(reader, attrs(group)["hypsography_surface"]),
             )
         elseif hypsography_type == "SLEVEAdaption"
             # Store hyps object for general use ?
             hypsography = Hypsography.SLEVEAdaption(
-                read_field(reader, attrs(group)["hypsography_obj"]).surface,
-                read_field(reader, attrs(group)["hypsography_obj"]).ηₕ,
-                read_field(reader, attrs(group)["hypsography_obj"]).s,
+                read_field(reader, attrs(group)["hypsography_surface"]),
+                get(attrs(group), "hypsography_ηₕ", "hypsography_surface_ηₕ"),
+                get(attrs(group), "hypsography_s", "hypsography_surface_s"),
             )
         else
             error("Unsupported hypsography type $hypsography_type")

--- a/src/InputOutput/writers.jl
+++ b/src/InputOutput/writers.jl
@@ -381,12 +381,18 @@ function write_new!(
         write_attribute(
             group,
             "hypsography_surface",
-            write!(writer, space.hypsography.surface, "_z_surface/$name"),
+            write!(writer, space.hypsography.surface, "_z_surface/$name"), # Change to save "space.hyps"
+        )
+    elseif space.hypsography isa Hypsography.SLEVEAdaption
+        write_attribute(group, "hypsography_type", "SLEVEAdaption")
+        write_attribute(
+            group,
+            write!(writer, space.hypsography, "SLEVEAdaption"),
+            "hypsography_obj",
         )
     end
     return name
 end
-
 
 function write_new!(
     writer::HDF5Writer,
@@ -468,6 +474,7 @@ function write!(
     end
     return name
 end
+
 
 """
     write!(writer::HDF5Writer, name => value...)

--- a/src/InputOutput/writers.jl
+++ b/src/InputOutput/writers.jl
@@ -363,6 +363,12 @@ function write_new!(
     return name
 end
 
+
+"""
+    write_new!(writer, domain, name)
+
+Writes an object of type 'Hypsography' and name 'name' to the HDF5 file.
+"""
 function write_new!(
     writer::HDF5Writer,
     space::Grids.ExtrudedFiniteDifferenceGrid,
@@ -385,14 +391,17 @@ function write_new!(
         )
     elseif space.hypsography isa Hypsography.SLEVEAdaption
         write_attribute(group, "hypsography_type", "SLEVEAdaption")
+        write_attribute(group, "hypsography_ηₕ", space.hypsography.ηₕ)
+        write_attribute(group, "hypsography_s", space.hypsography.s)
         write_attribute(
             group,
-            write!(writer, space.hypsography, "SLEVEAdaption"),
-            "hypsography_obj",
+            "hypsography_surface",
+            write!(writer, space.hypsography.surface, "_z_surface/$name"),
         )
     end
     return name
 end
+
 
 function write_new!(
     writer::HDF5Writer,

--- a/src/Remapping/distributed_remapping.jl
+++ b/src/Remapping/distributed_remapping.jl
@@ -240,7 +240,7 @@ function interpolate(
     axes(field) == remapper.space ||
         error("Field is defined on a different space than remapper")
 
-    FT = eltype(field)
+    FT = Spaces.undertype(axes(field))
 
     if length(remapper.target_zcoords) == 0
         out_local_array = zeros(FT, size(remapper.local_target_hcoords_bitmask))

--- a/src/Remapping/distributed_remapping.jl
+++ b/src/Remapping/distributed_remapping.jl
@@ -190,6 +190,11 @@ function Remapper(target_hcoords, target_zcoords, space)
 end
 
 
+import Base.+
+(+)(x::AbstractFloat, y::Geometry.ZPoint) = x + eltype(x)(y.z)
+(+)(x::Geometry.ZPoint, y::AbstractFloat) = eltype(y)(x.z) + y
+
+
 """
    interpolate(remapper, field; physical_z = false)
 

--- a/src/Remapping/interpolate_array.jl
+++ b/src/Remapping/interpolate_array.jl
@@ -590,10 +590,6 @@ function interpolate_column(
     # we have to make sure that we are passing around views of the same array (as opposed to
     # copied of it).
     if physical_z
-        # We are hardcoding the transformation from Hypsography.LinearAdaption
-        space.hypsography isa Hypsography.LinearAdaption ||
-            error("Cannot interpolate $(space.hypsography) hypsography")
-
         FT = Spaces.undertype(axes(field))
 
         # interpolate_slab! takes a vector
@@ -609,8 +605,12 @@ function interpolate_column(
         z_top = Spaces.vertical_topology(space).mesh.domain.coord_max.z
 
         zpts_ref = [
-            Geometry.ZPoint((z.z - z_surface) / (1 - z_surface / z_top)) for
-            z in zpts if z.z > z_surface
+            Hypsography.physical_z_to_ref_z(
+                Spaces.hypsography(space),
+                z_ref,
+                z_surface,
+                z_top,
+            ) for z_ref in zpts
         ]
 
         # When zpts = zpts_ref, all the points are above the surface

--- a/src/Remapping/interpolate_array.jl
+++ b/src/Remapping/interpolate_array.jl
@@ -601,7 +601,7 @@ function interpolate_column(
 
         interpolate_slab!(
             z_surface,
-            space.hypsography.surface,
+            space.hypsography.surface.z,
             [Fields.SlabIndex(nothing, gidx)],
             [Is],
         )

--- a/src/Remapping/interpolate_array.jl
+++ b/src/Remapping/interpolate_array.jl
@@ -606,7 +606,7 @@ function interpolate_column(
 
         zpts_ref = [
             Hypsography.physical_z_to_ref_z(
-                Spaces.hypsography(space),
+                Spaces.grid(space).hypsography,
                 z_ref,
                 z_surface,
                 z_top,

--- a/test/Geometry/geometry.jl
+++ b/test/Geometry/geometry.jl
@@ -588,14 +588,44 @@ end
         global_geom,
     ) ≈ 2 * deg2rad(180.0) rtol = 2eps()
 
-    # test between two LatLongZPoints
-    @test Geometry.great_circle_distance(
-        Geometry.LatLongZPoint(22.0, 32.0, 2.0),
-        Geometry.LatLongZPoint(22.0, 32.0, 2.0),
-        global_geom,
-    ) == 0.0
 end
 
+
+@testset "shallow great circle distance" begin
+    global_geom = Geometry.ShallowSphericalGlobalGeometry(2.0)
+
+    # test between two LatLongZPoints
+    @test Geometry.great_circle_distance(
+        Geometry.LatLongZPoint(0.0, 30.0, 0.0),
+        Geometry.LatLongZPoint(0.0, 40.0, 0.0),
+        global_geom,
+    ) ≈ 2 * deg2rad(10.0) rtol = 2eps()
+
+    @test Geometry.great_circle_distance(
+        Geometry.LatLongZPoint(0.0, 30.0, 10.0),
+        Geometry.LatLongZPoint(0.0, 40.0, 10.0),
+        global_geom,
+    ) ≈ 2 * deg2rad(10.0) rtol = 2eps()
+
+end
+
+@testset "deep great circle distance" begin
+    global_geom = Geometry.DeepSphericalGlobalGeometry(2.0)
+
+    # test between two LatLongZPoints
+    @test Geometry.great_circle_distance(
+        Geometry.LatLongZPoint(0.0, 30.0, 0.0),
+        Geometry.LatLongZPoint(0.0, 40.0, 0.0),
+        global_geom,
+    ) ≈ 2 * deg2rad(10.0) rtol = 2eps()
+
+    @test Geometry.great_circle_distance(
+        Geometry.LatLongZPoint(0.0, 30.0, 10.0),
+        Geometry.LatLongZPoint(0.0, 40.0, 10.0),
+        global_geom,
+    ) ≈ (10 + 2) * deg2rad(10.0) rtol = 2eps()
+
+end
 @testset "1D XPoint Euclidean distance" begin
     for FT in (Float32, Float64, BigFloat)
         pt_1 = Geometry.XPoint(one(FT))

--- a/test/Spaces/sphere.jl
+++ b/test/Spaces/sphere.jl
@@ -1,7 +1,7 @@
 using LinearAlgebra, IntervalSets
 using ClimaComms
 import ClimaCore:
-    Domains, Topologies, Meshes, Spaces, Geometry, column, Quadratures
+    Domains, Topologies, Meshes, Grids, Spaces, Geometry, column, Quadratures
 
 using Test
 
@@ -87,7 +87,7 @@ end
 @testset "Volume of a spherical shell" begin
     FT = Float64
     context = ClimaComms.SingletonCommsContext()
-    radius = FT(128)
+    radius = FT(10)
     zlim = (0, 1)
     helem = 4
     zelem = 10
@@ -99,21 +99,31 @@ end
         boundary_tags = (:bottom, :top),
     )
     vertmesh = Meshes.IntervalMesh(vertdomain, nelems = zelem)
-    vert_center_space = Spaces.CenterFiniteDifferenceSpace(vertmesh)
+    vertgrid = Grids.FiniteDifferenceGrid(vertmesh)
 
     horzdomain = Domains.SphereDomain(radius)
     horzmesh = Meshes.EquiangularCubedSphere(horzdomain, helem)
     horztopology = Topologies.Topology2D(context, horzmesh)
     quad = Quadratures.GLL{Nq}()
-    horzspace = Spaces.SpectralElementSpace2D(horztopology, quad)
-
+    horzgrid = Grids.SpectralElementGrid2D(horztopology, quad)
+    horzspace = Spaces.SpectralElementSpace2D(horzgrid)
     @test Spaces.node_horizontal_length_scale(horzspace) ≈
           sqrt((4 * pi * radius^2) / (helem^2 * 6 * (Nq - 1)^2))
 
-    hv_center_space =
-        Spaces.ExtrudedFiniteDifferenceSpace(horzspace, vert_center_space)
-
     # "shallow atmosphere" spherical shell: volume = surface area * height
-    @test sum(ones(hv_center_space)) ≈ 4pi * radius^2 * (zlim[2] - zlim[1]) rtol =
-        1e-3
+    shallow_grid = Grids.ExtrudedFiniteDifferenceGrid(horzgrid, vertgrid)
+
+    @test sum(ones(Spaces.CenterExtrudedFiniteDifferenceSpace(shallow_grid))) ≈
+          4pi * radius^2 * (zlim[2] - zlim[1]) rtol = 1e-3
+    @test sum(ones(Spaces.FaceExtrudedFiniteDifferenceSpace(shallow_grid))) ≈
+          4pi * radius^2 * (zlim[2] - zlim[1]) rtol = 1e-3
+
+    deep_grid =
+        Grids.ExtrudedFiniteDifferenceGrid(horzgrid, vertgrid; deep = true)
+
+    @test sum(ones(Spaces.CenterExtrudedFiniteDifferenceSpace(deep_grid))) ≈
+          4pi / 3 * ((zlim[2] + radius)^3 - (zlim[1] + radius)^3) rtol = 1e-3
+    @test sum(ones(Spaces.FaceExtrudedFiniteDifferenceSpace(deep_grid))) ≈
+          4pi / 3 * ((zlim[2] + radius)^3 - (zlim[1] + radius)^3) rtol = 1e-3
+
 end

--- a/test/Spaces/terrain_warp.jl
+++ b/test/Spaces/terrain_warp.jl
@@ -496,16 +496,10 @@ end
             z_surface = warp_sin_2d.(Fields.coordinate_field(hspace))
             # Generate space with known mesh-warp parameters ηₕ = 1; s = 0.1
             # Scale height is poorly specified, so code should throw warning.
-            @test_logs (
-                :warn,
-                "Decay scale (s*z_top = 0.1) must be higher than max surface elevation (max(z_surface) = 0.5). Returning s = FT(0.8). Scale height is therefore s=0.8 m.",
-            )
-            (
-                fspace = Spaces.ExtrudedFiniteDifferenceSpace(
-                    hspace,
-                    vert_face_space,
-                    Hypsography.SLEVEAdaption(z_surface, FT(1), FT(0.1)),
-                )
+            @test_throws ErrorException Spaces.ExtrudedFiniteDifferenceSpace(
+                hspace,
+                vert_face_space,
+                Hypsography.SLEVEAdaption(z_surface, FT(1), FT(0.1)),
             )
         end
     end

--- a/test/Spaces/terrain_warp.jl
+++ b/test/Spaces/terrain_warp.jl
@@ -111,11 +111,8 @@ function get_adaptation(adaption, z_surface::Fields.Field)
     if adaption <: Hypsography.LinearAdaption
         return adaption(z_surface)
     elseif adaption <: Hypsography.SLEVEAdaption
-        return adaption(
-            z_surface,
-            eltype(z_surface)(0.75),
-            eltype(z_surface)(0.60),
-        )
+        FT = eltype(eltype(z_surface))
+        return adaption(z_surface, FT(0.75), FT(0.60))
     end
 end
 

--- a/test/Spaces/terrain_warp.jl
+++ b/test/Spaces/terrain_warp.jl
@@ -90,7 +90,7 @@ function generate_smoothed_orography(
     test_smoothing::Bool = false,
 )
     # Extrusion
-    z_surface = warp_fn.(Fields.coordinate_field(hspace))
+    z_surface = Geometry.ZPoint.(warp_fn.(Fields.coordinate_field(hspace)))
     # An Euler step defines the diffusion coefficient 
     # (See e.g. cfl condition for diffusive terms).
     x_array = parent(Fields.coordinate_field(hspace).x)


### PR DESCRIPTION
Adds option to configure an extruded sphere with the metric terms for a deep atmosphere.

Part of https://github.com/CliMA/ClimaAtmos.jl/issues/2497

I think this should also fix #1524.

Todo
- [x] add tests: any ideas?
- [x] add topography support

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
