### PR TITLE
3 component dss transform

### DIFF
--- a/src/Hypsography/Hypsography.jl
+++ b/src/Hypsography/Hypsography.jl
@@ -239,8 +239,6 @@ function _ExtrudedFiniteDifferenceGrid(
         f = Spaces.create_dss_buffer(face_∇Z_field),
     )
 
-    Spaces.weighted_dss!(center_∇Z_field => buffer.c, face_∇Z_field => buffer.f)
-
     # construct full local geometry
     center_local_geometry =
         Geometry.product_geometry.(

--- a/src/Topologies/dss_transform.jl
+++ b/src/Topologies/dss_transform.jl
@@ -233,18 +233,31 @@ end
 # helper functions for DSS2
 
 function _get_idx_metric(sizet::NTuple{5, Int}, loc::NTuple{4, Int})
-    @inbounds begin
-        nmetric = sizet[4]
-        (i11, i12, i21, i22) = nmetric == 4 ? (1, 2, 3, 4) : (1, 2, 4, 5)
-        (level, i, j, elem) = loc
-        inds = (
-            linear_ind(sizet, (level, i, j, i11, elem)),
-            linear_ind(sizet, (level, i, j, i12, elem)),
-            linear_ind(sizet, (level, i, j, i21, elem)),
-            linear_ind(sizet, (level, i, j, i22, elem)),
-        )
-        return inds
-    end
+    nmetric = sizet[4]
+    (i11, i12, i21, i22) = nmetric == 4 ? (1, 2, 3, 4) : (1, 2, 4, 5)
+    (level, i, j, elem) = loc
+    return (
+        linear_ind(sizet, (level, i, j, i11, elem)),
+        linear_ind(sizet, (level, i, j, i12, elem)),
+        linear_ind(sizet, (level, i, j, i21, elem)),
+        linear_ind(sizet, (level, i, j, i22, elem)),
+    )
+end
+
+function _get_idx_metric_3d(sizet::NTuple{5, Int}, loc::NTuple{4, Int})
+    nmetric = sizet[4]
+    (level, i, j, elem) = loc
+    return (
+        linear_ind(sizet, (level, i, j, 1, elem)),
+        linear_ind(sizet, (level, i, j, 2, elem)),
+        linear_ind(sizet, (level, i, j, 3, elem)),
+        linear_ind(sizet, (level, i, j, 4, elem)),
+        linear_ind(sizet, (level, i, j, 5, elem)),
+        linear_ind(sizet, (level, i, j, 6, elem)),
+        linear_ind(sizet, (level, i, j, 7, elem)),
+        linear_ind(sizet, (level, i, j, 8, elem)),
+        linear_ind(sizet, (level, i, j, 9, elem)),
+    )
 end
 
 function _representative_slab(

--- a/test/Spaces/ddss1_cs.jl
+++ b/test/Spaces/ddss1_cs.jl
@@ -58,7 +58,7 @@ import ClimaCore:
     )
 end
 
-@testset "DSS of Covarinat12Vector & Covariant123Vector on extruded Cubed Sphere mesh (ne = 3, serial run)" begin
+@testset "DSS of Covariant12Vector & Covariant123Vector on extruded Cubed Sphere mesh (ne = 3, serial run)" begin
     FT = Float64
     context = ClimaComms.SingletonCommsContext(ClimaComms.CUDADevice())
     context_cpu =

--- a/test/Spaces/terrain_warp.jl
+++ b/test/Spaces/terrain_warp.jl
@@ -369,6 +369,114 @@ end
     end
 end
 
+@testset "3D Extruded Terrain Warped Space: DSS" begin
+    device = ClimaComms.device()
+    context_gen = ClimaComms.SingletonCommsContext(device)
+    context_cpu =
+        ClimaComms.SingletonCommsContext(ClimaComms.CPUSingleThreaded()) # CPU context for comparison
+    for FT in (Float32, Float64)
+        # Extruded FD-Spectral Hybrid
+        xmin, xmax = FT(0), FT(π)
+        ymin, ymax = FT(0), FT(π)
+        zmin, zmax = FT(0), FT(1)
+        levels = (5, 10)
+        polynom = (2, 5, 10)
+        horzelem = (2, 5, 10)
+        for nl in levels, np in polynom, nh in horzelem
+            hv_center_space, hv_face_space = warpedspace_3D(
+                FT,
+                (xmin, xmax),
+                (ymin, ymax),
+                (zmin, zmax),
+                nh,
+                nl,
+                np;
+                device,
+            )
+            hv_center_space_cpu, hv_face_space_cpu = warpedspace_3D(
+                FT,
+                (xmin, xmax),
+                (ymin, ymax),
+                (zmin, zmax),
+                nh,
+                nl,
+                np;
+                device = ClimaComms.CPUSingleThreaded(),
+            )
+            ᶜcoords = Fields.coordinate_field(hv_center_space)
+            ᶠcoords = Fields.coordinate_field(hv_face_space)
+            ᶜcoords_cpu = Fields.coordinate_field(hv_center_space_cpu)
+            ᶠcoords_cpu = Fields.coordinate_field(hv_face_space_cpu)
+
+            y1 = one.(Fields.coordinate_field(hv_center_space).z)
+            y2 = -1 .* y1
+            y3 = y1
+            y12 = @. Geometry.Covariant12Vector(y1, y2)
+
+            y1_cpu = one.(Fields.coordinate_field(hv_center_space_cpu).z)
+            y2_cpu = -1 .* y1_cpu
+            y3_cpu = @. y1_cpu
+            y12_cpu = @. Geometry.Covariant12Vector(y1_cpu, y2_cpu)
+
+            dss_buffer12 = Spaces.create_dss_buffer(y12)
+            dss_buffer12_cpu = Spaces.create_dss_buffer(y12_cpu)
+
+            Spaces.weighted_dss!(y12 => dss_buffer12)
+            Spaces.weighted_dss!(y12_cpu => dss_buffer12_cpu)
+
+            yinit12 = copy(y12)
+            yinit12_cpu = copy(y12_cpu)
+
+            @test yinit12 ≈ y12
+            @test yinit12_cpu ≈ y12_cpu
+            @test parent(y12_cpu) ≈ Array(parent(y12))
+
+            # test DSS for a Covariant123Vector
+            y123 = @. Geometry.Covariant123Vector(y1, y2, y3)
+            y123_cpu = @. Geometry.Covariant123Vector(y1_cpu, y2_cpu, y3_cpu)
+
+            dss_buffer123 = Spaces.create_dss_buffer(y123)
+            dss_buffer123_cpu = Spaces.create_dss_buffer(y123_cpu)
+
+            # ensure physical velocity is continous across SE boundary for initial state
+            Spaces.weighted_dss!(y123 => dss_buffer123)
+            Spaces.weighted_dss!(y123_cpu => dss_buffer123_cpu)
+
+            yinit123 = copy(y123)
+            yinit123_cpu = copy(y123_cpu)
+
+            Spaces.weighted_dss!(y123, dss_buffer123)
+            Spaces.weighted_dss!(y123_cpu, dss_buffer123_cpu)
+
+            @test yinit123 ≈ y123
+            @test yinit123_cpu ≈ y123_cpu
+            @test parent(y123_cpu) ≈ Array(parent(y123))
+
+            # test DSS for a Contravariant123Vector
+            y123 = @. Geometry.Contravariant123Vector(y1, y2, y3)
+            y123_cpu =
+                @. Geometry.Contravariant123Vector(y1_cpu, y2_cpu, y3_cpu)
+
+            dss_buffer123 = Spaces.create_dss_buffer(y123)
+            dss_buffer123_cpu = Spaces.create_dss_buffer(y123_cpu)
+
+            # ensure physical velocity is continous across SE boundary for initial state
+            Spaces.weighted_dss!(y123 => dss_buffer123)
+            Spaces.weighted_dss!(y123_cpu => dss_buffer123_cpu)
+
+            yinit123 = copy(y123)
+            yinit123_cpu = copy(y123_cpu)
+
+            Spaces.weighted_dss!(y123, dss_buffer123)
+            Spaces.weighted_dss!(y123_cpu, dss_buffer123_cpu)
+
+            @test yinit123 ≈ y123
+            @test yinit123_cpu ≈ y123_cpu
+            @test parent(y123_cpu) ≈ Array(parent(y123))
+        end
+    end
+end
+
 @testset "3D Extruded Terrain Laplacian Smoothing" begin
     # Test smoothing for known parameters
     device = ClimaComms.device()


### PR DESCRIPTION
Currently, the dss_transform function treats the 3rd component of a 
Covariant123Vector datatype as a scalar. This PR updates the metric index getter methods and the transform functions to apply the 3 component vector dss. 

- [x] Update tests
- [x] Update docstrings