### PR TITLE
Define and use `auto_launch!`

### DIFF
--- a/ext/ClimaCoreCUDAExt.jl
+++ b/ext/ClimaCoreCUDAExt.jl
@@ -13,6 +13,7 @@ import ClimaCore.Utilities: half
 import ClimaCore.RecursiveApply:
     ⊠, ⊞, ⊟, radd, rmul, rsub, rdiv, rmap, rzero, rmin, rmax
 
+include(joinpath("cuda", "cuda_utils.jl"))
 include(joinpath("cuda", "data_layouts.jl"))
 include(joinpath("cuda", "fields.jl"))
 include(joinpath("cuda", "topologies_dss.jl"))
@@ -23,8 +24,8 @@ include(joinpath("cuda", "remapping_interpolate_array.jl"))
 include(joinpath("cuda", "limiters.jl"))
 include(joinpath("cuda", "operators_sem_shmem.jl"))
 include(joinpath("cuda", "operators_thomas_algorithm.jl"))
+include(joinpath("cuda", "matrix_fields_single_field_solve.jl"))
 include(joinpath("cuda", "matrix_fields_multiple_field_solve.jl"))
 include(joinpath("cuda", "operators_spectral_element.jl"))
-include(joinpath("cuda", "matrix_fields_single_field_solve.jl"))
 
 end

--- a/ext/cuda/cuda_utils.jl
+++ b/ext/cuda/cuda_utils.jl
@@ -1,0 +1,94 @@
+import CUDA
+import ClimaCore.Fields
+import ClimaCore.DataLayouts
+
+get_n_items(field::Fields.Field) =
+    prod(size(parent(Fields.field_values(field))))
+get_n_items(data::DataLayouts.AbstractData) = prod(size(parent(data)))
+get_n_items(arr::AbstractArray) = prod(size(parent(arr)))
+get_n_items(tup::Tuple) = prod(tup)
+
+"""
+    auto_launch!(f!::F!, args,
+        ::Union{
+            Int,
+            NTuple{N, <:Int},
+            AbstractArray,
+            AbstractData,
+            Field,
+        };
+        threads_s,
+        blocks_s,
+        always_inline = true
+    )
+
+Launch a cuda kernel, using `CUDA.launch_configuration`
+to determine the number of threads/blocks.
+
+Suggested threads and blocks (`threads_s`, `blocks_s`) can be given
+to benchmark compare against auto-determined threads/blocks.
+"""
+function auto_launch!(
+    f!::F!,
+    args,
+    data;
+    threads_s,
+    blocks_s,
+    always_inline = true,
+) where {F!}
+    nitems = get_n_items(data)
+    # For now, we'll simply use the
+    # suggested threads and blocks:
+    CUDA.@cuda always_inline = always_inline threads = threads_s blocks =
+        blocks_s f!(args...)
+
+    # Soon, we'll experiment with `CUDA.launch_configuration`
+    # kernel = CUDA.@cuda always_inline = true launch = false f!(args...)
+    # config = CUDA.launch_configuration(kernel.fun)
+    # threads = min(nitems, config.threads)
+    # blocks = cld(nitems, threads)
+    # s = ""
+    # s *= "Launching kernel $f! with following config:\n"
+    # s *= "     nitems: $nitems\n"
+    # s *= "     threads: $threads\n"
+    # s *= "     blocks: $blocks\n"
+    # @info s
+    # kernel(args...; threads, blocks) # This knows to use always_inline from above.
+end
+
+"""
+    kernel_indexes(n)
+Return a tuple of indexes from the kernel,
+where `n` is a tuple of max lengths along each
+dimension of the accessed data.
+"""
+function kernel_indexes(n::Tuple)
+    tidx = (CUDA.blockIdx().x - 1) * CUDA.blockDim().x + CUDA.threadIdx().x
+    inds = if 1 ≤ tidx ≤ prod(n)
+        CartesianIndices(map(x -> Base.OneTo(x), n))[tidx].I
+    else
+        ntuple(x -> -1, length(n))
+    end
+    return inds
+end
+
+"""
+    valid_range(inds, n)
+Returns a `Bool` indicating if the thread index
+is in the valid range, based on `inds` (the result
+of `kernel_indexes`) and `n`, a tuple of max lengths
+along each dimension of the accessed data.
+```julia
+function kernel!(data, n)
+    inds = kernel_indexes(n)
+    if valid_range(inds, n)
+        do_work!(data[inds...])
+    end
+end
+```
+"""
+valid_range(inds::NTuple, n::Tuple) = all(i -> 1 ≤ inds[i] ≤ n[i], 1:length(n))
+function valid_range(n::Tuple)
+    inds = kernel_indexes(n)
+    return all(i -> 1 ≤ inds[i] ≤ n[i], 1:length(n))
+end

--- a/ext/cuda/data_layouts.jl
+++ b/ext/cuda/data_layouts.jl
@@ -56,9 +56,12 @@ function Base.copyto!(
 ) where {S, Nij, A <: CUDA.CuArray}
     _, _, _, _, Nh = size(bc)
     if Nh > 0
-        CUDA.@cuda always_inline = true threads = (Nij, Nij) blocks = (Nh, 1) knl_copyto!(
-            dest,
-            bc,
+        auto_launch!(
+            knl_copyto!,
+            (dest, bc),
+            dest;
+            threads_s = (Nij, Nij),
+            blocks_s = (Nh, 1),
         )
     end
     return dest
@@ -73,9 +76,12 @@ function Base.fill!(
 }
     _, _, _, _, Nh = size(dest)
     if Nh > 0
-        CUDA.@cuda always_inline = true threads = (Nij, Nij) blocks = (Nh, 1) knl_fill!(
-            dest,
-            val,
+        auto_launch!(
+            knl_fill!,
+            (dest, val),
+            dest;
+            threads_s = (Nij, Nij),
+            blocks_s = (Nh, 1),
         )
     end
     return dest
@@ -91,8 +97,13 @@ function Base.copyto!(
     if Nv > 0 && Nh > 0
         Nv_per_block = min(Nv, fld(256, Nij * Nij))
         Nv_blocks = cld(Nv, Nv_per_block)
-        CUDA.@cuda always_inline = true threads = (Nij, Nij, Nv_per_block) blocks =
-            (Nh, Nv_blocks) knl_copyto!(dest, bc)
+        auto_launch!(
+            knl_copyto!,
+            (dest, bc),
+            dest;
+            threads_s = (Nij, Nij, Nv_per_block),
+            blocks_s = (Nh, Nv_blocks),
+        )
     end
     return dest
 end
@@ -104,8 +115,13 @@ function Base.fill!(
     if Nv > 0 && Nh > 0
         Nv_per_block = min(Nv, fld(256, Nij * Nij))
         Nv_blocks = cld(Nv, Nv_per_block)
-        CUDA.@cuda always_inline = true threads = (Nij, Nij, Nv_per_block) blocks =
-            (Nh, Nv_blocks) knl_fill!(dest, val)
+        auto_launch!(
+            knl_fill!,
+            (dest, val),
+            dest;
+            threads_s = (Nij, Nij, Nv_per_block),
+            blocks_s = (Nh, Nv_blocks),
+        )
     end
     return dest
 end
@@ -117,9 +133,12 @@ function Base.copyto!(
 ) where {S, A <: CUDA.CuArray}
     _, _, _, Nv, Nh = size(bc)
     if Nv > 0 && Nh > 0
-        CUDA.@cuda always_inline = true threads = (1, 1) blocks = (Nh, Nv) knl_copyto!(
-            dest,
-            bc,
+        auto_launch!(
+            knl_copyto!,
+            (dest, bc),
+            dest;
+            threads_s = (1, 1),
+            blocks_s = (Nh, Nv),
         )
     end
     return dest
@@ -127,9 +146,12 @@ end
 function Base.fill!(dest::VF{S, A}, val) where {S, A <: CUDA.CuArray}
     _, _, _, Nv, Nh = size(dest)
     if Nv > 0 && Nh > 0
-        CUDA.@cuda always_inline = true threads = (1, 1) blocks = (Nh, Nv) knl_fill!(
-            dest,
-            val,
+        auto_launch!(
+            knl_fill!,
+            (dest, val),
+            dest;
+            threads_s = (1, 1),
+            blocks_s = (Nh, Nv),
         )
     end
     return dest
@@ -139,16 +161,22 @@ function Base.copyto!(
     dest::DataF{S},
     bc::Union{DataF{S, A}, Base.Broadcast.Broadcasted{DataFStyle{A}}},
 ) where {S, A <: CUDA.CuArray}
-    CUDA.@cuda always_inline = true threads = (1, 1) blocks = (1, 1) knl_copyto!(
-        dest,
-        bc,
+    auto_launch!(
+        knl_copyto!,
+        (dest, bc),
+        dest;
+        threads_s = (1, 1),
+        blocks_s = (1, 1),
     )
     return dest
 end
 function Base.fill!(dest::DataF{S, A}, val) where {S, A <: CUDA.CuArray}
-    CUDA.@cuda always_inline = true threads = (1, 1) blocks = (1, 1) knl_fill!(
-        dest,
-        val,
+    auto_launch!(
+        knl_fill!,
+        (dest, val),
+        dest;
+        threads_s = (1, 1),
+        blocks_s = (1, 1),
     )
     return dest
 end

--- a/ext/cuda/operators_finite_difference.jl
+++ b/ext/cuda/operators_finite_difference.jl
@@ -31,7 +31,7 @@ function Base.copyto!(
     max_threads = 256
     nitems = Nv * Nq * Nq * Nh # # of independent items
     (nthreads, nblocks) = _configure_threadblock(max_threads, nitems)
-    @cuda always_inline = true threads = (nthreads,) blocks = (nblocks,) copyto_stencil_kernel!(
+    args = (
         strip_space(out, space),
         strip_space(bc, space),
         axes(out),
@@ -39,6 +39,13 @@ function Base.copyto!(
         Nq,
         Nh,
         Nv,
+    )
+    auto_launch!(
+        copyto_stencil_kernel!,
+        args,
+        out;
+        threads_s = (nthreads,),
+        blocks_s = (nblocks,),
     )
     return out
 end

--- a/ext/cuda/operators_spectral_element.jl
+++ b/ext/cuda/operators_spectral_element.jl
@@ -44,12 +44,18 @@ function Base.copyto!(
     Nvthreads = fld(max_threads, Nq * Nq)
     Nvblocks = cld(Nv, Nvthreads)
     # executed
-    @cuda always_inline = true threads = (Nq, Nq, Nvthreads) blocks =
-        (Nh, Nvblocks) copyto_spectral_kernel!(
+    args = (
         strip_space(out, space),
         strip_space(sbc, space),
         space,
         Val(Nvthreads),
+    )
+    auto_launch!(
+        copyto_spectral_kernel!,
+        args,
+        out;
+        threads_s = (Nq, Nq, Nvthreads),
+        blocks_s = (Nh, Nvblocks),
     )
     return out
 end

--- a/ext/cuda/operators_thomas_algorithm.jl
+++ b/ext/cuda/operators_thomas_algorithm.jl
@@ -7,9 +7,13 @@ using CUDA: @cuda
 function column_thomas_solve!(::ClimaComms.CUDADevice, A, b)
     Ni, Nj, _, _, Nh = size(Fields.field_values(A))
     nthreads, nblocks = _configure_threadblock(Ni * Nj * Nh)
-    @cuda always_inline = true threads = nthreads blocks = nblocks thomas_algorithm_kernel!(
-        A,
-        b,
+    args = (A, b)
+    auto_launch!(
+        thomas_algorithm_kernel!,
+        args,
+        size(Fields.field_values(A));
+        threads_s = nthreads,
+        blocks_s = nblocks,
     )
 end
 

--- a/ext/cuda/remapping_distributed.jl
+++ b/ext/cuda/remapping_distributed.jl
@@ -19,13 +19,20 @@ function _set_interpolated_values_device!(
     field_values = tuple(map(f -> Fields.field_values(f), fields)...)
     nblocks, _ = size(interpolation_matrix[1])
     nthreads = length(vert_interpolation_weights)
-    @cuda always_inline = true threads = (nthreads) blocks = (nblocks) set_interpolated_values_kernel!(
+    args = (
         out,
         interpolation_matrix,
         local_horiz_indices,
         vert_interpolation_weights,
         vert_bounding_indices,
         field_values,
+    )
+    auto_launch!(
+        set_interpolated_values_kernel!,
+        args,
+        out;
+        threads_s = (nthreads),
+        blocks_s = (nblocks),
     )
 end
 
@@ -150,11 +157,18 @@ function _set_interpolated_values_device!(
     field_values = tuple(map(f -> Fields.field_values(f), fields)...)
     nitems = length(out)
     nthreads, nblocks = _configure_threadblock(nitems)
-    @cuda always_inline = true threads = (nthreads) blocks = (nblocks) set_interpolated_values_kernel!(
+    args = (
         out,
         local_horiz_interpolation_weights,
         local_horiz_indices,
         field_values,
+    )
+    auto_launch!(
+        set_interpolated_values_kernel!,
+        args,
+        out;
+        threads_s = (nthreads),
+        blocks_s = (nblocks),
     )
 end
 

--- a/ext/cuda/remapping_interpolate_array.jl
+++ b/ext/cuda/remapping_interpolate_array.jl
@@ -19,11 +19,13 @@ function interpolate_slab!(
     nitems = length(output_array)
     nthreads, nblocks = _configure_threadblock(nitems)
 
-    @cuda always_inline = true threads = (nthreads) blocks = (nblocks) interpolate_slab_kernel!(
-        output_cuarray,
-        field,
-        cuslab_indices,
-        cuweights,
+    args = (output_cuarray, field, cuslab_indices, cuweights)
+    auto_launch!(
+        interpolate_slab_kernel!,
+        args,
+        output_cuarray;
+        threads_s = (nthreads),
+        blocks_s = (nblocks),
     )
 
     output_array .= Array(output_cuarray)
@@ -102,12 +104,13 @@ function interpolate_slab_level!(
 
     nitems = length(vidx_ref_coordinates)
     nthreads, nblocks = _configure_threadblock(nitems)
-    @cuda always_inline = true threads = (nthreads) blocks = (nblocks) interpolate_slab_level_kernel!(
-        output_cuarray,
-        field,
-        cuvidx_ref_coordinates,
-        h,
-        Is,
+    args = (output_cuarray, field, cuvidx_ref_coordinates, h, Is)
+    auto_launch!(
+        interpolate_slab_level_kernel!,
+        args,
+        out;
+        threads_s = (nthreads),
+        blocks_s = (nblocks),
     )
     output_array .= Array(output_cuarray)
 end

--- a/test/DataLayouts/cuda.jl
+++ b/test/DataLayouts/cuda.jl
@@ -1,3 +1,7 @@
+#=
+julia -g2 --check-bounds=yes --project=test
+using Revise; include(joinpath("test", "DataLayouts", "cuda.jl"))
+=#
 using Test
 using CUDA
 using ClimaCore.DataLayouts


### PR DESCRIPTION
This PR was updated to only define and use `auto_launch!` with suggested threads and blocks. This will allow us to easily and experimentally optimize the number of threads and blocks kernel.

This PR is a no-op.

Next, we can leverages CUDA.jl's [`launch_configuration`](https://cuda.juliagpu.org/dev/lib/driver/#CUDA.launch_configuration) function, to auto-tune the number of blocks and threads, for most kernel launches. I've excluded those where we specify shmem (spectral element kernels), because it's not yet clear to me how we can use it there.

This will allow us to remove the hard-coded `_max_threads_cuda() = 256`.

I'm going to try this out in ClimaAtmos, and run the target pipeline with this.