### PR TITLE
Add test and improve inference of monotonic_check

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -143,6 +143,10 @@ steps:
         key: unit_meshes_rectangle
         command: "julia --color=yes --check-bounds=yes --project=.buildkite test/Meshes/rectangle.jl"
 
+      - label: "Unit: meshes opt"
+        key: unit_meshes_opt
+        command: "julia --color=yes --check-bounds=yes --project=.buildkite test/Meshes/opt_meshes.jl"
+
       - label: "Unit: meshes cubedsphere"
         key: unit_meshes_cubed_sphere
         command: "julia --color=yes --check-bounds=yes --project=.buildkite test/Meshes/cubedsphere.jl"

--- a/src/Meshes/interval.jl
+++ b/src/Meshes/interval.jl
@@ -89,15 +89,29 @@ function boundary_face_name(mesh::IntervalMesh, elem::Integer, face)
     return nothing
 end
 
-function monotonic_check(faces)
-    if !(hasproperty(first(faces), :z) || eltype(faces) <: Real)
-        return nothing
-    end
-    z(face::AbstractFloat) = face
-    z(face::Geometry.AbstractPoint) = face.z
+monotonic_check(
+    faces::Union{
+        LinRange{<:Geometry.AbstractPoint},
+        Vector{<:Geometry.AbstractPoint},
+    },
+) = :no_check
+
+function monotonic_check(
+    faces::Union{
+        LinRange{<:Geometry.ZPoint},
+        LinRange{<:Real},
+        Vector{<:Geometry.ZPoint},
+        Vector{<:Real},
+    },
+)
     n = length(faces) - 1
-    monotonic_incr = all(map(i -> z(faces[i]) < z(faces[i + 1]), 1:n))
-    monotonic_decr = all(map(i -> z(faces[i]) > z(faces[i + 1]), 1:n))
+    if eltype(faces) <: Geometry.AbstractPoint
+        monotonic_incr = all(i -> faces[i].z < faces[i + 1].z, 1:n)
+        monotonic_decr = all(i -> faces[i].z > faces[i + 1].z, 1:n)
+    else
+        monotonic_incr = all(i -> faces[i] < faces[i + 1], 1:n)
+        monotonic_decr = all(i -> faces[i] > faces[i + 1], 1:n)
+    end
     if !(monotonic_incr || monotonic_decr)
         error(
             string(
@@ -106,7 +120,7 @@ function monotonic_check(faces)
             ),
         )
     end
-    return nothing
+    return :pass
 end
 
 abstract type StretchingRule end

--- a/test/Meshes/interval.jl
+++ b/test/Meshes/interval.jl
@@ -314,3 +314,27 @@ end
     @test Meshes.coordinates(trunc_mesh, 1, length(trunc_mesh.faces)) ==
           Geometry.ZPoint(z_top)
 end
+
+@testset "monotonic_check - dispatch" begin
+    faces = range(Geometry.XPoint(0), Geometry.XPoint(10); length = 11)
+    @test Meshes.monotonic_check(faces) == :no_check
+    @test Meshes.monotonic_check(collect(faces)) == :no_check
+end
+
+@testset "monotonic_check" begin
+    faces = range(Geometry.ZPoint(0), Geometry.ZPoint(10); length = 11)
+    @test Meshes.monotonic_check(faces) == :pass # monotonic increasing
+    @test Meshes.monotonic_check(collect(faces)) == :pass # monotonic increasing
+    @test Meshes.monotonic_check(map(x -> x.z, faces)) == :pass # monotonic increasing
+
+    faces = range(Geometry.ZPoint(0), Geometry.ZPoint(-10); length = 11)
+    @test Meshes.monotonic_check(faces) == :pass # monotonic decreasing
+    @test Meshes.monotonic_check(collect(faces)) == :pass # monotonic decreasing
+    @test Meshes.monotonic_check(map(x -> x.z, faces)) == :pass # monotonic decreasing
+
+    faces = map(z -> Geometry.ZPoint(1), 1:10)
+    @test_throws ErrorException Meshes.monotonic_check(faces) # non-monotonic
+
+    faces = range(Geometry.ZPoint(0), Geometry.ZPoint(10); length = 11)
+    cfaces = collect(faces)
+end

--- a/test/Meshes/opt_meshes.jl
+++ b/test/Meshes/opt_meshes.jl
@@ -1,0 +1,17 @@
+#=
+julia --project
+using Revise; include(joinpath("test", "Meshes", "opt_meshes.jl"))
+=#
+using Test
+using SparseArrays
+using JET
+
+import ClimaCore: ClimaCore, Domains, Meshes, Geometry
+
+@testset "monotonic_check" begin
+    faces = range(Geometry.ZPoint(0), Geometry.ZPoint(10); length = 11)
+    cfaces = collect(faces)
+    @test_opt Meshes.monotonic_check(faces)
+    @test_opt Meshes.monotonic_check(cfaces)
+    @test 0 == @allocated Meshes.monotonic_check(cfaces)
+end

--- a/test/Spaces/opt_spaces.jl
+++ b/test/Spaces/opt_spaces.jl
@@ -33,22 +33,22 @@ end
 #! format: off
     if ClimaComms.device(context) isa ClimaComms.CUDADevice
         test_n_failures(86,   TU.PointSpace, context)
-        test_n_failures(142,  TU.SpectralElementSpace1D, context)
-        test_n_failures(1082, TU.SpectralElementSpace2D, context)
-        test_n_failures(26,   TU.ColumnCenterFiniteDifferenceSpace, context)
-        test_n_failures(27,   TU.ColumnFaceFiniteDifferenceSpace, context)
-        test_n_failures(1082, TU.SphereSpectralElementSpace, context)
-        test_n_failures(1097, TU.CenterExtrudedFiniteDifferenceSpace, context)
-        test_n_failures(1097, TU.FaceExtrudedFiniteDifferenceSpace, context)
+        test_n_failures(144,  TU.SpectralElementSpace1D, context)
+        test_n_failures(1103,  TU.SpectralElementSpace2D, context)
+        test_n_failures(4,    TU.ColumnCenterFiniteDifferenceSpace, context)
+        test_n_failures(5,    TU.ColumnFaceFiniteDifferenceSpace, context)
+        test_n_failures(1104,  TU.SphereSpectralElementSpace, context)
+        test_n_failures(1109,  TU.CenterExtrudedFiniteDifferenceSpace, context)
+        test_n_failures(1109,  TU.FaceExtrudedFiniteDifferenceSpace, context)
     else
         test_n_failures(0,    TU.PointSpace, context)
-        test_n_failures(138,  TU.SpectralElementSpace1D, context)
-        test_n_failures(280,  TU.SpectralElementSpace2D, context)
-        test_n_failures(26,   TU.ColumnCenterFiniteDifferenceSpace, context)
-        test_n_failures(27,   TU.ColumnFaceFiniteDifferenceSpace, context)
+        test_n_failures(137,  TU.SpectralElementSpace1D, context)
+        test_n_failures(279,  TU.SpectralElementSpace2D, context)
+        test_n_failures(4,    TU.ColumnCenterFiniteDifferenceSpace, context)
+        test_n_failures(5,    TU.ColumnFaceFiniteDifferenceSpace, context)
         test_n_failures(280,  TU.SphereSpectralElementSpace, context)
-        test_n_failures(305,  TU.CenterExtrudedFiniteDifferenceSpace, context)
-        test_n_failures(305,  TU.FaceExtrudedFiniteDifferenceSpace, context)
+        test_n_failures(285,  TU.CenterExtrudedFiniteDifferenceSpace, context)
+        test_n_failures(285,  TU.FaceExtrudedFiniteDifferenceSpace, context)
     end
 #! format: on
 end


### PR DESCRIPTION
This PR adds unit tests for `monotonic_check`, and inference tests (a step towards #1797). Previously, the closure `z` was getting captured inside `any`, and `map` was returning an object.