### PR TITLE
Add kernel statistics collection to auto_launch

### DIFF
--- a/ext/cuda/cuda_utils.jl
+++ b/ext/cuda/cuda_utils.jl
@@ -1,12 +1,17 @@
 import CUDA
 import ClimaCore.Fields
 import ClimaCore.DataLayouts
+import ClimaCore.DataLayouts: empty_kernel_stats
 
 get_n_items(field::Fields.Field) =
     prod(size(parent(Fields.field_values(field))))
 get_n_items(data::DataLayouts.AbstractData) = prod(size(parent(data)))
 get_n_items(arr::AbstractArray) = prod(size(parent(arr)))
 get_n_items(tup::Tuple) = prod(tup)
+
+const reported_stats = Dict()
+empty_kernel_stats(::ClimaComms.CUDADevice) = empty!(reported_stats)
+collect_kernel_stats() = false
 
 """
     auto_launch!(f!::F!, args,
@@ -39,21 +44,36 @@ function auto_launch!(
     nitems = get_n_items(data)
     # For now, we'll simply use the
     # suggested threads and blocks:
-    CUDA.@cuda always_inline = always_inline threads = threads_s blocks =
-        blocks_s f!(args...)
+    kernel =
+        CUDA.@cuda always_inline = always_inline threads = threads_s blocks =
+            blocks_s f!(args...)
 
-    # Soon, we'll experiment with `CUDA.launch_configuration`
-    # kernel = CUDA.@cuda always_inline = true launch = false f!(args...)
-    # config = CUDA.launch_configuration(kernel.fun)
-    # threads = min(nitems, config.threads)
-    # blocks = cld(nitems, threads)
-    # s = ""
-    # s *= "Launching kernel $f! with following config:\n"
-    # s *= "     nitems: $nitems\n"
-    # s *= "     threads: $threads\n"
-    # s *= "     blocks: $blocks\n"
-    # @info s
-    # kernel(args...; threads, blocks) # This knows to use always_inline from above.
+    if collect_kernel_stats() # only for development use
+        key = (F!, typeof(args))
+        if !haskey(reported_stats, key)
+            kernel = CUDA.@cuda always_inline = true launch = false f!(args...)
+            config = CUDA.launch_configuration(kernel.fun)
+            threads = min(nitems, config.threads)
+            blocks = cld(nitems, threads)
+            s = ""
+            s *= "Launching kernel $f! with following config:\n"
+            s *= "     nitems:         $(nitems)\n"
+            s *= "     threads_s:      $(threads_s)\n"
+            s *= "     blocks_s:       $(blocks_s)\n"
+            s *= "     threads:        $(threads)\n"
+            s *= "     blocks:         $(blocks)\n"
+            s *= "     Δthreads:       $(threads - prod(threads_s))\n"
+            s *= "     Δblocks:        $(blocks - prod(blocks_s))\n"
+            s *= "     maxthreads:     $(CUDA.maxthreads(kernel))\n"
+            s *= "     registers:      $(CUDA.registers(kernel))\n"
+            s *= "     threads_s_frac: $(prod(threads_s)/CUDA.maxthreads(kernel))\n"
+            s *= "     memory:         $(CUDA.memory(kernel))\n"
+            @info s
+            reported_stats[key] = true
+        end
+        # For now, let's just collect info, later we can benchmark
+        # kernel(args...; threads, blocks) # This knows to use always_inline from above.
+    end
 end
 
 """

--- a/src/DataLayouts/DataLayouts.jl
+++ b/src/DataLayouts/DataLayouts.jl
@@ -1458,5 +1458,7 @@ Adapt.adapt_structure(to, data::DataF{S}) where {S} =
 device_from_array_type(::Type{<:AbstractArray}) = ClimaComms.CPUSingleThreaded()
 ClimaComms.device(data::AbstractData) =
     device_from_array_type(typeof(parent(data)))
+empty_kernel_stats(::ClimaComms.AbstractDevice) = nothing
+empty_kernel_stats() = empty_kernel_stats(ClimaComms.device())
 
 end # module

--- a/test/MatrixFields/field_matrix_solvers.jl
+++ b/test/MatrixFields/field_matrix_solvers.jl
@@ -1,3 +1,7 @@
+#=
+julia --project=test
+using Revise; include(joinpath("test", "MatrixFields", "field_matrix_solvers.jl"))
+=#
 import Logging
 import Logging: Debug
 import LinearAlgebra: I, norm


### PR DESCRIPTION
This PR adds a simple mechanism for collecting statistics about kernels (e.g., threads, blocks, registers, and memory usage).