### PR TITLE
CPU-GPU specialization -> dispatching

### DIFF
--- a/ext/ClimaCoreCUDAExt.jl
+++ b/ext/ClimaCoreCUDAExt.jl
@@ -10,14 +10,12 @@ using CUDA
 using CUDA: threadIdx, blockIdx, blockDim
 import StaticArrays: SVector, SMatrix, SArray
 import ClimaCore.DataLayouts: mapreduce_cuda
+import ClimaCore.DataLayouts: ToCUDA
 import ClimaCore.DataLayouts: slab, column
 import ClimaCore.Utilities: half
 import ClimaCore.Utilities: cart_ind, linear_ind
 import ClimaCore.RecursiveApply:
     ⊠, ⊞, ⊟, radd, rmul, rsub, rdiv, rmap, rzero, rmin, rmax
-
-const CuArrayBackedTypes =
-    Union{CUDA.CuArray, SubArray{<:Any, <:Any, <:CUDA.CuArray}}
 
 include(joinpath("cuda", "cuda_utils.jl"))
 include(joinpath("cuda", "data_layouts.jl"))

--- a/ext/cuda/data_layouts.jl
+++ b/ext/cuda/data_layouts.jl
@@ -73,7 +73,8 @@ end
 
 function fused_copyto!(
     fmbc::FusedMultiBroadcast,
-    dest1::VIJFH{S, Nv, Nij, <:CuArrayBackedTypes},
+    dest1::VIJFH{S, Nv, Nij},
+    ::ToCUDA,
 ) where {S, Nv, Nij}
     _, _, _, _, Nh = size(dest1)
     if Nv > 0 && Nh > 0
@@ -92,7 +93,8 @@ end
 
 function fused_copyto!(
     fmbc::FusedMultiBroadcast,
-    dest1::IJFH{S, Nij, <:CuArrayBackedTypes},
+    dest1::IJFH{S, Nij},
+    ::ToCUDA,
 ) where {S, Nij}
     _, _, _, _, Nh = size(dest1)
     if Nh > 0
@@ -108,7 +110,8 @@ function fused_copyto!(
 end
 function fused_copyto!(
     fmbc::FusedMultiBroadcast,
-    dest1::VF{S, Nv, <:CuArrayBackedTypes},
+    dest1::VF{S, Nv},
+    ::ToCUDA,
 ) where {S, Nv}
     _, _, _, _, Nh = size(dest1)
     if Nv > 0 && Nh > 0
@@ -125,7 +128,8 @@ end
 
 function fused_copyto!(
     fmbc::FusedMultiBroadcast,
-    dest1::DataF{S, <:CuArrayBackedTypes},
+    dest1::DataF{S},
+    ::ToCUDA,
 ) where {S}
     auto_launch!(
         knl_fused_copyto!,

--- a/ext/cuda/data_layouts_copyto.jl
+++ b/ext/cuda/data_layouts_copyto.jl
@@ -1,3 +1,5 @@
+DataLayouts._device_dispatch(x::CUDA.CuArray) = ToCUDA()
+
 function knl_copyto!(dest, src)
 
     i = CUDA.threadIdx().x
@@ -15,8 +17,9 @@ end
 
 function Base.copyto!(
     dest::IJFH{S, Nij},
-    bc::DataLayouts.BroadcastedUnionIJFH{S, Nij, A},
-) where {S, Nij, A <: CuArrayBackedTypes}
+    bc::DataLayouts.BroadcastedUnionIJFH{S, Nij},
+    ::ToCUDA,
+) where {S, Nij}
     _, _, _, _, Nh = size(bc)
     if Nh > 0
         auto_launch!(
@@ -32,8 +35,9 @@ end
 
 function Base.copyto!(
     dest::VIJFH{S, Nv, Nij},
-    bc::DataLayouts.BroadcastedUnionVIJFH{S, Nv, Nij, A},
-) where {S, Nv, Nij, A <: CuArrayBackedTypes}
+    bc::DataLayouts.BroadcastedUnionVIJFH{S, Nv, Nij},
+    ::ToCUDA,
+) where {S, Nv, Nij}
     _, _, _, _, Nh = size(bc)
     if Nv > 0 && Nh > 0
         Nv_per_block = min(Nv, fld(256, Nij * Nij))
@@ -51,8 +55,9 @@ end
 
 function Base.copyto!(
     dest::VF{S, Nv},
-    bc::DataLayouts.BroadcastedUnionVF{S, Nv, A},
-) where {S, Nv, A <: CuArrayBackedTypes}
+    bc::DataLayouts.BroadcastedUnionVF{S, Nv},
+    ::ToCUDA,
+) where {S, Nv}
     _, _, _, _, Nh = size(dest)
     if Nv > 0 && Nh > 0
         auto_launch!(
@@ -68,8 +73,9 @@ end
 
 function Base.copyto!(
     dest::DataF{S},
-    bc::DataLayouts.BroadcastedUnionDataF{S, A},
-) where {S, A <: CUDA.CuArray}
+    bc::DataLayouts.BroadcastedUnionDataF{S},
+    ::ToCUDA,
+) where {S}
     auto_launch!(
         knl_copyto!,
         (dest, bc),
@@ -104,12 +110,12 @@ end
 # TODO: can we use CUDA's luanch configuration for all data layouts?
 # Currently, it seems to have a slight performance degredation.
 #! format: off
-# Base.copyto!(dest::IJFH{S, Nij, <:CuArrayBackedTypes},      bc::DataLayouts.BroadcastedUnionIJFH{S, Nij, <:CuArrayBackedTypes}) where {S, Nij} = cuda_copyto!(dest, bc)
-Base.copyto!(dest::IFH{S, Ni, <:CuArrayBackedTypes},        bc::DataLayouts.BroadcastedUnionIFH{S, Ni, <:CuArrayBackedTypes}) where {S, Ni} = cuda_copyto!(dest, bc)
-Base.copyto!(dest::IJF{S, Nij, <:CuArrayBackedTypes},       bc::DataLayouts.BroadcastedUnionIJF{S, Nij, <:CuArrayBackedTypes}) where {S, Nij} = cuda_copyto!(dest, bc)
-Base.copyto!(dest::IF{S, Ni, <:CuArrayBackedTypes},         bc::DataLayouts.BroadcastedUnionIF{S, Ni, <:CuArrayBackedTypes}) where {S, Ni} = cuda_copyto!(dest, bc)
-# Base.copyto!(dest::VIFH{S, Nv, Ni, <:CuArrayBackedTypes},   bc::DataLayouts.BroadcastedUnionVIFH{S, Nv, Ni, <:CuArrayBackedTypes}) where {S, Nv, Ni} = cuda_copyto!(dest, bc)
-# Base.copyto!(dest::VIJFH{S, Nv, Nij, <:CuArrayBackedTypes}, bc::DataLayouts.BroadcastedUnionVIJFH{S, Nv, Nij, <:CuArrayBackedTypes}) where {S, Nv, Nij} = cuda_copyto!(dest, bc)
-# Base.copyto!(dest::VF{S, Nv, <:CuArrayBackedTypes},         bc::DataLayouts.BroadcastedUnionVF{S, Nv, <:CuArrayBackedTypes}) where {S, Nv} = cuda_copyto!(dest, bc)
-# Base.copyto!(dest::DataF{S, <:CuArrayBackedTypes},          bc::DataLayouts.BroadcastedUnionDataF{S, <:CuArrayBackedTypes}) where {S} = cuda_copyto!(dest, bc)
+# Base.copyto!(dest::IJFH{S, Nij},      bc::DataLayouts.BroadcastedUnionIJFH{S, Nij}, ::ToCUDA) where {S, Nij} = cuda_copyto!(dest, bc)
+Base.copyto!(dest::IFH{S, Ni},        bc::DataLayouts.BroadcastedUnionIFH{S, Ni}, ::ToCUDA) where {S, Ni} = cuda_copyto!(dest, bc)
+Base.copyto!(dest::IJF{S, Nij},       bc::DataLayouts.BroadcastedUnionIJF{S, Nij}, ::ToCUDA) where {S, Nij} = cuda_copyto!(dest, bc)
+Base.copyto!(dest::IF{S, Ni},         bc::DataLayouts.BroadcastedUnionIF{S, Ni}, ::ToCUDA) where {S, Ni} = cuda_copyto!(dest, bc)
+Base.copyto!(dest::VIFH{S, Nv, Ni},   bc::DataLayouts.BroadcastedUnionVIFH{S, Nv, Ni}, ::ToCUDA) where {S, Nv, Ni} = cuda_copyto!(dest, bc)
+# Base.copyto!(dest::VIJFH{S, Nv, Nij}, bc::DataLayouts.BroadcastedUnionVIJFH{S, Nv, Nij}, ::ToCUDA) where {S, Nv, Nij} = cuda_copyto!(dest, bc)
+# Base.copyto!(dest::VF{S, Nv},         bc::DataLayouts.BroadcastedUnionVF{S, Nv}, ::ToCUDA) where {S, Nv} = cuda_copyto!(dest, bc)
+# Base.copyto!(dest::DataF{S},          bc::DataLayouts.BroadcastedUnionDataF{S}, ::ToCUDA) where {S} = cuda_copyto!(dest, bc)
 #! format: on

--- a/ext/cuda/data_layouts_fill.jl
+++ b/ext/cuda/data_layouts_fill.jl
@@ -19,12 +19,12 @@ function cuda_fill!(dest::AbstractData, val)
 end
 
 #! format: off
-Base.fill!(dest::IJFH{<:Any, <:Any, <:CuArrayBackedTypes},         val) = cuda_fill!(dest, val)
-Base.fill!(dest::IFH{<:Any, <:Any, <:CuArrayBackedTypes},          val) = cuda_fill!(dest, val)
-Base.fill!(dest::IJF{<:Any, <:Any, <:CuArrayBackedTypes},          val) = cuda_fill!(dest, val)
-Base.fill!(dest::IF{<:Any, <:Any, <:CuArrayBackedTypes},           val) = cuda_fill!(dest, val)
-Base.fill!(dest::VIFH{<:Any, <:Any, <:Any, <:CuArrayBackedTypes},  val) = cuda_fill!(dest, val)
-Base.fill!(dest::VIJFH{<:Any, <:Any, <:Any, <:CuArrayBackedTypes}, val) = cuda_fill!(dest, val)
-Base.fill!(dest::VF{<:Any, <:Any, <:CuArrayBackedTypes},           val) = cuda_fill!(dest, val)
-Base.fill!(dest::DataF{<:Any, <:CuArrayBackedTypes},               val) = cuda_fill!(dest, val)
+Base.fill!(dest::IJFH{<:Any, <:Any},         val, ::ToCUDA) = cuda_fill!(dest, val)
+Base.fill!(dest::IFH{<:Any, <:Any},          val, ::ToCUDA) = cuda_fill!(dest, val)
+Base.fill!(dest::IJF{<:Any, <:Any},          val, ::ToCUDA) = cuda_fill!(dest, val)
+Base.fill!(dest::IF{<:Any, <:Any},           val, ::ToCUDA) = cuda_fill!(dest, val)
+Base.fill!(dest::VIFH{<:Any, <:Any, <:Any},  val, ::ToCUDA) = cuda_fill!(dest, val)
+Base.fill!(dest::VIJFH{<:Any, <:Any, <:Any}, val, ::ToCUDA) = cuda_fill!(dest, val)
+Base.fill!(dest::VF{<:Any, <:Any},           val, ::ToCUDA) = cuda_fill!(dest, val)
+Base.fill!(dest::DataF{<:Any},               val, ::ToCUDA) = cuda_fill!(dest, val)
 #! format: on

--- a/src/Fields/broadcast.jl
+++ b/src/Fields/broadcast.jl
@@ -129,7 +129,7 @@ function todata(bc::Base.Broadcast.Broadcasted{FieldStyle{DS}}) where {DS}
     Base.Broadcast.Broadcasted{DS}(bc.f, _args)
 end
 
-# same logic as Base.Broadcasted (which only defines it for Tuples)
+# same logic as Base.Broadcast.Broadcasted (which only defines it for Tuples)
 Base.axes(bc::Base.Broadcast.Broadcasted{<:AbstractFieldStyle}) =
     _axes(bc, bc.axes)
 _axes(bc, ::Nothing) = Base.Broadcast.combine_axes(bc.args...)

--- a/test/DataLayouts/cuda.jl
+++ b/test/DataLayouts/cuda.jl
@@ -49,8 +49,8 @@ end
     data1 = IJFH{S1, 2}(data_arr1)
     data2 = IJFH{S2, 2}(data_arr2)
 
-    f(a1, a2) = a1.a.re * a2 + a1.b
-    res = f.(data1, data2)
+    f1(a1, a2) = a1.a.re * a2 + a1.b
+    res = f1.(data1, data2)
     @test res isa IJFH{Float64}
     @test Array(parent(res)) == FT[2 for i in 1:2, j in 1:2, f in 1:1, h in 1:2]
 
@@ -60,8 +60,8 @@ end
     data1 = VIJFH{S1, Nv, 4}(data_arr1)
     data2 = VIJFH{S2, Nv, 4}(data_arr2)
 
-    f(a1, a2) = a1.a.re * a2 + a1.b
-    res = f.(data1, data2)
+    f2(a1, a2) = a1.a.re * a2 + a1.b
+    res = f2.(data1, data2)
     @test res isa VIJFH{Float64, Nv}
     @test Array(parent(res)) ==
           FT[2 for v in 1:Nv, i in 1:4, j in 1:4, f in 1:1, h in 1:2]

--- a/test/DataLayouts/unit_fill.jl
+++ b/test/DataLayouts/unit_fill.jl
@@ -98,3 +98,55 @@ end
     # data = DataLayouts.IJKFVH{S, Nij, Nk}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); test_fill!(data, (2,3)) # TODO: test
     # data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));             test_fill!(data, (2,3)) # TODO: test
 end
+
+@testset "Reshaped Arrays" begin
+    device = ClimaComms.device()
+    device_zeros(args...) = ClimaComms.array_type(device)(zeros(args...))
+    function reshaped_array(data2)
+        # `reshape` does not always return a `ReshapedArray`, which
+        # we need to specialize on to correctly dispatch when its
+        # parent array is backed by a CuArray. So, let's first
+        # In order to get a ReshapedArray back, let's first create view
+        # via `data.:2`. This doesn't guarantee that the result is a
+        # ReshapedArray, but it works for several cases. Tests when
+        # are commented out for cases when Julia Base manages to return
+        # a parent-similar array.
+        data = data.:2
+        array₀ = DataLayouts.data2array(data)
+        @test typeof(array₀) <: Base.ReshapedArray
+        rdata = DataLayouts.array2data(array₀, data)
+        newdata = DataLayouts.rebuild(
+            data,
+            SubArray(
+                parent(rdata),
+                ntuple(i -> Base.OneTo(size(parent(rdata), i)), ndims(rdata)),
+            ),
+        )
+        rarray = parent(parent(newdata))
+        @test typeof(rarray) <: Base.ReshapedArray
+        subarray = parent(rarray)
+        @test typeof(subarray) <: Base.SubArray
+        array = parent(subarray)
+        newdata
+    end
+    FT = Float64
+    S = Tuple{FT, FT} # need at least 2 components to make a SubArray
+    Nf = 2
+    Nv = 4
+    Nij = 3
+    Nh = 5
+    Nk = 6
+    # directly so that we can easily test all cases:
+#! format: off
+    data = IJFH{S, Nij}(device_zeros(FT,Nij,Nij,Nf,Nh));         test_fill!(reshaped_array(data), 2)
+    data = IFH{S, Nij}(device_zeros(FT,Nij,Nf,Nh));              test_fill!(reshaped_array(data), 2)
+    # data = IJF{S, Nij}(device_zeros(FT,Nij,Nij,Nf));             test_fill!(reshaped_array(data), 2)
+    # data = IF{S, Nij}(device_zeros(FT,Nij,Nf));                  test_fill!(reshaped_array(data), 2)
+    # data = VF{S, Nv}(device_zeros(FT,Nv,Nf));                    test_fill!(reshaped_array(data), 2)
+    data = VIJFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nij,Nf,Nh)); test_fill!(reshaped_array(data), 2)
+    data = VIFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nf,Nh));      test_fill!(reshaped_array(data), 2)
+#! format: on
+    # TODO: test this
+    # data = DataLayouts.IJKFVH{S, Nij, Nk}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); test_fill!(reshaped_array(data), 2) # TODO: test
+    # data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));             test_fill!(reshaped_array(data), 2) # TODO: test
+end


### PR DESCRIPTION
This PR is an alternative to #1861, and I'm feeling more inclined to move forward with this design. This PR switches from using specialization on `CuArrayBackedTypes`, which required naming specific types:

```julia
const cu_array = CUDA.CuArray
const TSubArray{T} = SubArray{<:Any, <:Any, <:T}
const TReshapedArray{T} = Base.ReshapedArray{<:Any, <:Any, <:T}

const CuArrayBackedTypes = Union{
    cu_array,
    TSubArray{cu_array},
    TSubArray{TReshapedArray{cu_array}},
    TSubArray{TReshapedArray{TSubArray{cu_array}}},
    TReshapedArray{cu_array},
    TReshapedArray{TSubArray{cu_array}},
}
```
that could be passed in, to using dispatch on either `Array` or `CuArray`. The advantage of dispatching is that we no longer have to account for every possible way that these types are composed (e.g., the above definition will break on `TSubArray{TSubArray{cu_array}}` and `TSubArray{TSubArray{TSubArray{cu_array}}}`). The way that this PR achieves this is by having the top-level methods (`Base.copyto!` and `Base.fill!`) call (for example) `Base.copyto!(dest, bc, backed_array(dest, bc))`. `backed_array` does some checking, and then calls an internal `_backed_array` which is recursively defined for all array types that we support:

```julia
_backed_array(x::CUDA.CuArray) = x # in extension
_backed_array(x::Array) = x
_backed_array(x::SubArray) = _backed_array(parent(x))
_backed_array(x::Base.ReshapedArray) = _backed_array(parent(x))
_backed_array(x::AbstractData) = _backed_array(parent(x))
```

This way, every possible combination of CPU/GPU-backed `SubArray` and `ReshapedArray` are now supported and should "just work".

The price we pay is that now we're dispatching on 3 arguments (e.g., `fill!(::VF, val, ::Array)`), which is not as pretty, but will not involve the existing whack-a-mole situation.