### PR TITLE
Remove CUDA from the test extras

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -93,7 +93,6 @@ AssociatedLegendrePolynomials = "2119f1ac-fb78-50f5-8cc0-dda848ebdb19"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 CountFlops = "1db9610d-79e1-487a-8d40-77f3295c7593"
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 Krylov = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
@@ -109,5 +108,5 @@ TerminalLoggers = "5d786b92-1e48-4d6f-9151-6b4477ca9bed"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ArgParse", "AssociatedLegendrePolynomials", "BenchmarkTools", "Combinatorics", "CountFlops", "CUDA", "Dates", "FastBroadcast", "Krylov", "JET", "Logging", "MPI", "OrderedCollections", "PrettyTables", "Random", "SafeTestsets", "StatsBase", "TerminalLoggers", "Test"]
+test = ["Aqua", "ArgParse", "AssociatedLegendrePolynomials", "BenchmarkTools", "Combinatorics", "CountFlops", "Dates", "FastBroadcast", "Krylov", "JET", "Logging", "MPI", "OrderedCollections", "PrettyTables", "Random", "SafeTestsets", "StatsBase", "TerminalLoggers", "Test"]
 

--- a/test/MatrixFields/field_matrix_solvers.jl
+++ b/test/MatrixFields/field_matrix_solvers.jl
@@ -54,8 +54,8 @@ function test_field_matrix_solver(; test_name, alg, A, b, use_rel_error = false)
         # In addition to ignoring the type instabilities from CUDA, ignore those
         # from CUBLAS (norm), KrylovKit (eigsolve), and CoreLogging (@debug).
         ignored = (
-            ignore_cuda...,
-            using_cuda ? AnyFrameModule(CUDA.CUBLAS) :
+            cuda_frames...,
+            cublas_frames...,
             AnyFrameModule(MatrixFields.KrylovKit),
             AnyFrameModule(Base.CoreLogging),
         )

--- a/test/MatrixFields/operator_matrices.jl
+++ b/test/MatrixFields/operator_matrices.jl
@@ -321,7 +321,7 @@ end
         )),
     )
         get_result()
-        @test_opt ignored_modules = ignore_cuda get_result()
+        @test_opt ignored_modules = cuda_frames get_result()
     end
 
     test_field_broadcast(;


### PR DESCRIPTION
This PR removes CUDA from the test environment.

I did comment out `Operators/spectralelement/opt.jl` of runtests.jl (it's still run on buildkite), due to https://github.com/aviatesk/JET.jl/issues/602.

I think soon we'll split off our tests into
 - `runtests_opt.jl` that performs all allocation, flop-counting, and inference tests.
 - `runtests_benchmark.jl` that performs all benchmarks
 - `runtests_convergence.jl` that performs all convergence tests

(https://github.com/CliMA/ClimaCore.jl/pull/1784)