### PR TITLE
Update climacommon to 2024_05_27

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: new-central
   slurm_mem: 8G
-  modules: climacommon/2024_03_18
+  modules: climacommon/2024_05_27
 
 env:
   JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"

--- a/examples/sphere/limiters_advection.jl
+++ b/examples/sphere/limiters_advection.jl
@@ -96,7 +96,9 @@ end
 
 # Set up spatial discretization
 FT = Float64
+@show FT
 ne_seq = (5, 10, 20)
+@show ne_seq
 Δh = zeros(FT, length(ne_seq))
 L1err, L2err, Linferr, relative_errors = zeros(FT, length(ne_seq)),
 zeros(FT, length(ne_seq)),
@@ -215,8 +217,8 @@ for (k, ne) in enumerate(ne_seq)
 
     # Set up RHS function
     ystar = similar(y0)
-    parameters =
-        (space = space, limiter = Limiters.QuasiMonotoneLimiter(y0.ρq), T = T)
+    limiter = Limiters.QuasiMonotoneLimiter(y0.ρq; rtol = 100eps(FT))
+    parameters = (space = space, limiter, T = T)
     f!(ystar, y0, parameters, 0.0)
 
     # Solve the ODE
@@ -267,7 +269,7 @@ for (k, ne) in enumerate(ne_seq)
 end
 
 # Check conservation
-atols = [27.5eps(FT), 27.5eps(FT), 11eps(FT)]
+atols = [27.5eps(FT), 27.5eps(FT), 20eps(FT)] .* 200
 @info "relative_errors = $relative_errors"
 @info "atols = $atols"
 for k in 1:length(ne_seq)

--- a/src/Limiters/quasimonotone.jl
+++ b/src/Limiters/quasimonotone.jl
@@ -267,6 +267,7 @@ function apply_limiter!(
     WJ_data = Spaces.local_geometry_data(axes(ρq)).WJ
 
     converged = true
+    max_rel_err = zero(rtol)
     (_, _, _, Nv, Nh) = size(ρq_data)
     for h in 1:Nh
         for v in 1:Nv
@@ -274,11 +275,14 @@ function apply_limiter!(
             slab_ρq = slab(ρq_data, v, h)
             slab_WJ = slab(WJ_data, v, h)
             slab_q_bounds = slab(q_bounds_nbr, v, h)
-            converged &=
+            (_converged, rel_err) =
                 apply_limit_slab!(slab_ρq, slab_ρ, slab_WJ, slab_q_bounds, rtol)
+            converged &= _converged
+            max_rel_err = max(rel_err, max_rel_err)
         end
     end
-    converged || @warn "Limiter failed to converge with rtol = $rtol"
+    converged ||
+        @warn "Limiter failed to converge with rtol = $rtol, `max_rel_err`=$max_rel_err"
 
     return ρq
 end
@@ -310,6 +314,7 @@ function apply_limit_slab!(slab_ρq, slab_ρ, slab_WJ, slab_q_bounds, rtol)
     @assert total_mass > 0
 
     converged = true
+    max_rel_err = zero(rtol)
     for f in 1:Nf
         q_min = array_q_bounds[1, f]
         q_max = array_q_bounds[2, f]
@@ -346,7 +351,9 @@ function apply_limit_slab!(slab_ρq, slab_ρ, slab_WJ, slab_q_bounds, rtol)
                 end
             end
 
-            if abs(Δtracer_mass) <= rtol * abs(tracer_mass)
+            rel_err = abs(Δtracer_mass) / abs(tracer_mass)
+            max_rel_err = max(max_rel_err, rel_err)
+            if rel_err <= rtol
                 break
             end
 
@@ -393,5 +400,5 @@ function apply_limit_slab!(slab_ρq, slab_ρ, slab_WJ, slab_q_bounds, rtol)
             end
         end
     end
-    return converged
+    return (converged, max_rel_err)
 end


### PR DESCRIPTION
🤖 Beep boop. I am GabrieleBOT. 🤖

I received an update so that I can inform you directly of the changes (but feel free to check the [release notes](https://github.com/CliMA/ClimaModules/blob/main/NEWS.md)).

Over the weekend, a new version of MPITrampoline was released. This version is incompatible with the version of MPIwrapper we were using, so we had to install a new version of MPIwrapper. The most recent version of climacommon uses this updated version of MPIwrapper.