### PR TITLE
Import Logging in field_matrix_solvers

### DIFF
--- a/test/MatrixFields/field_matrix_solvers.jl
+++ b/test/MatrixFields/field_matrix_solvers.jl
@@ -1,3 +1,4 @@
+import Logging
 import Logging: Debug
 import LinearAlgebra: I, norm
 import ClimaCore.Utilities: half


### PR DESCRIPTION
I just saw that `Logging` seems to be undefined in the `field_matrix_solvers` test: https://buildkite.com/clima/climacore-ci/builds/3165.