### PR TITLE
Define == for same-typed fieldvectors

### DIFF
--- a/src/Fields/fieldvector.jl
+++ b/src/Fields/fieldvector.jl
@@ -455,3 +455,7 @@ Returns `true` if `x == y` recursively.
 """
 rcompare(x::T, y::T) where {T <: Union{FieldVector, NamedTuple}} =
     _rcompare(true, x, y)
+
+# Define == to call rcompare for two fieldvectors of the same
+# exact type.
+Base.:(==)(x::T, y::T) where {T <: FieldVector} = rcompare(x, y)

--- a/test/Fields/unit_field.jl
+++ b/test/Fields/unit_field.jl
@@ -310,10 +310,10 @@ end
     Y.k.z = 3.0
     @test Y.k.z === 3.0
 
-    @test Fields.rcompare(Y, Y)
+    @test Y == Y
     Ydc = deepcopy(Y)
     Ydc.k.z += 1
-    @test !Fields.rcompare(Ydc, Y)
+    @test !(Ydc == Y)
     # Fields.@rprint_diff(Ydc, Y)
     s = sprint(
         Fields._rprint_diff,

--- a/test/Fields/utils_field_multi_broadcast_fusion.jl
+++ b/test/Fields/utils_field_multi_broadcast_fusion.jl
@@ -103,8 +103,8 @@ function test_kernel!(; fused!, unfused!, X, Y)
     @testset "Test correctness of $(nameof(typeof(fused!)))" begin
         Fields.@rprint_diff(X_fused, X_unfused)
         Fields.@rprint_diff(Y_fused, Y_unfused)
-        @test Fields.rcompare(X_fused, X_unfused)
-        @test Fields.rcompare(Y_fused, Y_unfused)
+        @test X_fused == X_unfused
+        @test Y_fused == Y_unfused
     end
 end
 


### PR DESCRIPTION
This PR defines `Base.:(==)` for field vectors of the same type to simply call `rcompare`. `rcompare` is more general in that it also works on fieldvectors and fields, but it's nice to be able to use `==` on fieldvectors instead of `rcompare`.