### PR TITLE
Deprecate mesh-only methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,10 +4,11 @@ ClimaCore.jl Release Notes
 main
 -------
 
-v0.15.0
--------
-
-- ![][badge-💥breaking] support for `IntervalTopology(::Mesh)` has been dropped in favor of using `IntervalTopology(::ClimaComms.AbstractDevice, ::Mesh)`. PR [#1821](https://github.com/CliMA/ClimaCore.jl/pull/1821).
+- Support for the following methods have been deprecated (PR [#1821](https://github.com/CliMA/ClimaCore.jl/pull/1821), ):
+  - `IntervalTopology(::Mesh)` in favor of using `IntervalTopology(::ClimaComms.AbstractDevice, ::Mesh)`
+  - `FaceFiniteDifferenceSpace(::Mesh)` in favor of using `FaceFiniteDifferenceSpace(::ClimaComms.AbstractDevice, ::Mesh)`
+  - `CenterFiniteDifferenceSpace(::Mesh)` in favor of using `CenterFiniteDifferenceSpace(::ClimaComms.AbstractDevice, ::Mesh)`
+  - `FiniteDifferenceGrid(::Mesh)` in favor of using `FiniteDifferenceGrid(::ClimaComms.AbstractDevice, ::Mesh)`
 
 v0.14.9
 -------

--- a/examples/hybrid/box/bubble_3d_invariant_rhotheta.jl
+++ b/examples/hybrid/box/bubble_3d_invariant_rhotheta.jl
@@ -49,7 +49,6 @@ function hvspace_3D(
     horzdomain = Domains.RectangleDomain(xdomain, ydomain)
     horzmesh = Meshes.RectilinearMesh(horzdomain, xelem, yelem)
     horztopology = Topologies.Topology2D(context, horzmesh)
-    #horztopology = Topologies.Topology2D(horzmesh)
     device = ClimaComms.device(context)
 
     zdomain = Domains.IntervalDomain(

--- a/src/Topologies/interval.jl
+++ b/src/Topologies/interval.jl
@@ -55,10 +55,7 @@ function _IntervalTopology(
     end
     IntervalTopology(context, mesh, boundaries)
 end
-# IntervalTopology(mesh::Meshes.IntervalMesh) = IntervalTopology(
-#     ClimaComms.SingletonCommsContext(ClimaComms.device()),
-#     mesh,
-# )
+
 IntervalTopology(device::ClimaComms.AbstractDevice, mesh::Meshes.IntervalMesh) =
     IntervalTopology(ClimaComms.SingletonCommsContext(device), mesh)
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,1 +1,28 @@
 # Deprecated methods
+
+import ClimaComms
+import .Grids: FiniteDifferenceGrid, CellFace, CellCenter
+import .Spaces:
+    CenterFiniteDifferenceSpace,
+    FaceFiniteDifferenceSpace,
+    FiniteDifferenceSpace
+import .Topologies: IntervalTopology
+import .Meshes: IntervalMesh
+
+@deprecate IntervalTopology(mesh::IntervalMesh) IntervalTopology(
+    ClimaComms.SingletonCommsContext(ClimaComms.device()),
+    mesh,
+)
+
+@deprecate FaceFiniteDifferenceSpace(mesh::IntervalMesh) FiniteDifferenceSpace(
+    FiniteDifferenceGrid(ClimaComms.device(), mesh),
+    CellFace(),
+)
+@deprecate CenterFiniteDifferenceSpace(mesh::IntervalMesh) FiniteDifferenceSpace(
+    FiniteDifferenceGrid(ClimaComms.device(), mesh),
+    CellCenter(),
+)
+
+@deprecate FiniteDifferenceGrid(mesh::IntervalMesh) FiniteDifferenceGrid(
+    IntervalTopology(ClimaComms.device(), mesh),
+)

--- a/test/deprecations.jl
+++ b/test/deprecations.jl
@@ -1,0 +1,49 @@
+#=
+julia --project
+using Revise; include(joinpath("test", "deprecations.jl"))
+=#
+using Test
+using ClimaCore: Geometry, Quadratures, Domains, Meshes, Topologies, Spaces
+import ClimaCore.Spaces:
+    CenterFiniteDifferenceSpace,
+    FaceFiniteDifferenceSpace,
+    FiniteDifferenceSpace
+import ClimaCore.Grids: FiniteDifferenceGrid
+import ClimaComms
+ClimaComms.@import_required_backends
+
+@testset "Deprecations" begin
+    FT = Float64
+    context = ClimaComms.SingletonCommsContext()
+    R = FT(6.371229e6)
+    npoly = 3
+    z_max = FT(30e3)
+    z_elem = 64
+    h_elem = 30
+    # horizontal space
+    domain = Domains.SphereDomain(R)
+    horizontal_mesh = Meshes.EquiangularCubedSphere(domain, h_elem)
+    horizontal_topology = Topologies.Topology2D(
+        context,
+        horizontal_mesh,
+        Topologies.spacefillingcurve(horizontal_mesh),
+    )
+    quad = Quadratures.GLL{npoly + 1}()
+    h_space = Spaces.SpectralElementSpace2D(horizontal_topology, quad)
+
+    # vertical space
+    z_domain = Domains.IntervalDomain(
+        Geometry.ZPoint(zero(z_max)),
+        Geometry.ZPoint(z_max);
+        boundary_names = (:bottom, :top),
+    )
+    z_mesh = Meshes.IntervalMesh(z_domain, nelems = z_elem)
+
+    # deprecated methods:
+    @test_deprecated Topologies.IntervalTopology(z_mesh)
+    @test_deprecated FaceFiniteDifferenceSpace(z_mesh)
+    @test_deprecated CenterFiniteDifferenceSpace(z_mesh)
+    @test_deprecated FiniteDifferenceGrid(z_mesh)
+end
+
+nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,6 +78,7 @@ UnitTest("InputOutput - hybrid3dcubedsphere_topo"  ,"InputOutput/hybrid3dcubedsp
 UnitTest("Array interpolation"                     ,"Remapping/interpolate_array.jl"),
 UnitTest("Array interpolation"                     ,"Remapping/distributed_remapping.jl"),
 UnitTest("Aqua"                                    ,"aqua.jl"),
+UnitTest("Deprecations"                            ,"deprecations.jl"),
 UnitTest("GPU - cuda"                              ,"gpu/cuda.jl";meta=:gpu_only),
 UnitTest("GPU - data"                              ,"DataLayouts/cuda.jl";meta=:gpu_only),
 UnitTest("Spaces - serial CUDA DSS on CubedSphere" ,"Spaces/ddss1_cs.jl";meta=:gpu_only),


### PR DESCRIPTION
This is a followup to #1821. This PR adds deprecations for the methods removed in #1821 so that we can do a patch release instead. This will allow us to incrementally upgrade a bit more smoothly.