### PR TITLE
Remove some explicit CUDA dependence in tests

### DIFF
--- a/ext/cuda/matrix_fields_multiple_field_solve.jl
+++ b/ext/cuda/matrix_fields_multiple_field_solve.jl
@@ -6,11 +6,10 @@ import ClimaCore.MatrixFields
 import ClimaCore.MatrixFields: _single_field_solve!
 import ClimaCore.MatrixFields: multiple_field_solve!
 import ClimaCore.MatrixFields: is_CuArray_type
-import ClimaCore.MatrixFields: allow_scalar_func
+import ClimaCore: allow_scalar
 import ClimaCore.Utilities.UnrolledFunctions: unrolled_map
 
-allow_scalar_func(::ClimaComms.CUDADevice, f, args) =
-    CUDA.@allowscalar f(args...)
+allow_scalar(f, ::ClimaComms.CUDADevice, args...) = CUDA.@allowscalar f(args...)
 
 is_CuArray_type(::Type{T}) where {T <: CUDA.CuArray} = true
 

--- a/src/ClimaCore.jl
+++ b/src/ClimaCore.jl
@@ -2,6 +2,7 @@ module ClimaCore
 
 using PkgVersion
 const VERSION = PkgVersion.@Version
+import ClimaComms
 
 include("interface.jl")
 include("devices.jl")

--- a/src/MatrixFields/MatrixFields.jl
+++ b/src/MatrixFields/MatrixFields.jl
@@ -63,6 +63,7 @@ import ..Spaces
 import ..Spaces: local_geometry_type
 import ..Fields
 import ..Operators
+import ..allow_scalar
 
 using ..Utilities.UnrolledFunctions
 
@@ -117,11 +118,9 @@ function Base.show(io::IO, field::ColumnwiseBandMatrixField)
         end
         column_field = Fields.column(field, 1, 1, 1)
         io = IOContext(io, :compact => true, :limit => true)
-        allow_scalar_func(
-            ClimaComms.device(field),
-            Base.print_array,
-            (io, column_field2array_view(column_field)),
-        )
+        allow_scalar(ClimaComms.device(field)) do
+            Base.print_array(io, column_field2array_view(column_field))
+        end
     else
         # When a BandedMatrix with non-number entries is printed, it currently
         # either prints in an illegible format (e.g., if it has AxisTensor or

--- a/src/MatrixFields/field2arrays.jl
+++ b/src/MatrixFields/field2arrays.jl
@@ -53,23 +53,21 @@ function column_field2array(field::Fields.FiniteDifferenceField)
             last_row = matrix_d < n_cols - n_rows ? n_rows : n_cols - matrix_d
 
             diagonal_data_view = view(diagonal_data, first_row:last_row)
-            allow_scalar_func(
-                ClimaComms.device(field),
-                copyto!,
-                (matrix_diagonal, diagonal_data_view),
-            )
+            allow_scalar(ClimaComms.device(field)) do
+                copyto!(matrix_diagonal, diagonal_data_view)
+            end
+            allow_scalar(ClimaComms.device(field)) do
+                copyto!(matrix_diagonal, diagonal_data_view)
+            end
         end
         return matrix
     else # field represents a vector
-        return allow_scalar_func(
-            ClimaComms.device(field),
-            Array,
-            (column_field2array_view(field),),
-        )
+        return allow_scalar(ClimaComms.device(field)) do
+            Array(column_field2array_view(field))
+        end
     end
 end
 
-allow_scalar_func(::ClimaComms.AbstractDevice, f, args) = f(args...)
 
 """
     column_field2array_view(field)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -41,3 +41,6 @@ Base.@propagate_inbounds column_args(args::Tuple{Any}, inds...) =
 Base.@propagate_inbounds column_args(args::Tuple{}, inds...) = ()
 
 function level end
+
+# TODO: move to ClimaComms
+allow_scalar(f, ::ClimaComms.AbstractDevice, args...) = f(args...)

--- a/test/DataLayouts/cuda.jl
+++ b/test/DataLayouts/cuda.jl
@@ -3,7 +3,9 @@ julia -g2 --check-bounds=yes --project=test
 using Revise; include(joinpath("test", "DataLayouts", "cuda.jl"))
 =#
 using Test
+using ClimaComms
 using CUDA
+ClimaComms.@import_required_backends
 using ClimaCore.DataLayouts
 
 function knl_copy!(dst, src)
@@ -20,14 +22,16 @@ function knl_copy!(dst, src)
 end
 
 function test_copy!(dst, src)
-    @cuda threads = (4, 4) blocks = (10,) knl_copy!(dst, src)
+    CUDA.@cuda threads = (4, 4) blocks = (10,) knl_copy!(dst, src)
 end
 
 @testset "data in GPU kernels" begin
 
     S = Tuple{Complex{Float64}, Float64}
-    src = IJFH{S, 4}(CuArray(rand(4, 4, 3, 10)))
-    dst = IJFH{S, 4}(CuArray(zeros(4, 4, 3, 10)))
+    device = ClimaComms.device()
+    ArrayType = ClimaComms.array_type(device)
+    src = IJFH{S, 4}(ArrayType(rand(4, 4, 3, 10)))
+    dst = IJFH{S, 4}(ArrayType(zeros(4, 4, 3, 10)))
 
     test_copy!(dst, src)
 
@@ -38,8 +42,10 @@ end
     FT = Float64
     S1 = NamedTuple{(:a, :b), Tuple{Complex{Float64}, Float64}}
     S2 = Float64
-    data_arr1 = CuArray(ones(FT, 2, 2, 3, 2))
-    data_arr2 = CuArray(ones(FT, 2, 2, 1, 2))
+    device = ClimaComms.device()
+    ArrayType = ClimaComms.array_type(device)
+    data_arr1 = ArrayType(ones(FT, 2, 2, 3, 2))
+    data_arr2 = ArrayType(ones(FT, 2, 2, 1, 2))
     data1 = IJFH{S1, 2}(data_arr1)
     data2 = IJFH{S2, 2}(data_arr2)
 
@@ -49,8 +55,8 @@ end
     @test Array(parent(res)) == FT[2 for i in 1:2, j in 1:2, f in 1:1, h in 1:2]
 
     Nv = 33
-    data_arr1 = CuArray(ones(FT, Nv, 4, 4, 3, 2))
-    data_arr2 = CuArray(ones(FT, Nv, 4, 4, 1, 2))
+    data_arr1 = ArrayType(ones(FT, Nv, 4, 4, 3, 2))
+    data_arr2 = ArrayType(ones(FT, Nv, 4, 4, 1, 2))
     data1 = VIJFH{S1, Nv, 4}(data_arr1)
     data2 = VIJFH{S2, Nv, 4}(data_arr2)
 
@@ -65,19 +71,21 @@ end
 @testset "broadcasting assignment from scalar" begin
     FT = Float64
     S = Complex{FT}
-    data = IJFH{S, 2}(CuArray{FT}, 3)
+    device = ClimaComms.device()
+    ArrayType = ClimaComms.array_type(device)
+    data = IJFH{S, 2}(ArrayType{FT}, 3)
     data .= Complex(1.0, 2.0)
     @test Array(parent(data)) ==
           FT[f == 1 ? 1 : 2 for i in 1:2, j in 1:2, f in 1:2, h in 1:3]
 
     Nv = 33
-    data = VIJFH{S, Nv, 4}(CuArray{FT}(undef, Nv, 4, 4, 2, 3))
+    data = VIJFH{S, Nv, 4}(ArrayType{FT}(undef, Nv, 4, 4, 2, 3))
     data .= Complex(1.0, 2.0)
     @test Array(parent(data)) == FT[
         f == 1 ? 1 : 2 for v in 1:Nv, i in 1:4, j in 1:4, f in 1:2, h in 1:3
     ]
 
-    data = DataF{S}(CuArray{FT})
+    data = DataF{S}(ArrayType{FT})
     data .= Complex(1.0, 2.0)
     @test Array(parent(data)) == FT[f == 1 ? 1 : 2 for f in 1:2]
 end

--- a/test/Fields/field_multi_broadcast_fusion.jl
+++ b/test/Fields/field_multi_broadcast_fusion.jl
@@ -9,6 +9,7 @@ using JET
 using BenchmarkTools
 
 using ClimaComms
+ClimaComms.@import_required_backends
 using OrderedCollections
 using StaticArrays, IntervalSets
 import ClimaCore
@@ -30,8 +31,6 @@ import ClimaCore.Fields: @fused_direct
 using LinearAlgebra: norm
 using Statistics: mean
 using ForwardDiff
-using CUDA
-using CUDA: @allowscalar
 
 util_file =
     joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl")
@@ -319,7 +318,6 @@ end
 @testset "FusedMultiBroadcast IJFH" begin
     FT = Float64
     device = ClimaComms.device()
-    ArrayType = device isa ClimaComms.CUDADevice ? CuArray : Array
     sem_space =
         TU.SphereSpectralElementSpace(FT; context = ClimaComms.context(device))
     IJFH_data() = Fields.Field(FT, sem_space)
@@ -342,7 +340,6 @@ end
 @testset "FusedMultiBroadcast VF" begin
     FT = Float64
     device = ClimaComms.device()
-    ArrayType = device isa ClimaComms.CUDADevice ? CuArray : Array
     colspace = TU.ColumnCenterFiniteDifferenceSpace(
         FT;
         zelem = 3,
@@ -361,7 +358,7 @@ end
 @testset "FusedMultiBroadcast DataF" begin
     FT = Float64
     device = ClimaComms.device()
-    ArrayType = device isa ClimaComms.CUDADevice ? CuArray : Array
+    ArrayType = ClimaComms.array_type(device)
     DataF_data() = DataF{FT}(ArrayType(ones(FT, 2)))
     X = Fields.FieldVector(;
         x1 = DataF_data(),

--- a/test/Fields/reduction_cuda.jl
+++ b/test/Fields/reduction_cuda.jl
@@ -1,6 +1,6 @@
 using Test
-using CUDA
 using ClimaComms
+ClimaComms.@import_required_backends
 using Statistics
 using LinearAlgebra
 

--- a/test/Fields/reduction_cuda_distributed.jl
+++ b/test/Fields/reduction_cuda_distributed.jl
@@ -1,5 +1,4 @@
 using Test
-using CUDA
 using ClimaComms
 ClimaComms.@import_required_backends
 using Statistics

--- a/test/Operators/finitedifference/column.jl
+++ b/test/Operators/finitedifference/column.jl
@@ -1,11 +1,10 @@
 using Test
 using StaticArrays, IntervalSets, LinearAlgebra
 
-import ClimaComms
+using ClimaComms
+ClimaComms.@import_required_backends
 import ClimaCore: slab, Domains, Meshes, Topologies, Spaces, Fields, Operators
 import ClimaCore.Domains: Geometry
-import CUDA
-CUDA.allowscalar(false)
 
 device = ClimaComms.device()
 

--- a/test/Operators/finitedifference/opt_examples.jl
+++ b/test/Operators/finitedifference/opt_examples.jl
@@ -1,4 +1,6 @@
-import ClimaCore, ClimaComms, CUDA
+import ClimaCore
+using ClimaComms
+ClimaComms.@import_required_backends
 using BenchmarkTools
 @isdefined(TU) || include(
     joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl"),
@@ -577,10 +579,6 @@ end
     p_allocated = @allocated set_ᶠuₕ³!(ᶜx, ᶠx)
     @show p_allocated
 
-    trial = if device isa ClimaComms.CUDADevice
-        @benchmark CUDA.@sync set_ᶠuₕ³!($ ᶜx, $ᶠx)
-    else
-        @benchmark set_ᶠuₕ³!($ ᶜx, $ᶠx)
-    end
+    trial = @benchmark ClimaComms.@cuda_sync $device set_ᶠuₕ³!($ ᶜx, $ᶠx)
     show(stdout, MIME("text/plain"), trial)
 end

--- a/test/Operators/hybrid/extruded_3dbox_cuda.jl
+++ b/test/Operators/hybrid/extruded_3dbox_cuda.jl
@@ -3,8 +3,9 @@ julia --project
 using Revise; include(joinpath("test", "Spaces", "extruded_3dbox_cuda.jl"))
 =#
 using LinearAlgebra, IntervalSets
-using CUDA
-using ClimaComms, ClimaCore
+using ClimaComms
+ClimaComms.@import_required_backends
+using ClimaCore
 import ClimaCore:
     Domains,
     Topologies,
@@ -157,8 +158,6 @@ end
             2 .* cos.(coords_gpu.y .+ coords_gpu.x .+ coords_gpu.z),
             cos.(coords_gpu.z),
         )
-
-    CUDA.allowscalar(false)
 
     # Test weak grad operator
     wgrad = Operators.WeakGradient()

--- a/test/Operators/hybrid/extruded_sphere_cuda.jl
+++ b/test/Operators/hybrid/extruded_sphere_cuda.jl
@@ -3,8 +3,9 @@ julia --project
 using Revise; include(joinpath("test", "Spaces", "extruded_sphere_cuda.jl"))
 =#
 using LinearAlgebra, IntervalSets
-using CUDA
-using ClimaComms, ClimaCore
+using ClimaComms
+ClimaComms.@import_required_backends
+using ClimaCore
 import ClimaCore:
     Domains,
     Topologies,
@@ -74,7 +75,7 @@ end
             2 .* cos.(coords_cpu.long .+ coords_cpu.lat),
         )
     x_gpu = Geometry.UVWVector.(cosd.(coords_gpu.lat), 0.0, 0.0)
-    CUDA.allowscalar(false)
+
     f_gpu = sin.(coords_gpu.lat .+ 2 .* coords_gpu.long)
     g_gpu =
         Geometry.UVVector.(


### PR DESCRIPTION
This PR removes some explicit CUDA dependence in some tests. Once we remove all of them, CUDA will not be needed in our CPU test suite. This is still helpful if a user tries running some of these individual tests locally and only need CPU resources.