### PR TITLE
Fix dispatching for some cuda kernels

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -77,6 +77,10 @@ steps:
         key: unit_data0d
         command: "julia --color=yes --check-bounds=yes --project=.buildkite test/DataLayouts/data0d.jl"
 
+      - label: "Unit: data_fill"
+        key: unit_data_fill
+        command: "julia --color=yes --check-bounds=yes --project=.buildkite test/DataLayouts/unit_fill.jl"
+
       - label: "Unit: data1d"
         key: unit_data1d
         command: "julia --color=yes --check-bounds=yes --project=.buildkite test/DataLayouts/data1d.jl"
@@ -98,6 +102,16 @@ steps:
         command:
           - "julia --project=.buildkite -e 'using CUDA; CUDA.versioninfo()'"
           - "julia --color=yes --check-bounds=yes --project=.buildkite test/DataLayouts/cuda.jl CUDA"
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+        agents:
+          slurm_gpus: 1
+
+      - label: "Unit: data fill"
+        key: gpu_unit_data_fill
+        command:
+          - "julia --project=.buildkite -e 'using CUDA; CUDA.versioninfo()'"
+          - "julia --color=yes --check-bounds=yes --project=.buildkite test/DataLayouts/unit_fill.jl"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -1059,6 +1073,23 @@ steps:
       - label: "Perf: Axis tensor conversion benchmarks"
         key: "cpu_axis_tensor_conversion_perf_bm"
         command: "julia --color=yes --project=.buildkite test/Geometry/axistensor_conversion_benchmarks.jl"
+
+  - group: "Perf: DataLayouts"
+    steps:
+
+      - label: "Perf: DataLayouts fill"
+        key: "cpu_datalayouts_fill"
+        command: "julia --color=yes --project=.buildkite test/DataLayouts/benchmark_fill.jl"
+
+      - label: "Perf: DataLayouts fill"
+        key: "gpu_datalayouts_fill"
+        command:
+          - "julia --project=.buildkite -e 'using CUDA; CUDA.versioninfo()'"
+          - "julia --color=yes --project=.buildkite test/DataLayouts/benchmark_fill.jl"
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+        agents:
+          slurm_gpus: 1
 
   - group: "Perf: Fields"
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           version: '1.10'
       - name: Install dependencies
-        run: julia --project=docs -e 'using Pkg; Pkg.instantiate(;verbose=true)'
+        run: julia --project=docs -e 'using Pkg; Pkg.develop(path="."); Pkg.instantiate(;verbose=true)'
       - name: Build and deploy
         env:
           GKSwstype: "100" # headless GR: https://discourse.julialang.org/t/generation-of-documentation-fails-qt-qpa-xcb-could-not-connect-to-display/60988/2

--- a/ext/ClimaCoreCUDAExt.jl
+++ b/ext/ClimaCoreCUDAExt.jl
@@ -14,6 +14,9 @@ import ClimaCore.Utilities: half
 import ClimaCore.RecursiveApply:
     ⊠, ⊞, ⊟, radd, rmul, rsub, rdiv, rmap, rzero, rmin, rmax
 
+const CuArrayBackedTypes =
+    Union{CUDA.CuArray, SubArray{<:Any, <:Any, CUDA.CuArray}}
+
 include(joinpath("cuda", "cuda_utils.jl"))
 include(joinpath("cuda", "data_layouts.jl"))
 include(joinpath("cuda", "fields.jl"))

--- a/ext/cuda/fill.jl
+++ b/ext/cuda/fill.jl
@@ -1,0 +1,30 @@
+cartesian_index(::AbstractData, inds) = CartesianIndex(inds)
+
+function knl_fill_flat!(dest::AbstractData, val)
+    n = DataLayouts.universal_size(dest)
+    inds = kernel_indexes(n)
+    if valid_range(inds, n)
+        I = cartesian_index(dest, inds)
+        @inbounds dest[I] = val
+    end
+    return nothing
+end
+
+function cuda_fill!(dest::AbstractData, val)
+    (_, _, Nf, Nv, Nh) = DataLayouts.universal_size(dest)
+    if Nv > 0 && Nh > 0 && Nf > 0
+        auto_launch!(knl_fill_flat!, (dest, val), dest; auto = true)
+    end
+    return dest
+end
+
+#! format: off
+Base.fill!(dest::IJFH{<:Any, <:Any, <:CuArrayBackedTypes},         val) = cuda_fill!(dest, val)
+Base.fill!(dest::IFH{<:Any, <:Any, <:CuArrayBackedTypes},          val) = cuda_fill!(dest, val)
+Base.fill!(dest::IJF{<:Any, <:Any, <:CuArrayBackedTypes},          val) = cuda_fill!(dest, val)
+Base.fill!(dest::IF{<:Any, <:Any, <:CuArrayBackedTypes},           val) = cuda_fill!(dest, val)
+Base.fill!(dest::VIFH{<:Any, <:Any, <:Any, <:CuArrayBackedTypes},  val) = cuda_fill!(dest, val)
+Base.fill!(dest::VIJFH{<:Any, <:Any, <:Any, <:CuArrayBackedTypes}, val) = cuda_fill!(dest, val)
+Base.fill!(dest::VF{<:Any, <:Any, <:CuArrayBackedTypes},           val) = cuda_fill!(dest, val)
+Base.fill!(dest::DataF{<:Any, <:CuArrayBackedTypes},               val) = cuda_fill!(dest, val)
+#! format: on

--- a/src/DataLayouts/broadcast.jl
+++ b/src/DataLayouts/broadcast.jl
@@ -678,13 +678,12 @@ function Base.copyto!(
         end,
     )
     # check_fused_broadcast_axes(fmbc) # we should already have checked the axes
-    fused_copyto!(fmb_inst, dest1, ClimaComms.device(dest1))
+    fused_copyto!(fmb_inst, dest1)
 end
 
 function fused_copyto!(
     fmbc::FusedMultiBroadcast,
     dest1::VIJFH{S1, Nv1, Nij},
-    ::ClimaComms.AbstractCPUDevice,
 ) where {S1, Nv1, Nij}
     _, _, _, _, Nh = size(dest1)
     for (dest, bc) in fmbc.pairs
@@ -700,9 +699,8 @@ end
 
 function fused_copyto!(
     fmbc::FusedMultiBroadcast,
-    dest1::IJFH{S, Nij, A},
-    ::ClimaComms.AbstractCPUDevice,
-) where {S, Nij, A}
+    dest1::IJFH{S, Nij},
+) where {S, Nij}
     # copy contiguous columns
     _, _, _, Nv, Nh = size(dest1)
     for (dest, bc) in fmbc.pairs
@@ -717,9 +715,8 @@ end
 
 function fused_copyto!(
     fmbc::FusedMultiBroadcast,
-    dest1::VIFH{S, Nv1, Ni, A},
-    ::ClimaComms.AbstractCPUDevice,
-) where {S, Nv1, Ni, A}
+    dest1::VIFH{S, Nv1, Ni},
+) where {S, Nv1, Ni}
     # copy contiguous columns
     _, _, _, _, Nh = size(dest1)
     for (dest, bc) in fmbc.pairs
@@ -734,9 +731,8 @@ end
 
 function fused_copyto!(
     fmbc::FusedMultiBroadcast,
-    dest1::VF{S1, Nv1, A},
-    ::ClimaComms.AbstractCPUDevice,
-) where {S1, Nv1, A}
+    dest1::VF{S1, Nv1},
+) where {S1, Nv1}
     for (dest, bc) in fmbc.pairs
         @inbounds for v in 1:Nv1
             I = CartesianIndex(1, 1, 1, v, 1)
@@ -747,11 +743,7 @@ function fused_copyto!(
     return nothing
 end
 
-function fused_copyto!(
-    fmbc::FusedMultiBroadcast,
-    dest::DataF{S},
-    ::ClimaComms.AbstractCPUDevice,
-) where {S}
+function fused_copyto!(fmbc::FusedMultiBroadcast, dest::DataF{S}) where {S}
     for (dest, bc) in fmbc.pairs
         @inbounds dest[] = convert(S, bc[])
     end

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -143,6 +143,7 @@ const ExtrudedCubedSphereSpectralElementField3D{V, S} = Field{
 }
 
 Base.propertynames(field::Field) = propertynames(getfield(field, :values))
+Base.ndims(::Type{Field{V, S}}) where {V, S} = Base.ndims(V)
 @inline field_values(field::Field) = getfield(field, :values)
 
 # Define the axes field to be the todata(bc) of the return field

--- a/test/DataLayouts/benchmark_fill.jl
+++ b/test/DataLayouts/benchmark_fill.jl
@@ -1,0 +1,40 @@
+#=
+julia --project
+using Revise; include(joinpath("test", "DataLayouts", "benchmark_fill.jl"))
+=#
+using Test
+using ClimaCore.DataLayouts
+using BenchmarkTools
+import ClimaComms
+@static pkgversion(ClimaComms) >= v"0.6" && ClimaComms.@import_required_backends
+
+function benchmarkfill!(device, data, val)
+    trial = @benchmark ClimaComms.@cuda_sync $device fill!($data, $val)
+    show(stdout, MIME("text/plain"), trial)
+    println()
+end
+
+@testset "fill! with Nf = 1" begin
+    device = ClimaComms.device()
+    device_zeros(args...) = ClimaComms.array_type(device)(zeros(args...))
+    FT = Float64
+    S = FT
+    Nf = 1
+    Nv = 63
+    Nij = 4
+    Nh = 30
+    Nk = 6
+#! format: off
+    data = DataF{S}(device_zeros(FT,Nf));                        benchmarkfill!(device, data, 3); @test all(parent(data) .== 3)
+    data = IJFH{S, Nij}(device_zeros(FT,Nij,Nij,Nf,Nh));         benchmarkfill!(device, data, 3); @test all(parent(data) .== 3)
+    data = IFH{S, Nij}(device_zeros(FT,Nij,Nf,Nh));              benchmarkfill!(device, data, 3); @test all(parent(data) .== 3)
+    data = IJF{S, Nij}(device_zeros(FT,Nij,Nij,Nf));             benchmarkfill!(device, data, 3); @test all(parent(data) .== 3)
+    data = IF{S, Nij}(device_zeros(FT,Nij,Nf));                  benchmarkfill!(device, data, 3); @test all(parent(data) .== 3)
+    data = VF{S, Nv}(device_zeros(FT,Nv,Nf));                    benchmarkfill!(device, data, 3); @test all(parent(data) .== 3)
+    data = VIJFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nij,Nf,Nh)); benchmarkfill!(device, data, 3); @test all(parent(data) .== 3)
+    data = VIFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nf,Nh));      benchmarkfill!(device, data, 3); @test all(parent(data) .== 3)
+#! format: on
+
+    # data = IJKFVH{S}(device_zeros(FT,Nij,Nij,Nk,Nf,Nh)); benchmarkfill!(device, data, 3); @test all(parent(data) .== 3) # TODO: test
+    # data = IH1JH2{S}(device_zeros(FT,Nij,Nij,Nk,Nf,Nh)); benchmarkfill!(device, data, 3); @test all(parent(data) .== 3) # TODO: test
+end

--- a/test/DataLayouts/unit_fill.jl
+++ b/test/DataLayouts/unit_fill.jl
@@ -1,0 +1,57 @@
+#=
+julia --project
+using Revise; include(joinpath("test", "DataLayouts", "fill.jl"))
+=#
+using Test
+using ClimaCore.DataLayouts
+import ClimaComms
+ClimaComms.@import_required_backends
+
+@testset "fill! with Nf = 1" begin
+    device = ClimaComms.device()
+    device_zeros(args...) = ClimaComms.array_type(device)(zeros(args...))
+    FT = Float64
+    S = FT
+    Nf = 1
+    Nv = 4
+    Nij = 3
+    Nh = 5
+    Nk = 6
+#! format: off
+    data = DataF{S}(device_zeros(FT,Nf));                        fill!(data, 3); @test all(parent(data) .== 3)
+    data = IJFH{S, Nij}(device_zeros(FT,Nij,Nij,Nf,Nh));         fill!(data, 3); @test all(parent(data) .== 3)
+    data = IFH{S, Nij}(device_zeros(FT,Nij,Nf,Nh));              fill!(data, 3); @test all(parent(data) .== 3)
+    data = IJF{S, Nij}(device_zeros(FT,Nij,Nij,Nf));             fill!(data, 3); @test all(parent(data) .== 3)
+    data = IF{S, Nij}(device_zeros(FT,Nij,Nf));                  fill!(data, 3); @test all(parent(data) .== 3)
+    data = VF{S, Nv}(device_zeros(FT,Nv,Nf));                    fill!(data, 3); @test all(parent(data) .== 3)
+    data = VIJFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nij,Nf,Nh)); fill!(data, 3); @test all(parent(data) .== 3)
+    data = VIFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nf,Nh));      fill!(data, 3); @test all(parent(data) .== 3)
+#! format: on
+    # data = DataLayouts.IJKFVH{S, Nij, Nk}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); fill!(data, (2,3)); @test all(parent(data) .== 3) # TODO: test
+    # data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));             fill!(data, (2,3)); @test all(parent(data) .== 3) # TODO: test
+end
+
+@testset "fill! with Nf > 1" begin
+    device = ClimaComms.device()
+    device_zeros(args...) = ClimaComms.array_type(device)(zeros(args...))
+    FT = Float64
+    S = Tuple{FT, FT}
+    Nf = 2
+    Nv = 4
+    Nij = 3
+    Nh = 5
+    Nk = 6
+#! format: off
+    data = DataF{S}(device_zeros(FT,Nf));                        fill!(data, (2,3)); @test all(parent(data.:1) .== 2); @test all(parent(data.:2) .== 3)
+    data = IJFH{S, Nij}(device_zeros(FT,Nij,Nij,Nf,Nh));         fill!(data, (2,3)); @test all(parent(data.:1) .== 2); @test all(parent(data.:2) .== 3)
+    data = IFH{S, Nij}(device_zeros(FT,Nij,Nf,Nh));              fill!(data, (2,3)); @test all(parent(data.:1) .== 2); @test all(parent(data.:2) .== 3)
+    data = IJF{S, Nij}(device_zeros(FT,Nij,Nij,Nf));             fill!(data, (2,3)); @test all(parent(data.:1) .== 2); @test all(parent(data.:2) .== 3)
+    data = IF{S, Nij}(device_zeros(FT,Nij,Nf));                  fill!(data, (2,3)); @test all(parent(data.:1) .== 2); @test all(parent(data.:2) .== 3)
+    data = VF{S, Nv}(device_zeros(FT,Nv,Nf));                    fill!(data, (2,3)); @test all(parent(data.:1) .== 2); @test all(parent(data.:2) .== 3)
+    data = VIJFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nij,Nf,Nh)); fill!(data, (2,3)); @test all(parent(data.:1) .== 2); @test all(parent(data.:2) .== 3)
+    data = VIFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nf,Nh));      fill!(data, (2,3)); @test all(parent(data.:1) .== 2); @test all(parent(data.:2) .== 3)
+#! format: on
+    # TODO: test this
+    # data = DataLayouts.IJKFVH{S, Nij, Nk}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); fill!(data, (2,3)); @test all(parent(data) .== (2,3)) # TODO: test
+    # data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));             fill!(data, (2,3)); @test all(parent(data) .== (2,3)) # TODO: test
+end

--- a/test/DataLayouts/unit_ndims.jl
+++ b/test/DataLayouts/unit_ndims.jl
@@ -1,0 +1,32 @@
+#=
+julia --project
+using Revise; include(joinpath("test", "DataLayouts", "ndims.jl"))
+=#
+using Test
+using ClimaCore.DataLayouts
+import ClimaComms
+ClimaComms.@import_required_backends
+
+@testset "Base.ndims" begin
+    device = ClimaComms.device()
+    device_zeros(args...) = ClimaComms.array_type(device)(zeros(args...))
+    FT = Float64
+    S = FT
+    Nf = 1
+    Nv = 4
+    Nij = 3
+    Nh = 5
+    Nk = 6
+#! format: off
+    data = DataF{S}(device_zeros(FT,Nf));                                        @test ndims(data) == 1; @test ndims(typeof(data)) == 1
+    data = IF{S, Nij}(device_zeros(FT,Nij,Nf));                                  @test ndims(data) == 2; @test ndims(typeof(data)) == 2
+    data = VF{S, Nv}(device_zeros(FT,Nv,Nf));                                    @test ndims(data) == 2; @test ndims(typeof(data)) == 2
+    data = IFH{S, Nij}(device_zeros(FT,Nij,Nf,Nh));                              @test ndims(data) == 3; @test ndims(typeof(data)) == 3
+    data = IJF{S, Nij}(device_zeros(FT,Nij,Nij,Nf));                             @test ndims(data) == 3; @test ndims(typeof(data)) == 3
+    data = IJFH{S, Nij}(device_zeros(FT,Nij,Nij,Nf,Nh));                         @test ndims(data) == 4; @test ndims(typeof(data)) == 4
+    data = VIFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nf,Nh));                      @test ndims(data) == 4; @test ndims(typeof(data)) == 4
+    data = VIJFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nij,Nf,Nh));                 @test ndims(data) == 5; @test ndims(typeof(data)) == 5
+    data = DataLayouts.IJKFVH{S, Nij, Nk}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); @test ndims(data) == 6; @test ndims(typeof(data)) == 6
+    data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));             @test ndims(data) == 2; @test ndims(typeof(data)) == 2
+#! format: on
+end

--- a/test/Fields/field_multi_broadcast_fusion.jl
+++ b/test/Fields/field_multi_broadcast_fusion.jl
@@ -72,9 +72,9 @@ function CenterExtrudedFiniteDifferenceSpaceLineHSpace(
     return Spaces.ExtrudedFiniteDifferenceSpace(hspace, vspace)
 end
 
-function benchmark_kernel!(f!, X, Y)
+function benchmark_kernel!(f!, X, Y, device)
     println("\n--------------------------- $(nameof(typeof(f!))) ")
-    trial = benchmark_kernel!(f!, X, Y, ClimaComms.device(X.x1))
+    trial = benchmark_kernel!(f!, X, Y, device)
     show(stdout, MIME("text/plain"), trial)
 end
 benchmark_kernel!(f!, X, Y, ::ClimaComms.CUDADevice) =
@@ -250,11 +250,12 @@ end
 
 @testset "FusedMultiBroadcast VIJFH and VF" begin
     FT = Float64
+    device = ClimaComms.device()
     space = TU.CenterExtrudedFiniteDifferenceSpace(
         FT;
         zelem = 3,
         helem = 4,
-        context = ClimaComms.context(),
+        context = ClimaComms.context(device),
     )
     X = Fields.FieldVector(
         x1 = rand_field(FT, space),
@@ -269,11 +270,11 @@ end
     test_kernel!(; fused!, unfused!, X, Y)
     test_kernel!(; fused! = fused_bycolumn!, unfused! = unfused_bycolumn!, X, Y)
 
-    benchmark_kernel!(unfused!, X, Y)
-    benchmark_kernel!(fused!, X, Y)
+    benchmark_kernel!(unfused!, X, Y, device)
+    benchmark_kernel!(fused!, X, Y, device)
 
-    benchmark_kernel!(unfused_bycolumn!, X, Y)
-    benchmark_kernel!(fused_bycolumn!, X, Y)
+    benchmark_kernel!(unfused_bycolumn!, X, Y, device)
+    benchmark_kernel!(fused_bycolumn!, X, Y, device)
     nothing
 end
 
@@ -306,11 +307,11 @@ end
             Y,
         )
 
-        benchmark_kernel!(unfused!, X, Y)
-        benchmark_kernel!(fused!, X, Y)
+        benchmark_kernel!(unfused!, X, Y, device)
+        benchmark_kernel!(fused!, X, Y, device)
 
-        benchmark_kernel!(unfused_bycolumn!, X, Y)
-        benchmark_kernel!(fused_bycolumn!, X, Y)
+        benchmark_kernel!(unfused_bycolumn!, X, Y, device)
+        benchmark_kernel!(fused_bycolumn!, X, Y, device)
         nothing
     end
 end
@@ -332,8 +333,8 @@ end
         y3 = IJFH_data(),
     )
     test_kernel!(; fused!, unfused!, X, Y)
-    benchmark_kernel!(unfused!, X, Y)
-    benchmark_kernel!(fused!, X, Y)
+    benchmark_kernel!(unfused!, X, Y, device)
+    benchmark_kernel!(fused!, X, Y, device)
     nothing
 end
 
@@ -350,8 +351,8 @@ end
     X = Fields.FieldVector(; x1 = VF_data(), x2 = VF_data(), x3 = VF_data())
     Y = Fields.FieldVector(; y1 = VF_data(), y2 = VF_data(), y3 = VF_data())
     test_kernel!(; fused!, unfused!, X, Y)
-    benchmark_kernel!(unfused!, X, Y)
-    benchmark_kernel!(fused!, X, Y)
+    benchmark_kernel!(unfused!, X, Y, device)
+    benchmark_kernel!(fused!, X, Y, device)
     nothing
 end
 
@@ -359,7 +360,7 @@ end
     FT = Float64
     device = ClimaComms.device()
     ArrayType = ClimaComms.array_type(device)
-    DataF_data() = DataF{FT}(ArrayType(ones(FT, 2)))
+    DataF_data() = DataF{FT}(ArrayType(ones(FT, 1)))
     X = Fields.FieldVector(;
         x1 = DataF_data(),
         x2 = DataF_data(),
@@ -371,7 +372,7 @@ end
         y3 = DataF_data(),
     )
     test_kernel!(; fused!, unfused!, X, Y)
-    benchmark_kernel!(unfused!, X, Y)
-    benchmark_kernel!(fused!, X, Y)
+    benchmark_kernel!(unfused!, X, Y, device)
+    benchmark_kernel!(fused!, X, Y, device)
     nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,8 @@ ERROR: Package ClimaCore errored during testing (exit code: 541541187)
 Stacktrace:
  [1] pkgerror(msg::String)
 =#
+@safetestset "DataLayouts fill" begin @time include("DataLayouts/unit_fill.jl") end
+@safetestset "DataLayouts ndims" begin @time include("DataLayouts/unit_ndims.jl") end
 if !Sys.iswindows()
     #=
     @safetestset "Recursive" begin @time include("RecursiveApply/recursive_apply.jl") end


### PR DESCRIPTION
This should close https://github.com/CliMA/ClimaCore.jl/issues/1786, but I think we need more careful testing around this.

This PR:
 - revamps and adds tests for `fill!`
 - Makes `size` return the correct number of fields for all datalayouts, instead of returning 1 (this may need to be reverted if we rely on this).
 - Fixes a bug in our `setindex!` for `IFH` datalayouts.

cc @trontrytel 