### PR TITLE
Add GPU job for stencil benchmarks

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1183,7 +1183,16 @@ steps:
       - label: "Perf: FD operator benchmarks"
         key: "perf_fd_ops"
         command: "julia --color=yes --project=.buildkite test/Operators/finitedifference/benchmark_column.jl"
-        soft_fail: true
+
+      - label: "Perf: GPU FD operator benchmarks"
+        key: "gpu_perf_fd_ops"
+        command:
+          - "julia --project=.buildkite -e 'using CUDA; CUDA.versioninfo()'"
+          - "julia --color=yes --project=.buildkite test/Operators/finitedifference/benchmark_column.jl"
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+        agents:
+          slurm_gpus: 1
 
       - label: "Perf: SEM operator benchmarks (cuda Float32)"
         key: "perf_gpu_spectral_ops_cuda_float32"

--- a/test/Operators/finitedifference/benchmark_column.jl
+++ b/test/Operators/finitedifference/benchmark_column.jl
@@ -1,11 +1,11 @@
 #=
-julia --project=test
+julia --project
 using Revise; include(joinpath("test", "Operators", "finitedifference", "benchmark_column.jl"))
 =#
 include("benchmark_column_utils.jl")
 
 @testset "Benchmark operators" begin
-    benchmark_operators(1000, Float64)
+    benchmark_operators(Float64; z_elems = 63, helem = 30, Nq = 4)
 end
 
 nothing

--- a/test/Operators/finitedifference/benchmark_column_kernels.jl
+++ b/test/Operators/finitedifference/benchmark_column_kernels.jl
@@ -1,5 +1,5 @@
 #### Gradients
-function op_GradientF2C!(c, f, bcs = ())
+function op_GradientF2C!(c, f, bcs = (;))
     ∇f = Operators.GradientF2C(bcs)
     @. c.∇x = ∇f(f.y)
     return nothing
@@ -10,7 +10,7 @@ function op_GradientC2F!(c, f, bcs)
     return nothing
 end
 #### Divergences
-function op_DivergenceF2C!(c, f, bcs = ())
+function op_DivergenceF2C!(c, f, bcs = (;))
     div = Operators.DivergenceF2C(bcs)
     @. c.x = div(Geometry.WVector(f.y))
     return nothing
@@ -21,7 +21,7 @@ function op_DivergenceC2F!(c, f, bcs)
     return nothing
 end
 #### Interpolations
-function op_InterpolateF2C!(c, f, bcs = ())
+function op_InterpolateF2C!(c, f, bcs = (;))
     interp = Operators.InterpolateF2C(bcs)
     @. c.x = interp(f.y)
     return nothing
@@ -36,7 +36,7 @@ function op_LeftBiasedC2F!(c, f, bcs)
     @. f.x = interp(c.y)
     return nothing
 end
-function op_LeftBiasedF2C!(c, f, bcs = ())
+function op_LeftBiasedF2C!(c, f, bcs = (;))
     interp = Operators.LeftBiasedF2C(bcs)
     @. c.x = interp(f.y)
     return nothing
@@ -46,24 +46,24 @@ function op_RightBiasedC2F!(c, f, bcs)
     @. f.x = interp(c.y)
     return nothing
 end
-function op_RightBiasedF2C!(c, f, bcs = ())
+function op_RightBiasedF2C!(c, f, bcs = (;))
     interp = Operators.RightBiasedF2C(bcs)
     @. c.x = interp(f.y)
     return nothing
 end
 #### Curl
-function op_CurlC2F!(c, f, bcs = ())
+function op_CurlC2F!(c, f, bcs = (;))
     curl = Operators.CurlC2F(bcs)
     @. f.curluₕ = curl(c.uₕ)
     return nothing
 end
 #### Mixed/adaptive
-function op_UpwindBiasedProductC2F!(c, f, bcs = ())
+function op_UpwindBiasedProductC2F!(c, f, bcs = (;))
     upwind = Operators.UpwindBiasedProductC2F(bcs)
     @. f.contra3 = upwind(f.w, c.x)
     return nothing
 end
-function op_Upwind3rdOrderBiasedProductC2F!(c, f, bcs = ())
+function op_Upwind3rdOrderBiasedProductC2F!(c, f, bcs = (;))
     upwind = Operators.Upwind3rdOrderBiasedProductC2F(bcs)
     @. f.contra3 = upwind(f.w, c.x)
     return nothing


### PR DESCRIPTION
This PR:
 - adds a GPU job for the existing CPU stencil benchmarks
 - Removes the `soft_fail`, and instead prints warnings when potential regressions occur (https://github.com/CliMA/ClimaCore.jl/issues/1760)

I've also switched to using the minimum time, as this is the best at noise rejection.