### PR TITLE
Refactor DSS to better leverage DataLayouts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ ClimaCore.jl Release Notes
 main
 -------
 
+- DSS was refactored, and machine precision changes can be expected. PR [#1958](https://github.com/CliMA/ClimaCore.jl/pull/1958).
+
 v0.14.12
 -------
 - Added hyperbolic tangent stretching. PR [#1930](https://github.com/CliMA/ClimaCore.jl/pull/1930).

--- a/src/Topologies/dss_transform.jl
+++ b/src/Topologies/dss_transform.jl
@@ -201,34 +201,6 @@ end
 
 # helper functions for DSS2
 
-function _get_idx_metric(sizet::NTuple{5, Int}, loc::NTuple{4, Int})
-    nmetric = sizet[4]
-    (i11, i12, i21, i22) = nmetric == 4 ? (1, 2, 3, 4) : (1, 2, 4, 5)
-    (level, i, j, elem) = loc
-    return (
-        linear_ind(sizet, (level, i, j, i11, elem)),
-        linear_ind(sizet, (level, i, j, i12, elem)),
-        linear_ind(sizet, (level, i, j, i21, elem)),
-        linear_ind(sizet, (level, i, j, i22, elem)),
-    )
-end
-
-function _get_idx_metric_3d(sizet::NTuple{5, Int}, loc::NTuple{4, Int})
-    nmetric = sizet[4]
-    (level, i, j, elem) = loc
-    return (
-        linear_ind(sizet, (level, i, j, 1, elem)),
-        linear_ind(sizet, (level, i, j, 2, elem)),
-        linear_ind(sizet, (level, i, j, 3, elem)),
-        linear_ind(sizet, (level, i, j, 4, elem)),
-        linear_ind(sizet, (level, i, j, 5, elem)),
-        linear_ind(sizet, (level, i, j, 6, elem)),
-        linear_ind(sizet, (level, i, j, 7, elem)),
-        linear_ind(sizet, (level, i, j, 8, elem)),
-        linear_ind(sizet, (level, i, j, 9, elem)),
-    )
-end
-
 function _representative_slab(
     data::Union{DataLayouts.AbstractData, Nothing},
     ::Type{DA},

--- a/test/Spaces/unit_dss.jl
+++ b/test/Spaces/unit_dss.jl
@@ -110,22 +110,4 @@ end
     @test n_dss_affected_y12 * 3 / 2 ==
           n_dss_affected_y123 ==
           n_dss_affected_y3 * 3
-
-    @test nt.dss_buffer.y12.scalarfidx == Int[]
-    @test nt.dss_buffer.y12.covariant12fidx == Int[1]
-    @test nt.dss_buffer.y12.contravariant12fidx == Int[]
-    @test nt.dss_buffer.y12.covariant123fidx == Int[]
-    @test nt.dss_buffer.y12.contravariant123fidx == Int[]
-
-    @test nt.dss_buffer.y123.scalarfidx == Int[]
-    @test nt.dss_buffer.y123.covariant12fidx == Int[]
-    @test nt.dss_buffer.y123.contravariant12fidx == Int[]
-    @test nt.dss_buffer.y123.covariant123fidx == Int[1]
-    @test nt.dss_buffer.y123.contravariant123fidx == Int[]
-
-    @test nt.dss_buffer.y3.scalarfidx == Int[1]
-    @test nt.dss_buffer.y3.covariant12fidx == Int[]
-    @test nt.dss_buffer.y3.contravariant12fidx == Int[]
-    @test nt.dss_buffer.y3.covariant123fidx == Int[]
-    @test nt.dss_buffer.y3.contravariant123fidx == Int[]
 end


### PR DESCRIPTION
This PR refactors DSS to avoid using DataLayout internals, and reduces code duplication. We can apply a similar pattern to the cuda code (wip).

This should make fixing #1910 easier.

What this PR does:
 - We pass the datalayouts themselves into the dss function, instead of the underlying array.
 - Swap the field and level order of the loops, and indexing into the datalayouts using the universal spatial index `(I, J, F, V, H)`, which recursively indexes into the field variables via `get_struct`/`set_struct`.
 - I'm reusing the already existing `dss_transform` to transform the data.
 - The only unexpected thing I ran into was the need to define `drop_vert_dim` in `Geometry.UVWVector` due to a comment in `dss.jl`: `For DSS of Covariant123Vector, the third component is treated like a scalar and is not transformed`. I'm not 100% sure if what I did was correct here
 
The last bullet point still confuses me because it seems like `N` variables come in and `N - M` are defined. Can someone confirm that this is correct? 