### PR TITLE
Use recursion to fix mat field inference

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -693,7 +693,6 @@ steps:
       - label: "Unit: matrix field broadcasting (CPU)"
         key: unit_matrix_field_broadcasting_cpu_scalar_14
         command: "julia --color=yes --check-bounds=yes --project=test test/MatrixFields/matrix_fields_broadcasting/test_scalar_14.jl"
-        soft_fail: true
 
       - label: "Unit: matrix field broadcasting (CPU)"
         key: unit_matrix_field_broadcasting_cpu_scalar_15
@@ -819,7 +818,6 @@ steps:
       - label: "Unit: matrix field broadcasting (GPU)"
         key: unit_matrix_field_broadcasting_gpu_scalar_14
         command: "julia --color=yes --check-bounds=yes --project=test test/MatrixFields/matrix_fields_broadcasting/test_scalar_14.jl"
-        soft_fail: true
         agents:
           slurm_gpus: 1
           slurm_mem: 10GB


### PR DESCRIPTION
This PR fixes the inference failure for `test_scalar_14`.

Hi @dennisYatunin, I tried using UnrolledUtilities.jl, but that didn't seem to work (I updated #1675).