### PR TITLE
Add support for SetDivergence to DivergenceF2C

### DIFF
--- a/src/MatrixFields/operator_matrices.jl
+++ b/src/MatrixFields/operator_matrices.jl
@@ -855,6 +855,16 @@ Base.@propagate_inbounds function op_matrix_last_row(
     J⁻ = Geometry.LocalGeometry(space, idx - half, hidx).J
     return BidiagonalMatrixRow(-C3(J⁻)', C3(FT(0))') * invJ
 end
+op_matrix_first_row(
+    ::Operators.DivergenceF2C,
+    ::Operators.SetDivergence,
+    ::Type{FT},
+) where {FT} = UpperDiagonalMatrixRow(C3(FT(0))')
+op_matrix_last_row(
+    ::Operators.DivergenceF2C,
+    ::Operators.SetDivergence,
+    ::Type{FT},
+) where {FT} = LowerDiagonalMatrixRow(C3(FT(0))')
 Base.@propagate_inbounds function op_matrix_first_row(
     ::Operators.DivergenceF2C,
     ::Operators.Extrapolate,

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -2560,6 +2560,32 @@ Base.@propagate_inbounds function stencil_right_boundary(
     (Ju³₊ ⊟ Ju³₋) ⊠ local_geometry.invJ
 end
 
+boundary_width(::DivergenceF2C, ::SetDivergence) = 1
+Base.@propagate_inbounds function stencil_left_boundary(
+    ::DivergenceF2C,
+    bc::SetDivergence,
+    loc,
+    space,
+    idx,
+    hidx,
+    arg,
+)
+    @assert idx == left_center_boundary_idx(space)
+    getidx(space, bc.val, loc, nothing, hidx)
+end
+Base.@propagate_inbounds function stencil_right_boundary(
+    ::DivergenceF2C,
+    bc::SetDivergence,
+    loc,
+    space,
+    idx,
+    hidx,
+    arg,
+)
+    @assert idx == right_center_boundary_idx(space)
+    getidx(space, bc.val, loc, nothing, hidx)
+end
+
 boundary_width(::DivergenceF2C, ::Extrapolate) = 1
 Base.@propagate_inbounds function stencil_left_boundary(
     op::DivergenceF2C,
@@ -2592,6 +2618,10 @@ end
 
 function Adapt.adapt_structure(to, bc::SetValue)
     SetValue(Adapt.adapt_structure(to, bc.val))
+end
+
+function Adapt.adapt_structure(to, bc::SetDivergence)
+    SetDivergence(Adapt.adapt_structure(to, bc.val))
 end
 
 

--- a/test/MatrixFields/operator_matrices.jl
+++ b/test/MatrixFields/operator_matrices.jl
@@ -176,6 +176,7 @@ end
     test_op_matrix(DivergenceC2F, SetDivergence, (ᶜuvw,))
     test_op_matrix(DivergenceF2C, Nothing, (ᶠuvw,))
     test_op_matrix(DivergenceF2C, SetValue, (ᶠuvw,))
+    test_op_matrix(DivergenceF2C, SetDivergence, (ᶠuvw,))
     test_op_matrix(DivergenceF2C, Extrapolate, (ᶠuvw,))
     test_op_matrix(CurlC2F, Nothing, (ᶜc12,), true)
     test_op_matrix(CurlC2F, SetValue, (ᶜc12,))


### PR DESCRIPTION
This PR fixes a bug in ClimaAtmos related to the advection of precipitation.

Advection is implemented using the `DivergenceF2C` operator, and, at the bottom cell center, we need to enforce a zero-divergence boundary condition for precipitation. We initially implemented this using `SetDivergence`, but this is not supported for `DivergenceF2C` and was ignored due to the following fallback method in `finitedifference.jl`:
```
boundary_width(::DivergenceF2C, ::AbstractBoundaryCondition) = 0
```

This PR adds support for `SetDivergence` to `DivergenceF2C`, as well as its operator matrix. It also includes a new unit test for these additions.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
