### PR TITLE
Reduce use of DataLayouts internals

### DIFF
--- a/ext/cuda/data_layouts_copyto.jl
+++ b/ext/cuda/data_layouts_copyto.jl
@@ -23,8 +23,7 @@ function Base.copyto!(
     if Nh > 0
         auto_launch!(
             knl_copyto!,
-            (dest, bc),
-            dest;
+            (dest, bc);
             threads_s = (Nij, Nij),
             blocks_s = (Nh, 1),
         )
@@ -42,8 +41,7 @@ function Base.copyto!(
         Nv_blocks = cld(Nv, Nv_per_block)
         auto_launch!(
             knl_copyto!,
-            (dest, bc),
-            dest;
+            (dest, bc);
             threads_s = (Nij, Nij, Nv_per_block),
             blocks_s = (Nh, Nv_blocks),
         )
@@ -59,8 +57,7 @@ function Base.copyto!(
     if Nv > 0
         auto_launch!(
             knl_copyto!,
-            (dest, bc),
-            dest;
+            (dest, bc);
             threads_s = (1, 1),
             blocks_s = (1, Nv),
         )
@@ -73,13 +70,7 @@ function Base.copyto!(
     bc::DataLayouts.BroadcastedUnionDataF{S},
     ::ToCUDA,
 ) where {S}
-    auto_launch!(
-        knl_copyto!,
-        (dest, bc),
-        dest;
-        threads_s = (1, 1),
-        blocks_s = (1, 1),
-    )
+    auto_launch!(knl_copyto!, (dest, bc); threads_s = (1, 1), blocks_s = (1, 1))
     return dest
 end
 
@@ -100,7 +91,8 @@ function cuda_copyto!(dest::AbstractData, bc)
     (_, _, Nv, _, Nh) = DataLayouts.universal_size(dest)
     us = DataLayouts.UniversalSize(dest)
     if Nv > 0 && Nh > 0
-        auto_launch!(knl_copyto_flat!, (dest, bc, us), dest; auto = true)
+        nitems = prod(DataLayouts.universal_size(dest))
+        auto_launch!(knl_copyto_flat!, (dest, bc, us), nitems; auto = true)
     end
     return dest
 end

--- a/ext/cuda/data_layouts_fill.jl
+++ b/ext/cuda/data_layouts_fill.jl
@@ -14,7 +14,8 @@ function cuda_fill!(dest::AbstractData, val)
     (_, _, Nv, _, Nh) = DataLayouts.universal_size(dest)
     us = DataLayouts.UniversalSize(dest)
     if Nv > 0 && Nh > 0
-        auto_launch!(knl_fill_flat!, (dest, val, us), dest; auto = true)
+        nitems = prod(DataLayouts.universal_size(dest))
+        auto_launch!(knl_fill_flat!, (dest, val, us), nitems; auto = true)
     end
     return dest
 end

--- a/ext/cuda/data_layouts_fused_copyto.jl
+++ b/ext/cuda/data_layouts_fused_copyto.jl
@@ -50,8 +50,7 @@ function fused_copyto!(
         Nv_blocks = cld(Nv, Nv_per_block)
         auto_launch!(
             knl_fused_copyto!,
-            (fmbc,),
-            dest1;
+            (fmbc,);
             threads_s = (Nij, Nij, Nv_per_block),
             blocks_s = (Nh, Nv_blocks),
         )
@@ -68,8 +67,7 @@ function fused_copyto!(
     if Nh > 0
         auto_launch!(
             knl_fused_copyto!,
-            (fmbc,),
-            dest1;
+            (fmbc,);
             threads_s = (Nij, Nij),
             blocks_s = (Nh, 1),
         )
@@ -85,8 +83,7 @@ function fused_copyto!(
     if Nv > 0 && Nh > 0
         auto_launch!(
             knl_fused_copyto!,
-            (fmbc,),
-            dest1;
+            (fmbc,);
             threads_s = (1, 1),
             blocks_s = (Nh, Nv),
         )
@@ -101,8 +98,7 @@ function fused_copyto!(
 ) where {S}
     auto_launch!(
         knl_fused_copyto!,
-        (fmbc,),
-        dest1;
+        (fmbc,);
         threads_s = (1, 1),
         blocks_s = (1, 1),
     )

--- a/ext/cuda/data_layouts_mapreduce.jl
+++ b/ext/cuda/data_layouts_mapreduce.jl
@@ -28,7 +28,7 @@ function mapreduce_cuda(
     pdata = parent(data)
     T = eltype(pdata)
     (Ni, Nj, Nk, Nv, Nh) = size(data)
-    Nf = div(length(pdata), prod(size(data))) # length of field dimension
+    Nf = DataLayouts.ncomponents(data) # length of field dimension
     pwt = parent(weighted_jacobian)
 
     nitems = Nv * Ni * Nj * Nk * Nh

--- a/ext/cuda/matrix_fields_multiple_field_solve.jl
+++ b/ext/cuda/matrix_fields_multiple_field_solve.jl
@@ -38,8 +38,7 @@ NVTX.@annotate function multiple_field_solve!(
 
     auto_launch!(
         multiple_field_solve_kernel!,
-        args,
-        x1;
+        args;
         threads_s = nthreads,
         blocks_s = nblocks,
         always_inline = true,

--- a/ext/cuda/matrix_fields_single_field_solve.jl
+++ b/ext/cuda/matrix_fields_single_field_solve.jl
@@ -21,8 +21,7 @@ function single_field_solve!(device::ClimaComms.CUDADevice, cache, x, A, b)
     args = (device, cache, x, A, b)
     auto_launch!(
         single_field_solve_kernel!,
-        args,
-        x;
+        args;
         threads_s = nthreads,
         blocks_s = nblocks,
     )

--- a/ext/cuda/operators_finite_difference.jl
+++ b/ext/cuda/operators_finite_difference.jl
@@ -36,8 +36,7 @@ function Base.copyto!(
         (strip_space(out, space), strip_space(bc, space), axes(out), bounds, us)
     auto_launch!(
         copyto_stencil_kernel!,
-        args,
-        out;
+        args;
         threads_s = (nthreads,),
         blocks_s = (nblocks,),
     )

--- a/ext/cuda/operators_integral.jl
+++ b/ext/cuda/operators_integral.jl
@@ -29,7 +29,7 @@ function column_reduce_device!(
         init,
         space,
     )
-    auto_launch!(bycolumn_kernel!, args, (); threads_s, blocks_s)
+    auto_launch!(bycolumn_kernel!, args; threads_s, blocks_s)
 end
 
 function column_accumulate_device!(
@@ -52,7 +52,7 @@ function column_accumulate_device!(
         init,
         space,
     )
-    auto_launch!(bycolumn_kernel!, args, (); threads_s, blocks_s)
+    auto_launch!(bycolumn_kernel!, args; threads_s, blocks_s)
 end
 
 bycolumn_kernel!(

--- a/ext/cuda/operators_spectral_element.jl
+++ b/ext/cuda/operators_spectral_element.jl
@@ -51,8 +51,7 @@ function Base.copyto!(
     )
     auto_launch!(
         copyto_spectral_kernel!,
-        args,
-        out;
+        args;
         threads_s = (Nq, Nq, Nvthreads),
         blocks_s = (Nh, Nvblocks),
     )

--- a/ext/cuda/operators_thomas_algorithm.jl
+++ b/ext/cuda/operators_thomas_algorithm.jl
@@ -10,8 +10,7 @@ function column_thomas_solve!(::ClimaComms.CUDADevice, A, b)
     args = (A, b)
     auto_launch!(
         thomas_algorithm_kernel!,
-        args,
-        size(Fields.field_values(A));
+        args;
         threads_s = nthreads,
         blocks_s = nblocks,
     )

--- a/ext/cuda/remapping_distributed.jl
+++ b/ext/cuda/remapping_distributed.jl
@@ -29,8 +29,7 @@ function _set_interpolated_values_device!(
     )
     auto_launch!(
         set_interpolated_values_kernel!,
-        args,
-        out;
+        args;
         threads_s = (nthreads),
         blocks_s = (nblocks),
     )
@@ -163,8 +162,7 @@ function _set_interpolated_values_device!(
     )
     auto_launch!(
         set_interpolated_values_kernel!,
-        args,
-        out;
+        args;
         threads_s = (nthreads),
         blocks_s = (nblocks),
     )

--- a/ext/cuda/remapping_interpolate_array.jl
+++ b/ext/cuda/remapping_interpolate_array.jl
@@ -22,8 +22,7 @@ function interpolate_slab!(
     args = (output_cuarray, field, cuslab_indices, cuweights)
     auto_launch!(
         interpolate_slab_kernel!,
-        args,
-        output_cuarray;
+        args;
         threads_s = (nthreads),
         blocks_s = (nblocks),
     )
@@ -107,8 +106,7 @@ function interpolate_slab_level!(
     args = (output_cuarray, field, cuvidx_ref_coordinates, h, Is)
     auto_launch!(
         interpolate_slab_level_kernel!,
-        args,
-        out;
+        args;
         threads_s = (nthreads),
         blocks_s = (nblocks),
     )

--- a/src/Topologies/dss.jl
+++ b/src/Topologies/dss.jl
@@ -66,9 +66,7 @@ function create_dss_buffer(
     convert_to_array = DA isa Array ? false : true
     (_, _, _, Nv, Nh) = Base.size(data)
     Np = length(perimeter)
-    Nf =
-        length(parent(data)) == 0 ? 0 :
-        cld(length(parent(data)), (Nij * Nij * Nv * Nh))
+    Nf = DataLayouts.ncomponents(data)
     nfacedof = Nij - 2
     T = eltype(parent(data))
     TS = _transformed_type(data, local_geometry, local_weights, DA) # extract transformed type
@@ -941,7 +939,7 @@ function fill_send_buffer!(
 )
     (; perimeter_data, send_buf_idx, send_data) = dss_buffer
     (Np, _, _, Nv, nelems) = size(perimeter_data)
-    Nf = cld(length(parent(perimeter_data)), (Nv * Np * nelems))
+    Nf = DataLayouts.ncomponents(perimeter_data)
     pdata = parent(perimeter_data)
     nsend = size(send_buf_idx, 1)
     ctr = 1
@@ -970,7 +968,7 @@ function load_from_recv_buffer!(
 )
     (; perimeter_data, recv_buf_idx, recv_data) = dss_buffer
     (Np, _, _, Nv, nelems) = size(perimeter_data)
-    Nf = cld(length(parent(perimeter_data)), (Nv * Np * nelems))
+    Nf = DataLayouts.ncomponents(perimeter_data)
     pdata = parent(perimeter_data)
     nrecv = size(recv_buf_idx, 1)
     ctr = 1

--- a/src/Topologies/dss_transform.jl
+++ b/src/Topologies/dss_transform.jl
@@ -285,7 +285,7 @@ function create_ghost_buffer(
         )
         k = stride(parent(send_data), 4)
     else
-        Nv, _, _, Nf, _ = size(parent(data))
+        Nv, _, _, Nf, _ = DataLayouts.farray_size(data)
         send_data =
             DataLayouts.VIJFH{S, Nv, Nij, Topologies.nsendelems(topology)}(
                 similar(

--- a/test/DataLayouts/unit_copyto.jl
+++ b/test/DataLayouts/unit_copyto.jl
@@ -17,7 +17,7 @@ function test_copyto_float!(data)
     rand_data = DataLayouts.rebuild(data, similar(parent(data)))
     ArrayType = ClimaComms.array_type(ClimaComms.device())
     parent(rand_data) .=
-        ArrayType(rand(eltype(parent(data)), size(parent(data))))
+        ArrayType(rand(eltype(parent(data)), DataLayouts.farray_size(data)))
     Base.copyto!(data, rand_data) # test copyto!(::AbstractData, ::AbstractData)
     @test all(parent(data) .== parent(rand_data))
     Base.copyto!(data, Base.Broadcast.broadcasted(+, rand_data, 1)) # test copyto!(::AbstractData, ::Broadcasted)
@@ -30,7 +30,7 @@ function test_copyto!(data)
     rand_data = DataLayouts.rebuild(data, similar(parent(data)))
     ArrayType = ClimaComms.array_type(ClimaComms.device())
     parent(rand_data) .=
-        ArrayType(rand(eltype(parent(data)), size(parent(data))))
+        ArrayType(rand(eltype(parent(data)), DataLayouts.farray_size(data)))
     Base.copyto!(data, rand_data) # test copyto!(::AbstractData, ::AbstractData)
     @test all(parent(data.:1) .== parent(rand_data.:1))
     @test all(parent(data.:2) .== parent(rand_data.:2))
@@ -98,7 +98,7 @@ end
         SubArray(
             parent(data),
             ntuple(
-                i -> Base.Slice(Base.OneTo(size(parent(data), i))),
+                i -> Base.Slice(Base.OneTo(DataLayouts.farray_size(data, i))),
                 ndims(data),
             ),
         ),

--- a/test/DataLayouts/unit_fill.jl
+++ b/test/DataLayouts/unit_fill.jl
@@ -73,7 +73,10 @@ end
         data,
         SubArray(
             parent(data),
-            ntuple(i -> Base.OneTo(size(parent(data), i)), ndims(data)),
+            ntuple(
+                i -> Base.OneTo(DataLayouts.farray_size(data, i)),
+                ndims(data),
+            ),
         ),
     )
     FT = Float64
@@ -119,7 +122,10 @@ end
             data,
             SubArray(
                 parent(rdata),
-                ntuple(i -> Base.OneTo(size(parent(rdata), i)), ndims(rdata)),
+                ntuple(
+                    i -> Base.OneTo(DataLayouts.farray_size(rdata, i)),
+                    ndims(rdata),
+                ),
             ),
         )
         rarray = parent(parent(newdata))

--- a/test/DataLayouts/unit_mapreduce.jl
+++ b/test/DataLayouts/unit_mapreduce.jl
@@ -24,7 +24,8 @@ function test_mapreduce_1!(context, data)
     Random.seed!(1234)
     device = ClimaComms.device(context)
     ArrayType = ClimaComms.array_type(device)
-    rand_data = ArrayType(rand(eltype(parent(data)), size(parent(data))))
+    rand_data =
+        ArrayType(rand(eltype(parent(data)), DataLayouts.farray_size(data)))
     parent(data) .= rand_data
     if device isa ClimaComms.CUDADevice
         @test wrapper(context, identity, min, data) == minimum(parent(data))
@@ -40,7 +41,8 @@ function test_mapreduce_2!(context, data)
     Random.seed!(1234)
     device = ClimaComms.device(context)
     ArrayType = ClimaComms.array_type(device)
-    rand_data = ArrayType(rand(eltype(parent(data)), size(parent(data))))
+    rand_data =
+        ArrayType(rand(eltype(parent(data)), DataLayouts.farray_size(data)))
     parent(data) .= rand_data
     # mapreduce orders tuples lexicographically:
     #    minimum(((2,3), (1,4))) # (1, 4)
@@ -116,7 +118,10 @@ end
         data,
         SubArray(
             parent(data),
-            ntuple(i -> Base.OneTo(size(parent(data), i)), ndims(data)),
+            ntuple(
+                i -> Base.OneTo(DataLayouts.farray_size(data, i)),
+                ndims(data),
+            ),
         ),
     )
     FT = Float64

--- a/test/Operators/spectralelement/benchmark_utils.jl
+++ b/test/Operators/spectralelement/benchmark_utils.jl
@@ -6,6 +6,7 @@ using LinearAlgebra: ×
 import PrettyTables
 import LinearAlgebra as LA
 import OrderedCollections
+import ClimaCore.DataLayouts
 import ClimaCore.Operators as Operators
 import ClimaCore.Domains as Domains
 import ClimaCore.Meshes as Meshes
@@ -229,7 +230,7 @@ function setup_kernel_args(ARGS::Vector{String} = ARGS)
     f_comp2_buffer = Spaces.create_dss_buffer(f_comp2)
     f = @. Geometry.Contravariant3Vector(Geometry.WVector(ϕ))
 
-    s = size(parent(ϕ))
+    s = DataLayouts.farray_size(Fields.field_values(ϕ))
     ArrayType = ClimaComms.array_type(device)
     ϕ_arr = ArrayType(fill(FT(1), s))
     ψ_arr = ArrayType(fill(FT(2), s))

--- a/test/Spaces/distributed_cuda/ddss2.jl
+++ b/test/Spaces/distributed_cuda/ddss2.jl
@@ -108,7 +108,7 @@ pid, nprocs = ClimaComms.init(context)
     end
 #! format: on
     p = @allocated Spaces.weighted_dss!(y0, dss_buffer)
-    iamroot && @test p ≤ 8064
+    iamroot && @test p ≤ 8832
 
     #testing weighted dss on a vector field
     init_vectorstate(local_geometry, p) = Geometry.Covariant12Vector(1.0, -1.0)

--- a/test/Spaces/distributed_cuda/ddss4.jl
+++ b/test/Spaces/distributed_cuda/ddss4.jl
@@ -100,7 +100,7 @@ pid, nprocs = ClimaComms.init(context)
     end
     p = @allocated Spaces.weighted_dss!(y0, dss_buffer)
     if pid == 1
-        @test p ≤ 7008
+        @test p ≤ 7776
     end
 
 end

--- a/test/Spaces/opt_spaces.jl
+++ b/test/Spaces/opt_spaces.jl
@@ -35,19 +35,19 @@ end
     if ClimaComms.device(context) isa ClimaComms.CUDADevice
         test_n_failures(86,   TU.PointSpace, context)
         test_n_failures(144,  TU.SpectralElementSpace1D, context)
-        test_n_failures(1120, TU.SpectralElementSpace2D, context)
+        test_n_failures(1141, TU.SpectralElementSpace2D, context)
         test_n_failures(123,  TU.ColumnCenterFiniteDifferenceSpace, context)
         test_n_failures(123,  TU.ColumnFaceFiniteDifferenceSpace, context)
-        test_n_failures(1126, TU.SphereSpectralElementSpace, context)
+        test_n_failures(1131, TU.SphereSpectralElementSpace, context)
         test_n_failures(1139, TU.CenterExtrudedFiniteDifferenceSpace, context)
         test_n_failures(1139, TU.FaceExtrudedFiniteDifferenceSpace, context)
     else
         test_n_failures(0,    TU.PointSpace, context)
         test_n_failures(137,  TU.SpectralElementSpace1D, context)
-        test_n_failures(308,  TU.SpectralElementSpace2D, context)
+        test_n_failures(310,  TU.SpectralElementSpace2D, context)
         test_n_failures(118,  TU.ColumnCenterFiniteDifferenceSpace, context)
         test_n_failures(118,  TU.ColumnFaceFiniteDifferenceSpace, context)
-        test_n_failures(314,  TU.SphereSpectralElementSpace, context)
+        test_n_failures(316,  TU.SphereSpectralElementSpace, context)
         test_n_failures(321,  TU.CenterExtrudedFiniteDifferenceSpace, context)
         test_n_failures(321,  TU.FaceExtrudedFiniteDifferenceSpace, context)
 


### PR DESCRIPTION
This is basically a peel off from #1929, and extends #1932. This PR:
 - Reduces the use of `parent(data)` and especially `size(parent(data))`
 - eliminates `get_n_items`, and instead only integers are passed (when needed)
 - Uses `UniversalSize` to leverage static parameters more
 - Introduces `DataLayouts.array_size` and `DataLayouts.farray_size`, which return static sizes of the datalayouts (`array_size` uses a field dimension of 1, which is often helpful)

This does increase some inference failures because I've passed some additional variables through to gpu kernels using `Val`, which should result in statically known offsets, potentially improving performance of some kernels (likely by no more than 30%).