### PR TITLE
Fix type parameters in similar

### DIFF
--- a/src/DataLayouts/broadcast.jl
+++ b/src/DataLayouts/broadcast.jl
@@ -363,9 +363,9 @@ function Base.similar(
 end
 
 Base.similar(
-    bc::BroadcastedUnionVIJFH{<:Any, Nv, Nij, A},
+    bc::BroadcastedUnionVIJFH{<:Any, Nv, Nij, Nh, A},
     ::Type{Eltype},
-) where {Nv, Nij, A, Eltype} = similar(bc, Eltype, Val(Nv))
+) where {Nv, Nij, Nh, A, Eltype} = similar(bc, Eltype, Val(Nv))
 
 function Base.similar(
     bc::BroadcastedUnionVIJFH{<:Any, Nv, Nij, Nh, A},


### PR DESCRIPTION
This PR fixes the type parameter in `similar`. It's not actually a bug fix-- more of a name fix, because that type parameter is never actually used.