### PR TITLE
Define `local_geometry_type`

### DIFF
--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -7,7 +7,7 @@ import ..DataLayouts: DataLayouts, AbstractData, DataStyle
 import ..Domains
 import ..Topologies
 import ..Quadratures
-import ..Grids: ColumnIndex
+import ..Grids: ColumnIndex, local_geometry_type
 import ..Spaces: Spaces, AbstractSpace, AbstractPointSpace
 import ..Geometry: Geometry, Cartesian12Vector
 import ..Utilities: PlusHalf, half, UnrolledFunctions
@@ -38,6 +38,8 @@ Field(values::V, space::S) where {V <: AbstractData, S <: AbstractSpace} =
 
 Field(::Type{T}, space::S) where {T, S <: AbstractSpace} =
     Field(similar(Spaces.coordinates_data(space), T), space)
+
+local_geometry_type(::Field{V, S}) where {V, S} = local_geometry_type(S)
 
 ClimaComms.context(field::Field) = ClimaComms.context(axes(field))
 

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -49,6 +49,16 @@ If the grid is not staggered, `staggering` should be `nothing`.
 """
 function local_geometry_data end
 
+"""
+    Grids.local_geometry_type(::Type)
+
+Get the `LocalGeometry` type.
+"""
+function local_geometry_type end
+
+# Fallback, but this requires user error-handling
+local_geometry_type(::Type{T}) where {T} = Union{}
+
 function local_dss_weights end
 function quadrature_style end
 function vertical_topology end

--- a/src/Grids/column.jl
+++ b/src/Grids/column.jl
@@ -36,6 +36,8 @@ struct ColumnGrid{
     colidx::C
 end
 
+local_geometry_type(::Type{ColumnGrid{G, C}}) where {G, C} =
+    local_geometry_type(G)
 
 column(grid::AbstractExtrudedFiniteDifferenceGrid, colidx::ColumnIndex) =
     ColumnGrid(grid, colidx)

--- a/src/Grids/extruded.jl
+++ b/src/Grids/extruded.jl
@@ -37,6 +37,10 @@ mutable struct ExtrudedFiniteDifferenceGrid{
     face_local_geometry::LG
 end
 
+local_geometry_type(
+    ::Type{ExtrudedFiniteDifferenceGrid{H, V, A, GG, LG}},
+) where {H, V, A, GG, LG} = eltype(LG) # calls eltype from DataLayouts
+
 function ExtrudedFiniteDifferenceGrid(
     horizontal_grid::Union{SpectralElementGrid1D, SpectralElementGrid2D},
     vertical_grid::FiniteDifferenceGrid,
@@ -125,7 +129,6 @@ vertical_topology(grid::ExtrudedFiniteDifferenceGrid) =
 local_dss_weights(grid::ExtrudedFiniteDifferenceGrid) =
     local_dss_weights(grid.horizontal_grid)
 
-
 local_geometry_data(grid::AbstractExtrudedFiniteDifferenceGrid, ::CellCenter) =
     grid.center_local_geometry
 local_geometry_data(grid::AbstractExtrudedFiniteDifferenceGrid, ::CellFace) =
@@ -146,6 +149,10 @@ struct DeviceExtrudedFiniteDifferenceGrid{VT, Q, GG, LG} <:
     center_local_geometry::LG
     face_local_geometry::LG
 end
+
+local_geometry_type(
+    ::Type{DeviceExtrudedFiniteDifferenceGrid{VT, Q, GG, LG}},
+) where {VT, Q, GG, LG} = eltype(LG) # calls eltype from DataLayouts
 
 Adapt.adapt_structure(to, grid::ExtrudedFiniteDifferenceGrid) =
     DeviceExtrudedFiniteDifferenceGrid(

--- a/src/Grids/finitedifference.jl
+++ b/src/Grids/finitedifference.jl
@@ -168,6 +168,9 @@ FiniteDifferenceGrid(mesh::Meshes.IntervalMesh) =
 topology(grid::FiniteDifferenceGrid) = grid.topology
 vertical_topology(grid::FiniteDifferenceGrid) = grid.topology
 
+local_geometry_type(::Type{FiniteDifferenceGrid{T, GG, LG}}) where {T, GG, LG} =
+    eltype(LG) # calls eltype from DataLayouts
+
 local_geometry_data(grid::FiniteDifferenceGrid, ::CellCenter) =
     grid.center_local_geometry
 local_geometry_data(grid::FiniteDifferenceGrid, ::CellFace) =
@@ -181,6 +184,10 @@ struct DeviceFiniteDifferenceGrid{T, GG, LG} <: AbstractFiniteDifferenceGrid
     center_local_geometry::LG
     face_local_geometry::LG
 end
+
+local_geometry_type(
+    ::Type{DeviceFiniteDifferenceGrid{T, GG, LG}},
+) where {T, GG, LG} = eltype(LG) # calls eltype from DataLayouts
 
 Adapt.adapt_structure(to, grid::FiniteDifferenceGrid) =
     DeviceFiniteDifferenceGrid(

--- a/src/Grids/level.jl
+++ b/src/Grids/level.jl
@@ -18,6 +18,8 @@ topology(levelgrid::LevelGrid) = topology(levelgrid.full_grid)
 
 local_dss_weights(grid::LevelGrid) = local_dss_weights(grid.full_grid)
 
+local_geometry_type(::Type{LevelGrid{G, L}}) where {G, L} =
+    local_geometry_type(G)
 local_geometry_data(levelgrid::LevelGrid{<:Any, Int}, ::Nothing) = level(
     local_geometry_data(levelgrid.full_grid, CellCenter()),
     levelgrid.level,

--- a/src/Grids/spectralelement.jl
+++ b/src/Grids/spectralelement.jl
@@ -21,6 +21,10 @@ mutable struct SpectralElementGrid1D{
     dss_weights::D
 end
 
+local_geometry_type(
+    ::Type{SpectralElementGrid1D{T, Q, GG, LG}},
+) where {T, Q, GG, LG} = eltype(LG) # calls eltype from DataLayouts
+
 # non-view grids are cached based on their input arguments
 # this means that if data is saved in two different files, reloading will give fields which live on the same grid
 function SpectralElementGrid1D(
@@ -117,6 +121,10 @@ mutable struct SpectralElementGrid2D{
     internal_surface_geometry::IS
     boundary_surface_geometries::BS
 end
+
+local_geometry_type(
+    ::Type{SpectralElementGrid2D{T, Q, GG, LG, D, IS, BS}},
+) where {T, Q, GG, LG, D, IS, BS} = eltype(LG) # calls eltype from DataLayouts
 
 """
     SpectralElementSpace2D(topology, quadrature_style; enable_bubble)

--- a/src/MatrixFields/MatrixFields.jl
+++ b/src/MatrixFields/MatrixFields.jl
@@ -60,6 +60,7 @@ import ..DataLayouts: AbstractData
 import ..Geometry
 import ..Topologies
 import ..Spaces
+import ..Spaces: local_geometry_type
 import ..Fields
 import ..Operators
 

--- a/src/MatrixFields/single_field_solver.jl
+++ b/src/MatrixFields/single_field_solver.jl
@@ -13,11 +13,14 @@ x_eltype(A::ColumnwiseBandMatrixField, b) =
     x_eltype(eltype(eltype(A)), eltype(b))
 x_eltype(::Type{T_A}, ::Type{T_b}) where {T_A, T_b} =
     rmul_return_type(inv_return_type(T_A), T_b)
+# Base.promote_op(rmul_with_projection, inv_return_type(T_A), T_b, LG)
 
-unit_eltype(A::UniformScaling) = unit_eltype(eltype(A))
-unit_eltype(A::ColumnwiseBandMatrixField) = unit_eltype(eltype(eltype(A)))
-unit_eltype(::Type{T_A}) where {T_A} =
+unit_eltype(A::UniformScaling) = eltype(A)
+unit_eltype(A::ColumnwiseBandMatrixField) =
+    unit_eltype(eltype(eltype(A)), local_geometry_type(A))
+unit_eltype(::Type{T_A}, ::Type{LG}) where {T_A, LG} =
     rmul_return_type(inv_return_type(T_A), T_A)
+# Base.promote_op(rmul_with_projection, inv_return_type(T_A), T_A, LG)
 
 ################################################################################
 

--- a/src/Spaces/Spaces.jl
+++ b/src/Spaces/Spaces.jl
@@ -31,6 +31,7 @@ import ..Grids:
     CellCenter,
     topology,
     vertical_topology,
+    local_geometry_type,
     local_geometry_data,
     global_geometry,
     local_dss_weights,

--- a/src/Spaces/extruded.jl
+++ b/src/Spaces/extruded.jl
@@ -8,6 +8,9 @@ struct ExtrudedFiniteDifferenceSpace{
     staggering::S
 end
 
+local_geometry_type(::Type{ExtrudedFiniteDifferenceSpace{G, S}}) where {G, S} =
+    local_geometry_type(G)
+
 space(grid::Grids.ExtrudedFiniteDifferenceGrid, staggering::Staggering) =
     ExtrudedFiniteDifferenceSpace(grid, staggering)
 

--- a/src/Spaces/finitedifference.jl
+++ b/src/Spaces/finitedifference.jl
@@ -21,6 +21,8 @@ FiniteDifferenceSpace(
     staggering::Staggering,
 ) = FiniteDifferenceSpace(Grids.FiniteDifferenceGrid(topology), staggering)
 
+local_geometry_type(::Type{FiniteDifferenceSpace{G, S}}) where {G, S} =
+    local_geometry_type(G)
 
 const FaceFiniteDifferenceSpace{G} = FiniteDifferenceSpace{G, CellFace}
 const CenterFiniteDifferenceSpace{G} = FiniteDifferenceSpace{G, CellCenter}

--- a/src/Spaces/pointspace.jl
+++ b/src/Spaces/pointspace.jl
@@ -15,6 +15,8 @@ struct PointSpace{
     local_geometry::LG
 end
 
+local_geometry_type(::Type{PointSpace{C, LG}}) where {C, LG} = eltype(LG) # calls eltype from DataLayouts
+
 ClimaComms.device(space::PointSpace) = ClimaComms.device(space.context)
 ClimaComms.context(space::PointSpace) = space.context
 

--- a/src/Spaces/spectralelement.jl
+++ b/src/Spaces/spectralelement.jl
@@ -57,6 +57,10 @@ space(grid::Grids.LevelGrid{<:Grids.ExtrudedSpectralElementGrid2D}, ::Nothing) =
     SpectralElementSpace1D(grid)
 grid(space::Spaces.SpectralElementSpace1D) = getfield(space, :grid)
 
+local_geometry_type(::Type{SpectralElementSpace1D{G}}) where {G} =
+    local_geometry_type(G)
+
+
 function SpectralElementSpace1D(
     topology::Topologies.IntervalTopology,
     quadrature_style::Quadratures.QuadratureStyle,
@@ -76,6 +80,9 @@ space(grid::Grids.SpectralElementGrid2D, ::Nothing) =
     SpectralElementSpace2D(grid)
 space(grid::Grids.LevelGrid{<:Grids.ExtrudedSpectralElementGrid3D}, ::Nothing) =
     SpectralElementSpace2D(grid)
+
+local_geometry_type(::Type{SpectralElementSpace2D{G}}) where {G} =
+    local_geometry_type(G)
 
 grid(space::Spaces.SpectralElementSpace2D) = getfield(space, :grid)
 
@@ -110,6 +117,8 @@ struct SpectralElementSpaceSlab{Q, G} <: AbstractSpectralElementSpace
     local_geometry::G
 end
 
+local_geometry_type(::Type{SpectralElementSpaceSlab{Q, G}}) where {Q, G} =
+    eltype(G) # calls eltype from DataLayouts
 const SpectralElementSpaceSlab1D =
     SpectralElementSpaceSlab{Q, DL} where {Q, DL <: DataLayouts.DataSlab1D}
 

--- a/test/Spaces/spaces.jl
+++ b/test/Spaces/spaces.jl
@@ -70,10 +70,14 @@ on_gpu = ClimaComms.device() isa ClimaComms.CUDADevice
         end
     end
 
+    @test Spaces.local_geometry_type(typeof(space)) <: Geometry.LocalGeometry
+
     point_space = Spaces.column(space, 1, 1)
     @test point_space isa Spaces.PointSpace
     @test Spaces.coordinates_data(point_space)[] ==
           Spaces.column(coord_data, 1, 1)[]
+    @test Spaces.local_geometry_type(typeof(point_space)) <:
+          Geometry.LocalGeometry
 end
 
 on_gpu || @testset "extruded (2d 1×3) finite difference space" begin
@@ -105,6 +109,8 @@ on_gpu || @testset "extruded (2d 1×3) finite difference space" begin
     array = parent(Spaces.coordinates_data(c_space))
     z = Fields.coordinate_field(c_space).z
     @test size(array) == (10, 4, 2, 5) # 10V, 4I, 2F(x,z), 5H
+    @test Spaces.local_geometry_type(typeof(f_space)) <: Geometry.LocalGeometry
+    @test Spaces.local_geometry_type(typeof(c_space)) <: Geometry.LocalGeometry
 
     # Define test col index
     colidx = Fields.ColumnIndex{1}((4,), 5)
@@ -137,6 +143,8 @@ end
     @test point_space isa Spaces.PointSpace
     @test Spaces.coordinates_data(point_space)[] ==
           Spaces.level(coord_data, 1)[]
+
+    @test Spaces.local_geometry_type(typeof(space)) <: Geometry.LocalGeometry
 
     x_max = FT(1)
     y_max = FT(1)
@@ -208,6 +216,7 @@ end
     @test coord_slab[1, 4] ≈ Geometry.XYPoint{FT}(-3.0, 8.0)
     @test coord_slab[4, 4] ≈ Geometry.XYPoint{FT}(5.0, 8.0)
 
+    @test Spaces.local_geometry_type(typeof(space)) <: Geometry.LocalGeometry
     local_geometry_slab = slab(Spaces.local_geometry_data(space), 1)
     dss_weights_slab = slab(Spaces.local_dss_weights(space), 1)
 
@@ -265,6 +274,8 @@ end
     grid_topology = Topologies.Topology2D(context, mesh)
     space = Spaces.SpectralElementSpace2D(grid_topology, quad)
     perimeter = Spaces.perimeter(space)
+    @test Spaces.local_geometry_type(typeof(space)) <: Geometry.LocalGeometry
+
 
     reference = [
         (1, 1),  # vertex 1


### PR DESCRIPTION
This PR defines, `local_geometry_type`, which will allow us to migrate from `mul_return_type`/`rmul_return_type` to `Base.promote_op`.

`local_geometry_type` statically returns the local geometry type, given a space type.

This is a peel off from #1673, in case this may be needed to fix other inference issues (#1679, #1678, #1675).

None of this is actually being used yet, although I did add tests, because this seems to impact compiler inference, perhaps due to heuristics. I'm still digging into why. I've also defined a new version of `Operators.return_eltype`, which I hope that we'll use in the long run.