### PR TITLE
Add downstream tests

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -1,0 +1,40 @@
+name: Downstream
+on:
+  push:
+    branches:
+      - main
+    tags: '*'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: downstream ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - 'ClimaAtmos.jl'
+          - 'ClimaCoupler.jl'
+          - 'ClimaDiagnostics.jl'
+          - 'ClimaLand.jl'
+          - 'ClimaTimeSteppers.jl'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1.10'
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: actions/checkout@v4
+        with:
+          repository: 'CliMA/${{ matrix.package }}'
+          path: ${{ matrix.package }}
+      - run: |
+          julia --color=yes --project=${{ matrix.package }} -e 'using Pkg; Pkg.instantiate()'
+          julia --color=yes --project=${{ matrix.package }} -e 'using Pkg; Pkg.develop(; path = ".")'
+          julia --color=yes --project=${{ matrix.package }} -e 'using Pkg; Pkg.test()'


### PR DESCRIPTION
Lots of packages depend on ClimaCore and it is hard to predict the ripple effects of small changes. This commit adds tests for the main downstream repositories that depend on ClimaCore. Passing these tests are not required to merge PRs, but can be a valuable piece of information.

Closes #1776 