### PR TITLE
Do not test field mat solvers logs on gpu

### DIFF
--- a/test/MatrixFields/field_matrix_solvers.jl
+++ b/test/MatrixFields/field_matrix_solvers.jl
@@ -298,7 +298,10 @@ end
     end
 
     @testset "approximate iterative solve with debugging" begin
-        Logging.with_logger(Logging.SimpleLogger(stderr, Logging.Debug)) do
+        logger =
+            using_cuda ? Logging.NullLogger() :
+            Logging.SimpleLogger(stderr, Logging.Debug)
+        Logging.with_logger(logger) do
             # Recreate the setup from the previous unit test.
             alg = MatrixFields.ApproximateBlockArrowheadIterativeSolve(
                 @name(c);


### PR DESCRIPTION
This PR fixes CI, I must have only tested this on the CPU locally (I don't think this was previously working, but the debug config changed how it was being run in the test suite).