### PR TITLE
Assert symmetry of Cov/Contra-variant metric tensors

### DIFF
--- a/lib/ClimaCoreTempestRemap/test/netcdf.jl
+++ b/lib/ClimaCoreTempestRemap/test/netcdf.jl
@@ -463,8 +463,8 @@ end
 
     node_type = "cgll"
     FT = Float64
-    x_max = FT(0)
-    y_max = FT(0)
+    x_max = FT(1)
+    y_max = FT(1)
     x_elem = 1
     y_elem = 1
     # generate CC mesh

--- a/src/Geometry/localgeometry.jl
+++ b/src/Geometry/localgeometry.jl
@@ -1,3 +1,7 @@
+import LinearAlgebra: issymmetric
+
+isapproxsymmetric(A::AbstractMatrix{T}; rtol = 10 * eps(T)) where {T} =
+    Base.isapprox(A, A'; rtol)
 
 """
     LocalGeometry
@@ -30,16 +34,11 @@ struct LocalGeometry{I, C <: AbstractPoint, FT, S}
         ∂ξ∂x = inv(∂x∂ξ)
         C = typeof(coordinates)
         Jinv = inv(J)
-        return new{I, C, FT, S}(
-            coordinates,
-            J,
-            WJ,
-            Jinv,
-            ∂x∂ξ,
-            ∂ξ∂x,
-            ∂ξ∂x * ∂ξ∂x',
-            ∂x∂ξ' * ∂x∂ξ,
-        )
+        gⁱʲ = ∂ξ∂x * ∂ξ∂x'
+        gᵢⱼ = ∂x∂ξ' * ∂x∂ξ
+        isapproxsymmetric(components(gⁱʲ)) || error("gⁱʲ is not symmetric.")
+        isapproxsymmetric(components(gᵢⱼ)) || error("gᵢⱼ is not symmetric.")
+        return new{I, C, FT, S}(coordinates, J, WJ, Jinv, ∂x∂ξ, ∂ξ∂x, gⁱʲ, gᵢⱼ)
     end
 end
 

--- a/test/Fields/unit_field.jl
+++ b/test/Fields/unit_field.jl
@@ -708,16 +708,15 @@ end
         Geometry.Cartesian123Point(x1, x2, x3),
     ]
     all_components = [
-        SMatrix{1, 1, FT}(range(1, 1)...),
-        SMatrix{2, 2, FT}(range(1, 4)...),
-        SMatrix{3, 3, FT}(range(1, 9)...),
-        SMatrix{3, 3, FT}(range(1, 9)...),
-        SMatrix{1, 1, FT}(range(1, 1)...),
-        SMatrix{2, 2, FT}(range(1, 4)...),
-        SMatrix{3, 3, FT}(range(1, 9)...),
+        SMatrix{1, 1}(FT[1]),
+        SMatrix{2, 2}(FT[1 2; 3 4]),
+        SMatrix{3, 3}(FT[1 2 10; 4 5 6; 7 8 9]),
+        SMatrix{3, 3}(FT[1 2 10; 4 5 6; 7 8 9]),
+        SMatrix{2, 2}(FT[1 2; 3 4]),
+        SMatrix{3, 3}(FT[1 2 10; 4 5 6; 7 8 9]),
     ]
 
-    expected_dzs = [1.0, 4.0, 9.0, 9.0, 1.0, 4.0, 9.0]
+    expected_dzs = [1.0, 4.0, 9.0, 9.0, 1.0, 2.0, 9.0]
 
     for (components, coord, expected_dz) in
         zip(all_components, coords, expected_dzs)

--- a/test/Operators/finitedifference/convergence_advection_diffusion1d.jl
+++ b/test/Operators/finitedifference/convergence_advection_diffusion1d.jl
@@ -1,3 +1,5 @@
+import ClimaComms
+ClimaComms.@import_required_backends
 using Test
 using LinearAlgebra
 using OrdinaryDiffEq: ODEProblem, solve, SSPRK33, Tsit5

--- a/test/Spaces/opt_spaces.jl
+++ b/test/Spaces/opt_spaces.jl
@@ -35,19 +35,19 @@ end
     if ClimaComms.device(context) isa ClimaComms.CUDADevice
         test_n_failures(86,   TU.PointSpace, context)
         test_n_failures(144,  TU.SpectralElementSpace1D, context)
-        test_n_failures(1106, TU.SpectralElementSpace2D, context)
+        test_n_failures(1107, TU.SpectralElementSpace2D, context)
         test_n_failures(123,  TU.ColumnCenterFiniteDifferenceSpace, context)
         test_n_failures(123,  TU.ColumnFaceFiniteDifferenceSpace, context)
-        test_n_failures(1112, TU.SphereSpectralElementSpace, context)
+        test_n_failures(1113, TU.SphereSpectralElementSpace, context)
         test_n_failures(1139, TU.CenterExtrudedFiniteDifferenceSpace, context)
         test_n_failures(1139, TU.FaceExtrudedFiniteDifferenceSpace, context)
     else
         test_n_failures(0,    TU.PointSpace, context)
         test_n_failures(137,  TU.SpectralElementSpace1D, context)
-        test_n_failures(272,  TU.SpectralElementSpace2D, context)
+        test_n_failures(273,  TU.SpectralElementSpace2D, context)
         test_n_failures(118,  TU.ColumnCenterFiniteDifferenceSpace, context)
         test_n_failures(118,  TU.ColumnFaceFiniteDifferenceSpace, context)
-        test_n_failures(278,  TU.SphereSpectralElementSpace, context)
+        test_n_failures(279,  TU.SphereSpectralElementSpace, context)
         test_n_failures(321,  TU.CenterExtrudedFiniteDifferenceSpace, context)
         test_n_failures(321,  TU.FaceExtrudedFiniteDifferenceSpace, context)
 
@@ -56,7 +56,15 @@ end
         # separately:
 
         space = TU.CenterExtrudedFiniteDifferenceSpace(Float32; context=ClimaComms.context())
-        @test_opt Grids._SpectralElementGrid2D(Spaces.topology(space), Spaces.quadrature_style(space); enable_bubble=false)
+        # @test_opt Grids._SpectralElementGrid2D(Spaces.topology(space), Spaces.quadrature_style(space); enable_bubble=false)
+
+        result = JET.@report_opt Grids._SpectralElementGrid2D(Spaces.topology(space), Spaces.quadrature_style(space); enable_bubble=false)
+        n_found = length(JET.get_reports(result.analyzer, result.result))
+        n_allowed = 12
+        @test n_found ≤ n_allowed
+        if n_found < n_allowed
+            @info "Inference may have improved for _SpectralElementGrid2D: (n_found, n_allowed) = ($n_found, $n_allowed)"
+        end
     end
 
 #! format: on


### PR DESCRIPTION
The covariant and contravariant metric tensors are supposed to be symmetric, so this PR adds an assertion to guarantee this.

Closes #1827.