### PR TITLE
Remove soft-fail from cubedsphere test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -146,7 +146,6 @@ steps:
       - label: "Unit: meshes cubedsphere"
         key: unit_meshes_cubed_sphere
         command: "julia --color=yes --check-bounds=yes --project=.buildkite test/Meshes/cubedsphere.jl"
-        soft_fail: true
 
   - group: "Unit: Topologies"
     steps:

--- a/test/Meshes/cubedsphere.jl
+++ b/test/Meshes/cubedsphere.jl
@@ -1,3 +1,7 @@
+#=
+julia --project
+using Revise; include(joinpath("test", "Meshes", "cubedsphere.jl"))
+=#
 using ClimaCore: Geometry, Domains, Meshes
 using Test
 using StaticArrays, SparseArrays, LinearAlgebra, ForwardDiff
@@ -120,7 +124,7 @@ end
                     @test norm(Geometry.components(coord)) ≈ 5 rtol = 3eps(FT)
                     @test Meshes.containing_element(mesh, coord) == elem
                     @test Meshes.reference_coordinates(mesh, elem, coord) ≈ ξ atol =
-                        10eps(FT)
+                        20eps(FT)
                 end
 
                 for vert in 1:4
@@ -191,11 +195,11 @@ end
             )
         end
         @test M[1, 1] < 0
-        @test M[2, 1] == 0
+        @test abs(M[2, 1]) ≤ eps(Float64)
         @test M[3, 1] > 0
-        @test M[1, 2] == 0
+        @test abs(M[1, 2]) ≤ eps(Float64)
         @test M[2, 2] < 0
-        @test M[3, 2] == 0
+        @test abs(M[3, 2]) ≤ eps(Float64)
 
         M = ForwardDiff.jacobian(SVector(-1.0, -1.0)) do ξ
             Geometry.components(
@@ -203,11 +207,11 @@ end
             )
         end
         @test M[1, 1] < 0
-        @test M[2, 1] == 0
+        @test abs(M[2, 1]) ≤ eps(Float64)
         @test M[3, 1] > 0
-        @test M[1, 2] == 0
+        @test abs(M[1, 2]) ≤ eps(Float64)
         @test M[2, 2] < 0
-        @test M[3, 2] == 0
+        @test abs(M[3, 2]) ≤ eps(Float64)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,7 +20,7 @@ UnitTest("Geometry"                                ,"Geometry/geometry.jl"),
 UnitTest("AxisTensors"                             ,"Geometry/axistensors.jl"),
 UnitTest("Interval mesh"                           ,"Meshes/interval.jl"),
 UnitTest("Rectangle mesh"                          ,"Meshes/rectangle.jl"),
-# UnitTest("Cubedsphere mesh"                        ,"Meshes/cubedsphere.jl"), # broken on GHA
+UnitTest("Cubedsphere mesh"                        ,"Meshes/cubedsphere.jl"),
 UnitTest("Interval topology"                       ,"Topologies/interval.jl"),
 UnitTest("Rectangle topology"                      ,"Topologies/rectangle.jl"),
 UnitTest("Rectangle surface topology"              ,"Topologies/rectangle_sfc.jl"),


### PR DESCRIPTION
This PR
 - removes the soft-fail (and fixes the existing issues with the test) from the cubedsphere test
 - Adds the cubedsphere unit test to runtests.jl