### PR TITLE
Force allocation for interpolate on CPU

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 ClimaCore.jl Release Notes
 ========================
 
+v0.13.2
+-------
+
+- ![][badge-🐛bugfix] fixed array allocation for interpolation on CPU.
+  PR [#1643](https://github.com/CliMA/ClimaCore.jl/pull/1643).
+
 v0.13.1
 -------
 

--- a/src/Remapping/distributed_remapping.jl
+++ b/src/Remapping/distributed_remapping.jl
@@ -679,23 +679,6 @@ interpolated data.
 `_collect_and_return_interpolated_values!` is type-unstable and allocates new return arrays.
 """
 function _collect_and_return_interpolated_values!(remapper::Remapper)
-    return _collect_and_return_interpolated_values!(
-        remapper::Remapper,
-        ClimaComms.device(remapper.comms_ctx),
-    )
-end
-
-function _collect_and_return_interpolated_values!(
-    remapper::Remapper,
-    ::ClimaComms.AbstractCPUDevice,
-)
-    ClimaComms.reduce(remapper.comms_ctx, remapper._interpolated_values, +)
-end
-
-function _collect_and_return_interpolated_values!(
-    remapper::Remapper,
-    ::ClimaComms.CUDADevice,
-)
     ClimaComms.reduce!(remapper.comms_ctx, remapper._interpolated_values, +)
     return ClimaComms.iamroot(remapper.comms_ctx) ?
            Array(remapper._interpolated_values) : nothing


### PR DESCRIPTION
MPI.reduce does not always allocate a new array. As a result, the remapper in interpolate calls may retain ownership of the output array. This PR ensures that interpolate always hands off a new array.
