### PR TITLE
Add getidx benchmarks, refactor, update code loading

### DIFF
--- a/test/MatrixFields/matrix_field_broadcasting.jl
+++ b/test/MatrixFields/matrix_field_broadcasting.jl
@@ -3,35 +3,61 @@ julia --project
 ENV["CLIMACOMMS_DEVICE"] = "CPU"
 ENV["BUILDKITE"] = "true" # to also run opt tests
 using Revise; include(joinpath("test", "MatrixFields", "matrix_field_broadcasting.jl"))
+
+# For profiling/benchmarking:
+
+```
+import Profile, ProfileCanvas
+
+function do_work(space, bc, loc, idx, hidx, n)
+    for i in 1:n
+        call_getidx(space, bc, loc, idx, hidx)
+    end
+    return nothing
+end
+
+(; space, bc, loc_l, loc_i, loc_r, idx, hidx) = get_getidx_args(bc);
+do_work(space, bc, loc_i, idx, hidx, 1)
+Profile.clear()
+prof = Profile.@profile do_work(space, bc, loc_i, idx, hidx, 10^6)
+results = Profile.fetch()
+Profile.clear()
+ProfileCanvas.html_file("flame.html", results)
+
+benchmark_getidx(bc)
+```
 =#
 using Test
 
+print_mem = get(ENV, "BUILDKITE", "") == "true"
 #! format: off
 @testset "Scalar Matrix Field Broadcasting" begin
-    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_1.jl")); @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
-    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_2.jl")); @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
-    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_3.jl")); @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
-    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_4.jl")); @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
-    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_5.jl")); @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
-    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_6.jl")); @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
-    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_7.jl")); @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
-    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_8.jl")); @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
-    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_9.jl")); @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
-    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_10.jl")); @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
-    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_11.jl")); @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
-    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_12.jl")); @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
-    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_13.jl")); @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
-    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_14.jl")); @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
-    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_15.jl")); @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
-    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_16.jl")); @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
+    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_1.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
+    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_2.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
+    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_3.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
+    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_4.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
+    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_5.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
+    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_6.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
+    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_7.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
+    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_8.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
+    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_9.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
+    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_10.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
+    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_11.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
+    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_12.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
+    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_13.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
+    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_14.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
+    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_15.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
+    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_scalar_16.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
     GC.gc()
 end
 
 @testset "Non-scalar Matrix Field Broadcasting" begin
-    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_non_scalar_1.jl")); @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
-    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_non_scalar_2.jl")); @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
-    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_non_scalar_3.jl")); @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
-    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_non_scalar_4.jl")); @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
+    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_non_scalar_1.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
+    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_non_scalar_2.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
+    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_non_scalar_3.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
+    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_non_scalar_4.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
     GC.gc()
 end
 #! format: on
+
+nothing

--- a/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_1.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_1.jl
@@ -29,4 +29,5 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
     )
 
     test_opt && opt_test_field_broadcast(result, bc; ref_set_result!)
+    test_opt && !using_cuda && benchmark_getidx(bc)
 end

--- a/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_2.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_2.jl
@@ -34,4 +34,5 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
     )
 
     test_opt && opt_test_field_broadcast(result, bc; ref_set_result!)
+    test_opt && !using_cuda && benchmark_getidx(bc)
 end

--- a/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_3.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_3.jl
@@ -36,4 +36,5 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
     )
 
     test_opt && opt_test_field_broadcast(result, bc; ref_set_result!)
+    test_opt && !using_cuda && benchmark_getidx(bc)
 end

--- a/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_4.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_4.jl
@@ -31,4 +31,5 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
     )
 
     test_opt && opt_test_field_broadcast(result, bc; ref_set_result!)
+    test_opt && !using_cuda && benchmark_getidx(bc)
 end

--- a/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_utils.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_utils.jl
@@ -3,46 +3,95 @@ import LinearAlgebra: I, mul!
 
 include(joinpath("..", "matrix_field_test_utils.jl"))
 
-const FT = Float64
-const center_space, face_space = test_spaces(FT)
+if !(@isdefined(unit_test_field_broadcast))
+    const FT = Float64
+    const center_space, face_space = test_spaces(FT)
 
-const ᶜlg = Fields.local_geometry_field(center_space)
-const ᶠlg = Fields.local_geometry_field(face_space)
+    const ᶜlg = Fields.local_geometry_field(center_space)
+    const ᶠlg = Fields.local_geometry_field(face_space)
 
-seed!(1) # ensures reproducibility
-const ᶜvec = random_field(FT, center_space)
-const ᶠvec = random_field(FT, face_space)
-const ᶜᶠmat = random_field(BidiagonalMatrixRow{FT}, center_space)
-const ᶜᶠmat2 = random_field(BidiagonalMatrixRow{FT}, center_space)
-const ᶜᶠmat3 = random_field(BidiagonalMatrixRow{FT}, center_space)
-const ᶠᶜmat = random_field(QuaddiagonalMatrixRow{FT}, face_space)
-const ᶠᶜmat2 = random_field(QuaddiagonalMatrixRow{FT}, face_space)
-const ᶠᶜmat3 = random_field(QuaddiagonalMatrixRow{FT}, face_space)
+    seed!(1) # ensures reproducibility
+    const ᶜvec = random_field(FT, center_space)
+    const ᶠvec = random_field(FT, face_space)
+    const ᶜᶠmat = random_field(BidiagonalMatrixRow{FT}, center_space)
+    const ᶜᶠmat2 = random_field(BidiagonalMatrixRow{FT}, center_space)
+    const ᶜᶠmat3 = random_field(BidiagonalMatrixRow{FT}, center_space)
+    const ᶠᶜmat = random_field(QuaddiagonalMatrixRow{FT}, face_space)
+    const ᶠᶜmat2 = random_field(QuaddiagonalMatrixRow{FT}, face_space)
+    const ᶠᶜmat3 = random_field(QuaddiagonalMatrixRow{FT}, face_space)
 
-const ᶜᶠmat_AC1 =
-    map(row -> map(adjoint ∘ Geometry.Covariant1Vector, row), ᶜᶠmat)
-const ᶜᶠmat_C12 = map(
-    (row1, row2) -> map(Geometry.Covariant12Vector, row1, row2),
-    ᶜᶠmat2,
-    ᶜᶠmat3,
+    const ᶜᶠmat_AC1 =
+        map(row -> map(adjoint ∘ Geometry.Covariant1Vector, row), ᶜᶠmat)
+    const ᶜᶠmat_C12 = map(
+        (row1, row2) -> map(Geometry.Covariant12Vector, row1, row2),
+        ᶜᶠmat2,
+        ᶜᶠmat3,
+    )
+    const ᶠᶜmat_AC1 =
+        map(row -> map(adjoint ∘ Geometry.Covariant1Vector, row), ᶠᶜmat)
+    const ᶠᶜmat_C12 = map(
+        (row1, row2) -> map(Geometry.Covariant12Vector, row1, row2),
+        ᶠᶜmat2,
+        ᶠᶜmat3,
+    )
+
+    const ᶜᶠmat_AC1_num =
+        map((row1, row2) -> map(tuple, row1, row2), ᶜᶠmat_AC1, ᶜᶠmat)
+    const ᶜᶠmat_num_C12 =
+        map((row1, row2) -> map(tuple, row1, row2), ᶜᶠmat, ᶜᶠmat_C12)
+    const ᶠᶜmat_C12_AC1 =
+        map((row1, row2) -> map(tuple, row1, row2), ᶠᶜmat_C12, ᶠᶜmat_AC1)
+
+    const ᶜvec_NT = @. nested_type(ᶜvec, ᶜvec, ᶜvec)
+    const ᶜᶠmat_NT =
+        map((rows...) -> map(nested_type, rows...), ᶜᶠmat, ᶜᶠmat2, ᶜᶠmat3)
+    const ᶠᶜmat_NT =
+        map((rows...) -> map(nested_type, rows...), ᶠᶜmat, ᶠᶜmat2, ᶠᶜmat3)
+end
+
+function unit_test_field_broadcast(
+    result,
+    bc;
+    ref_set_result!,
+    allowed_max_eps_error = 10,
 )
-const ᶠᶜmat_AC1 =
-    map(row -> map(adjoint ∘ Geometry.Covariant1Vector, row), ᶠᶜmat)
-const ᶠᶜmat_C12 = map(
-    (row1, row2) -> map(Geometry.Covariant12Vector, row1, row2),
-    ᶠᶜmat2,
-    ᶠᶜmat3,
-)
+    result_copy = copy(result)
+    set_result!(result, bc)
+    # Test that set_result! sets the same value as get_result.
+    @test result == result_copy
 
-const ᶜᶠmat_AC1_num =
-    map((row1, row2) -> map(tuple, row1, row2), ᶜᶠmat_AC1, ᶜᶠmat)
-const ᶜᶠmat_num_C12 =
-    map((row1, row2) -> map(tuple, row1, row2), ᶜᶠmat, ᶜᶠmat_C12)
-const ᶠᶜmat_C12_AC1 =
-    map((row1, row2) -> map(tuple, row1, row2), ᶠᶜmat_C12, ᶠᶜmat_AC1)
+    ref_result = similar(result)
+    ref_set_result!(ref_result)
+    max_error = mapreduce(
+        (a, b) -> (abs(a - b)),
+        max,
+        parent(result),
+        parent(ref_result),
+    )
+    max_eps_error = ceil(Int, max_error / eps(typeof(max_error)))
 
-const ᶜvec_NT = @. nested_type(ᶜvec, ᶜvec, ᶜvec)
-const ᶜᶠmat_NT =
-    map((rows...) -> map(nested_type, rows...), ᶜᶠmat, ᶜᶠmat2, ᶜᶠmat3)
-const ᶠᶜmat_NT =
-    map((rows...) -> map(nested_type, rows...), ᶠᶜmat, ᶠᶜmat2, ᶠᶜmat3)
+    # Test that set_result! is performant and correct when compared
+    # against ref_set_result!.
+    @test max_eps_error <= allowed_max_eps_error
+    return nothing
+end
+
+function opt_test_field_broadcast(result, bc; ref_set_result!)
+    time = @benchmark set_result!(result, bc)
+    ref_result = similar(result)
+    ref_time = @benchmark ref_set_result!(ref_result)
+    print_time_comparison(; time, ref_time)
+
+    # Test get_result and set_result! for type instabilities, and test
+    # set_result! for allocations. Ignore the type instabilities in CUDA and
+    # the allocations they incur.
+    @test_opt ignored_modules = cuda_frames materialize(bc)
+    @test_opt ignored_modules = cuda_frames set_result!(result, bc)
+    using_cuda || @test (@allocated set_result!(result, bc)) == 0
+
+    # Test ref_set_result! for type instabilities and allocations to
+    # ensure that the performance comparison is fair.
+    @test_opt ignored_modules = cuda_frames ref_set_result!(ref_result)
+    using_cuda || @test (@allocated ref_set_result!(ref_result)) == 0
+    return nothing
+end

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_1.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_1.jl
@@ -1,12 +1,11 @@
 #=
-julia --project
+julia --project=.buildkite
+ENV["CLIMACOMMS_DEVICE"] = "CPU"
 using Revise; include(joinpath("test", "MatrixFields", "matrix_fields_broadcasting", "test_scalar_1.jl"))
 =#
 import ClimaCore
 #! format: off
-if !(@isdefined(unit_test_field_broadcast_vs_array_reference))
-    include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
-end
+include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "diagonal matrix times vector" begin
@@ -26,4 +25,5 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
         input_fields,
         using_cuda,
     )
+    test_opt && !using_cuda && benchmark_getidx(bc)
 end

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_10.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_10.jl
@@ -4,9 +4,7 @@ using Revise; include(joinpath("test", "MatrixFields", "matrix_fields_broadcasti
 =#
 import ClimaCore
 #! format: off
-if !(@isdefined(unit_test_field_broadcast_vs_array_reference))
-    include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
-end
+include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "diagonal matrix times bi-diagonal matrix times \
@@ -61,4 +59,5 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
         ref_set_result!,
         using_cuda,
     )
+    test_opt && !using_cuda && benchmark_getidx(bc)
 end

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_11.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_11.jl
@@ -4,9 +4,7 @@ using Revise; include(joinpath("test", "MatrixFields", "matrix_fields_broadcasti
 =#
 import ClimaCore
 #! format: off
-if !(@isdefined(unit_test_field_broadcast_vs_array_reference))
-    include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
-end
+include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "linear combination of matrix products and LinearAlgebra.I" begin
@@ -57,4 +55,5 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
         ref_set_result!,
         using_cuda,
     )
+    test_opt && !using_cuda && benchmark_getidx(bc)
 end

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_12.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_12.jl
@@ -4,9 +4,7 @@ using Revise; include(joinpath("test", "MatrixFields", "matrix_fields_broadcasti
 =#
 import ClimaCore
 #! format: off
-if !(@isdefined(unit_test_field_broadcast_vs_array_reference))
-    include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
-end
+include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "another linear combination of matrix products and \
@@ -58,4 +56,5 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
         ref_set_result!,
         using_cuda,
     )
+    test_opt && !using_cuda && benchmark_getidx(bc)
 end

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_13.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_13.jl
@@ -4,9 +4,7 @@ using Revise; include(joinpath("test", "MatrixFields", "matrix_fields_broadcasti
 =#
 import ClimaCore
 #! format: off
-if !(@isdefined(unit_test_field_broadcast_vs_array_reference))
-    include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
-end
+include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "matrix times linear combination" begin
@@ -61,4 +59,5 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
         ref_set_result!,
         using_cuda,
     )
+    test_opt && !using_cuda && benchmark_getidx(bc)
 end

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_14.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_14.jl
@@ -4,9 +4,7 @@ using Revise; include(joinpath("test", "MatrixFields", "matrix_fields_broadcasti
 =#
 import ClimaCore
 #! format: off
-if !(@isdefined(unit_test_field_broadcast_vs_array_reference))
-    include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
-end
+include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "linear combination times another linear combination" begin
@@ -79,4 +77,5 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
         ref_set_result!,
         using_cuda,
     )
+    test_opt && !using_cuda && benchmark_getidx(bc)
 end

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_15.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_15.jl
@@ -4,9 +4,7 @@ using Revise; include(joinpath("test", "MatrixFields", "matrix_fields_broadcasti
 =#
 import ClimaCore
 #! format: off
-if !(@isdefined(unit_test_field_broadcast_vs_array_reference))
-    include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
-end
+include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "matrix times matrix times linear combination times matrix \
@@ -101,4 +99,5 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
         ref_set_result!,
         using_cuda,
     )
+    test_opt && !using_cuda && benchmark_getidx(bc)
 end

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_16.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_16.jl
@@ -4,9 +4,7 @@ using Revise; include(joinpath("test", "MatrixFields", "matrix_fields_broadcasti
 =#
 import ClimaCore
 #! format: off
-if !(@isdefined(unit_test_field_broadcast_vs_array_reference))
-    include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
-end
+include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "matrix constructions and multiplications" begin
@@ -72,4 +70,5 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
         ref_set_result!,
         using_cuda,
     )
+    test_opt && !using_cuda && benchmark_getidx(bc)
 end

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_2.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_2.jl
@@ -4,9 +4,7 @@ using Revise; include(joinpath("test", "MatrixFields", "matrix_fields_broadcasti
 =#
 import ClimaCore
 #! format: off
-if !(@isdefined(unit_test_field_broadcast_vs_array_reference))
-    include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
-end
+include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "tri-diagonal matrix times vector" begin
@@ -27,4 +25,5 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
         input_fields,
         using_cuda,
     )
+    test_opt && !using_cuda && benchmark_getidx(bc)
 end

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_3.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_3.jl
@@ -4,9 +4,7 @@ using Revise; include(joinpath("test", "MatrixFields", "matrix_fields_broadcasti
 =#
 import ClimaCore
 #! format: off
-if !(@isdefined(unit_test_field_broadcast_vs_array_reference))
-    include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
-end
+include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "quad-diagonal matrix times vector" begin
@@ -31,4 +29,5 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
         ref_set_result!,
         using_cuda,
     )
+    test_opt && !using_cuda && benchmark_getidx(bc)
 end

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_4.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_4.jl
@@ -4,9 +4,7 @@ using Revise; include(joinpath("test", "MatrixFields", "matrix_fields_broadcasti
 =#
 import ClimaCore
 #! format: off
-if !(@isdefined(unit_test_field_broadcast_vs_array_reference))
-    include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
-end
+include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "diagonal matrix times bi-diagonal matrix" begin
@@ -31,4 +29,5 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
         ref_set_result!,
         using_cuda,
     )
+    test_opt && !using_cuda && benchmark_getidx(bc)
 end

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_5.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_5.jl
@@ -4,9 +4,7 @@ using Revise; include(joinpath("test", "MatrixFields", "matrix_fields_broadcasti
 =#
 import ClimaCore
 #! format: off
-if !(@isdefined(unit_test_field_broadcast_vs_array_reference))
-    include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
-end
+include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "tri-diagonal matrix times tri-diagonal matrix" begin
@@ -31,4 +29,5 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
         ref_set_result!,
         using_cuda,
     )
+    test_opt && !using_cuda && benchmark_getidx(bc)
 end

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_6.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_6.jl
@@ -4,9 +4,7 @@ using Revise; include(joinpath("test", "MatrixFields", "matrix_fields_broadcasti
 =#
 import ClimaCore
 #! format: off
-if !(@isdefined(unit_test_field_broadcast_vs_array_reference))
-    include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
-end
+include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "quad-diagonal matrix times diagonal matrix" begin
@@ -31,4 +29,5 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
         ref_set_result!,
         using_cuda,
     )
+    test_opt && !using_cuda && benchmark_getidx(bc)
 end

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_7.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_7.jl
@@ -4,9 +4,7 @@ using Revise; include(joinpath("test", "MatrixFields", "matrix_fields_broadcasti
 =#
 import ClimaCore
 #! format: off
-if !(@isdefined(unit_test_field_broadcast_vs_array_reference))
-    include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
-end
+include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "diagonal matrix times bi-diagonal matrix times \
@@ -40,4 +38,5 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
         ref_set_result!,
         using_cuda,
     )
+    test_opt && !using_cuda && benchmark_getidx(bc)
 end

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_8.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_8.jl
@@ -4,9 +4,7 @@ using Revise; include(joinpath("test", "MatrixFields", "matrix_fields_broadcasti
 =#
 import ClimaCore
 #! format: off
-if !(@isdefined(unit_test_field_broadcast_vs_array_reference))
-    include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
-end
+include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "diagonal matrix times bi-diagonal matrix times \
@@ -46,4 +44,5 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
         ref_set_result!,
         using_cuda,
     )
+    test_opt && !using_cuda && benchmark_getidx(bc)
 end

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_9.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_9.jl
@@ -4,9 +4,7 @@ using Revise; include(joinpath("test", "MatrixFields", "matrix_fields_broadcasti
 =#
 import ClimaCore
 #! format: off
-if !(@isdefined(unit_test_field_broadcast_vs_array_reference))
-    include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
-end
+include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "diagonal matrix times bi-diagonal matrix times \
@@ -56,4 +54,5 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
         ref_set_result!,
         using_cuda,
     )
+    test_opt && !using_cuda && benchmark_getidx(bc)
 end

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_utils.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_utils.jl
@@ -3,13 +3,88 @@ import LinearAlgebra: I, mul!
 
 include(joinpath("..", "matrix_field_test_utils.jl"))
 
-const FT = Float64
-const center_space, face_space = test_spaces(FT)
+if !(@isdefined(unit_test_field_broadcast_vs_array_reference))
+    const FT = Float64
+    const center_space, face_space = test_spaces(FT)
 
-seed!(1) # ensures reproducibility
-const ᶜvec = random_field(FT, center_space)
-const ᶠvec = random_field(FT, face_space)
-const ᶜᶜmat = random_field(DiagonalMatrixRow{FT}, center_space)
-const ᶜᶠmat = random_field(BidiagonalMatrixRow{FT}, center_space)
-const ᶠᶠmat = random_field(TridiagonalMatrixRow{FT}, face_space)
-const ᶠᶜmat = random_field(QuaddiagonalMatrixRow{FT}, face_space)
+    seed!(1) # ensures reproducibility
+    const ᶜvec = random_field(FT, center_space)
+    const ᶠvec = random_field(FT, face_space)
+    const ᶜᶜmat = random_field(DiagonalMatrixRow{FT}, center_space)
+    const ᶜᶠmat = random_field(BidiagonalMatrixRow{FT}, center_space)
+    const ᶠᶠmat = random_field(TridiagonalMatrixRow{FT}, face_space)
+    const ᶠᶜmat = random_field(QuaddiagonalMatrixRow{FT}, face_space)
+end
+
+function unit_test_field_broadcast_vs_array_reference(
+    result,
+    bc;
+    input_fields,
+    temp_value_fields = (),
+    using_cuda,
+    ref_set_result! = mul!,
+    allowed_max_eps_error = 0,
+)
+    inputs_arrays = map(MatrixFields.field2arrays, input_fields)
+    temp_values_arrays = map(MatrixFields.field2arrays, temp_value_fields)
+    result_arrays = MatrixFields.field2arrays(result)
+    ref_result_arrays = MatrixFields.field2arrays(similar(result))
+    result = materialize(bc)
+    result₀ = copy(result)
+    set_result!(result, bc)
+    @test result == result₀
+    call_ref_set_result!(
+        ref_set_result!,
+        ref_result_arrays,
+        inputs_arrays,
+        temp_values_arrays,
+    )
+    max_error = compute_max_error(result_arrays, ref_result_arrays)
+    max_eps_error = ceil(Int, max_error / eps(typeof(max_error)))
+    @test max_eps_error ≤ allowed_max_eps_error
+    return nothing
+end
+
+function opt_test_field_broadcast_against_array_reference(
+    result,
+    bc;
+    input_fields,
+    temp_value_fields = (),
+    ref_set_result!::F = mul!,
+    using_cuda,
+) where {F}
+    temp_values_arrays = map(MatrixFields.field2arrays, temp_value_fields)
+    inputs_arrays = map(MatrixFields.field2arrays, input_fields)
+    ref_result_arrays = MatrixFields.field2arrays(similar(result))
+    ref_time = BT.@belapsed call_ref_set_result!(
+        $ref_set_result!,
+        $ref_result_arrays,
+        $inputs_arrays,
+        $temp_values_arrays,
+    )
+    time = BT.@belapsed set_result!($result, $bc)
+    print_time_comparison(; time, ref_time)
+
+    # Test get_result and set_result! for type instabilities, and test
+    # set_result! for allocations. Ignore the type instabilities in CUDA and
+    # the allocations they incur.
+    @test_opt ignored_modules = cuda_frames materialize(bc)
+    @test_opt ignored_modules = cuda_frames set_result!(result, bc)
+    using_cuda || @test (@allocated set_result!(result, bc)) == 0
+
+    # Test ref_set_result! for type instabilities and allocations to ensure
+    # that the performance comparison is fair.
+    @test_opt ignored_modules = cuda_frames call_ref_set_result!(
+        ref_set_result!,
+        ref_result_arrays,
+        inputs_arrays,
+        temp_values_arrays,
+    )
+    using_cuda || @test (@allocated call_ref_set_result!(
+        ref_set_result!,
+        ref_result_arrays,
+        inputs_arrays,
+        temp_values_arrays,
+    )) == 0
+    return nothing
+end


### PR DESCRIPTION
This PR adds `getidx` micro benchmarks for some matrix field operators. I've also refactored things a bit so that we can run some flame graphs on these functions. Here's what the output looks like for `test/MatrixFields/matrix_field_broadcasting.jl`:


```julia
julia> using Revise; include(joinpath("test", "MatrixFields", "matrix_field_broadcasting.jl"))
comms_device = ClimaComms.CPUSingleThreaded()
[ Info: getidx times max(interior,left,right) = (3 nanoseconds,3 nanoseconds,3 nanoseconds)
[ Info: getidx times max(interior,left,right) = (4 nanoseconds,4 nanoseconds,4 nanoseconds)
[ Info: getidx times max(interior,left,right) = (4 nanoseconds,4 nanoseconds,5 nanoseconds)
[ Info: getidx times max(interior,left,right) = (4 nanoseconds,4 nanoseconds,4 nanoseconds)
[ Info: getidx times max(interior,left,right) = (7 nanoseconds,7 nanoseconds,7 nanoseconds)
[ Info: getidx times max(interior,left,right) = (4 nanoseconds,5 nanoseconds,5 nanoseconds)
[ Info: getidx times max(interior,left,right) = (14 nanoseconds,14 nanoseconds,14 nanoseconds)
[ Info: getidx times max(interior,left,right) = (22 nanoseconds,24 nanoseconds,24 nanoseconds)
[ Info: getidx times max(interior,left,right) = (19 nanoseconds,19 nanoseconds,19 nanoseconds)
[ Info: getidx times max(interior,left,right) = (35 nanoseconds,36 nanoseconds,36 nanoseconds)
[ Info: getidx times max(interior,left,right) = (20 nanoseconds,50 nanoseconds,45 nanoseconds)
[ Info: getidx times max(interior,left,right) = (16 nanoseconds,17 nanoseconds,17 nanoseconds)
[ Info: getidx times max(interior,left,right) = (75 nanoseconds,120 nanoseconds,116 nanoseconds)
[ Info: getidx times max(interior,left,right) = (193 nanoseconds,242 nanoseconds,257 nanoseconds)
[ Info: getidx times max(interior,left,right) = (1 microsecond, 246 nanoseconds,1 microsecond, 575 nanoseconds,1 microsecond, 684 nanoseconds)
[ Info: getidx times max(interior,left,right) = (110 nanoseconds,142 nanoseconds,148 nanoseconds)
Test Summary:                    | Pass  Total     Time
Scalar Matrix Field Broadcasting |  112    112  5m26.4s
comms_device = ClimaComms.CPUSingleThreaded()
[ Info: getidx times max(interior,left,right) = (11 nanoseconds,11 nanoseconds,11 nanoseconds)
[ Info: getidx times max(interior,left,right) = (58 nanoseconds,59 nanoseconds,84 nanoseconds)
[ Info: getidx times max(interior,left,right) = (48 nanoseconds,48 nanoseconds,47 nanoseconds)
[ Info: getidx times max(interior,left,right) = (71 nanoseconds,78 nanoseconds,78 nanoseconds)
Test Summary:                        | Pass  Total     Time
Non-scalar Matrix Field Broadcasting |   28     28  1m13.6s
```

This nicely lines up indicating that `test_scalar_15` is problematic.