### PR TITLE
Fix type instability in `copyto_stencil_kernel!`

### DIFF
--- a/ext/cuda/operators_finite_difference.jl
+++ b/ext/cuda/operators_finite_difference.jl
@@ -55,21 +55,18 @@ function copyto_stencil_kernel!(out, bc, space, bds, us)
             (v, i, j, h) = cart_ind((Nv, Nq, Nq, Nh), gid).I
             hidx = (i, j, h)
             idx = v - 1 + li
-            window =
-                idx < lw ?
-                LeftBoundaryWindow{Spaces.left_boundary_name(space)}() :
-                (
-                    idx > rw ?
-                    RightBoundaryWindow{Spaces.right_boundary_name(space)}() :
-                    Interior()
-                )
-            setidx!(
-                space,
-                out,
-                idx,
-                hidx,
-                Operators.getidx(space, bc, window, idx, hidx),
-            )
+            if idx < lw
+                lwindow = LeftBoundaryWindow{Spaces.left_boundary_name(space)}()
+                val = Operators.getidx(space, bc, lwindow, idx, hidx)
+            elseif idx > rw
+                rwindow =
+                    RightBoundaryWindow{Spaces.right_boundary_name(space)}()
+                val = Operators.getidx(space, bc, rwindow, idx, hidx)
+            else
+                iwindow = Interior()
+                val = Operators.getidx(space, bc, iwindow, idx, hidx)
+            end
+            setidx!(space, out, idx, hidx, val)
         end
     end
     return nothing


### PR DESCRIPTION
This PR removes the `window` variable in `copyto_stencil_kernel!`, and instead, uses different windows depending on `gid`.

I'm actually not sure how the gpu even allows this block of code:

```julia
            (v, i, j, h) = cart_ind((Nv, Nq, Nq, Nh), gid).I
            hidx = (i, j, h)
            idx = v - 1 + li
            window =
                idx < lw ?
                LeftBoundaryWindow{Spaces.left_boundary_name(space)}() :
                (
                    idx > rw ?
                    RightBoundaryWindow{Spaces.right_boundary_name(space)}() :
                    Interior()
                )
            setidx!(
                space,
                out,
                idx,
                hidx,
                Operators.getidx(space, bc, window, idx, hidx),
            )
```
because

 - the type of `window` depends on the value of `idx`
 - the value of `idx` depends on the value of `v`
 - the value of `v` depends on the value of `gid`
 - the value of `gid` depends on the individual thread, which is most definitely non-deterministic

The only way I could see this being type stable is if the compiler can determine that all three branches result in the same return type, and that, then, it doesn't matter what the value of `window` will be within the scope of `copyto_stencil_kernel!`.

This is surprising to me. Any insights @vchuravy?