### PR TITLE
Test reapply some of 1011 with tests

### DIFF
--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -46,7 +46,7 @@ Base.@propagate_inbounds function Geometry.LocalGeometry(
 )
     v = idx
     if Topologies.isperiodic(Spaces.vertical_topology(space))
-        v = mod1(v, length(space))
+        v = mod1(v, Spaces.nlevels(space))
     end
     i, j, h = hidx
     local_geom =
@@ -60,7 +60,7 @@ Base.@propagate_inbounds function Geometry.LocalGeometry(
 )
     v = idx + half
     if Topologies.isperiodic(Spaces.vertical_topology(space))
-        v = mod1(v, length(space))
+        v = mod1(v, Spaces.nlevels(space))
     end
     i, j, h = hidx
     local_geom = Grids.local_geometry_data(Spaces.grid(space), Grids.CellFace())
@@ -3119,7 +3119,7 @@ function vidx(space::AllFaceFiniteDifferenceSpace, idx)
     @assert idx isa PlusHalf
     v = idx + half
     if Topologies.isperiodic(Spaces.vertical_topology(space))
-        v = mod1(v, length(space))
+        v = mod1(v, Spaces.nlevels(space))
     end
     return v
 end
@@ -3127,7 +3127,7 @@ function vidx(space::AllCenterFiniteDifferenceSpace, idx)
     @assert idx isa Integer
     v = idx
     if Topologies.isperiodic(Spaces.vertical_topology(space))
-        v = mod1(v, length(space))
+        v = mod1(v, Spaces.nlevels(space))
     end
     return v
 end
@@ -3373,7 +3373,7 @@ end
 function window_bounds(space, bc)
     if Topologies.isperiodic(Spaces.vertical_topology(space))
         li = lw = left_idx(space)
-        ri = rw = left_idx(space) + length(space) - 1
+        ri = rw = right_idx(space)
     else
         lbw = LeftBoundaryWindow{Spaces.left_boundary_name(space)}()
         rbw = RightBoundaryWindow{Spaces.right_boundary_name(space)}()


### PR DESCRIPTION
This PR applies some of #1011 with some tests to check the validity of the bug fixes. `RecursiveApply.rdiv((w⁺ ⊠ a⁺) ⊞ (w⁻ ⊠ a⁻), (w⁺ ⊞ w⁻))` has already been corrected in main, so I've skipped that change.