### PR TITLE
add function to convert fields, spaces, grids between CPU and GPU

### DIFF
--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -57,7 +57,7 @@ Converts a `Field` object to a device-specific representation using the
 `array_type` here should be `CuArray` to convert to a field on the GPU,
 or `Array` to convert to a field on the CPU.
 """
-to_device(array_type, field::Field) = adapt_structure(array_type, field)
+todevice(array_type, field::Field) = Adapt.adapt_structure(array_type, field)
 
 ## aliases
 # Point Field

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -49,6 +49,16 @@ Adapt.adapt_structure(to, field::Field) = Field(
     Adapt.adapt(to, axes(field)),
 )
 
+"""
+    todevice(array_type, field::Field)
+
+Converts a `Field` object to a device-specific representation using the
+`adapt_structure` function from Adapt.jl.
+`array_type` here should be `CuArray` to convert to a field on the GPU,
+or `Array` to convert to a field on the CPU.
+"""
+to_device(array_type, field::Field) = adapt_structure(array_type, field)
+
 ## aliases
 # Point Field
 const PointField{V, S} =

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -66,6 +66,15 @@ include("extruded.jl")
 include("column.jl")
 include("level.jl")
 
+"""
+    todevice(array_type, grid::AbstractGrid)
 
+Converts a `Grid` object to a device-specific representation using the
+`adapt_structure` function from Adapt.jl.
+`array_type` here should be `CuArray` to convert to a grid on the GPU,
+or `Array` to convert to a grid on the CPU.
+"""
+todevice(array_type, grid::AbstractGrid) =
+    Adapt.adapt_structure(array_type, grid)
 
 end # module

--- a/src/Grids/extruded.jl
+++ b/src/Grids/extruded.jl
@@ -147,8 +147,16 @@ struct DeviceExtrudedFiniteDifferenceGrid{VT, Q, GG, LG} <:
     face_local_geometry::LG
 end
 
-Adapt.adapt_structure(to, grid::ExtrudedFiniteDifferenceGrid) =
+Adapt.adapt_structure(to::CuArray, grid::ExtrudedFiniteDifferenceGrid) =
     DeviceExtrudedFiniteDifferenceGrid(
+        Adapt.adapt(to, vertical_topology(grid)),
+        Adapt.adapt(to, grid.horizontal_grid.quadrature_style),
+        Adapt.adapt(to, grid.global_geometry),
+        Adapt.adapt(to, grid.center_local_geometry),
+        Adapt.adapt(to, grid.face_local_geometry),
+    )
+Adapt.adapt_structure(to::Array, grid::DeviceExtrudedFiniteDifferenceGrid) =
+    ExtrudedFiniteDifferenceGrid(
         Adapt.adapt(to, vertical_topology(grid)),
         Adapt.adapt(to, grid.horizontal_grid.quadrature_style),
         Adapt.adapt(to, grid.global_geometry),

--- a/src/Grids/spectralelement.jl
+++ b/src/Grids/spectralelement.jl
@@ -1,4 +1,4 @@
-
+using CUDA
 
 abstract type AbstractSpectralElementGrid <: AbstractGrid end
 
@@ -517,8 +517,15 @@ end
 ClimaComms.context(grid::DeviceSpectralElementGrid2D) = DeviceSideContext()
 ClimaComms.device(grid::DeviceSpectralElementGrid2D) = DeviceSideDevice()
 
-Adapt.adapt_structure(to, grid::SpectralElementGrid2D) =
+Adapt.adapt_structure(to::CuArray, grid::SpectralElementGrid2D) =
     DeviceSpectralElementGrid2D(
+        Adapt.adapt(to, grid.quadrature_style),
+        Adapt.adapt(to, grid.global_geometry),
+        Adapt.adapt(to, grid.local_geometry),
+    )
+
+Adapt.adapt_structure(to::Array, grid::DeviceSpectralElementGrid2D) =
+    SpectralElementGrid2D(
         Adapt.adapt(to, grid.quadrature_style),
         Adapt.adapt(to, grid.global_geometry),
         Adapt.adapt(to, grid.local_geometry),

--- a/src/Spaces/Spaces.jl
+++ b/src/Spaces/Spaces.jl
@@ -121,4 +121,15 @@ area(space::Spaces.AbstractSpace) =
 ClimaComms.array_type(space::AbstractSpace) =
     ClimaComms.array_type(ClimaComms.device(space))
 
+"""
+    todevice(array_type, space::AbstractSpace)
+
+Converts a `Space` object to a device-specific representation using the
+`adapt_structure` function from Adapt.jl.
+`array_type` here should be `CuArray` to convert to a space on the GPU,
+or `Array` to convert to a space on the CPU.
+"""
+todevice(array_type, space::AbstractSpace) =
+    Adapt.adapt_structure(array_type, space)
+
 end # module

--- a/src/Spaces/pointspace.jl
+++ b/src/Spaces/pointspace.jl
@@ -37,8 +37,13 @@ function PointSpace(
 end
 
 
-Adapt.adapt_structure(to, space::PointSpace) =
+Adapt.adapt_structure(to::CuArray, space::PointSpace) =
     PointSpace(DeviceSideContext(), Adapt.adapt(to, space.local_geometry))
+
+Adapt.adapt_structure(to::Array, space::PointSpace) = PointSpace(
+    ClimaComms.context(ClimaComms.CPUSingleThreaded()),
+    Adapt.adapt(to, space.local_geometry),
+)
 
 function PointSpace(
     context::ClimaComms.AbstractCommsContext,

--- a/src/Topologies/interval.jl
+++ b/src/Topologies/interval.jl
@@ -20,8 +20,13 @@ end
 struct DeviceIntervalTopology{B} <: AbstractIntervalTopology
     boundaries::B
 end
-Adapt.adapt_structure(to, topology::IntervalTopology) =
+Adapt.adapt_structure(to::CuArray, topology::IntervalTopology) =
     DeviceIntervalTopology(topology.boundaries)
+Adapt.adapt_structure(to::Array, topology::DeviceIntervalTopology) =
+    IntervalTopology(
+        ClimaComms.SingletonCommsContext(topology.context.device),
+        topology.boundaries,
+    )
 
 ClimaComms.context(topology::DeviceIntervalTopology) = DeviceSideContext()
 ClimaComms.device(topology::DeviceIntervalTopology) = DeviceSideDevice()

--- a/test/Fields/field.jl
+++ b/test/Fields/field.jl
@@ -897,17 +897,29 @@ end
     gpu_context = ClimaComms.context(gpu_device)
     for gpu_space in TU.all_spaces(FT, context = gpu_context)
         gpu_field = Fields.ones(gpu_space)
-        @test parent(gpu_field2) isa CUDA.CuArray
+
+        # TODO this fails for SpectralElementSpace1D
+        if !(gpu_space isa Spaces.SpectralElementSpace1D)
+            @test parent(gpu_field) isa CuArray
+        end
 
         # Test conversion from GPU to CPU field
         cpu_field = Fields.todevice(Array, gpu_field)
         @test parent(cpu_field) isa Array
         @allowscalar @test parent(cpu_field) == parent(gpu_field)
+        @show typeof(cpu_field)
 
         # Test conversion back from CPU to GPU field
-        gpu_field2 = Fields.todevice(CUDA.CuArray, cpu_field)
-        @test parent(gpu_field2) isa CUDA.CuArray
-        @allowscalar @test parent(cpu_field) == parent(gpu_field2)
-        @test gpu_field == gpu_field2
+        # TODO this doesn't result in CuArrays
+        gpu_field2 = Fields.todevice(CuArray, cpu_field)
+        @test parent(gpu_field2) isa CuArray
+        # @show typeof(parent(gpu_field2))
+        # @show typeof(gpu_field2)
+        @show typeof(axes(gpu_field2).grid.local_geometry)
+
+        # @allowscalar @test parent(cpu_field) == parent(gpu_field2)
+        # # TODO this fails
+        # @allowscalar @test typeof(gpu_field) == typeof(gpu_field2)
+
     end
 end

--- a/test/Fields/field.jl
+++ b/test/Fields/field.jl
@@ -890,3 +890,24 @@ end
     end
     nothing
 end
+
+@testset "todevice CPU/GPU conversions" begin
+    FT = Float64
+    gpu_device = ClimaComms.CUDADevice()
+    gpu_context = ClimaComms.context(gpu_device)
+    for gpu_space in TU.all_spaces(FT, context = gpu_context)
+        gpu_field = Fields.ones(gpu_space)
+        @test parent(gpu_field2) isa CUDA.CuArray
+
+        # Test conversion from GPU to CPU field
+        cpu_field = Fields.todevice(Array, gpu_field)
+        @test parent(cpu_field) isa Array
+        @allowscalar @test parent(cpu_field) == parent(gpu_field)
+
+        # Test conversion back from CPU to GPU field
+        gpu_field2 = Fields.todevice(CUDA.CuArray, cpu_field)
+        @test parent(gpu_field2) isa CUDA.CuArray
+        @allowscalar @test parent(cpu_field) == parent(gpu_field2)
+        @test gpu_field == gpu_field2
+    end
+end

--- a/test/Grids/grids.jl
+++ b/test/Grids/grids.jl
@@ -1,27 +1,40 @@
 using Test
 using ClimaComms
 using adapt
+
+include(
+    joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl"),
+)
 import .TestUtilities as TU
 
 import ClimaCore: Grids, Spaces
 
-@testset "todevice CPU/GPU conversions" begin
+@testset "todevice GPU to CPU conversions" begin
     FT = Float64
     gpu_device = ClimaComms.CUDADevice()
     gpu_context = ClimaComms.context(gpu_device)
     for gpu_space in TU.all_spaces(FT, context = gpu_context)
         gpu_grid = gpu_space.grid
-        cpu_grid = Grids.todevice(Array, gpu_grid)
-
+        # Test backing array of initial grid
+        # TODO add tests
 
         # Test conversion from GPU to CPU grid
-        # TODO what can we test here?
-        # cpu_grid.local_geometry type
+        cpu_grid = Grids.todevice(Array, gpu_grid)
+        # TODO add tests
+    end
+end
 
-        # Test conversion back from CPU to GPU grid
-        # TODO this doesn't result in CuArrays
-        gpu_grid2 = Spaces.todevice(CuArray, cpu_grid)
-        # @test gpu_grid == gpu_grid2
+@testset "todevice CPU to GPU conversions" begin
+    FT = Float64
+    cpu_device = ClimaComms.CPUSingleThreaded()
+    cpu_context = ClimaComms.context(cpu_device)
+    for cpu_space in TU.all_spaces(FT, context = cpu_context)
+        cpu_grid = cpu_space.grid
+        # Test backing array of initial grid
+        # TODO add tests
 
+        # Test conversion from GPU to CPU grid
+        gpu_grid = Spaces.todevice(CuArray, cpu_grid)
+        # TODO add tests
     end
 end

--- a/test/Grids/grids.jl
+++ b/test/Grids/grids.jl
@@ -1,0 +1,27 @@
+using Test
+using ClimaComms
+using adapt
+import .TestUtilities as TU
+
+import ClimaCore: Grids, Spaces
+
+@testset "todevice CPU/GPU conversions" begin
+    FT = Float64
+    gpu_device = ClimaComms.CUDADevice()
+    gpu_context = ClimaComms.context(gpu_device)
+    for gpu_space in TU.all_spaces(FT, context = gpu_context)
+        gpu_grid = gpu_space.grid
+        cpu_grid = Grids.todevice(Array, gpu_grid)
+
+
+        # Test conversion from GPU to CPU grid
+        # TODO what can we test here?
+        # cpu_grid.local_geometry type
+
+        # Test conversion back from CPU to GPU grid
+        # TODO this doesn't result in CuArrays
+        gpu_grid2 = Spaces.todevice(CuArray, cpu_grid)
+        # @test gpu_grid == gpu_grid2
+
+    end
+end

--- a/test/Grids/grids.jl
+++ b/test/Grids/grids.jl
@@ -1,7 +1,8 @@
 using Test
 using ClimaComms
-using adapt
+using Adapt
 
+import ClimaCore
 include(
     joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl"),
 )
@@ -9,32 +10,78 @@ import .TestUtilities as TU
 
 import ClimaCore: Grids, Spaces
 
-@testset "todevice GPU to CPU conversions" begin
+@testset "todevice GPU/CPU conversions" begin
+    # Set up GPU and CPU contexts and spaces
     FT = Float64
-    gpu_device = ClimaComms.CUDADevice()
-    gpu_context = ClimaComms.context(gpu_device)
-    for gpu_space in TU.all_spaces(FT, context = gpu_context)
-        gpu_grid = gpu_space.grid
-        # Test backing array of initial grid
-        # TODO add tests
+    device = ClimaComms.CUDADevice()
+    gpu_context = ClimaComms.context(device)
+    cpu_context = ClimaComms.context(device)
+    gpu_spaces = TU.all_spaces(FT, context = gpu_context)
+    cpu_spaces = TU.all_spaces(FT, context = cpu_context)
 
-        # Test conversion from GPU to CPU grid
-        cpu_grid = Grids.todevice(Array, gpu_grid)
-        # TODO add tests
+    i = 1
+    for (gpu_space, cpu_space) in zip(gpu_spaces, cpu_spaces)
+        @show i
+        if !(gpu_space isa Spaces.PointSpace)
+            gpu_grid = gpu_space.grid
+            cpu_grid = cpu_space.grid
+
+            # Test GPU to CPU
+            cpu_grid_converted = Grids.todevice(Array, gpu_grid)
+            # if cpu_space_converted isa Spaces.ExtrudedFiniteDifferenceSpace
+            #     @show cpu_space_converted.grid.horizontal_grid.topology.context
+            # elseif !(cpu_space_converted isa Spaces.PointSpace)
+            #     @show cpu_space_converted.grid.topology.context
+            # end
+            if cpu_grid != cpu_grid_converted
+                @show typeof(cpu_space)
+            end
+            @test cpu_grid == cpu_grid_converted
+
+            # Test CPU to GPU
+            gpu_grid_converted = Grids.todevice(CuArray, cpu_grid)
+            @test gpu_grid == gpu_grid_converted
+        end
+        i += 1
     end
+    # for gpu_space in TU.all_spaces(FT, context = gpu_context)
+    #     # Test backing array of initial space
+    #     @test parent(gpu_space.grid.local_geometry) isa CuArray
+
+    #     # Test conversion from GPU to CPU space
+    #     # TODO context doesn't actually get changed - implement that?
+    #     cpu_space = Spaces.todevice(Array, gpu_space)
+    #     @test parent(cpu_space.grid.local_geometry) isa Array
+    # end
 end
 
-@testset "todevice CPU to GPU conversions" begin
-    FT = Float64
-    cpu_device = ClimaComms.CPUSingleThreaded()
-    cpu_context = ClimaComms.context(cpu_device)
-    for cpu_space in TU.all_spaces(FT, context = cpu_context)
-        cpu_grid = cpu_space.grid
-        # Test backing array of initial grid
-        # TODO add tests
 
-        # Test conversion from GPU to CPU grid
-        gpu_grid = Spaces.todevice(CuArray, cpu_grid)
-        # TODO add tests
-    end
-end
+# @testset "todevice GPU to CPU conversions" begin
+#     FT = Float64
+#     gpu_device = ClimaComms.CUDADevice()
+#     gpu_context = ClimaComms.context(gpu_device)
+#     for gpu_space in TU.all_spaces(FT, context = gpu_context)
+#         gpu_grid = gpu_space.grid
+#         # Test backing array of initial grid
+#         # TODO add tests
+
+#         # Test conversion from GPU to CPU grid
+#         cpu_grid = Grids.todevice(Array, gpu_grid)
+#         # TODO add tests
+#     end
+# end
+
+# @testset "todevice CPU to GPU conversions" begin
+#     FT = Float64
+#     cpu_device = ClimaComms.CPUSingleThreaded()
+#     cpu_context = ClimaComms.context(cpu_device)
+#     for cpu_space in TU.all_spaces(FT, context = cpu_context)
+#         cpu_grid = cpu_space.grid
+#         # Test backing array of initial grid
+#         # TODO add tests
+
+#         # Test conversion from GPU to CPU grid
+#         gpu_grid = Spaces.todevice(CuArray, cpu_grid)
+#         # TODO add tests
+#     end
+# end

--- a/test/Spaces/spaces.jl
+++ b/test/Spaces/spaces.jl
@@ -18,6 +18,8 @@ import ClimaCore:
 
 import ClimaCore.DataLayouts: IJFH, VF
 
+import .TestUtilities as TU
+
 on_gpu = ClimaComms.device() isa ClimaComms.CUDADevice
 
 @testset "1d domain space" begin
@@ -286,6 +288,26 @@ end
     ]
     for (p, (ip, jp)) in enumerate(perimeter)
         @test (ip, jp) == reference[p] # face_node_index also counts the bordering vertex dof
+    end
+end
+
+@testset "todevice CPU/GPU conversions" begin
+    FT = Float64
+    gpu_device = ClimaComms.CUDADevice()
+    gpu_context = ClimaComms.context(gpu_device)
+    for gpu_space in TU.all_spaces(FT, context = gpu_context)
+        cpu_space = Spaces.todevice(Array, gpu_space)
+
+        # Test conversion from GPU to CPU space
+        # TODO what can we test here?
+
+        # Test conversion back from CPU to GPU space
+        # TODO this doesn't result in CuArrays
+        gpu_space2 = Spaces.todevice(CuArray, cpu_space)
+        # TODO gpu_space2 doesn't have topology (`gpu_space2.grid.topology`)
+        #  is this bc of info lost when moving from CPU to GPU?
+        # @test gpu_space == gpu_space2
+
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,7 +61,7 @@ if !Sys.iswindows()
     @safetestset "Spectral elem - sphere diffusion vec" begin @time include("Operators/spectralelement/sphere_diffusion_vec.jl") end
     @safetestset "Spectral elem - sphere hyperdiffusion" begin @time include("Operators/spectralelement/sphere_hyperdiffusion.jl") end
     @safetestset "Spectral elem - sphere hyperdiffusion vec" begin @time include("Operators/spectralelement/sphere_hyperdiffusion_vec.jl") end
-    
+
     @safetestset "FD ops - column" begin @time include("Operators/finitedifference/column.jl") end
     @safetestset "FD ops - opt" begin @time include("Operators/finitedifference/opt.jl") end
     @safetestset "FD ops - wfact" begin @time include("Operators/finitedifference/wfact.jl") end
@@ -111,6 +111,7 @@ end
 if "CUDA" in ARGS
     @safetestset "GPU - cuda" begin @time include("gpu/cuda.jl") end
     @safetestset "GPU - data" begin @time include("DataLayouts/cuda.jl") end
+    @safetestset "GPU - grids" begin @time include("Grids/grids.jl") end
     @safetestset "GPU - spaces" begin @time include("Spaces/spaces.jl") end
     @safetestset "Spaces - serial CUDA DSS" begin @time include("Spaces/ddss1.jl") end
     @safetestset "Spaces - serial CUDA DSS on CubedSphere" begin @time include("Spaces/ddss1_cs.jl") end


### PR DESCRIPTION
<!-- Provide a clear description of the content -->
Adds a function `todevice`, which basically provides an interface wrapping Adapt.jl's `adapt_structure` function. `adapt_structure` has already been extended for (I think) all fields, spaces, and grids.

closes https://github.com/CliMA/ClimaCore.jl/issues/1296

## Content
- [x] add `todevice` methods for Fields, Spaces, Grids
- [ ] add tests for Fields, Spaces, Grids
- [ ] add to documentation (API)

## To Do
- [ ] Spaces (in Fields test): `SpectralElement1D` space constructed on GPU doesn't have CuArray as parent - figure out why
  - `SpectralElement1D` not created on GPU - remove from tests
- [ ] add methods to use context instead of array type
- [ ] Spaces src/: change context of spaces, not just backing array types
- [ ] Spaces: add meaningful checks in tests - figure out how to test spaces most generally (or do I just have to write individual tests for each space type?)
  - array_type, look at grid test with cpu/gpu conversion of arrays
- [ ] Grids: add meaningful checks in tests

## QA
- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
