### PR TITLE
Dispatch over hypsography

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -285,6 +285,7 @@ Fields.Δz_field
 Hypsography.LinearAdaption
 Hypsography.SLEVEAdaption
 Hypsography.diffuse_surface_elevation!
+Hypsography.ref_z_to_physical_z
 ```
 
 ## Limiters


### PR DESCRIPTION
This commits extracts the calculation of physical `z` out of the function that computes the metric terms and dispatches over the type of adaption.

This function is then used in Atmos to compute the physical z is the NetCDF output.