### PR TITLE
Add wrapper for FieldMatrix and FieldMatrixSolver

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,12 @@ ClimaCore.jl Release Notes
 main
 -------
 
+v0.14.8
+-------
+
+- ![][badge-✨feature/enhancement] Added `FieldMatrixWithSolver`, a wrapper that helps defining implicit Jacobians. PR [#1788](https://github.com/CliMA/ClimaCore.jl/pull/1788)
+
+
 v0.14.6
 -------
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.14.7"
+version = "0.14.8"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/docs/src/matrix_fields.md
+++ b/docs/src/matrix_fields.md
@@ -31,6 +31,7 @@ operator_matrix
 ```@docs
 FieldMatrixSolverAlgorithm
 FieldMatrixSolver
+FieldMatrixWithSolver
 field_matrix_solve!
 BlockDiagonalSolve
 BlockLowerTriangularSolve

--- a/src/MatrixFields/MatrixFields.jl
+++ b/src/MatrixFields/MatrixFields.jl
@@ -43,7 +43,8 @@ multiples of `LinearAlgebra.I`. This comes with the following functionality:
 """
 module MatrixFields
 
-import LinearAlgebra: I, UniformScaling, Adjoint, AdjointAbsVec, mul!, inv, norm
+import LinearAlgebra: I, UniformScaling, Adjoint, AdjointAbsVec
+import LinearAlgebra: inv, norm, ldiv!, mul!
 import StaticArrays: SMatrix, SVector
 import BandedMatrices: BandedMatrix, band, _BandedMatrix
 import RecursiveArrayTools: recursive_bottom_eltype
@@ -73,7 +74,7 @@ export DiagonalMatrixRow,
     QuaddiagonalMatrixRow,
     PentadiagonalMatrixRow
 export FieldVectorKeys, FieldMatrixKeys, FieldVectorView, FieldMatrix
-export ⋅, FieldMatrixSolver, field_matrix_solve!
+export FieldMatrixWithSolver, ⋅
 
 # Types that are teated as single values when using matrix fields.
 const SingleValue =
@@ -106,6 +107,7 @@ include("single_field_solver.jl")
 include("multiple_field_solver.jl")
 include("field_matrix_solver.jl")
 include("field_matrix_iterative_solver.jl")
+include("field_matrix_with_solver.jl")
 
 function Base.show(io::IO, field::ColumnwiseBandMatrixField)
     print(io, eltype(field), "-valued Field")

--- a/src/MatrixFields/field_matrix_with_solver.jl
+++ b/src/MatrixFields/field_matrix_with_solver.jl
@@ -1,0 +1,48 @@
+"""
+    FieldMatrixWithSolver(A, b, [alg])
+
+A wrapper that combines a `FieldMatrix` `A` with a `FieldMatrixSolver` that can
+be used to solve the equation `A * x = b` for `x`, where `x` and `b` are both
+`FieldVector`s. Similar to a `LinearAlgebra.Factorization`, this wrapper can be
+passed to `ldiv!`, whereas a regular `FieldMatrix` cannot be passed to `ldiv!`.
+
+By default, the `FieldMatrixSolverAlgorithm` `alg` is set to a
+[`BlockDiagonalSolve`](@ref), so a custom `alg` must be specified when `A` is
+not a block diagonal matrix.
+"""
+struct FieldMatrixWithSolver{M, S} <: AbstractDict{FieldNamePair, Any}
+    matrix::M
+    solver::S
+end
+FieldMatrixWithSolver(
+    A::FieldMatrix,
+    b::Fields.FieldVector,
+    alg::FieldMatrixSolverAlgorithm = BlockDiagonalSolve(),
+) = FieldMatrixWithSolver(A, FieldMatrixSolver(alg, A, b))
+
+# TODO: Find a simple way to make b an optional argument and add a method for
+# Base.one(::FieldMatrixWithSolver).
+
+Base.keys(A::FieldMatrixWithSolver) = keys(A.matrix)
+
+Base.values(A::FieldMatrixWithSolver) = values(A.matrix)
+
+Base.pairs(A::FieldMatrixWithSolver) = pairs(A.matrix)
+
+Base.length(A::FieldMatrixWithSolver) = length(A.matrix)
+
+Base.iterate(A::FieldMatrixWithSolver, index = 1) = iterate(A.matrix, index)
+
+Base.getindex(A::FieldMatrixWithSolver, key) = getindex(A.matrix, key)
+
+Base.:(==)(A1::FieldMatrixWithSolver, A2::FieldMatrixWithSolver) =
+    A1.matrix == A2.matrix && A1.solver.alg == A2.solver.alg
+
+Base.similar(A::FieldMatrixWithSolver) =
+    FieldMatrixWithSolver(similar(A.matrix), A.solver)
+
+ldiv!(x::Fields.FieldVector, A::FieldMatrixWithSolver, b::Fields.FieldVector) =
+    field_matrix_solve!(A.solver, x, A.matrix, b)
+
+mul!(b::Fields.FieldVector, A::FieldMatrixWithSolver, x::Fields.FieldVector) =
+    @. b = A.matrix * x


### PR DESCRIPTION
<!-- Provide a clear description of the content -->
This PR adds the `InvertibleFieldMatrix` struct, which is a simple wrapper for a `FieldMatrix` and a corresponding `FieldMatrixSolver`. The wrapper has a constructor that specifies a default `FieldMatrixSolverAlgorithm`, and it also has methods for `similar`, `ldiv!`, and `mul!`. This should allow us to remove a lot of boilerplate code that is currently needed to set up implicit solvers (see [this comment](https://github.com/CliMA/ClimaTimeSteppers.jl/pull/292#discussion_r1630312851) in ClimaTimeSteppers).

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
