### PR TITLE
Fix allocations for operator matrices with mixed boundary conditions

### DIFF
--- a/src/MatrixFields/operator_matrices.jl
+++ b/src/MatrixFields/operator_matrices.jl
@@ -73,7 +73,7 @@ has_affine_bc(op) = any(
     op.bcs,
 )
 
-uses_extrapolate(op) = any(bc -> bc isa Operators.Extrapolate, op.bcs)
+uses_extrapolate(op) = unrolled_any(bc -> bc isa Operators.Extrapolate, op.bcs)
 
 ################################################################################
 
@@ -859,12 +859,12 @@ op_matrix_first_row(
     ::Operators.DivergenceF2C,
     ::Operators.SetDivergence,
     ::Type{FT},
-) where {FT} = UpperDiagonalMatrixRow(C3(FT(0))')
+) where {FT} = BidiagonalMatrixRow(C3(FT(0))', C3(FT(0))')
 op_matrix_last_row(
     ::Operators.DivergenceF2C,
     ::Operators.SetDivergence,
     ::Type{FT},
-) where {FT} = LowerDiagonalMatrixRow(C3(FT(0))')
+) where {FT} = BidiagonalMatrixRow(C3(FT(0))', C3(FT(0))')
 Base.@propagate_inbounds function op_matrix_first_row(
     ::Operators.DivergenceF2C,
     ::Operators.Extrapolate,


### PR DESCRIPTION
This PR fixes the performance issues currently seen in CliMA/ClimaAtmos.jl#2538.

Specifically, this PR replaces `any` with `unrolled_any` in a function that determines the `eltype`s of matrix fields, which improves type stability for operators with mixed boundary conditions (e.g., `SetDivergence` at the bottom and `SetValue` at the top).

It also changes how matrix entries are specified for `DivergenceF2C` with a `SetDivergence` boundary condition, making the relevant methods consistent with the other method definitions for `DivergenceF2C`.