### PR TITLE
Fix broken GPU dispatching

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -81,6 +81,10 @@ steps:
         key: unit_data_fill
         command: "julia --color=yes --check-bounds=yes --project=.buildkite test/DataLayouts/unit_fill.jl"
 
+      - label: "Unit: data_ndims"
+        key: unit_data_ndims
+        command: "julia --color=yes --check-bounds=yes --project=.buildkite test/DataLayouts/unit_ndims.jl"
+
       - label: "Unit: data1d"
         key: unit_data1d
         command: "julia --color=yes --check-bounds=yes --project=.buildkite test/DataLayouts/data1d.jl"

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@ ClimaCore.jl Release Notes
 main
 -------
 
+v0.14.9
+-------
+
+- ![][badge-🐛bugfix] GPU dispatching with `copyto!` and `fill!` have been fixed PR [#1802](https://github.com/CliMA/ClimaCore.jl/pull/1802).
+
 v0.14.8
 -------
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.14.8"
+version = "0.14.9"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/ext/ClimaCoreCUDAExt.jl
+++ b/ext/ClimaCoreCUDAExt.jl
@@ -15,7 +15,7 @@ import ClimaCore.RecursiveApply:
     ⊠, ⊞, ⊟, radd, rmul, rsub, rdiv, rmap, rzero, rmin, rmax
 
 const CuArrayBackedTypes =
-    Union{CUDA.CuArray, SubArray{<:Any, <:Any, CUDA.CuArray}}
+    Union{CUDA.CuArray, SubArray{<:Any, <:Any, <:CUDA.CuArray}}
 
 include(joinpath("cuda", "cuda_utils.jl"))
 include(joinpath("cuda", "data_layouts.jl"))

--- a/src/DataLayouts/DataLayouts.jl
+++ b/src/DataLayouts/DataLayouts.jl
@@ -841,6 +841,9 @@ struct IF{S, Ni, A} <: DataSlab1D{S, Ni}
     array::A
 end
 
+rebuild(data::IF{S, Nij}, array::A) where {S, Nij, A <: AbstractArray} =
+    IF{S, Nij, A}(array)
+
 parent_array_type(::Type{IF{S, Ni, A}}) where {S, Ni, A} = A
 
 function IF{S, Ni}(array::AbstractArray{T, 2}) where {S, Ni, T}

--- a/test/DataLayouts/unit_fill.jl
+++ b/test/DataLayouts/unit_fill.jl
@@ -7,6 +7,16 @@ using ClimaCore.DataLayouts
 import ClimaComms
 ClimaComms.@import_required_backends
 
+function test_fill!(data, vals::Tuple{<:Any, <:Any})
+    fill!(data, vals)
+    @test all(parent(data.:1) .== vals[1])
+    @test all(parent(data.:2) .== vals[2])
+end
+function test_fill!(data, val::Real)
+    fill!(data, val)
+    @test all(parent(data) .== val)
+end
+
 @testset "fill! with Nf = 1" begin
     device = ClimaComms.device()
     device_zeros(args...) = ClimaComms.array_type(device)(zeros(args...))
@@ -18,17 +28,17 @@ ClimaComms.@import_required_backends
     Nh = 5
     Nk = 6
 #! format: off
-    data = DataF{S}(device_zeros(FT,Nf));                        fill!(data, 3); @test all(parent(data) .== 3)
-    data = IJFH{S, Nij}(device_zeros(FT,Nij,Nij,Nf,Nh));         fill!(data, 3); @test all(parent(data) .== 3)
-    data = IFH{S, Nij}(device_zeros(FT,Nij,Nf,Nh));              fill!(data, 3); @test all(parent(data) .== 3)
-    data = IJF{S, Nij}(device_zeros(FT,Nij,Nij,Nf));             fill!(data, 3); @test all(parent(data) .== 3)
-    data = IF{S, Nij}(device_zeros(FT,Nij,Nf));                  fill!(data, 3); @test all(parent(data) .== 3)
-    data = VF{S, Nv}(device_zeros(FT,Nv,Nf));                    fill!(data, 3); @test all(parent(data) .== 3)
-    data = VIJFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nij,Nf,Nh)); fill!(data, 3); @test all(parent(data) .== 3)
-    data = VIFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nf,Nh));      fill!(data, 3); @test all(parent(data) .== 3)
+    data = DataF{S}(device_zeros(FT,Nf));                        test_fill!(data, 3)
+    data = IJFH{S, Nij}(device_zeros(FT,Nij,Nij,Nf,Nh));         test_fill!(data, 3)
+    data = IFH{S, Nij}(device_zeros(FT,Nij,Nf,Nh));              test_fill!(data, 3)
+    data = IJF{S, Nij}(device_zeros(FT,Nij,Nij,Nf));             test_fill!(data, 3)
+    data = IF{S, Nij}(device_zeros(FT,Nij,Nf));                  test_fill!(data, 3)
+    data = VF{S, Nv}(device_zeros(FT,Nv,Nf));                    test_fill!(data, 3)
+    data = VIJFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nij,Nf,Nh)); test_fill!(data, 3)
+    data = VIFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nf,Nh));      test_fill!(data, 3)
 #! format: on
-    # data = DataLayouts.IJKFVH{S, Nij, Nk}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); fill!(data, (2,3)); @test all(parent(data) .== 3) # TODO: test
-    # data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));             fill!(data, (2,3)); @test all(parent(data) .== 3) # TODO: test
+    # data = DataLayouts.IJKFVH{S, Nij, Nk}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); test_fill!(data, 3) # TODO: test
+    # data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));             test_fill!(data, 3) # TODO: test
 end
 
 @testset "fill! with Nf > 1" begin
@@ -42,16 +52,49 @@ end
     Nh = 5
     Nk = 6
 #! format: off
-    data = DataF{S}(device_zeros(FT,Nf));                        fill!(data, (2,3)); @test all(parent(data.:1) .== 2); @test all(parent(data.:2) .== 3)
-    data = IJFH{S, Nij}(device_zeros(FT,Nij,Nij,Nf,Nh));         fill!(data, (2,3)); @test all(parent(data.:1) .== 2); @test all(parent(data.:2) .== 3)
-    data = IFH{S, Nij}(device_zeros(FT,Nij,Nf,Nh));              fill!(data, (2,3)); @test all(parent(data.:1) .== 2); @test all(parent(data.:2) .== 3)
-    data = IJF{S, Nij}(device_zeros(FT,Nij,Nij,Nf));             fill!(data, (2,3)); @test all(parent(data.:1) .== 2); @test all(parent(data.:2) .== 3)
-    data = IF{S, Nij}(device_zeros(FT,Nij,Nf));                  fill!(data, (2,3)); @test all(parent(data.:1) .== 2); @test all(parent(data.:2) .== 3)
-    data = VF{S, Nv}(device_zeros(FT,Nv,Nf));                    fill!(data, (2,3)); @test all(parent(data.:1) .== 2); @test all(parent(data.:2) .== 3)
-    data = VIJFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nij,Nf,Nh)); fill!(data, (2,3)); @test all(parent(data.:1) .== 2); @test all(parent(data.:2) .== 3)
-    data = VIFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nf,Nh));      fill!(data, (2,3)); @test all(parent(data.:1) .== 2); @test all(parent(data.:2) .== 3)
+    data = DataF{S}(device_zeros(FT,Nf));                        test_fill!(data, (2,3))
+    data = IJFH{S, Nij}(device_zeros(FT,Nij,Nij,Nf,Nh));         test_fill!(data, (2,3))
+    data = IFH{S, Nij}(device_zeros(FT,Nij,Nf,Nh));              test_fill!(data, (2,3))
+    data = IJF{S, Nij}(device_zeros(FT,Nij,Nij,Nf));             test_fill!(data, (2,3))
+    data = IF{S, Nij}(device_zeros(FT,Nij,Nf));                  test_fill!(data, (2,3))
+    data = VF{S, Nv}(device_zeros(FT,Nv,Nf));                    test_fill!(data, (2,3))
+    data = VIJFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nij,Nf,Nh)); test_fill!(data, (2,3))
+    data = VIFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nf,Nh));      test_fill!(data, (2,3))
 #! format: on
     # TODO: test this
-    # data = DataLayouts.IJKFVH{S, Nij, Nk}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); fill!(data, (2,3)); @test all(parent(data) .== (2,3)) # TODO: test
-    # data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));             fill!(data, (2,3)); @test all(parent(data) .== (2,3)) # TODO: test
+    # data = DataLayouts.IJKFVH{S, Nij, Nk}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); test_fill!(data, (2,3)) # TODO: test
+    # data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));             test_fill!(data, (2,3)) # TODO: test
+end
+
+@testset "fill! views with Nf > 1" begin
+    device = ClimaComms.device()
+    device_zeros(args...) = ClimaComms.array_type(device)(zeros(args...))
+    data_view(data) = DataLayouts.rebuild(
+        data,
+        SubArray(
+            parent(data),
+            ntuple(i -> Base.OneTo(size(parent(data), i)), ndims(data)),
+        ),
+    )
+    FT = Float64
+    S = Tuple{FT, FT}
+    Nf = 2
+    Nv = 4
+    Nij = 3
+    Nh = 5
+    Nk = 6
+    # Rather than using level/slab/column, let's just make views/SubArrays
+    # directly so that we can easily test all cases:
+#! format: off
+    data = IJFH{S, Nij}(device_zeros(FT,Nij,Nij,Nf,Nh));         test_fill!(data_view(data), (2,3))
+    data = IFH{S, Nij}(device_zeros(FT,Nij,Nf,Nh));              test_fill!(data_view(data), (2,3))
+    data = IJF{S, Nij}(device_zeros(FT,Nij,Nij,Nf));             test_fill!(data_view(data), (2,3))
+    data = IF{S, Nij}(device_zeros(FT,Nij,Nf));                  test_fill!(data_view(data), (2,3))
+    data = VF{S, Nv}(device_zeros(FT,Nv,Nf));                    test_fill!(data_view(data), (2,3))
+    data = VIJFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nij,Nf,Nh)); test_fill!(data_view(data), (2,3))
+    data = VIFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nf,Nh));      test_fill!(data_view(data), (2,3))
+#! format: on
+    # TODO: test this
+    # data = DataLayouts.IJKFVH{S, Nij, Nk}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); test_fill!(data, (2,3)) # TODO: test
+    # data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));             test_fill!(data, (2,3)) # TODO: test
 end

--- a/test/DataLayouts/unit_ndims.jl
+++ b/test/DataLayouts/unit_ndims.jl
@@ -1,6 +1,6 @@
 #=
 julia --project
-using Revise; include(joinpath("test", "DataLayouts", "ndims.jl"))
+using Revise; include(joinpath("test", "DataLayouts", "unit_ndims.jl"))
 =#
 using Test
 using ClimaCore.DataLayouts


### PR DESCRIPTION
Sadly, #1787 was 2 characters away (`<:`) from being correct, but the result was that it introduced a bug. GPU dispatching is broken on the main branch, this PR fixes the issue, and adds and fixes the test (which requires views to catch the `SubArray` case).

I've also defined `rebuild(data::IF{S, Nij}` since I found it was missing, and I've included `unit_ndims.jl` into the buildkite pipeline.

cc @trontrytel, @AlexisRenchon, @szy21 