### PR TITLE
Remove multiple integer indexing in DataLayouts

### DIFF
--- a/ext/cuda/matrix_fields_single_field_solve.jl
+++ b/ext/cuda/matrix_fields_single_field_solve.jl
@@ -115,8 +115,8 @@ function band_matrix_solve_local_mem!(
         b_local[v] = b[vi(v)]
     end
     cache_local = (Ux_local, U₊₁_local)
-    Aⱼs_local = (A₋₁, A₀, A₊₁)
-    band_matrix_solve!(t, cache_local, x_local, Aⱼs_local, b_local, vi)
+    Aⱼs_local = (A₋₁_local, A₀_local, A₊₁_local)
+    band_matrix_solve!(t, cache_local, x_local, Aⱼs_local, b_local, identity)
     @inbounds for v in 1:Nv
         x[vi(v)] = x_local[v]
     end
@@ -153,8 +153,8 @@ function band_matrix_solve_local_mem!(
         b_local[v] = b[vi(v)]
     end
     cache_local = (Ux_local, U₊₁_local, U₊₂_local)
-    Aⱼs_local = (A₋₂, A₋₁, A₀, A₊₁, A₊₂)
-    band_matrix_solve!(t, cache_local, x_local, Aⱼs_local, b_local, vi)
+    Aⱼs_local = (A₋₂_local, A₋₁_local, A₀_local, A₊₁_local, A₊₂_local)
+    band_matrix_solve!(t, cache_local, x_local, Aⱼs_local, b_local, identity)
     @inbounds for v in 1:Nv
         x[vi(v)] = x_local[v]
     end

--- a/ext/cuda/remapping_distributed.jl
+++ b/ext/cuda/remapping_distributed.jl
@@ -59,7 +59,7 @@ function set_interpolated_values_kernel!(
     totalThreadsZ = gridDim().z * blockDim().z
 
     _, Nq = size(I1)
-
+    CI = CartesianIndex
     for i in hindex:totalThreadsX:num_horiz
         h = local_horiz_indices[i]
         for j in vindex:totalThreadsY:num_vert
@@ -73,8 +73,8 @@ function set_interpolated_values_kernel!(
                             I1[i, t] *
                             I2[i, s] *
                             (
-                                A * field_values[k][t, s, nothing, v_lo, h] +
-                                B * field_values[k][t, s, nothing, v_hi, h]
+                                A * field_values[k][CI(t, s, 1, v_lo, h)] +
+                                B * field_values[k][CI(t, s, 1, v_hi, h)]
                             )
                     end
                 end
@@ -107,7 +107,7 @@ function set_interpolated_values_kernel!(
     totalThreadsZ = gridDim().z * blockDim().z
 
     _, Nq = size(I)
-
+    CI = CartesianIndex
     for i in hindex:totalThreadsX:num_horiz
         h = local_horiz_indices[i]
         for j in vindex:totalThreadsY:num_vert
@@ -121,10 +121,8 @@ function set_interpolated_values_kernel!(
                             I[i, t] *
                             I[i, s] *
                             (
-                                A *
-                                field_values[k][t, nothing, nothing, v_lo, h] +
-                                B *
-                                field_values[k][t, nothing, nothing, v_hi, h]
+                                A * field_values[k][CI(t, 1, 1, v_lo, h)] +
+                                B * field_values[k][CI(t, 1, 1, v_hi, h)]
                             )
                     end
                 end
@@ -199,7 +197,7 @@ function set_interpolated_values_kernel!(
                     out[i, k] +=
                         I1[i, t] *
                         I2[i, s] *
-                        field_values[k][t, s, nothing, nothing, h]
+                        field_values[k][CartesianIndex(t, s, 1, 1, h)]
                 end
             end
         end
@@ -232,8 +230,7 @@ function set_interpolated_values_kernel!(
                 out[i, k] = 0
                 for t in 1:Nq, s in 1:Nq
                     out[i, k] +=
-                        I[i, i] *
-                        field_values[k][t, nothing, nothing, nothing, h]
+                        I[i, i] * field_values[k][CartesianIndex(t, 1, 1, 1, h)]
                 end
             end
         end

--- a/lib/ClimaCorePlots/src/ClimaCorePlots.jl
+++ b/lib/ClimaCorePlots/src/ClimaCorePlots.jl
@@ -4,6 +4,7 @@ import RecipesBase
 import TriplotBase
 
 import ClimaComms
+import ClimaCore.DataLayouts: slab_index
 import ClimaCore:
     ClimaCore,
     DataLayouts,
@@ -308,7 +309,7 @@ function _slice_along(field, coord)
     hdata = ClimaCore.slab(hcoord_data, hidx)
     hnode_idx = 1
     for i in axes(hdata)[axis]
-        pt = axis == 1 ? hdata[i, 1] : hdata[1, i]
+        pt = axis == 1 ? hdata[slab_index(i, 1)] : hdata[slab_index(1, i)]
         axis_value = Geometry.component(pt, axis)
         coord_value = Geometry.component(coord, 1)
         if axis_value > coord_value
@@ -353,8 +354,9 @@ function _slice_along(field, coord)
             islab = ClimaCore.slab(ortho_data, v, i)
             # copy the nodal data
             for ni in 1:size(islab)[1]
-                islab[ni] =
-                    axis == 1 ? ijslab[hnode_idx, ni] : ijslab[ni, hnode_idx]
+                islab[slab_index(ni)] =
+                    axis == 1 ? ijslab[slab_index(hnode_idx, ni)] :
+                    ijslab[slab_index(ni, hnode_idx)]
             end
         end
     end

--- a/lib/ClimaCoreTempestRemap/src/netcdf.jl
+++ b/lib/ClimaCoreTempestRemap/src/netcdf.jl
@@ -1,5 +1,6 @@
 import CommonDataModel
 import ClimaCore: slab, column
+import ClimaCore.DataLayouts: slab_index
 
 """
     def_time_coord(nc::NCDataset, length=Inf, eltype=Float64;
@@ -97,7 +98,7 @@ function def_space_coord(
     coords = Spaces.coordinates_data(space)
 
     for (col, ((i, j), e)) in enumerate(nodes)
-        coord = slab(coords, e)[i, j]
+        coord = slab(coords, e)[slab_index(i, j)]
         X[col] = coord.x
         Y[col] = coord.y
     end
@@ -149,7 +150,7 @@ function def_space_coord(
     coords = Spaces.coordinates_data(space)
 
     for (col, ((i, j), e)) in enumerate(nodes)
-        coord = slab(coords, e)[i, j]
+        coord = slab(coords, e)[slab_index(i, j)]
         lon[col] = coord.long
         lat[col] = coord.lat
     end
@@ -328,7 +329,7 @@ function Base.setindex!(
     end
     data = Fields.field_values(field)
     for (col, ((i, j), e)) in enumerate(nodes)
-        var[col, extraidx...] = slab(data, e)[i, j]
+        var[col, extraidx...] = slab(data, e)[slab_index(i, j)]
     end
     return var
 end

--- a/src/DataLayouts/fill.jl
+++ b/src/DataLayouts/fill.jl
@@ -21,14 +21,14 @@ end
 
 function Base.fill!(data::IJF{S, Nij}, val, ::ToCPU) where {S, Nij}
     @inbounds for j in 1:Nij, i in 1:Nij
-        data[i, j] = val
+        data[CartesianIndex(i, j, 1, 1, 1)] = val
     end
     return data
 end
 
 function Base.fill!(data::IF{S, Ni}, val, ::ToCPU) where {S, Ni}
     @inbounds for i in 1:Ni
-        data[i] = val
+        data[CartesianIndex(i, 1, 1, 1, 1)] = val
     end
     return data
 end
@@ -36,7 +36,7 @@ end
 function Base.fill!(data::VF, val, ::ToCPU)
     Nv = nlevels(data)
     @inbounds for v in 1:Nv
-        data[v] = val
+        data[CartesianIndex(1, 1, 1, v, 1)] = val
     end
     return data
 end

--- a/src/Fields/broadcast.jl
+++ b/src/Fields/broadcast.jl
@@ -46,7 +46,7 @@ function _first end
 # we're trying to do is throw a more helpful
 # error message. So, let's throw it here instead.
 _first(bc, ::Any) = throw(BroadcastInferenceError(bc))
-_first_data_layout(data::DataLayouts.VF) = data[1]
+_first_data_layout(data::DataLayouts.VF) = data[CartesianIndex(1, 1, 1, 1, 1)]
 _first_data_layout(data::DataLayouts.DataF) = data[]
 _first(bc, x::Real) = x
 _first(bc, x::Geometry.LocalGeometry) = x

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -2,6 +2,7 @@ module Grids
 
 import ClimaComms, Adapt, ForwardDiff, LinearAlgebra
 import LinearAlgebra: det, norm
+import ..DataLayouts: slab_index, vindex
 import ..DataLayouts,
     ..Domains, ..Meshes, ..Topologies, ..Geometry, ..Quadratures
 import ..Utilities: PlusHalf, half, Cache

--- a/src/Grids/finitedifference.jl
+++ b/src/Grids/finitedifference.jl
@@ -59,7 +59,7 @@ function _FiniteDifferenceGrid(topology::Topologies.IntervalTopology)
     # construct on CPU, adapt to GPU
     face_coordinates = DataLayouts.VF{CT, Nv_face}(Array{FT}, Nv_face)
     for v in 1:Nv_face
-        face_coordinates[v] = mesh.faces[v]
+        face_coordinates[vindex(v)] = mesh.faces[v]
     end
     center_local_geometry, face_local_geometry =
         fd_geometry_data(face_coordinates, Val(Topologies.isperiodic(topology)))

--- a/src/Grids/spectralelement.jl
+++ b/src/Grids/spectralelement.jl
@@ -70,7 +70,7 @@ function _SpectralElementGrid1D(
                 ) / 2
             J = abs(∂x∂ξ)
             WJ = J * quad_weights[i]
-            local_geometry_slab[i] = Geometry.LocalGeometry(
+            local_geometry_slab[slab_index(i)] = Geometry.LocalGeometry(
                 x,
                 J,
                 WJ,
@@ -266,7 +266,7 @@ function _SpectralElementGrid2D(
             WJ = J * quad_weights[i] * quad_weights[j]
             elem_area += WJ
             if !enable_bubble
-                local_geometry_slab[i, j] =
+                local_geometry_slab[slab_index(i, j)] =
                     Geometry.LocalGeometry(u, J, WJ, ∂u∂ξ)
             end
         end
@@ -285,7 +285,7 @@ function _SpectralElementGrid2D(
                     )
                     J = det(Geometry.components(∂u∂ξ))
                     WJ = J * quad_weights[i] * quad_weights[j]
-                    local_geometry_slab[i, j] =
+                    local_geometry_slab[slab_index(i, j)] =
                         Geometry.LocalGeometry(u, J, WJ, ∂u∂ξ)
                 end
             else
@@ -315,7 +315,7 @@ function _SpectralElementGrid2D(
                         J = det(Geometry.components(∂u∂ξ))
                         J += Δarea / Nq^2
                         WJ = J * quad_weights[i] * quad_weights[j]
-                        local_geometry_slab[i, j] =
+                        local_geometry_slab[slab_index(i, j)] =
                             Geometry.LocalGeometry(u, J, WJ, ∂u∂ξ)
                     end
                 else # Higher-order elements: Use HOMME bubble correction for the interior nodes
@@ -356,7 +356,7 @@ function _SpectralElementGrid2D(
                         end
                         WJ = J * quad_weights[i] * quad_weights[j]
                         # Finally allocate local geometry
-                        local_geometry_slab[i, j] =
+                        local_geometry_slab[slab_index(i, j)] =
                             Geometry.LocalGeometry(u, J, WJ, ∂u∂ξ)
                     end
                 end
@@ -408,7 +408,7 @@ function _SpectralElementGrid2D(
                 @assert sgeom⁻.sWJ ≈ sgeom⁺.sWJ
                 @assert sgeom⁻.normal ≈ -sgeom⁺.normal
 
-                internal_surface_geometry_slab[q] = sgeom⁻
+                internal_surface_geometry_slab[slab_index(q)] = sgeom⁻
             end
         end
         internal_surface_geometry =
@@ -425,7 +425,7 @@ function _SpectralElementGrid2D(
                         slab(boundary_surface_geometry, iface)
                     local_geometry_slab = slab(local_geometry, elem)
                     for q in 1:Nq
-                        boundary_surface_geometry_slab[q] =
+                        boundary_surface_geometry_slab[slab_index(q)] =
                             compute_surface_geometry(
                                 local_geometry_slab,
                                 quad_weights,
@@ -501,7 +501,7 @@ function compute_surface_geometry(
     @assert size(local_geometry_slab) == (Nq, Nq, 1, 1, 1)
     i, j = Topologies.face_node_index(face, Nq, q, reversed)
 
-    local_geometry = local_geometry_slab[i, j]
+    local_geometry = local_geometry_slab[slab_index(i, j)]
     (; J, ∂ξ∂x) = local_geometry
 
     # surface mass matrix

--- a/src/Limiters/quasimonotone.jl
+++ b/src/Limiters/quasimonotone.jl
@@ -1,6 +1,7 @@
 import ClimaComms
 import ..Operators
 import ..RecursiveApply: ⊠, ⊞, ⊟, rmap, rzero, rdiv
+import ..DataLayouts: slab_index
 import Adapt
 
 """
@@ -111,7 +112,10 @@ function compute_element_bounds!(
             local q_min, q_max
             for j in 1:Nj
                 for i in 1:Ni
-                    q = rdiv(slab_ρq[i, j], slab_ρ[i, j])
+                    q = rdiv(
+                        slab_ρq[slab_index(i, j)],
+                        slab_ρ[slab_index(i, j)],
+                    )
                     if i == 1 && j == 1
                         q_min = q
                         q_max = q
@@ -122,8 +126,8 @@ function compute_element_bounds!(
                 end
             end
             slab_q_bounds = slab(q_bounds, v, h)
-            slab_q_bounds[1] = q_min
-            slab_q_bounds[2] = q_max
+            slab_q_bounds[slab_index(1)] = q_min
+            slab_q_bounds[slab_index(2)] = q_max
         end
     end
     return nothing
@@ -152,16 +156,16 @@ function compute_neighbor_bounds_local!(
     for h in 1:Nh
         for v in 1:Nv
             slab_q_bounds = slab(q_bounds, v, h)
-            q_min = slab_q_bounds[1]
-            q_max = slab_q_bounds[2]
+            q_min = slab_q_bounds[slab_index(1)]
+            q_max = slab_q_bounds[slab_index(2)]
             for h_nbr in Topologies.local_neighboring_elements(topology, h)
                 slab_q_bounds = slab(q_bounds, v, h_nbr)
-                q_min = rmin(q_min, slab_q_bounds[1])
-                q_max = rmax(q_max, slab_q_bounds[2])
+                q_min = rmin(q_min, slab_q_bounds[slab_index(1)])
+                q_max = rmax(q_max, slab_q_bounds[slab_index(2)])
             end
             slab_q_bounds_nbr = slab(q_bounds_nbr, v, h)
-            slab_q_bounds_nbr[1] = q_min
-            slab_q_bounds_nbr[2] = q_max
+            slab_q_bounds_nbr[slab_index(1)] = q_min
+            slab_q_bounds_nbr[slab_index(2)] = q_max
         end
     end
     return nothing
@@ -187,16 +191,16 @@ function compute_neighbor_bounds_ghost!(
         for h in 1:Nh
             for v in 1:Nv
                 slab_q_bounds = slab(q_bounds_nbr, v, h)
-                q_min = slab_q_bounds[1]
-                q_max = slab_q_bounds[2]
+                q_min = slab_q_bounds[slab_index(1)]
+                q_max = slab_q_bounds[slab_index(2)]
                 for gidx in Topologies.ghost_neighboring_elements(topology, h)
                     ghost_slab_q_bounds = slab(q_bounds_ghost, v, gidx)
-                    q_min = rmin(q_min, ghost_slab_q_bounds[1])
-                    q_max = rmax(q_max, ghost_slab_q_bounds[2])
+                    q_min = rmin(q_min, ghost_slab_q_bounds[slab_index(1)])
+                    q_max = rmax(q_max, ghost_slab_q_bounds[slab_index(2)])
                 end
                 slab_q_bounds_nbr = slab(q_bounds_nbr, v, h)
-                slab_q_bounds_nbr[1] = q_min
-                slab_q_bounds_nbr[2] = q_max
+                slab_q_bounds_nbr[slab_index(1)] = q_min
+                slab_q_bounds_nbr[slab_index(2)] = q_max
             end
         end
     end

--- a/src/MatrixFields/MatrixFields.jl
+++ b/src/MatrixFields/MatrixFields.jl
@@ -58,6 +58,7 @@ import ..RecursiveApply:
     rmap, rmaptype, rpromote_type, rzero, rconvert, radd, rsub, rmul, rdiv
 import ..RecursiveApply: ⊠, ⊞, ⊟
 import ..DataLayouts: AbstractData
+import ..DataLayouts: vindex
 import ..Geometry
 import ..Topologies
 import ..Spaces

--- a/src/Operators/Operators.jl
+++ b/src/Operators/Operators.jl
@@ -9,6 +9,7 @@ import Base.Broadcast: Broadcasted
 import ..slab, ..slab_args, ..column, ..column_args
 import ClimaComms
 import ..DataLayouts: DataLayouts, Data2D, DataSlab2D
+import ..DataLayouts: vindex
 import ..Geometry: Geometry, Covariant12Vector, Contravariant12Vector, ⊗
 import ..Spaces: Spaces, Quadratures, AbstractSpace
 import ..Topologies

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -3144,7 +3144,7 @@ Base.@propagate_inbounds function getidx(
     field_data = Fields.field_values(bc)
     space = reconstruct_placeholder_space(axes(bc), parent_space)
     v = vidx(space, idx)
-    return @inbounds field_data[CartesianIndex(1, 1, 1, v, 1)]
+    return @inbounds field_data[vindex(v)]
 end
 Base.@propagate_inbounds function getidx(
     parent_space,

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -3144,7 +3144,7 @@ Base.@propagate_inbounds function getidx(
     field_data = Fields.field_values(bc)
     space = reconstruct_placeholder_space(axes(bc), parent_space)
     v = vidx(space, idx)
-    return @inbounds field_data[v]
+    return @inbounds field_data[CartesianIndex(1, 1, 1, v, 1)]
 end
 Base.@propagate_inbounds function getidx(
     parent_space,

--- a/src/Operators/numericalflux.jl
+++ b/src/Operators/numericalflux.jl
@@ -1,3 +1,4 @@
+import .DataLayouts: slab_index
 """
     add_numerical_flux_internal!(fn, dydt, args...)
 
@@ -40,7 +41,7 @@ function add_numerical_flux_internal!(fn, dydt, args...)
         dydt_slab⁺ = slab(Fields.field_values(dydt), elem⁺)
 
         for q in 1:Nq
-            sgeom⁻ = internal_surface_geometry_slab[q]
+            sgeom⁻ = internal_surface_geometry_slab[slab_index(q)]
 
             i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, q, false)
             i⁺, j⁺ = Topologies.face_node_index(face⁺, Nq, q, reversed)
@@ -48,17 +49,21 @@ function add_numerical_flux_internal!(fn, dydt, args...)
             numflux⁻ = fn(
                 sgeom⁻.normal,
                 map(
-                    slab -> slab isa DataSlab2D ? slab[i⁻, j⁻] : slab,
+                    slab ->
+                        slab isa DataSlab2D ? slab[slab_index(i⁻, j⁻)] : slab,
                     arg_slabs⁻,
                 ),
                 map(
-                    slab -> slab isa DataSlab2D ? slab[i⁺, j⁺] : slab,
+                    slab ->
+                        slab isa DataSlab2D ? slab[slab_index(i⁺, j⁺)] : slab,
                     arg_slabs⁺,
                 ),
             )
 
-            dydt_slab⁻[i⁻, j⁻] = dydt_slab⁻[i⁻, j⁻] ⊟ (sgeom⁻.sWJ ⊠ numflux⁻)
-            dydt_slab⁺[i⁺, j⁺] = dydt_slab⁺[i⁺, j⁺] ⊞ (sgeom⁻.sWJ ⊠ numflux⁻)
+            dydt_slab⁻[slab_index(i⁻, j⁻)] =
+                dydt_slab⁻[slab_index(i⁻, j⁻)] ⊟ (sgeom⁻.sWJ ⊠ numflux⁻)
+            dydt_slab⁺[slab_index(i⁺, j⁺)] =
+                dydt_slab⁺[slab_index(i⁺, j⁺)] ⊞ (sgeom⁻.sWJ ⊠ numflux⁻)
         end
     end
 end
@@ -115,17 +120,19 @@ function add_numerical_flux_boundary!(fn, dydt, args...)
             arg_slabs⁻ = map(arg -> slab(Fields.todata(arg), elem⁻), args)
             dydt_slab⁻ = slab(Fields.field_values(dydt), elem⁻)
             for q in 1:Nq
-                sgeom⁻ = boundary_surface_geometry_slab[q]
+                sgeom⁻ = boundary_surface_geometry_slab[slab_index(q)]
                 i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, q, false)
                 numflux⁻ = fn(
                     sgeom⁻.normal,
                     map(
-                        slab -> slab isa DataSlab2D ? slab[i⁻, j⁻] : slab,
+                        slab ->
+                            slab isa DataSlab2D ? slab[slab_index(i⁻, j⁻)] :
+                            slab,
                         arg_slabs⁻,
                     ),
                 )
-                dydt_slab⁻[i⁻, j⁻] =
-                    dydt_slab⁻[i⁻, j⁻] ⊟ (sgeom⁻.sWJ ⊠ numflux⁻)
+                dydt_slab⁻[slab_index(i⁻, j⁻)] =
+                    dydt_slab⁻[slab_index(i⁻, j⁻)] ⊟ (sgeom⁻.sWJ ⊠ numflux⁻)
             end
         end
     end

--- a/src/RecursiveApply/RecursiveApply.jl
+++ b/src/RecursiveApply/RecursiveApply.jl
@@ -212,38 +212,4 @@ rmuladd(X, w::Number, Y) = rmap((x, y) -> muladd(x, w, y), X, Y)
 rmuladd(X::Number, w::Number, Y) = rmap((x, y) -> muladd(x, w, y), X, Y)
 rmuladd(w::Number, x::Number, y::Number) = muladd(w, x, y)
 
-"""
-    rmatmul1(W, S, i, j)
-
-Recursive matrix product along the 1st dimension of `S`. Equivalent to:
-
-    mapreduce(⊠, ⊞, W[i,:], S[:,j])
-
-"""
-function rmatmul1(W, S, i, j)
-    Nq = size(W, 2)
-    @inbounds r = W[i, 1] ⊠ S[1, j]
-    @inbounds for ii in 2:Nq
-        r = rmuladd(W[i, ii], S[ii, j], r)
-    end
-    return r
-end
-
-"""
-    rmatmul2(W, S, i, j)
-
-Recursive matrix product along the 2nd dimension `S`. Equivalent to:
-
-    mapreduce(⊠, ⊞, W[j,:], S[i, :])
-
-"""
-function rmatmul2(W, S, i, j)
-    Nq = size(W, 2)
-    @inbounds r = W[j, 1] ⊠ S[i, 1]
-    @inbounds for jj in 2:Nq
-        r = rmuladd(W[j, jj], S[i, jj], r)
-    end
-    return r
-end
-
 end # module

--- a/src/Remapping/distributed_remapping.jl
+++ b/src/Remapping/distributed_remapping.jl
@@ -418,8 +418,8 @@ function set_interpolated_values_cpu_kernel!(
                 if prev_lidx != h || prev_vindex != vindex
                     for j in 1:Nq, i in 1:Nq
                         scratch_field_values[i, j] = (
-                            A * field_values[i, j, nothing, v_lo, h] +
-                            B * field_values[i, j, nothing, v_hi, h]
+                            A * field_values[CartesianIndex(i, j, 1, v_lo, h)] +
+                            B * field_values[CartesianIndex(i, j, 1, v_hi, h)]
                         )
                     end
                     prev_vindex, prev_lidx = vindex, h
@@ -467,8 +467,8 @@ function set_interpolated_values_cpu_kernel!(
                 if prev_lidx != h || prev_vindex != vindex
                     for i in 1:Nq
                         scratch_field_values[i] = (
-                            A * field_values[i, nothing, nothing, v_lo, h] +
-                            B * field_values[i, nothing, nothing, v_hi, h]
+                            A * field_values[CartesianIndex(i, 1, 1, v_lo, h)] +
+                            B * field_values[CartesianIndex(i, 1, 1, v_hi, h)]
                         )
                     end
                     prev_vindex, prev_lidx = vindex, h
@@ -577,13 +577,13 @@ function _set_interpolated_values_device!(
                     out[out_index, field_index] +=
                         local_horiz_interpolation_weights[1][out_index, i] *
                         local_horiz_interpolation_weights[2][out_index, j] *
-                        field_values[i, j, nothing, nothing, h]
+                        field_values[CartesianIndex(i, j, 1, 1, h)]
                 end
             elseif hdims == 1
                 for i in 1:Nq
                     out[out_index, field_index] +=
                         local_horiz_interpolation_weights[1][out_index, i] *
-                        field_values[i, nothing, nothing, nothing, h]
+                        field_values[CartesianIndex(i, 1, 1, 1, h)]
                 end
             end
         end

--- a/src/Topologies/Topologies.jl
+++ b/src/Topologies/Topologies.jl
@@ -10,6 +10,7 @@ import ..Geometry
 import ..Domains: Domains, coordinate_type
 import ..Meshes: Meshes, domain, coordinates
 import ..DataLayouts
+import ..DataLayouts: slab_index
 import ..slab, ..column, ..level
 
 import ..DeviceSideDevice, ..DeviceSideContext

--- a/src/Topologies/dss.jl
+++ b/src/Topologies/dss.jl
@@ -786,13 +786,13 @@ function dss_local_vertices!(
             ) do (lidx, vert)
                 ip = perimeter_vertex_node_index(vert)
                 perimeter_slab = slab(perimeter_data, level, lidx)
-                perimeter_slab[ip]
+                perimeter_slab[slab_index(ip)]
             end
             # scatter: assign sum to shared vertices
             for (lidx, vert) in vertex
                 perimeter_slab = slab(perimeter_data, level, lidx)
                 ip = perimeter_vertex_node_index(vert)
-                perimeter_slab[ip] = sum_data
+                perimeter_slab[slab_index(ip)] = sum_data
             end
         end
     end
@@ -815,9 +815,11 @@ function dss_local_faces!(
             perimeter_slab1 = slab(perimeter_data, level, lidx1)
             perimeter_slab2 = slab(perimeter_data, level, lidx2)
             for (ip1, ip2) in zip(pr1, pr2)
-                val = perimeter_slab1[ip1] ⊞ perimeter_slab2[ip2]
-                perimeter_slab1[ip1] = val
-                perimeter_slab2[ip2] = val
+                val =
+                    perimeter_slab1[slab_index(ip1)] ⊞
+                    perimeter_slab2[slab_index(ip2)]
+                perimeter_slab1[slab_index(ip1)] = val
+                perimeter_slab2[slab_index(ip2)] = val
             end
         end
     end
@@ -860,9 +862,12 @@ function dss_local_ghost!(
                     if !isghost
                         lidx = idx
                         perimeter_slab = slab(perimeter_data, level, lidx)
-                        perimeter_slab[ip]
+                        perimeter_slab[slab_index(ip)]
                     else
-                        RecursiveApply.rmap(zero, slab(perimeter_data, 1, 1)[1])
+                        RecursiveApply.rmap(
+                            zero,
+                            slab(perimeter_data, 1, 1)[slab_index(1)],
+                        )
                     end
                 end
                 for (isghost, idx, vert) in vertex
@@ -870,7 +875,7 @@ function dss_local_ghost!(
                         ip = perimeter_vertex_node_index(vert)
                         lidx = idx
                         perimeter_slab = slab(perimeter_data, level, lidx)
-                        perimeter_slab[ip] = sum_data
+                        perimeter_slab[slab_index(ip)] = sum_data
                     end
                 end
             end
@@ -906,13 +911,13 @@ function dss_ghost!(
             ipresult = perimeter_vertex_node_index(lvertresult)
             for level in 1:nlevels
                 result_slab = slab(perimeter_data, level, idxresult)
-                result = result_slab[ipresult]
+                result = result_slab[slab_index(ipresult)]
                 for (isghost, idx, vert) in vertex
                     if !isghost
                         ip = perimeter_vertex_node_index(vert)
                         lidx = idx
                         perimeter_slab = slab(perimeter_data, level, lidx)
-                        perimeter_slab[ip] = result
+                        perimeter_slab[slab_index(ip)] = result
                     end
                 end
             end

--- a/src/Topologies/dss_transform.jl
+++ b/src/Topologies/dss_transform.jl
@@ -2,47 +2,30 @@ import ..Topologies: Topology2D
 using ..RecursiveApply
 
 """
-    dss_transform(arg, local_geometry, weight, I...)
+    dss_transform(arg, local_geometry, weight, I)
 
-Transfrom `arg[I...]` to a basis for direct stiffness summation (DSS).
+Transfrom `arg[I]` to a basis for direct stiffness summation (DSS).
 Transformations only apply to vector quantities.
 
-- `local_geometry[I...]` is the relevant `LocalGeometry` object. If it is `nothing`, then no transformation is performed
-- `weight[I...]` is the relevant DSS weights. If `weight` is `nothing`, then the result is simply summation.
+- `local_geometry[I]` is the relevant `LocalGeometry` object. If it is `nothing`, then no transformation is performed
+- `weight[I]` is the relevant DSS weights. If `weight` is `nothing`, then the result is simply summation.
 
 See [`ClimaCore.Spaces.weighted_dss!`](@ref).
 """
-Base.@propagate_inbounds dss_transform(arg, local_geometry, weight, i, j) =
-    dss_transform(arg[i, j], local_geometry[i, j], weight[i, j])
+Base.@propagate_inbounds dss_transform(arg, local_geometry, weight, I) =
+    dss_transform(arg[I], local_geometry[I], weight[I])
 Base.@propagate_inbounds dss_transform(
     arg,
     local_geometry,
     weight::Nothing,
-    i,
-    j,
-) = dss_transform(arg[i, j], local_geometry[i, j], 1)
+    I,
+) = dss_transform(arg[I], local_geometry[I], 1)
 Base.@propagate_inbounds dss_transform(
     arg,
     local_geometry::Nothing,
     weight::Nothing,
-    i,
-    j,
-) = arg[i, j]
-
-Base.@propagate_inbounds dss_transform(arg, local_geometry, weight, i) =
-    dss_transform(arg[i], local_geometry[i], weight[i])
-Base.@propagate_inbounds dss_transform(
-    arg,
-    local_geometry,
-    weight::Nothing,
-    i,
-) = dss_transform(arg[i], local_geometry[i], 1)
-Base.@propagate_inbounds dss_transform(
-    arg,
-    local_geometry::Nothing,
-    weight::Nothing,
-    i,
-) = arg[i]
+    I,
+) = arg[I]
 
 @inline function dss_transform(
     arg::Tuple{},
@@ -152,23 +135,9 @@ Base.@propagate_inbounds dss_untransform(
     ::Type{T},
     targ,
     local_geometry,
-    i,
-    j,
-) where {T} = dss_untransform(T, targ, local_geometry[i, j])
-Base.@propagate_inbounds dss_untransform(
-    ::Type{T},
-    targ,
-    local_geometry::Nothing,
-    i,
-    j,
-) where {T} = dss_untransform(T, targ, local_geometry)
-Base.@propagate_inbounds dss_untransform(
-    ::Type{T},
-    targ,
-    local_geometry,
-    i,
-) where {T} = dss_untransform(T, targ, local_geometry[i])
-@inline dss_untransform(::Type{T}, targ, local_geometry::Nothing, i) where {T} =
+    I,
+) where {T} = dss_untransform(T, targ, local_geometry[I])
+@inline dss_untransform(::Type{T}, targ, local_geometry::Nothing, I) where {T} =
     dss_untransform(T, targ, local_geometry)
 @inline function dss_untransform(
     ::Type{NamedTuple{names, T}},
@@ -268,9 +237,12 @@ function _representative_slab(
     if isnothing(data)
         return nothing
     elseif rebuild_flag
-        return DataLayouts.rebuild(slab(data, 1, 1), Array)
+        return DataLayouts.rebuild(
+            slab(data, CartesianIndex(1, 1, 1, 1, 1)),
+            Array,
+        )
     else
-        return slab(data, 1, 1)
+        return slab(data, CartesianIndex(1, 1, 1, 1, 1))
     end
 end
 
@@ -284,8 +256,7 @@ _transformed_type(
         _representative_slab(data, DA),
         _representative_slab(local_geometry, DA),
         _representative_slab(local_weights, DA),
-        1,
-        1,
+        CartesianIndex(1, 1, 1, 1, 1),
     ),
 )
 

--- a/test/DataLayouts/cuda.jl
+++ b/test/DataLayouts/cuda.jl
@@ -7,6 +7,7 @@ using ClimaComms
 using CUDA
 ClimaComms.@import_required_backends
 using ClimaCore.DataLayouts
+using ClimaCore.DataLayouts: slab_index
 
 function knl_copy!(dst, src)
     i = threadIdx().x
@@ -17,7 +18,7 @@ function knl_copy!(dst, src)
     p_dst = slab(dst, h)
     p_src = slab(src, h)
 
-    @inbounds p_dst[i, j] = p_src[i, j]
+    @inbounds p_dst[slab_index(i, j)] = p_src[slab_index(i, j)]
     return nothing
 end
 

--- a/test/DataLayouts/data1d.jl
+++ b/test/DataLayouts/data1d.jl
@@ -7,7 +7,7 @@ using JET
 
 using ClimaCore.DataLayouts
 using StaticArrays
-using ClimaCore.DataLayouts: get_struct, set_struct!
+using ClimaCore.DataLayouts: get_struct, set_struct!, vindex
 
 TestFloatTypes = (Float32, Float64)
 
@@ -21,7 +21,7 @@ TestFloatTypes = (Float32, Float64)
         @test getfield(data.:1, :array) == @view(array[:, 1:2])
 
         # test tuple assignment
-        data[1] = (Complex{FT}(-1.0, -2.0), FT(-3.0))
+        data[vindex(1)] = (Complex{FT}(-1.0, -2.0), FT(-3.0))
         @test array[1, 1] == -1.0
         @test array[1, 2] == -2.0
         @test array[1, 3] == -3.0
@@ -47,9 +47,9 @@ end
     Nv = 4
     array = zeros(Float64, Nv, 3)
     data = VF{S, Nv}(array)
-    @test data[1][2] == zero(Float64)
-    @test_throws BoundsError data[-1]
-    @test_throws BoundsError data[5]
+    @test data[vindex(1)][2] == zero(Float64)
+    @test_throws BoundsError data[vindex(-1)]
+    @test_throws BoundsError data[vindex(5)]
 end
 
 @testset "VF type safety" begin
@@ -63,11 +63,11 @@ end
     data = VF{typeof(SA), Nv}(array)
 
     ret = begin
-        data[1] = SA
+        data[vindex(1)] = SA
     end
     @test ret === SA
-    @test data[1] isa typeof(SA)
-    @test_throws MethodError data[1] = SB
+    @test data[vindex(1)] isa typeof(SA)
+    @test_throws MethodError data[vindex(1)] = SB
 end
 
 @testset "VF broadcasting between 1D data objects and scalars" begin

--- a/test/DataLayouts/data1dx.jl
+++ b/test/DataLayouts/data1dx.jl
@@ -4,7 +4,7 @@ using Revise; include(joinpath("test", "DataLayouts", "data1dx.jl"))
 =#
 using Test
 using ClimaCore.DataLayouts
-import ClimaCore.DataLayouts: VIFH, slab, column, VF, IFH
+import ClimaCore.DataLayouts: VIFH, slab, column, VF, IFH, vindex, slab_index
 
 @testset "VIFH" begin
     TestFloatTypes = (Float32, Float64)
@@ -28,14 +28,14 @@ import ClimaCore.DataLayouts: VIFH, slab, column, VF, IFH
 
         # test tuple assignment on columns
         val = (Complex{FT}(-1.0, -2.0), FT(-3.0))
-        column(data, 1, 1)[1] = val
+        column(data, 1, 1)[vindex(1)] = val
         @test array[1, 1, 1, 1] == -1.0
         @test array[1, 1, 2, 1] == -2.0
         @test array[1, 1, 3, 1] == -3.0
 
         # test value of assing tuple on slab
         sdata = slab(data, 1, 1)
-        @test sdata[1] == val
+        @test sdata[slab_index(1)] == val
 
         # sum of all the first field elements
         @test sum(data.:1) ≈
@@ -68,8 +68,8 @@ end
     @test_throws BoundsError slab(data, 1, 3)
 
     sdata = slab(data, 1, 1)
-    @test_throws BoundsError sdata[-1]
-    @test_throws BoundsError sdata[2]
+    @test_throws BoundsError sdata[slab_index(-1)]
+    @test_throws BoundsError sdata[slab_index(2)]
 
     @test_throws BoundsError column(data, -1, 1)
     @test_throws BoundsError column(data, -1, 1, 1)
@@ -91,13 +91,13 @@ end
     data = VIFH{typeof(SA), Nv, Ni, Nh}(array)
 
     cdata = column(data, 1, 1)
-    cdata[1] = SA
-    @test cdata[1] isa typeof(SA)
-    @test_throws MethodError cdata[1] = SB
+    cdata[slab_index(1)] = SA
+    @test cdata[slab_index(1)] isa typeof(SA)
+    @test_throws MethodError cdata[slab_index(1)] = SB
 
     sdata = slab(data, 1, 1)
-    @test sdata[1] isa typeof(SA)
-    @test_throws MethodError sdata[1] = SB
+    @test sdata[slab_index(1)] isa typeof(SA)
+    @test_throws MethodError sdata[slab_index(1)] = SB
 end
 
 @testset "broadcasting between VIFH data object + scalars" begin

--- a/test/DataLayouts/data2dx.jl
+++ b/test/DataLayouts/data2dx.jl
@@ -4,7 +4,7 @@ using Revise; include(joinpath("test", "DataLayouts", "data2dx.jl"))
 =#
 using Test
 using ClimaCore.DataLayouts
-import ClimaCore.DataLayouts: VF, IJFH, VIJFH, slab, column
+import ClimaCore.DataLayouts: VF, IJFH, VIJFH, slab, column, slab_index, vindex
 
 @testset "VIJFH" begin
     Nv = 10 # number of vertical levels
@@ -29,14 +29,14 @@ import ClimaCore.DataLayouts: VF, IJFH, VIJFH, slab, column
         # test tuple assignment on columns
         val = (Complex{FT}(-1.0, -2.0), FT(-3.0))
 
-        column(data, 1, 2, 1)[1] = val
+        column(data, 1, 2, 1)[vindex(1)] = val
         @test array[1, 1, 2, 1, 1] == -1.0
         @test array[1, 1, 2, 2, 1] == -2.0
         @test array[1, 1, 2, 3, 1] == -3.0
 
         # test value of assing tuple on slab
         sdata = slab(data, 1, 1)
-        @test sdata[1, 2] == val
+        @test sdata[slab_index(1, 2)] == val
 
         # sum of all the first field elements
         @test sum(data.:1) ≈
@@ -91,13 +91,13 @@ end
     data = VIJFH{typeof(SA), Nv, Nij, Nh}(array)
 
     cdata = column(data, 1, 2, 1)
-    cdata[1] = SA
-    @test cdata[1] isa typeof(SA)
-    @test_throws MethodError cdata[1] = SB
+    cdata[vindex(1)] = SA
+    @test cdata[vindex(1)] isa typeof(SA)
+    @test_throws MethodError cdata[vindex(1)] = SB
 
     sdata = slab(data, 1, 1)
-    @test sdata[1, 2] isa typeof(SA)
-    @test_throws MethodError sdata[1] = SB
+    @test sdata[slab_index(1, 2)] isa typeof(SA)
+    @test_throws MethodError sdata[slab_index(1)] = SB
 end
 
 @testset "broadcasting between VIJFH data object + scalars" begin

--- a/test/Operators/finitedifference/convergence_column.jl
+++ b/test/Operators/finitedifference/convergence_column.jl
@@ -5,6 +5,7 @@ using ClimaComms
 ClimaComms.@import_required_backends
 import ClimaCore: slab, Domains, Meshes, Topologies, Spaces, Fields, Operators
 import ClimaCore.Domains: Geometry
+import ClimaCore.DataLayouts: vindex
 
 device = ClimaComms.device()
 
@@ -62,7 +63,7 @@ convergence_rate(err, Δh) =
             cent_field = operator.(face_field)
             wcent_field = woperator.(face_J, face_field)
 
-            Δh[k] = Spaces.local_geometry_data(fs).J[1]
+            Δh[k] = Spaces.local_geometry_data(fs).J[vindex(1)]
             err[k] = norm(cent_field .- cent_field_exact)
             werr[k] = norm(wcent_field .- cent_field_exact)
         end
@@ -116,7 +117,7 @@ end
             face_field = operator.(cent_field)
             wface_field = woperator.(cent_J, cent_field)
 
-            Δh[k] = Spaces.local_geometry_data(fs).J[1]
+            Δh[k] = Spaces.local_geometry_data(fs).J[vindex(1)]
             err[k] = norm(face_field .- face_field_exact)
             werr[k] = norm(wface_field .- face_field_exact)
         end
@@ -167,7 +168,7 @@ end
 
             face_field .= operator.(cent_field)
 
-            Δh[k] = Spaces.local_geometry_data(fs).J[1]
+            Δh[k] = Spaces.local_geometry_data(fs).J[vindex(1)]
             err[k] = norm(face_field .- face_field_exact)
         end
         conv = convergence_rate(err, Δh)
@@ -216,7 +217,7 @@ end
 
             cent_field .= operator.(face_field)
 
-            Δh[k] = Spaces.local_geometry_data(fs).J[1]
+            Δh[k] = Spaces.local_geometry_data(fs).J[vindex(1)]
             err[k] = norm(cent_field .- cent_field_exact)
         end
         conv = convergence_rate(err, Δh)
@@ -317,7 +318,7 @@ end
         curlsinᶠ = curlᶠ.(Geometry.Covariant1Vector.(sin.(centers)))
 
 
-        Δh[k] = Spaces.local_geometry_data(fs).J[1]
+        Δh[k] = Spaces.local_geometry_data(fs).J[vindex(1)]
         # Errors
         err_grad_sin_c[k] = norm(gradsinᶜ .- Geometry.WVector.(cos.(centers)))
         err_div_sin_c[k] = norm(divsinᶜ .- cos.(centers))
@@ -439,7 +440,7 @@ end
         divf2c = Operators.DivergenceF2C()
         adv_wc = divf2c.(third_order_fluxsinᶠ)
 
-        Δh[k] = Spaces.local_geometry_data(fs).J[1]
+        Δh[k] = Spaces.local_geometry_data(fs).J[vindex(1)]
 
         # Error
         err_adv_wc[k] = norm(adv_wc .- cos.(centers))
@@ -491,7 +492,7 @@ end
         divf2c = Operators.DivergenceF2C()
         adv_wc = divf2c.(third_order_fluxsinᶠ)
 
-        Δh[k] = Spaces.local_geometry_data(fs).J[1]
+        Δh[k] = Spaces.local_geometry_data(fs).J[vindex(1)]
 
         # Error
         err_adv_wc[k] =
@@ -554,7 +555,7 @@ end
 
             adv_wc = divf2c.(third_order_fluxᶠ.(w, c))
 
-            Δh[k] = Spaces.local_geometry_data(fs).J[1]
+            Δh[k] = Spaces.local_geometry_data(fs).J[vindex(1)]
 
             # Error
             err_adv_wc[k] = norm(adv_wc .- cos.(centers))
@@ -610,7 +611,7 @@ end
             )
             adv_wc = divf2c.(third_order_fluxᶠ.(w, c))
 
-            Δh[k] = Spaces.local_geometry_data(fs).J[1]
+            Δh[k] = Spaces.local_geometry_data(fs).J[vindex(1)]
             # Errors
             err_adv_wc[k] =
                 norm(adv_wc .- ((cos.(centers)) .^ 2 .- (sin.(centers)) .^ 2))
@@ -666,7 +667,7 @@ end
             @. divf2c(C * (third_order_fluxsinᶠ - first_order_fluxsinᶠ))
         adv_wc = @. divf2c.(first_order_fluxsinᶠ) + corrected_antidiff_flux
 
-        Δh[k] = Spaces.local_geometry_data(fs).J[1]
+        Δh[k] = Spaces.local_geometry_data(fs).J[vindex(1)]
 
         # Error
         err_adv_wc[k] = norm(adv_wc .- cos.(centers))
@@ -738,7 +739,7 @@ end
             adv_wc =
                 @. divf2c.(first_order_fluxᶠ(w, c)) + corrected_antidiff_flux
 
-            Δh[k] = Spaces.local_geometry_data(fs).J[1]
+            Δh[k] = Spaces.local_geometry_data(fs).J[vindex(1)]
 
             # Error
             err_adv_wc[k] = norm(adv_wc .- cos.(centers))
@@ -802,7 +803,7 @@ end
             adv_wc =
                 @. divf2c.(first_order_fluxᶠ(w, c)) + corrected_antidiff_flux
 
-            Δh[k] = Spaces.local_geometry_data(fs).J[1]
+            Δh[k] = Spaces.local_geometry_data(fs).J[vindex(1)]
             # Errors
             err_adv_wc[k] = norm(adv_wc .- cos.(centers))
 
@@ -854,7 +855,7 @@ end
         # Call the advection operator
         adv = advection(c, f, cs)
 
-        Δh[k] = Spaces.local_geometry_data(fs).J[1]
+        Δh[k] = Spaces.local_geometry_data(fs).J[vindex(1)]
         err[k] = norm(adv .- cos.(Fields.coordinate_field(cs).z))
     end
     # AdvectionC2C convergence rate

--- a/test/Spaces/opt_spaces.jl
+++ b/test/Spaces/opt_spaces.jl
@@ -44,10 +44,10 @@ end
     else
         test_n_failures(0,    TU.PointSpace, context)
         test_n_failures(137,  TU.SpectralElementSpace1D, context)
-        test_n_failures(295,  TU.SpectralElementSpace2D, context)
+        test_n_failures(298,  TU.SpectralElementSpace2D, context)
         test_n_failures(118,  TU.ColumnCenterFiniteDifferenceSpace, context)
         test_n_failures(118,  TU.ColumnFaceFiniteDifferenceSpace, context)
-        test_n_failures(301,  TU.SphereSpectralElementSpace, context)
+        test_n_failures(304,  TU.SphereSpectralElementSpace, context)
         test_n_failures(321,  TU.CenterExtrudedFiniteDifferenceSpace, context)
         test_n_failures(321,  TU.FaceExtrudedFiniteDifferenceSpace, context)
 

--- a/test/Spaces/unit_spaces.jl
+++ b/test/Spaces/unit_spaces.jl
@@ -21,7 +21,7 @@ import ClimaCore:
     DeviceSideContext,
     DeviceSideDevice
 
-import ClimaCore.DataLayouts: IJFH, VF
+import ClimaCore.DataLayouts: IJFH, VF, slab_index
 
 on_gpu = ClimaComms.device() isa ClimaComms.CUDADevice
 
@@ -55,23 +55,23 @@ on_gpu = ClimaComms.device() isa ClimaComms.CUDADevice
     array = parent(Spaces.coordinates_data(space))
     @test size(array) == (4, 1, 1)
     coord_slab = slab(Spaces.coordinates_data(space), 1)
-    @test coord_slab[1] == Geometry.XPoint{FT}(-3)
-    @test coord_slab[4] == Geometry.XPoint{FT}(5)
+    @test coord_slab[slab_index(1)] == Geometry.XPoint{FT}(-3)
+    @test coord_slab[slab_index(4)] == Geometry.XPoint{FT}(5)
 
     local_geometry_slab = slab(Spaces.local_geometry_data(space), 1)
     dss_weights_slab = slab(space.grid.dss_weights, 1)
 
     for i in 1:4
-        @test Geometry.components(local_geometry_slab[i].∂x∂ξ) ≈
+        @test Geometry.components(local_geometry_slab[slab_index(i)].∂x∂ξ) ≈
               @SMatrix [8 / 2]
-        @test Geometry.components(local_geometry_slab[i].∂ξ∂x) ≈
+        @test Geometry.components(local_geometry_slab[slab_index(i)].∂ξ∂x) ≈
               @SMatrix [2 / 8]
-        @test local_geometry_slab[i].J ≈ (8 / 2)
-        @test local_geometry_slab[i].WJ ≈ (8 / 2) * weights[i]
+        @test local_geometry_slab[slab_index(i)].J ≈ (8 / 2)
+        @test local_geometry_slab[slab_index(i)].WJ ≈ (8 / 2) * weights[i]
         if i in (1, 4)
-            @test dss_weights_slab[i] ≈ 1 / 2
+            @test dss_weights_slab[slab_index(i)] ≈ 1 / 2
         else
-            @test dss_weights_slab[i] ≈ 1
+            @test dss_weights_slab[slab_index(i)] ≈ 1
         end
     end
 
@@ -217,10 +217,10 @@ end
     array = parent(coord_data)
     @test size(array) == (4, 4, 2, 1)
     coord_slab = slab(coord_data, 1)
-    @test coord_slab[1, 1] ≈ Geometry.XYPoint{FT}(-3.0, -2.0)
-    @test coord_slab[4, 1] ≈ Geometry.XYPoint{FT}(5.0, -2.0)
-    @test coord_slab[1, 4] ≈ Geometry.XYPoint{FT}(-3.0, 8.0)
-    @test coord_slab[4, 4] ≈ Geometry.XYPoint{FT}(5.0, 8.0)
+    @test coord_slab[slab_index(1, 1)] ≈ Geometry.XYPoint{FT}(-3.0, -2.0)
+    @test coord_slab[slab_index(4, 1)] ≈ Geometry.XYPoint{FT}(5.0, -2.0)
+    @test coord_slab[slab_index(1, 4)] ≈ Geometry.XYPoint{FT}(-3.0, 8.0)
+    @test coord_slab[slab_index(4, 4)] ≈ Geometry.XYPoint{FT}(5.0, 8.0)
 
     @test Spaces.local_geometry_type(typeof(space)) <: Geometry.LocalGeometry
     local_geometry_slab = slab(Spaces.local_geometry_data(space), 1)
@@ -233,17 +233,17 @@ end
     end
 
     for i in 1:4, j in 1:4
-        @test Geometry.components(local_geometry_slab[i, j].∂x∂ξ) ≈
+        @test Geometry.components(local_geometry_slab[slab_index(i, j)].∂x∂ξ) ≈
               @SMatrix [8/2 0; 0 10/2]
-        @test Geometry.components(local_geometry_slab[i, j].∂ξ∂x) ≈
+        @test Geometry.components(local_geometry_slab[slab_index(i, j)].∂ξ∂x) ≈
               @SMatrix [2/8 0; 0 2/10]
-        @test local_geometry_slab[i, j].J ≈ (10 / 2) * (8 / 2)
-        @test local_geometry_slab[i, j].WJ ≈
+        @test local_geometry_slab[slab_index(i, j)].J ≈ (10 / 2) * (8 / 2)
+        @test local_geometry_slab[slab_index(i, j)].WJ ≈
               (10 / 2) * (8 / 2) * weights[i] * weights[j]
         if i in (1, 4)
-            @test dss_weights_slab[i, j] ≈ 1 / 2
+            @test dss_weights_slab[slab_index(i, j)] ≈ 1 / 2
         else
-            @test dss_weights_slab[i, j] ≈ 1
+            @test dss_weights_slab[slab_index(i, j)] ≈ 1
         end
     end
 


### PR DESCRIPTION
This PR removes multiple integer indexing in DataLayouts, which basically duplicates logic of the `CartesianIndex`ing. We will need to fix wherever we call this style indexing, but it also will allow us to use a single integer for linear indexing. This is technically breaking, but I don't think anyone is (or should be) using this.