### PR TITLE
Fix dss type param

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.14.6"
+version = "0.14.7"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/ext/cuda/topologies_dss.jl
+++ b/ext/cuda/topologies_dss.jl
@@ -17,9 +17,9 @@ _configure_threadblock(nitems) =
 function Topologies.dss_load_perimeter_data!(
     ::ClimaComms.CUDADevice,
     dss_buffer::Topologies.DSSBuffer,
-    data::Union{DataLayouts.IJFH{S, Nij}, DataLayouts.VIJFH{S, Nij}},
+    data::Union{DataLayouts.IJFH, DataLayouts.VIJFH},
     perimeter::Topologies.Perimeter2D,
-) where {S, Nij}
+)
     pperimeter_data = parent(dss_buffer.perimeter_data)
     pdata = parent(data)
     (nlevels, nperimeter, nfid, nelems) = size(pperimeter_data)
@@ -56,10 +56,10 @@ end
 
 function Topologies.dss_unload_perimeter_data!(
     ::ClimaComms.CUDADevice,
-    data::Union{DataLayouts.IJFH{S, Nij}, DataLayouts.VIJFH{S, Nij}},
+    data::Union{DataLayouts.IJFH, DataLayouts.VIJFH},
     dss_buffer::Topologies.DSSBuffer,
     perimeter,
-) where {S, Nij}
+)
     pperimeter_data = parent(dss_buffer.perimeter_data)
     pdata = parent(data)
     (nlevels, nperimeter, nfid, nelems) = size(pperimeter_data)

--- a/src/Spaces/dss.jl
+++ b/src/Spaces/dss.jl
@@ -27,9 +27,9 @@ perimeter(space::AbstractSpectralElementSpace) = Topologies.Perimeter2D(
 Creates a [`DSSBuffer`](@ref) for the field data corresponding to `data`
 """
 function create_dss_buffer(
-    data::Union{DataLayouts.IJFH{S, Nij}, DataLayouts.VIJFH{S, <:Any, Nij}},
+    data::Union{DataLayouts.IJFH, DataLayouts.VIJFH},
     hspace::SpectralElementSpace2D,
-) where {S, Nij}
+)
     create_dss_buffer(
         data,
         topology(hspace),
@@ -39,9 +39,9 @@ function create_dss_buffer(
 end
 
 function create_dss_buffer(
-    data::Union{DataLayouts.IFH{S, Nij}, DataLayouts.VIFH{S, <:Any, Nij}},
+    data::Union{DataLayouts.IFH, DataLayouts.VIFH},
     hspace::SpectralElementSpace1D,
-) where {S, Nij}
+)
     nothing
 end
 

--- a/src/Topologies/dss.jl
+++ b/src/Topologies/dss.jl
@@ -795,7 +795,7 @@ end
 Computed unweighted/pure DSS of `data`.
 """
 function dss!(
-    data::Union{DataLayouts.IJFH{S, Nij}, DataLayouts.VIJFH{S, Nij}},
+    data::Union{DataLayouts.IJFH{S, Nij}, DataLayouts.VIJFH{S, <:Any, Nij}},
     topology::Topology2D,
 ) where {S, Nij}
     length(parent(data)) == 0 && return nothing

--- a/src/Topologies/dss_transform.jl
+++ b/src/Topologies/dss_transform.jl
@@ -316,7 +316,7 @@ recv_buffer(ghost::GhostBuffer) = ghost.recv_data
 create_ghost_buffer(data, topology::Topologies.AbstractTopology) = nothing
 
 function create_ghost_buffer(
-    data::Union{DataLayouts.IJFH{S, Nij}, DataLayouts.VIJFH{S, Nij}},
+    data::Union{DataLayouts.IJFH{S, Nij}, DataLayouts.VIJFH{S, <:Any, Nij}},
     topology::Topologies.Topology2D,
 ) where {S, Nij}
     if data isa DataLayouts.IJFH


### PR DESCRIPTION
Closes #1772.

I've also removed type parameters from some of the other methods, since they are unused.

I'm actually a bit flabbergasted that this didn't require MSE changes (https://github.com/CliMA/ClimaAtmos.jl/pull/3058).

My thoughts on this are one of the following must be true:
 - This somehow (miraculously) worked due to `Nq`/`Nv` (though I doubt this)
 - ClimaAtmos' regression tests are insufficient or no longer working as expected (possible, though seems less likely)
 - The code that seems like it should break badly (below) is not actually executed/exercised (certainly possible)

Code that looks like it should break if `Nv` was sent in as `Nq`
```julia
Base.IteratorEltype(::Type{Perimeter2D{Nq}}) where {Nq} = Base.HasEltype()
Base.eltype(::Type{Perimeter2D{Nq}}) where {Nq} = Tuple{Int, Int}

Base.IteratorSize(::Type{Perimeter2D{Nq}}) where {Nq} = Base.HasLength()
Base.length(::Perimeter2D{Nq}) where {Nq} = 4 + (Nq - 2) * 4

function Base.iterate(perimeter::Perimeter2D{Nq}, loc = 1) where {Nq}
    if loc <= 4
        return (vertex_node_index(loc, Nq), loc + 1)
    elseif loc ≤ length(perimeter)
        f = cld(loc - 4, Nq - 2)
        n = mod(loc - 4, Nq - 2) == 0 ? (Nq - 2) : mod(loc - 4, Nq - 2)
        return (face_node_index(f, Nq, 1 + n), loc + 1)
    else
        return nothing
    end
end

function Base.getindex(perimeter::Perimeter2D{Nq}, loc = 1) where {Nq}
    if loc < 1 || loc > length(perimeter)
        return (-1, -1)
    elseif loc <= 4
        return vertex_node_index(loc, Nq)
    else
        f = cld(loc - 4, Nq - 2)
        n = mod(loc - 4, Nq - 2) == 0 ? (Nq - 2) : mod(loc - 4, Nq - 2)
        return face_node_index(f, Nq, 1 + n)
    end
end
```

Regardless, it would be nice if we somehow added tests for `Perimeter2D`. That said, the example that failed is a bit difficult to test precisely because we simply sent in the wrong integer into `Perimeter2D`'s type space. I don't think we should overcomplicate `Perimeter2D` for the sake of testing, but we should be able to somehow test `dss!` to take this into account. cc @sriharshakandala