### PR TITLE
Hoist eltype calls in matrix multiplication

### DIFF
--- a/src/MatrixFields/matrix_multiplication.jl
+++ b/src/MatrixFields/matrix_multiplication.jl
@@ -275,21 +275,22 @@ function Operators.return_eltype(
     matrix1,
     arg,
 )
-    eltype(matrix1) <: BandMatrixRow || error(
+    et_mat1 = eltype(matrix1)
+    et_arg = eltype(arg)
+    et_mat1 <: BandMatrixRow || error(
         "The first argument of ⋅ must have elements of type BandMatrixRow, but \
-         the given argument has elements of type $(eltype(matrix1))",
+         the given argument has elements of type $et_mat1",
     )
-    if eltype(arg) <: BandMatrixRow # matrix-matrix multiplication
+    if et_arg <: BandMatrixRow # matrix-matrix multiplication
         matrix2 = arg
-        ld1, ud1 = outer_diagonals(eltype(matrix1))
-        ld2, ud2 = outer_diagonals(eltype(matrix2))
+        ld1, ud1 = outer_diagonals(et_mat1)
+        ld2, ud2 = outer_diagonals(et_arg)
         prod_ld, prod_ud = ld1 + ld2, ud1 + ud2
-        prod_value_type =
-            rmul_return_type(eltype(eltype(matrix1)), eltype(eltype(matrix2)))
+        prod_value_type = rmul_return_type(eltype(et_mat1), eltype(et_arg))
         return band_matrix_row_type(prod_ld, prod_ud, prod_value_type)
     else # matrix-vector multiplication
         vector = arg
-        return rmul_return_type(eltype(eltype(matrix1)), eltype(vector))
+        return rmul_return_type(eltype(et_mat1), et_arg)
     end
 end
 
@@ -299,30 +300,28 @@ function Operators.return_eltype(
     arg,
     ::Type{LG},
 ) where {LG}
-    eltype(matrix1) <: BandMatrixRow || error(
+    et_mat1 = eltype(matrix1)
+    et_arg = eltype(arg)
+    et_mat1 <: BandMatrixRow || error(
         "The first argument of ⋅ must have elements of type BandMatrixRow, but \
-         the given argument has elements of type $(eltype(matrix1))",
+         the given argument has elements of type $et_mat1",
     )
-    if eltype(arg) <: BandMatrixRow # matrix-matrix multiplication
+    if et_arg <: BandMatrixRow # matrix-matrix multiplication
         matrix2 = arg
-        ld1, ud1 = outer_diagonals(eltype(matrix1))
-        ld2, ud2 = outer_diagonals(eltype(matrix2))
+        ld1, ud1 = outer_diagonals(et_mat1)
+        ld2, ud2 = outer_diagonals(et_arg)
         prod_ld, prod_ud = ld1 + ld2, ud1 + ud2
         prod_value_type = Base.promote_op(
             rmul_with_projection,
-            eltype(eltype(matrix1)),
-            eltype(eltype(matrix2)),
+            eltype(et_mat1),
+            eltype(et_arg),
             LG,
         )
         return band_matrix_row_type(prod_ld, prod_ud, prod_value_type)
     else # matrix-vector multiplication
         vector = arg
-        prod_value_type = Base.promote_op(
-            rmul_with_projection,
-            eltype(eltype(matrix1)),
-            eltype(vector),
-            LG,
-        )
+        prod_value_type =
+            Base.promote_op(rmul_with_projection, eltype(et_mat1), et_arg, LG)
     end
 end
 


### PR DESCRIPTION
This PR hoists eltype calls in the matrix multiplication.

main
```julia
main
julia> using Revise; include(joinpath("test", "MatrixFields", "matrix_field_broadcasting.jl"))
[ Info: getidx times max(interior,left,right) = (3 nanoseconds,3 nanoseconds,3 nanoseconds)
[ Info: getidx times max(interior,left,right) = (4 nanoseconds,4 nanoseconds,4 nanoseconds)
[ Info: getidx times max(interior,left,right) = (4 nanoseconds,4 nanoseconds,5 nanoseconds)
[ Info: getidx times max(interior,left,right) = (4 nanoseconds,4 nanoseconds,4 nanoseconds)
[ Info: getidx times max(interior,left,right) = (7 nanoseconds,7 nanoseconds,7 nanoseconds)
[ Info: getidx times max(interior,left,right) = (5 nanoseconds,5 nanoseconds,5 nanoseconds)
[ Info: getidx times max(interior,left,right) = (14 nanoseconds,14 nanoseconds,14 nanoseconds)
[ Info: getidx times max(interior,left,right) = (22 nanoseconds,23 nanoseconds,23 nanoseconds)
[ Info: getidx times max(interior,left,right) = (19 nanoseconds,19 nanoseconds,19 nanoseconds)
[ Info: getidx times max(interior,left,right) = (35 nanoseconds,36 nanoseconds,36 nanoseconds)
[ Info: getidx times max(interior,left,right) = (51 nanoseconds,43 nanoseconds,46 nanoseconds)
[ Info: getidx times max(interior,left,right) = (16 nanoseconds,17 nanoseconds,17 nanoseconds)
[ Info: getidx times max(interior,left,right) = (232 nanoseconds,297 nanoseconds,298 nanoseconds)
[ Info: getidx times max(interior,left,right) = (260 nanoseconds,334 nanoseconds,376 nanoseconds)
[ Info: getidx times max(interior,left,right) = (4 microseconds, 197 nanoseconds,5 microseconds, 570 nanoseconds,5 microseconds, 584 nanoseconds)
[ Info: getidx times max(interior,left,right) = (107 nanoseconds,156 nanoseconds,152 nanoseconds)
Test Summary:                    | Pass  Total     Time
Scalar Matrix Field Broadcasting |  112    112  5m23.0s
[ Info: getidx times max(interior,left,right) = (11 nanoseconds,11 nanoseconds,11 nanoseconds)
[ Info: getidx times max(interior,left,right) = (93 nanoseconds,96 nanoseconds,120 nanoseconds)
[ Info: getidx times max(interior,left,right) = (48 nanoseconds,48 nanoseconds,48 nanoseconds)
[ Info: getidx times max(interior,left,right) = (70 nanoseconds,77 nanoseconds,77 nanoseconds)
Test Summary:                        | Pass  Total     Time
Non-scalar Matrix Field Broadcasting |   28     28  1m07.7s
```

this PR
```julia
julia> using Revise; include(joinpath("test", "MatrixFields", "matrix_field_broadcasting.jl"))
[ Info: getidx times max(interior,left,right) = (3 nanoseconds,3 nanoseconds,3 nanoseconds)
[ Info: getidx times max(interior,left,right) = (4 nanoseconds,4 nanoseconds,4 nanoseconds)
[ Info: getidx times max(interior,left,right) = (4 nanoseconds,4 nanoseconds,4 nanoseconds)
[ Info: getidx times max(interior,left,right) = (4 nanoseconds,4 nanoseconds,4 nanoseconds)
[ Info: getidx times max(interior,left,right) = (7 nanoseconds,7 nanoseconds,7 nanoseconds)
[ Info: getidx times max(interior,left,right) = (5 nanoseconds,5 nanoseconds,5 nanoseconds)
[ Info: getidx times max(interior,left,right) = (14 nanoseconds,15 nanoseconds,14 nanoseconds)
[ Info: getidx times max(interior,left,right) = (22 nanoseconds,23 nanoseconds,23 nanoseconds)
[ Info: getidx times max(interior,left,right) = (19 nanoseconds,19 nanoseconds,19 nanoseconds)
[ Info: getidx times max(interior,left,right) = (35 nanoseconds,36 nanoseconds,36 nanoseconds)
[ Info: getidx times max(interior,left,right) = (15 nanoseconds,16 nanoseconds,16 nanoseconds)
[ Info: getidx times max(interior,left,right) = (15 nanoseconds,16 nanoseconds,16 nanoseconds)
[ Info: getidx times max(interior,left,right) = (57 nanoseconds,82 nanoseconds,93 nanoseconds)
[ Info: getidx times max(interior,left,right) = (134 nanoseconds,163 nanoseconds,182 nanoseconds)
[ Info: getidx times max(interior,left,right) = (723 nanoseconds,784 nanoseconds,829 nanoseconds)
[ Info: getidx times max(interior,left,right) = (97 nanoseconds,129 nanoseconds,130 nanoseconds)
Test Summary:                    | Pass  Total     Time
Scalar Matrix Field Broadcasting |  112    112  5m36.8s
[ Info: getidx times max(interior,left,right) = (11 nanoseconds,11 nanoseconds,11 nanoseconds)
[ Info: getidx times max(interior,left,right) = (95 nanoseconds,110 nanoseconds,99 nanoseconds)
[ Info: getidx times max(interior,left,right) = (48 nanoseconds,49 nanoseconds,49 nanoseconds)
[ Info: getidx times max(interior,left,right) = (70 nanoseconds,78 nanoseconds,78 nanoseconds)
Test Summary:                        | Pass  Total     Time
Non-scalar Matrix Field Broadcasting |   28     28  1m12.2s
```

So, scalar tests 11, 13, 14, and 15 are significantly faster with this PR.

The flame graph for 15 is a step towards #1871, but there is still some time in `eltype`, which seems odd.

<img width="2145" alt="Screenshot 2024-07-10 at 11 02 08 AM" src="https://github.com/CliMA/ClimaCore.jl/assets/1880641/adde5bdd-8ac1-4fa8-89e8-7e9fdd98701d">
