### PR TITLE
Test also on 1.9

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -11,13 +11,13 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            julia-version: '1.10'
+            julia-version: '1.9'
           - os: windows-latest
             julia-version: '1.10'
           - os: macos-latest
             julia-version: '1.10'
           - os: ubuntu-latest
-            julia-version: '~1.10.0-rc1'
+            julia-version: '1.10'
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
I am finding that something in ClimaCore fails for 1.9:

https://github.com/CliMA/ClimaDiagnostics.jl/actions/runs/8541780429/job/23401922394

We should at least have one runner on 1.9.

