### PR TITLE
Backport fix for style and release 0.13.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.13.3"
+version = "0.13.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Fields/fieldvector.jl
+++ b/src/Fields/fieldvector.jl
@@ -287,7 +287,7 @@ function Base.Broadcast.instantiate(
             Base.Broadcast.check_broadcast_axes(axes, bc.args...)
         end
     end
-    return Base.Broadcast.Broadcasted(bc.style, bc.f, bc.args, axes)
+    return Base.Broadcast.Broadcasted{FieldVectorStyle}(bc.f, bc.args, axes)
 end
 
 @inline function Base.copyto!(


### PR DESCRIPTION
https://github.com/CliMA/ClimaDiagnostics.jl/actions/runs/9050497025/job/24865933462 fails on Julia 1.9

For some reason, Julia wants to use ClimaCore 0.13.X, but the fix needed was added in ClimaCore 0.14. 

I am not going to merge this PR, but I would like to tag another release in the ClimaCore 0.13 series (in the 0.13.4 branch) so that the fix is available for julia 1.9 too.