### PR TITLE
Fix gpu dispatching on ReshapedArrays

### DIFF
--- a/ext/ClimaCoreCUDAExt.jl
+++ b/ext/ClimaCoreCUDAExt.jl
@@ -16,8 +16,19 @@ import ClimaCore.Utilities: cart_ind, linear_ind
 import ClimaCore.RecursiveApply:
     ⊠, ⊞, ⊟, radd, rmul, rsub, rdiv, rmap, rzero, rmin, rmax
 
-const CuArrayBackedTypes =
-    Union{CUDA.CuArray, SubArray{<:Any, <:Any, <:CUDA.CuArray}}
+const cu_array = CUDA.CuArray
+const TSubArray{T} = SubArray{<:Any, <:Any, <:T}
+const TReshapedArray{T} = Base.ReshapedArray{<:Any, <:Any, <:T}
+
+const CuArrayBackedTypes = Union{
+    cu_array,
+    TSubArray{cu_array},
+    TSubArray{TSubArray{cu_array}},
+    TSubArray{TReshapedArray{cu_array}},
+    TSubArray{TReshapedArray{TSubArray{cu_array}}},
+    TReshapedArray{cu_array},
+    TReshapedArray{TSubArray{cu_array}},
+}
 
 include(joinpath("cuda", "cuda_utils.jl"))
 include(joinpath("cuda", "data_layouts.jl"))

--- a/ext/cuda/data_layouts_copyto.jl
+++ b/ext/cuda/data_layouts_copyto.jl
@@ -50,26 +50,9 @@ function Base.copyto!(
 end
 
 function Base.copyto!(
-    dest::VF{S, Nv},
-    bc::DataLayouts.BroadcastedUnionVF{S, Nv, A},
-) where {S, Nv, A <: CuArrayBackedTypes}
-    _, _, _, _, Nh = size(dest)
-    if Nv > 0 && Nh > 0
-        auto_launch!(
-            knl_copyto!,
-            (dest, bc),
-            dest;
-            threads_s = (1, 1),
-            blocks_s = (Nh, Nv),
-        )
-    end
-    return dest
-end
-
-function Base.copyto!(
     dest::DataF{S},
     bc::DataLayouts.BroadcastedUnionDataF{S, A},
-) where {S, A <: CUDA.CuArray}
+) where {S, A <: CuArrayBackedTypes}
     auto_launch!(
         knl_copyto!,
         (dest, bc),
@@ -110,6 +93,6 @@ Base.copyto!(dest::IJF{S, Nij, <:CuArrayBackedTypes},       bc::DataLayouts.Broa
 Base.copyto!(dest::IF{S, Ni, <:CuArrayBackedTypes},         bc::DataLayouts.BroadcastedUnionIF{S, Ni, <:CuArrayBackedTypes}) where {S, Ni} = cuda_copyto!(dest, bc)
 # Base.copyto!(dest::VIFH{S, Nv, Ni, <:CuArrayBackedTypes},   bc::DataLayouts.BroadcastedUnionVIFH{S, Nv, Ni, <:CuArrayBackedTypes}) where {S, Nv, Ni} = cuda_copyto!(dest, bc)
 # Base.copyto!(dest::VIJFH{S, Nv, Nij, <:CuArrayBackedTypes}, bc::DataLayouts.BroadcastedUnionVIJFH{S, Nv, Nij, <:CuArrayBackedTypes}) where {S, Nv, Nij} = cuda_copyto!(dest, bc)
-# Base.copyto!(dest::VF{S, Nv, <:CuArrayBackedTypes},         bc::DataLayouts.BroadcastedUnionVF{S, Nv, <:CuArrayBackedTypes}) where {S, Nv} = cuda_copyto!(dest, bc)
+Base.copyto!(dest::VF{S, Nv, <:CuArrayBackedTypes},         bc::DataLayouts.BroadcastedUnionVF{S, Nv, <:CuArrayBackedTypes}) where {S, Nv} = cuda_copyto!(dest, bc)
 # Base.copyto!(dest::DataF{S, <:CuArrayBackedTypes},          bc::DataLayouts.BroadcastedUnionDataF{S, <:CuArrayBackedTypes}) where {S} = cuda_copyto!(dest, bc)
 #! format: on

--- a/test/DataLayouts/unit_fill.jl
+++ b/test/DataLayouts/unit_fill.jl
@@ -98,3 +98,55 @@ end
     # data = DataLayouts.IJKFVH{S, Nij, Nk}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); test_fill!(data, (2,3)) # TODO: test
     # data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));             test_fill!(data, (2,3)) # TODO: test
 end
+
+@testset "Reshaped Arrays" begin
+    device = ClimaComms.device()
+    device_zeros(args...) = ClimaComms.array_type(device)(zeros(args...))
+    function reshaped_array(data2)
+        # `reshape` does not always return a `ReshapedArray`, which
+        # we need to specialize on to correctly dispatch when its
+        # parent array is backed by a CuArray. So, let's first
+        # In order to get a ReshapedArray back, let's first create view
+        # via `data.:2`. This doesn't guarantee that the result is a
+        # ReshapedArray, but it works for several cases. Tests when
+        # are commented out for cases when Julia Base manages to return
+        # a parent-similar array.
+        data = data.:2
+        array₀ = DataLayouts.data2array(data)
+        @test typeof(array₀) <: Base.ReshapedArray
+        rdata = DataLayouts.array2data(array₀, data)
+        newdata = DataLayouts.rebuild(
+            data,
+            SubArray(
+                parent(rdata),
+                ntuple(i -> Base.OneTo(size(parent(rdata), i)), ndims(rdata)),
+            ),
+        )
+        rarray = parent(parent(newdata))
+        @test typeof(rarray) <: Base.ReshapedArray
+        subarray = parent(rarray)
+        @test typeof(subarray) <: Base.SubArray
+        array = parent(subarray)
+        newdata
+    end
+    FT = Float64
+    S = Tuple{FT, FT} # need at least 2 components to make a SubArray
+    Nf = 2
+    Nv = 4
+    Nij = 3
+    Nh = 5
+    Nk = 6
+    # directly so that we can easily test all cases:
+#! format: off
+    data = IJFH{S, Nij}(device_zeros(FT,Nij,Nij,Nf,Nh));         test_fill!(reshaped_array(data), 2)
+    data = IFH{S, Nij}(device_zeros(FT,Nij,Nf,Nh));              test_fill!(reshaped_array(data), 2)
+    # data = IJF{S, Nij}(device_zeros(FT,Nij,Nij,Nf));             test_fill!(reshaped_array(data), 2)
+    # data = IF{S, Nij}(device_zeros(FT,Nij,Nf));                  test_fill!(reshaped_array(data), 2)
+    # data = VF{S, Nv}(device_zeros(FT,Nv,Nf));                    test_fill!(reshaped_array(data), 2)
+    data = VIJFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nij,Nf,Nh)); test_fill!(reshaped_array(data), 2)
+    data = VIFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nf,Nh));      test_fill!(reshaped_array(data), 2)
+#! format: on
+    # TODO: test this
+    # data = DataLayouts.IJKFVH{S, Nij, Nk}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); test_fill!(reshaped_array(data), 2) # TODO: test
+    # data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));             test_fill!(reshaped_array(data), 2) # TODO: test
+end


### PR DESCRIPTION
This PR fixes gpu dispatching when the parent array fits into one of the following categories:

```julia
const cu_array = CUDA.CuArray
const TSubArray{T} = SubArray{<:Any, <:Any, <:T}
const TReshapedArray{T} = Base.ReshapedArray{<:Any, <:Any, <:T}

const CuArrayBackedTypes = Union{
    cu_array,
    TSubArray{cu_array},
    TSubArray{TReshapedArray{cu_array}},
    TSubArray{TReshapedArray{TSubArray{cu_array}}},
    TReshapedArray{cu_array},
    TReshapedArray{TSubArray{cu_array}},
}
```

After using `launch_configuration` for `VIJFH` datalayouts, this should fix #1854 (xref: https://github.com/CliMA/ClimaCore.jl/issues/1854#issuecomment-2200116511).

This PR also changes to using CUDA's `launch_configuration` for the VF datalayouts, I'll take a look at the stencil benchmarks to see if/how the performance changes.

I've added a test only for DataLayouts `fill!`, as we use `CuArrayBackedTypes` for the `copyto!` kernels as well. We should probably add correctness tests for these other cases, as these composite arrays (and presumably their indexing) is, I imagine, quite complex.

The type declaration for `CuArrayBackedTypes` is rather complicated, and it seems impossible to define this for all possible types. I think we might need to switch to a dispatch solution, by recursing through the parent array until we either find `Array` or `CuArray`, and then dispatch on a 3rd argument.