### PR TITLE
Fix broken Aqua test in julia 1.11

### DIFF
--- a/.buildkite/Manifest.toml
+++ b/.buildkite/Manifest.toml
@@ -308,7 +308,7 @@ weakdeps = ["CUDA", "MPI"]
 deps = ["Adapt", "BandedMatrices", "BlockArrays", "ClimaComms", "CubedSphere", "DataStructures", "DocStringExtensions", "ForwardDiff", "GaussQuadrature", "GilbertCurves", "HDF5", "InteractiveUtils", "IntervalSets", "KrylovKit", "LinearAlgebra", "MultiBroadcastFusion", "NVTX", "PkgVersion", "RecursiveArrayTools", "RootSolvers", "SparseArrays", "StaticArrays", "Statistics", "Unrolled"]
 path = ".."
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
-version = "0.14.9"
+version = "0.14.10"
 weakdeps = ["CUDA", "Krylov"]
 
     [deps.ClimaCore.extensions]

--- a/test/MatrixFields/band_matrix_row.jl
+++ b/test/MatrixFields/band_matrix_row.jl
@@ -51,4 +51,11 @@ include("matrix_field_test_utils.jl")
         TridiagonalMatrixRow{Int},
         PentadiagonalMatrixRow(0, 0, 1, 0, 0),
     )
+
+    @test map(tuple, DiagonalMatrixRow(1), DiagonalMatrixRow(1.0)) ==
+          DiagonalMatrixRow{Tuple{Int, Float64}}(((1, 1.0),))
+    @test map(tuple, DiagonalMatrixRow(1)) == DiagonalMatrixRow(tuple(1))
+    @test zero(typeof(DiagonalMatrixRow(1))) == DiagonalMatrixRow(0)
+    @test eltype(typeof(DiagonalMatrixRow(1))) == Int
+    @test inv(DiagonalMatrixRow(1)) == DiagonalMatrixRow(float(1))
 end


### PR DESCRIPTION
This PR breaks an aqua test in Julia 1.11 where `Base.map(f::F, rows::BandMatrixRow{ld}...) where {F, ld} = BandMatrixRow{ld}(map(f, map(row -> row.entries, rows)...)...)` results in unbound `ld` for an empty tuple of rows.