### PR TITLE
Fix inference using promote_op in multiply_matrix_at_index

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -630,7 +630,6 @@ steps:
       - label: "Unit: bidiag matrix row example (GPU)"
         key: gpu_compat_bidiag_matrix_row
         command: "julia --color=yes --project=test test/MatrixFields/gpu_compat_bidiag_matrix_row.jl"
-        soft_fail: true
         agents:
           slurm_gpus: 1
 

--- a/src/MatrixFields/matrix_multiplication.jl
+++ b/src/MatrixFields/matrix_multiplication.jl
@@ -270,29 +270,11 @@ function Operators.right_interior_idx(
     end
 end
 
-pick_inferred_type(
-    ::Type{Union{}},
-    ::Type{Y},
-) where {Y <: Geometry.LocalGeometry} = Y
-pick_inferred_type(
-    ::Type{X},
-    ::Type{Union{}},
-) where {X <: Geometry.LocalGeometry} = X
-pick_inferred_type(::Type{T}, ::Type{T}) where {T <: Geometry.LocalGeometry} = T
-pick_inferred_type(::Type{Union{}}, ::Type{Union{}}) =
-    error("Both LGs are not inferred")
-pick_inferred_type(::Type{X}, ::Type{Y}) where {X, Y} =
-    error("LGs do not match: X=$X, Y=$Y")
-
 function Operators.return_eltype(
     ::MultiplyColumnwiseBandMatrixField,
     matrix1,
     arg,
 )
-    # LG1 = local_geometry_type(typeof(axes(matrix1)))
-    # LG2 = local_geometry_type(typeof(axes(arg)))
-    # LG = pick_inferred_type(LG1, LG2)
-    # return Operators.return_eltype(op, matrix1, arg, LG)
     eltype(matrix1) <: BandMatrixRow || error(
         "The first argument of ⋅ must have elements of type BandMatrixRow, but \
          the given argument has elements of type $(eltype(matrix1))",
@@ -365,9 +347,8 @@ boundary_modified_ud(::BottomRightMatrixCorner, ud, column_space, i) =
 # matrix field broadcast expressions to take roughly 3 or 4 times longer to
 # evaluate, but this is less significant than the decrease in compilation time.
 function multiply_matrix_at_index(loc, space, idx, hidx, matrix1, arg, bc)
-    # lg = Geometry.LocalGeometry(space, idx, hidx)
-    # prod_type = Operators.return_eltype(⋅, matrix1, arg, typeof(lg))
-    prod_type = Operators.return_eltype(⋅, matrix1, arg)
+    lg = Geometry.LocalGeometry(space, idx, hidx)
+    prod_type = Operators.return_eltype(⋅, matrix1, arg, typeof(lg))
 
     column_space1 = column_axes(matrix1, space)
     ld1, ud1 = outer_diagonals(eltype(matrix1))


### PR DESCRIPTION
This PR fixes the inference failure in the `gpu_compat_bidiag_matrix_row` test (corresponding to the latest failure in the prognostic implicit EDMF on gpus).

Unfortunately, I wasn't able to handle this consistently. I think we can move forward with this to buy us some time, and go back to fix things more properly later.