### PR TITLE
Add another convenience constructor for Remapper

### DIFF
--- a/src/Remapping/distributed_remapping.jl
+++ b/src/Remapping/distributed_remapping.jl
@@ -188,6 +188,7 @@ end
 
 """
    Remapper(space, target_hcoords, target_zcoords)
+   Remapper(space, target_hcoords)
 
 Return a `Remapper` responsible for interpolating any `Field` defined on the given `space`
 to the Cartesian product of `target_hcoords` with `target_zcoords`.
@@ -332,6 +333,10 @@ function Remapper(
         :Remapper,
     )
     return Remapper(space, target_hcoords, target_zcoords)
+end
+
+function Remapper(space::Spaces.AbstractSpace, target_hcoords::AbstractArray)
+    return Remapper(space, target_hcoords, nothing)
 end
 
 """

--- a/test/Remapping/distributed_remapping.jl
+++ b/test/Remapping/distributed_remapping.jl
@@ -227,7 +227,7 @@ end
 
     # Horizontal space
     horiz_space = Spaces.horizontal_space(hv_center_space)
-    horiz_remapper = Remapping.Remapper(horiz_space, hcoords, nothing)
+    horiz_remapper = Remapping.Remapper(horiz_space, hcoords)
 
     coords = Fields.coordinate_field(horiz_space)
 


### PR DESCRIPTION
The `Remapper` can be used for purely hoziontal fields (as to interpolate the topography, or the surface in ClimaLand). This PR adds another convenience constructor for that case.