### PR TITLE
Add KinematicDriver to downstream tests

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -28,6 +28,7 @@ jobs:
           - 'ClimaDiagnostics.jl'
           - 'ClimaLand.jl'
           - 'ClimaTimeSteppers.jl'
+          - 'KinematicDriver.jl'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
KinematicDriver.jl uses ClimaCore. This PR adds it to the downstream tests to help catch breaking changes.