### PR TITLE
Add tofloat(Point)

### DIFF
--- a/src/Geometry/coordinates.jl
+++ b/src/Geometry/coordinates.jl
@@ -66,10 +66,16 @@ Define a subtype `name` of `AbstractPoint` with appropriate conversion functions
 macro pointtype(name, fields...)
     if length(fields) == 1
         supertype = :(Abstract1DPoint{FT})
+        coord = fields[1]
+        tofloat_expr = quote
+            tofloat(p::$name) = p.$coord
+        end
     elseif length(fields) == 2
         supertype = :(Abstract2DPoint{FT})
+        tofloat_expr = :()
     elseif length(fields) == 3
         supertype = :(Abstract3DPoint{FT})
+        tofloat_expr = :()
     end
     esc(
         quote
@@ -90,6 +96,7 @@ macro pointtype(name, fields...)
                 ::Type{$name{FT1}},
                 ::Type{$name{FT2}},
             ) where {FT1, FT2} = $name{promote_type(FT1, FT2)}
+            $tofloat_expr
         end,
     )
 end

--- a/test/Geometry/geometry.jl
+++ b/test/Geometry/geometry.jl
@@ -26,6 +26,7 @@ using LinearAlgebra, StaticArrays
             @test pt < pt * FT(2)
             @test pt <= pt
             @test pt <= pt * FT(2)
+            @test Geometry.tofloat(pt) == one(FT)
         end
     end
 


### PR DESCRIPTION
It is easy to go from a number to a Geometry.Point, but it is not easy to go in the other direction (unless the type of point of point is known). This PR adds new methods to Float32, Float64, and BigFloat to X/Y/Z/Lat/Long point to convert them into numbers.

This feature would be very useful in converting a Field of ZPoints into a scalar field, which is what we need for the interpolation routines
