### PR TITLE
Add broken GPU test for implicit prognostic edmf

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -614,7 +614,6 @@ steps:
       - label: "Unit: bidiag matrix row example (GPU)"
         key: gpu_compat_bidiag_matrix_row
         command: "julia --color=yes --project=test test/MatrixFields/gpu_compat_bidiag_matrix_row.jl"
-        soft_fail: true
         agents:
           slurm_gpus: 1
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -607,6 +607,17 @@ steps:
           slurm_gpus: 1
           slurm_mem: 40GB
 
+      - label: "Unit: bidiag matrix row example (CPU)"
+        key: cpu_gpu_compat_bidiag_matrix_row
+        command: "julia --color=yes --check-bounds=yes --project=test test/MatrixFields/gpu_compat_bidiag_matrix_row.jl"
+
+      - label: "Unit: bidiag matrix row example (GPU)"
+        key: gpu_compat_bidiag_matrix_row
+        command: "julia --color=yes --project=test test/MatrixFields/gpu_compat_bidiag_matrix_row.jl"
+        soft_fail: true
+        agents:
+          slurm_gpus: 1
+
       - label: "Unit: operator matrices (CPU)"
         key: unit_operator_matrices_cpu
         command: "julia --color=yes --check-bounds=yes --project=test test/MatrixFields/operator_matrices.jl"

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@ main
 -------
 
 - ![][badge-🐛bugfix] We fixed some fieldvector broadcasting on Julia 1.9. PR [#1658](https://github.com/CliMA/ClimaCore.jl/pull/1658).
+- ![][badge-🚀performance] We fixed GPU inference for certain broadcast expressions. PR [#1665](https://github.com/CliMA/ClimaCore.jl/pull/1665).
 
 v0.13.3
 -------

--- a/src/MatrixFields/matrix_multiplication.jl
+++ b/src/MatrixFields/matrix_multiplication.jl
@@ -284,12 +284,15 @@ function Operators.return_eltype(
         ld1, ud1 = outer_diagonals(eltype(matrix1))
         ld2, ud2 = outer_diagonals(eltype(matrix2))
         prod_ld, prod_ud = ld1 + ld2, ud1 + ud2
-        prod_value_type =
-            rmul_return_type(eltype(eltype(matrix1)), eltype(eltype(matrix2)))
+        prod_value_type = Base.promote_op(
+            rmul,
+            eltype(eltype(matrix1)),
+            eltype(eltype(matrix2)),
+        )
         return band_matrix_row_type(prod_ld, prod_ud, prod_value_type)
     else # matrix-vector multiplication
         vector = arg
-        return rmul_return_type(eltype(eltype(matrix1)), eltype(vector))
+        return Base.promote_op(rmul, eltype(eltype(matrix1)), eltype(vector))
     end
 end
 

--- a/src/MatrixFields/matrix_multiplication.jl
+++ b/src/MatrixFields/matrix_multiplication.jl
@@ -270,6 +270,7 @@ function Operators.right_interior_idx(
     end
 end
 
+# import InteractiveUtils
 function Operators.return_eltype(
     ::MultiplyColumnwiseBandMatrixField,
     matrix1,
@@ -284,15 +285,40 @@ function Operators.return_eltype(
         ld1, ud1 = outer_diagonals(eltype(matrix1))
         ld2, ud2 = outer_diagonals(eltype(matrix2))
         prod_ld, prod_ud = ld1 + ld2, ud1 + ud2
-        prod_value_type = Base.promote_op(
-            rmul,
-            eltype(eltype(matrix1)),
-            eltype(eltype(matrix2)),
-        )
+        prod_value_type =
+            rmul_return_type(eltype(eltype(matrix1)), eltype(eltype(matrix2)))
+        # prod_value_type_old =
+        #     rmul_return_type_old(eltype(eltype(matrix1)), eltype(eltype(matrix2)))
+        # if prod_value_type ≠ prod_value_type_old
+        #     s = InteractiveUtils.@which rmul_return_type(eltype(eltype(matrix1)), eltype(eltype(matrix2)))
+        #     @show s
+        #     @show eltype(eltype(matrix1))
+        #     @show eltype(eltype(matrix2))
+        #     @show eltype(eltype(matrix1)) <: Geometry.AdjointAxisTensor
+        #     @show eltype(eltype(matrix2)) <: Geometry.AdjointAxisTensor
+        #     @show prod_value_type
+        #     @show prod_value_type_old
+        #     error("Done")
+        # end
         return band_matrix_row_type(prod_ld, prod_ud, prod_value_type)
     else # matrix-vector multiplication
         vector = arg
-        return Base.promote_op(rmul, eltype(eltype(matrix1)), eltype(vector))
+        # prod_value_type = Base.promote_op(rmul, eltype(eltype(matrix1)), eltype(vector))
+        prod_value_type =
+            rmul_return_type(eltype(eltype(matrix1)), eltype(vector))
+        # prod_value_type_old = rmul_return_type_old(eltype(eltype(matrix1)), eltype(vector))
+        # if prod_value_type ≠ prod_value_type_old
+        #     s = InteractiveUtils.@which rmul_return_type(eltype(eltype(matrix1)), eltype(vector))
+        #     @show s
+        #     @show eltype(eltype(matrix1))
+        #     @show eltype(vector)
+        #     @show eltype(eltype(matrix1)) <: Geometry.AdjointAxisTensor
+        #     @show eltype(vector) <: Geometry.AdjointAxisTensor
+        #     @show prod_value_type
+        #     @show prod_value_type_old
+        #     error("Done")
+        # end
+        return prod_value_type
     end
 end
 

--- a/src/MatrixFields/rmul_with_projection.jl
+++ b/src/MatrixFields/rmul_with_projection.jl
@@ -146,46 +146,26 @@ Note that this is similar to calling the internal function `Base.promote_op`:
 """
 rmul_return_type(::Type{X}, ::Type{Y}) where {X, Y} =
     rmaptype((X′, Y′) -> mul_return_type(X′, Y′), X, Y)
-
-const SingleValueNonAdjoint = Union{Number, Geometry.AxisTensor}
-
-rmul_return_type(::Type{X}, ::Type{Y}) where {X <: SingleValueNonAdjoint, Y} =
-    Base.promote_op(rmul, X, Y)
-rmul_return_type(::Type{X}, ::Type{Y}) where {X, Y <: SingleValueNonAdjoint} =
-    Base.promote_op(rmul, X, Y)
-
-rmul_return_type(
-    ::Type{X},
-    ::Type{Y},
-) where {X <: SingleValueNonAdjoint, Y <: Adjoint} =
+rmul_return_type(::Type{X}, ::Type{Y}) where {X <: SingleValue, Y} =
     rmaptype(Y′ -> mul_return_type(X, Y′), Y)
-rmul_return_type(
-    ::Type{X},
-    ::Type{Y},
-) where {X <: Adjoint, Y <: SingleValueNonAdjoint} =
+rmul_return_type(::Type{X}, ::Type{Y}) where {X, Y <: SingleValue} =
     rmaptype(X′ -> mul_return_type(X′, Y), X)
-
-rmul_return_type(::Type{X}, ::Type{Y}) where {X <: Adjoint, Y <: Adjoint} =
-    mul_return_type(X, Y)
-
 rmul_return_type(
     ::Type{X},
     ::Type{Y},
-) where {X <: SingleValueNonAdjoint, Y <: SingleValueNonAdjoint} =
-    Base.promote_op(rmul, X, Y)
+) where {X <: SingleValue, Y <: SingleValue} = mul_return_type(X, Y)
 
+#####
+##### Old
+#####
 
-# #####
-# ##### Old
-# #####
-
-# rmul_return_type_old(::Type{X}, ::Type{Y}) where {X, Y} =
-#     rmaptype((X′, Y′) -> mul_return_type(X′, Y′), X, Y)
-# rmul_return_type_old(::Type{X}, ::Type{Y}) where {X <: SingleValue, Y} =
-#     rmaptype(Y′ -> mul_return_type(X, Y′), Y)
-# rmul_return_type_old(::Type{X}, ::Type{Y}) where {X, Y <: SingleValue} =
-#     rmaptype(X′ -> mul_return_type(X′, Y), X)
-# rmul_return_type_old(
-#     ::Type{X},
-#     ::Type{Y},
-# ) where {X <: SingleValue, Y <: SingleValue} = mul_return_type(X, Y)
+rmul_return_type_old(::Type{X}, ::Type{Y}) where {X, Y} =
+    rmaptype((X′, Y′) -> mul_return_type(X′, Y′), X, Y)
+rmul_return_type_old(::Type{X}, ::Type{Y}) where {X <: SingleValue, Y} =
+    rmaptype(Y′ -> mul_return_type(X, Y′), Y)
+rmul_return_type_old(::Type{X}, ::Type{Y}) where {X, Y <: SingleValue} =
+    rmaptype(X′ -> mul_return_type(X′, Y), X)
+rmul_return_type_old(
+    ::Type{X},
+    ::Type{Y},
+) where {X <: SingleValue, Y <: SingleValue} = mul_return_type(X, Y)

--- a/test/MatrixFields/gpu_compat_bidiag_matrix_row.jl
+++ b/test/MatrixFields/gpu_compat_bidiag_matrix_row.jl
@@ -1,0 +1,56 @@
+#=
+using Revise; include(joinpath("test", "MatrixFields", "gpu_compat_bidiag_matrix_row.jl"))
+=#
+import ClimaCore
+import ClimaComms
+if !(@isdefined(TU))
+    include(
+        joinpath(
+            pkgdir(ClimaCore),
+            "test",
+            "TestUtilities",
+            "TestUtilities.jl",
+        ),
+    )
+end
+import .TestUtilities as TU
+
+import ClimaCore: Spaces, Geometry, Operators, Fields, MatrixFields
+using ClimaCore.MatrixFields:
+    BidiagonalMatrixRow, TridiagonalMatrixRow, MultiplyColumnwiseBandMatrixField
+const C3 = Geometry.Covariant3Vector
+FT = Float64
+const ᶠgradᵥ = Operators.GradientC2F(
+    bottom = Operators.SetGradient(C3(0)),
+    top = Operators.SetGradient(C3(0)),
+)
+const ᶠgradᵥ_matrix = MatrixFields.operator_matrix(ᶠgradᵥ)
+const ⋅ = MultiplyColumnwiseBandMatrixField()
+
+device = ClimaComms.device()
+context = ClimaComms.context(device)
+cspace =
+    TU.CenterExtrudedFiniteDifferenceSpace(FT; zelem = 25, helem = 10, context)
+fspace = Spaces.FaceExtrudedFiniteDifferenceSpace(cspace)
+@info "device = $device"
+
+f = (;
+    ᶠtridiagonal_matrix_c3 = Fields.Field(TridiagonalMatrixRow{C3{FT}}, fspace),
+)
+
+const ᶜleft_bias = Operators.LeftBiasedF2C()
+const ᶜright_bias = Operators.RightBiasedF2C()
+const ᶜleft_bias_matrix = MatrixFields.operator_matrix(ᶜleft_bias)
+const ᶜright_bias_matrix = MatrixFields.operator_matrix(ᶜright_bias)
+
+conv(::Type{_FT}, ᶜbias_matrix) where {_FT} =
+    convert(BidiagonalMatrixRow{_FT}, ᶜbias_matrix)
+function foo(f)
+    (; ᶠtridiagonal_matrix_c3) = f
+    space = axes(ᶠtridiagonal_matrix_c3)
+    FT = Spaces.undertype(space)
+    @. ᶠtridiagonal_matrix_c3 = ᶠgradᵥ_matrix() ⋅ conv(FT, ᶜleft_bias_matrix())
+    return nothing
+end
+
+foo(f)

--- a/test/MatrixFields/rmul_with_projection.jl
+++ b/test/MatrixFields/rmul_with_projection.jl
@@ -40,7 +40,7 @@ end
 
     number = rand(FT)
     vector = Geometry.Covariant123Vector(rand(FT), rand(FT), rand(FT))
-    covector = Geometry.Covariant12Vector(rand(FT), rand(FT))';
+    covector = Geometry.Covariant12Vector(rand(FT), rand(FT))'
     tensor = vector * covector
     cotensor =
         (covector' * Geometry.Contravariant12Vector(rand(FT), rand(FT))')'

--- a/test/MatrixFields/rmul_with_projection.jl
+++ b/test/MatrixFields/rmul_with_projection.jl
@@ -40,7 +40,7 @@ end
 
     number = rand(FT)
     vector = Geometry.Covariant123Vector(rand(FT), rand(FT), rand(FT))
-    covector = Geometry.Covariant12Vector(rand(FT), rand(FT))'
+    covector = Geometry.Covariant12Vector(rand(FT), rand(FT))';
     tensor = vector * covector
     cotensor =
         (covector' * Geometry.Contravariant12Vector(rand(FT), rand(FT))')'


### PR DESCRIPTION
This PR adds a broken GPU test for `ᶠgradᵥ_matrix ⋅ BidiagonalMatrixRow`, which is used in implicit prognostic edmf. This test works on the CPU and fails on the GPU. I'm assuming that the GPUCompiler cannot prune the else branch in `eltype(arg) <: BandMatrixRow` of `multiply_matrix_at_index`.