### PR TITLE
Fix integrals for broadcasts and update docstrings

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -51,6 +51,8 @@ withenv("GKSwstype" => "nul") do
         prettyurls = !isempty(get(ENV, "CI", "")),
         mathengine = mathengine,
         collapselevel = 1,
+        size_threshold = 300_000, # default is 200_000
+        size_threshold_warn = 200_000, # default is 100_000
     )
 
     Documenter.makedocs(;

--- a/test/Operators/integrals.jl
+++ b/test/Operators/integrals.jl
@@ -34,11 +34,10 @@ function test_column_integral_definite!(center_space)
     ᶜz = Fields.coordinate_field(center_space).z
     ᶠz = Fields.coordinate_field(face_space).z
     z_top = Fields.level(ᶠz, Operators.right_idx(face_space))
-    ᶜu = map(z -> (; one = one(z), powers = (z, z^2, z^3)), ᶜz)
-    device = ClimaComms.device(ᶜu)
-    ∫u_ref = ClimaComms.allowscalar(device) do
-        map(z -> (; one = z, powers = (z^2 / 2, z^3 / 3, z^4 / 4)), z_top)
+    ᶜu = Base.Broadcast.broadcasted(ᶜz) do z
+        (; one = one(z), powers = (z, z^2, z^3))
     end
+    ∫u_ref = map(z -> (; one = z, powers = (z^2 / 2, z^3 / 3, z^4 / 4)), z_top)
     ∫u_test = similar(∫u_ref)
 
     column_integral_definite!(∫u_test, ᶜu)
@@ -57,7 +56,9 @@ function test_column_integral_indefinite!(center_space)
     face_space = center_to_face_space(center_space)
     ᶜz = Fields.coordinate_field(center_space).z
     ᶠz = Fields.coordinate_field(face_space).z
-    ᶜu = map(z -> (; one = one(z), powers = (z, z^2, z^3)), ᶜz)
+    ᶜu = Base.Broadcast.broadcasted(ᶜz) do z
+        (; one = one(z), powers = (z, z^2, z^3))
+    end
     ᶠ∫u_ref = map(z -> (; one = z, powers = (z^2 / 2, z^3 / 3, z^4 / 4)), ᶠz)
     ᶠ∫u_test = similar(ᶠ∫u_ref)
 


### PR DESCRIPTION
This PR fixes the issue identified in CliMA/ClimaAtmos.jl#3254, allowing the definite and indefinite integral functions to accept `AbstractBroadcasted`s in addition to `Field`s. It also makes the function argument names more consistent, updates the docstrings, and modifies the unit tests to use `AbstractBroadcasted`s instead of `Field`s.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
