### PR TITLE
Refactor and update benchmarks

### DIFF
--- a/benchmarks/scripts/benchmark_offset.jl
+++ b/benchmarks/scripts/benchmark_offset.jl
@@ -14,32 +14,33 @@ using Revise; include(joinpath("benchmarks", "scripts", "benchmark_offset.jl"))
 Clima A100:
 ```
 [ Info: ArrayType = CuArray
-Problem size: (63, 4, 4, 1, 5400), float_type = Float32, device_bandwidth_GBs=2039
-┌────────────────────────────────────────────────────────────────────┬──────────────────────────────────┬─────────┬─────────────┬────────────────┬────────┐
-│ funcs                                                              │ time per call                    │ bw %    │ achieved bw │ n-reads/writes │ n-reps │
-├────────────────────────────────────────────────────────────────────┼──────────────────────────────────┼─────────┼─────────────┼────────────────┼────────┤
-│     BO.aos_cart_offset!(X_aos_ref, Y_aos_ref, us; bm, nreps = 100) │ 68 microseconds, 834 nanoseconds │ 57.7908 │ 1178.35     │ 4              │ 100    │
-│     BO.aos_lin_offset!(X_aos, Y_aos, us; bm, nreps = 100)          │ 58 microseconds, 153 nanoseconds │ 68.4046 │ 1394.77     │ 4              │ 100    │
-│     BO.soa_linear_index!(X_soa, Y_soa, us; bm, nreps = 100)        │ 56 microseconds, 576 nanoseconds │ 70.3113 │ 1433.65     │ 4              │ 100    │
-│     BO.soa_cart_index!(X_soa, Y_soa, us; bm, nreps = 100)          │ 67 microseconds, 185 nanoseconds │ 59.2089 │ 1207.27     │ 4              │ 100    │
-└────────────────────────────────────────────────────────────────────┴──────────────────────────────────┴─────────┴─────────────┴────────────────┴────────┘
+Problem size: (63, 4, 4, 1, 5400), N reads-writes: 4, N-reps: 100,  Float_type = Float32, Device_bandwidth_GBs=2039
+┌────────────────────────────────────────────────────────────────┬──────────────────────────────────┬─────────┬─────────────┐
+│ funcs                                                          │ time per call                    │ bw %    │ achieved bw │
+├────────────────────────────────────────────────────────────────┼──────────────────────────────────┼─────────┼─────────────┤
+│ BO.aos_cart_offset!(X_aos_ref, Y_aos_ref, us; bm, nreps = 100) │ 84 microseconds, 726 nanoseconds │ 46.9507 │ 957.324     │
+│ BO.aos_lin_offset!(X_aos, Y_aos, us; bm, nreps = 100)          │ 58 microseconds, 102 nanoseconds │ 68.4649 │ 1396.0      │
+│ BO.soa_linear_index!(X_soa, Y_soa, us; bm, nreps = 100)        │ 56 microseconds, 331 nanoseconds │ 70.618  │ 1439.9      │
+│ BO.soa_cart_index!(X_soa, Y_soa, us; bm, nreps = 100)          │ 67 microseconds, 390 nanoseconds │ 59.029  │ 1203.6      │
+└────────────────────────────────────────────────────────────────┴──────────────────────────────────┴─────────┴─────────────┘
 
 [ Info: ArrayType = CuArray
-Problem size: (63, 4, 4, 1, 5400), float_type = Float32, device_bandwidth_GBs=2039
-┌────────────────────────────────────────────────────────────────────┬──────────────────────────────────┬─────────┬─────────────┬────────────────┬────────┐
-│ funcs                                                              │ time per call                    │ bw %    │ achieved bw │ n-reads/writes │ n-reps │
-├────────────────────────────────────────────────────────────────────┼──────────────────────────────────┼─────────┼─────────────┼────────────────┼────────┤
-│     BO.aos_cart_offset!(X_aos_ref, Y_aos_ref, us; bm, nreps = 100) │ 68 microseconds, 967 nanoseconds │ 57.6793 │ 1176.08     │ 4              │ 100    │
-│     BO.aos_lin_offset!(X_aos, Y_aos, us; bm, nreps = 100)          │ 58 microseconds, 82 nanoseconds  │ 68.489  │ 1396.49     │ 4              │ 100    │
-│     BO.soa_linear_index!(X_soa, Y_soa, us; bm, nreps = 100)        │ 56 microseconds, 597 nanoseconds │ 70.2858 │ 1433.13     │ 4              │ 100    │
-│     BO.soa_cart_index!(X_soa, Y_soa, us; bm, nreps = 100)          │ 67 microseconds, 288 nanoseconds │ 59.1188 │ 1205.43     │ 4              │ 100    │
-└────────────────────────────────────────────────────────────────────┴──────────────────────────────────┴─────────┴─────────────┴────────────────┴────────┘
+Problem size: (63, 4, 4, 1, 5400), N reads-writes: 4, N-reps: 100,  Float_type = Float64, Device_bandwidth_GBs=2039
+┌────────────────────────────────────────────────────────────────┬───────────────────────────────────┬─────────┬─────────────┐
+│ funcs                                                          │ time per call                     │ bw %    │ achieved bw │
+├────────────────────────────────────────────────────────────────┼───────────────────────────────────┼─────────┼─────────────┤
+│ BO.aos_cart_offset!(X_aos_ref, Y_aos_ref, us; bm, nreps = 100) │ 107 microseconds, 387 nanoseconds │ 74.086  │ 1510.61     │
+│ BO.aos_lin_offset!(X_aos, Y_aos, us; bm, nreps = 100)          │ 105 microseconds, 42 nanoseconds  │ 75.7399 │ 1544.34     │
+│ BO.soa_linear_index!(X_soa, Y_soa, us; bm, nreps = 100)        │ 102 microseconds, 636 nanoseconds │ 77.5157 │ 1580.54     │
+│ BO.soa_cart_index!(X_soa, Y_soa, us; bm, nreps = 100)          │ 106 microseconds, 896 nanoseconds │ 74.4266 │ 1517.56     │
+└────────────────────────────────────────────────────────────────┴───────────────────────────────────┴─────────┴─────────────┘
 ```
 =#
 
 #! format: off
 module BenchmarkOffset
 
+import CUDA
 include("benchmark_utils.jl")
 
 add3(x1, x2, x3) = x1 + x2 + x3
@@ -76,7 +77,7 @@ function aos_cart_offset!(X, Y, us; nreps = 1, bm=nothing, n_trials = 30)
             e = min(e, et)
         end
     end
-    push_info(bm; e, nreps, caller = @caller_name(@__FILE__),n_reads_writes=4)
+    push_info(bm; kernel_time_s=e/nreps, nreps, caller = @caller_name(@__FILE__),problem_size=size(us),n_reads_writes=4)
     return nothing
 end;
 function aos_cart_offset_kernel!(X, Y, us)
@@ -131,7 +132,7 @@ function aos_lin_offset!(X, Y, us; nreps = 1, bm=nothing, n_trials = 30)
             e = min(e, et)
         end
     end
-    push_info(bm; e, nreps, caller = @caller_name(@__FILE__),n_reads_writes=4)
+    push_info(bm; kernel_time_s=e/nreps, nreps, caller = @caller_name(@__FILE__),problem_size=size(us),n_reads_writes=4)
     return nothing
 end;
 function aos_lin_offset_kernel!(X, Y, us)
@@ -184,7 +185,7 @@ function soa_cart_index!(X, Y, us; nreps = 1, bm=nothing, n_trials = 30)
             e = min(e, et)
         end
     end
-    push_info(bm; e, nreps, caller = @caller_name(@__FILE__),n_reads_writes=4)
+    push_info(bm; kernel_time_s=e/nreps, nreps, caller = @caller_name(@__FILE__),problem_size=size(us),n_reads_writes=4)
     return nothing
 end;
 function soa_cart_index_kernel!(X, Y, us)
@@ -229,7 +230,7 @@ function soa_linear_index!(X, Y, us; nreps = 1, bm=nothing, n_trials = 30)
             e = min(e, et)
         end
     end
-    push_info(bm; e, nreps, caller = @caller_name(@__FILE__),n_reads_writes=4)
+    push_info(bm; kernel_time_s=e/nreps, nreps, caller = @caller_name(@__FILE__),problem_size=size(us),n_reads_writes=4)
     return nothing
 end;
 function soa_linear_index_kernel!(X, Y, us)
@@ -258,9 +259,10 @@ end
 using CUDA
 using Test
 @testset "Offset benchmark" begin
-    bm = BO.Benchmark(;problem_size=(63,4,4,1,5400), float_type=Float32) # size(problem_size, 4) == 1 to avoid double counting reads/writes
     ArrayType = CUDA.CuArray;
     # ArrayType = Base.identity;
+    device_name = CUDA.name(CUDA.device())
+    bm = BO.Benchmark(;problem_size=(63,4,4,1,5400), device_name, float_type=Float32) # size(problem_size, 4) == 1 to avoid double counting reads/writes
     arr(float_type, problem_size, T) = T(zeros(float_type, problem_size...))
 
     FT = Float64;

--- a/benchmarks/scripts/indexing_and_static_ndranges.jl
+++ b/benchmarks/scripts/indexing_and_static_ndranges.jl
@@ -107,6 +107,7 @@ Problem size: (63, 4, 4, 1, 5400), float_type = Float64, device_bandwidth_GBs=20
 
 module IndexStaticRangeBench
 
+import CUDA
 include("benchmark_utils.jl")
 
 # ============================================================ Non-extruded broadcast (start)
@@ -253,7 +254,7 @@ function at_dot_call!(X, Y; nreps = 1, bm=nothing, n_trials = 30)
         end
         e = min(e, et)
     end
-    push_info(bm; e, nreps, caller = @caller_name(@__FILE__),n_reads_writes=1)
+    push_info(bm; kernel_time_s=e/nreps, nreps, caller = @caller_name(@__FILE__),problem_size=size(X.x1),n_reads_writes=1)
     return nothing
 end;
 
@@ -280,7 +281,7 @@ function custom_sol_kernel!(X, Y, ::Val{N}; nreps = 1, bm=nothing, n_trials = 30
         end
         e = min(e, et)
     end
-    push_info(bm; e, nreps, caller = @caller_name(@__FILE__),n_reads_writes=1)
+    push_info(bm; kernel_time_s=e/nreps, nreps, caller = @caller_name(@__FILE__),problem_size=size(X.x1),n_reads_writes=1)
 
     return nothing
 end;
@@ -346,7 +347,7 @@ function custom_kernel_bc!(X, Y, us::AbstractUniversalSizes; printtb=false, use_
             e = min(e, et)
         end
     end
-    push_info(bm; e, nreps, caller = @caller_name(@__FILE__),n_reads_writes=1)
+    push_info(bm; kernel_time_s=e/nreps, nreps, caller = @caller_name(@__FILE__),problem_size=size(X.x1),n_reads_writes=1)
     return nothing
 end;
 @inline get_cart_lin_index(bc, n, I) = I
@@ -369,7 +370,8 @@ import .IndexStaticRangeBench as BSR
 
 using CUDA
 using Test
-bm = BSR.Benchmark(;problem_size=(63,4,4,1,5400), float_type=Float32)
+device_name = CUDA.name(CUDA.device())
+bm = BSR.Benchmark(;problem_size=(63,4,4,1,5400), device_name, float_type=Float32)
 # bm = BSR.Benchmark(;problem_size=(63,4,4,1,5400), float_type=Float64)
 ArrayType = CUDA.CuArray;
 # ArrayType = Base.identity;

--- a/benchmarks/scripts/thermo_bench_bw.jl
+++ b/benchmarks/scripts/thermo_bench_bw.jl
@@ -14,32 +14,33 @@ using Revise; include(joinpath("benchmarks", "scripts", "thermo_bench_bw.jl"))
 Clima A100:
 ```
 [ Info: device = ClimaComms.CUDADevice()
-Problem size: (63, 4, 4, 1, 5400), float_type = Float32, device_bandwidth_GBs=2039
-┌────────────────────────────────────────────────────┬───────────────────────────────────┬─────────┬─────────────┬────────────────┬────────┐
-│ funcs                                              │ time per call                     │ bw %    │ achieved bw │ n-reads/writes │ n-reps │
-├────────────────────────────────────────────────────┼───────────────────────────────────┼─────────┼─────────────┼────────────────┼────────┤
-│     TBB.singlefield_bc!(x_soa, us; nreps=100, bm)  │ 67 microseconds, 554 nanoseconds  │ 29.4429 │ 600.341     │ 2              │ 100    │
-│     TBB.singlefield_bc!(x_aos, us; nreps=100, bm)  │ 69 microseconds, 653 nanoseconds  │ 28.5556 │ 582.248     │ 2              │ 100    │
-│     TBB.thermo_func_bc!(x, us; nreps=100, bm)      │ 796 microseconds, 877 nanoseconds │ 12.4798 │ 254.462     │ 10             │ 100    │
-│     TBB.thermo_func_sol!(x_vec, us; nreps=100, bm) │ 131 microseconds, 72 nanoseconds  │ 75.873  │ 1547.05     │ 10             │ 100    │
-└────────────────────────────────────────────────────┴───────────────────────────────────┴─────────┴─────────────┴────────────────┴────────┘
+Problem size: (4, 4, 1, 63, 5400), N-reps: 100,  Float_type = Float32, Device_bandwidth_GBs=2039
+┌────────────────────────────────────────────────┬───────────────────────────────────┬─────────┬─────────────┬────────────────┐
+│ funcs                                          │ time per call                     │ bw %    │ achieved bw │ N reads-writes │
+├────────────────────────────────────────────────┼───────────────────────────────────┼─────────┼─────────────┼────────────────┤
+│ TBB.singlefield_bc!(x_soa, us; nreps=100, bm)  │ 62 microseconds, 864 nanoseconds  │ 31.6395 │ 645.129     │ 2              │
+│ TBB.singlefield_bc!(x_aos, us; nreps=100, bm)  │ 69 microseconds, 858 nanoseconds  │ 28.4718 │ 580.541     │ 2              │
+│ TBB.thermo_func_bc!(x, us; nreps=100, bm)      │ 794 microseconds, 225 nanoseconds │ 12.5214 │ 255.312     │ 10             │
+│ TBB.thermo_func_sol!(x_vec, us; nreps=100, bm) │ 133 microseconds, 530 nanoseconds │ 74.4766 │ 1518.58     │ 10             │
+└────────────────────────────────────────────────┴───────────────────────────────────┴─────────┴─────────────┴────────────────┘
 
 [ Info: device = ClimaComms.CUDADevice()
-Problem size: (63, 4, 4, 1, 5400), float_type = Float64, device_bandwidth_GBs=2039
-┌────────────────────────────────────────────────────┬───────────────────────────────────┬─────────┬─────────────┬────────────────┬────────┐
-│ funcs                                              │ time per call                     │ bw %    │ achieved bw │ n-reads/writes │ n-reps │
-├────────────────────────────────────────────────────┼───────────────────────────────────┼─────────┼─────────────┼────────────────┼────────┤
-│     TBB.singlefield_bc!(x_soa, us; nreps=100, bm)  │ 108 microseconds, 790 nanoseconds │ 36.5653 │ 745.567     │ 2              │ 100    │
-│     TBB.singlefield_bc!(x_aos, us; nreps=100, bm)  │ 123 microseconds, 730 nanoseconds │ 32.1501 │ 655.541     │ 2              │ 100    │
-│     TBB.thermo_func_bc!(x, us; nreps=100, bm)      │ 1 millisecond, 43 microseconds    │ 19.0568 │ 388.569     │ 10             │ 100    │
-│     TBB.thermo_func_sol!(x_vec, us; nreps=100, bm) │ 256 microseconds, 717 nanoseconds │ 77.477  │ 1579.76     │ 10             │ 100    │
-└────────────────────────────────────────────────────┴───────────────────────────────────┴─────────┴─────────────┴────────────────┴────────┘
+Problem size: (4, 4, 1, 63, 5400), N-reps: 100,  Float_type = Float64, Device_bandwidth_GBs=2039
+┌────────────────────────────────────────────────┬───────────────────────────────────┬─────────┬─────────────┬────────────────┐
+│ funcs                                          │ time per call                     │ bw %    │ achieved bw │ N reads-writes │
+├────────────────────────────────────────────────┼───────────────────────────────────┼─────────┼─────────────┼────────────────┤
+│ TBB.singlefield_bc!(x_soa, us; nreps=100, bm)  │ 108 microseconds, 514 nanoseconds │ 36.6585 │ 747.466     │ 2              │
+│ TBB.singlefield_bc!(x_aos, us; nreps=100, bm)  │ 118 microseconds, 989 nanoseconds │ 33.4311 │ 681.661     │ 2              │
+│ TBB.thermo_func_bc!(x, us; nreps=100, bm)      │ 1 millisecond, 44 microseconds    │ 19.0376 │ 388.177     │ 10             │
+│ TBB.thermo_func_sol!(x_vec, us; nreps=100, bm) │ 257 microseconds, 680 nanoseconds │ 77.1876 │ 1573.86     │ 10             │
+└────────────────────────────────────────────────┴───────────────────────────────────┴─────────┴─────────────┴────────────────┘
 ```
 =#
 
 #! format: off
 module ThermoBenchBandwidth
 
+import CUDA
 include("benchmark_utils.jl")
 
 import ClimaCore
@@ -74,7 +75,8 @@ function singlefield_bc!(x, us; nreps = 1, bm=nothing, n_trials = 30)
         end
         e = min(e, et)
     end
-    push_info(bm; e, nreps, caller = @caller_name(@__FILE__),n_reads_writes=2)
+    s = size(Fields.field_values(x.ρ_read))
+    push_info(bm; kernel_time_s=e/nreps, nreps, caller = @caller_name(@__FILE__),problem_size=s,n_reads_writes=2)
     return nothing
 end
 
@@ -89,7 +91,8 @@ function thermo_func_bc!(x, us; nreps = 1, bm=nothing, n_trials = 30)
         end
         e = min(e, et)
     end
-    push_info(bm; e, nreps, caller = @caller_name(@__FILE__),n_reads_writes=10)
+    s = size(Fields.field_values(x.ρ))
+    push_info(bm; kernel_time_s=e/nreps, nreps, caller = @caller_name(@__FILE__),problem_size=s,n_reads_writes=10)
     return nothing
 end
 
@@ -109,7 +112,8 @@ function thermo_func_sol!(x, us::UniversalSizesStatic; nreps = 1, bm=nothing, n_
         end
         e = min(e, et)
     end
-    push_info(bm; e, nreps, caller = @caller_name(@__FILE__),n_reads_writes=10)
+    s = size(x.ρ)
+    push_info(bm; kernel_time_s=e/nreps, nreps, caller = @caller_name(@__FILE__),problem_size=s,n_reads_writes=10)
     return nothing
 end
 
@@ -151,8 +155,9 @@ import .TestUtilities as TU;
 
 using Test
 @testset "Thermo state" begin
-    FT = Float32
-    bm = TBB.Benchmark(;problem_size=(63,4,4,1,5400), float_type=FT)
+    FT = Float64
+    device_name = CUDA.name(CUDA.device())
+    bm = TBB.Benchmark(;problem_size=(63,4,4,1,5400), device_name, float_type=FT)
     device = ClimaComms.device()
     context = ClimaComms.context(device)
     cspace = TU.CenterExtrudedFiniteDifferenceSpace(

--- a/test/DataLayouts/benchmark_copyto.jl
+++ b/test/DataLayouts/benchmark_copyto.jl
@@ -6,24 +6,36 @@ using Test
 using ClimaCore.DataLayouts
 using BenchmarkTools
 import ClimaComms
+import ClimaCore
 @static pkgversion(ClimaComms) >= v"0.6" && ClimaComms.@import_required_backends
+if ClimaComms.device() isa ClimaComms.CUDADevice
+    import CUDA
+    device_name = CUDA.name(CUDA.device()) # Move to ClimaComms
+else
+    device_name = "CPU"
+end
 
-function benchmarkcopyto!(device, data, val, name)
+include(joinpath(pkgdir(ClimaCore), "benchmarks/scripts/benchmark_utils.jl"))
+
+function benchmarkcopyto!(bm, device, data, val)
+    caller = string(nameof(typeof(data)))
+    @info "Benchmarking $caller..."
     data_rhs = similar(data)
     fill!(data_rhs, val)
-    println("Benchmarking ClimaCore copyto! for $name DataLayout")
     bc = Base.Broadcast.broadcasted(identity, data_rhs)
     bcp = Base.Broadcast.broadcasted(identity, parent(data_rhs))
     trial = @benchmark ClimaComms.@cuda_sync $device Base.copyto!($data, $bc)
-    show(stdout, MIME("text/plain"), trial)
-    println()
-    println("Benchmarking array copyto! for $name DataLayout")
-    trial = @benchmark ClimaComms.@cuda_sync $device Base.copyto!(
-        $(parent(data)),
-        $bcp,
+    t_min = minimum(trial.times) * 1e-9 # to seconds
+    nreps = length(trial.times)
+    n_reads_writes = DataLayouts.ncomponents(data) * 2
+    push_info(
+        bm;
+        kernel_time_s = t_min,
+        nreps = nreps,
+        caller,
+        problem_size = size(data),
+        n_reads_writes,
     )
-    show(stdout, MIME("text/plain"), trial)
-    println()
 end
 
 @testset "copyto! with Nf = 1" begin
@@ -36,18 +48,20 @@ end
     Nij = 4
     Nh = 30 * 30 * 6
     Nk = 6
+    bm = Benchmark(; float_type = FT, device_name)
 #! format: off
-    data = DataF{S}(device_zeros(FT,Nf));                        benchmarkcopyto!(device, data, 3, "DataF" ); @test all(parent(data) .== 3)
-    data = IJFH{S, Nij, Nh}(device_zeros(FT,Nij,Nij,Nf,Nh));     benchmarkcopyto!(device, data, 3, "IJFH"  ); @test all(parent(data) .== 3)
-    data = IFH{S, Nij, Nh}(device_zeros(FT,Nij,Nf,Nh));          benchmarkcopyto!(device, data, 3, "IFH"   ); @test all(parent(data) .== 3)
-    # The parent array of IJF and IF datalayouts are MArrays, and can therefore not be passed into CUDA kernels on the RHS.
-    # data = IJF{S, Nij}(device_zeros(FT,Nij,Nij,Nf));             benchmarkcopyto!(device, data, 3, "IJF"   ); @test all(parent(data) .== 3)
-    # data = IF{S, Nij}(device_zeros(FT,Nij,Nf));                  benchmarkcopyto!(device, data, 3, "IF"    ); @test all(parent(data) .== 3)
-    data = VF{S, Nv}(device_zeros(FT,Nv,Nf));                    benchmarkcopyto!(device, data, 3, "VF"    ); @test all(parent(data) .== 3)
-    data = VIJFH{S,Nv,Nij,Nh}(device_zeros(FT,Nv,Nij,Nij,Nf,Nh));benchmarkcopyto!(device, data, 3, "VIJFH" ); @test all(parent(data) .== 3)
-    data = VIFH{S, Nv, Nij, Nh}(device_zeros(FT,Nv,Nij,Nf,Nh));  benchmarkcopyto!(device, data, 3, "VIFH"  ); @test all(parent(data) .== 3)
+    data = DataF{S}(device_zeros(FT,Nf));                        benchmarkcopyto!(bm, device, data, 3); @test all(parent(data) .== 3)
+    data = IJFH{S, Nij, Nh}(device_zeros(FT,Nij,Nij,Nf,Nh));     benchmarkcopyto!(bm, device, data, 3); @test all(parent(data) .== 3)
+    data = IFH{S, Nij, Nh}(device_zeros(FT,Nij,Nf,Nh));          benchmarkcopyto!(bm, device, data, 3); @test all(parent(data) .== 3)
+    # The parent array of IJF and IF datalayouts are MArrays, and can therefore not bm, be passed into CUDA kernels on the RHS.
+    # data = IJF{S, Nij}(device_zeros(FT,Nij,Nij,Nf));             benchmarkcopyto!(bm, device, data, 3); @test all(parent(data) .== 3)
+    # data = IF{S, Nij}(device_zeros(FT,Nij,Nf));                  benchmarkcopyto!(bm, device, data, 3); @test all(parent(data) .== 3)
+    data = VF{S, Nv}(device_zeros(FT,Nv,Nf));                    benchmarkcopyto!(bm, device, data, 3); @test all(parent(data) .== 3)
+    data = VIJFH{S,Nv,Nij,Nh}(device_zeros(FT,Nv,Nij,Nij,Nf,Nh));benchmarkcopyto!(bm, device, data, 3); @test all(parent(data) .== 3)
+    data = VIFH{S, Nv, Nij, Nh}(device_zeros(FT,Nv,Nij,Nf,Nh));  benchmarkcopyto!(bm, device, data, 3); @test all(parent(data) .== 3)
 #! format: on
 
-    # data = IJKFVH{S}(device_zeros(FT,Nij,Nij,Nk,Nf,Nh)); benchmarkcopyto!(device, data, 3); @test all(parent(data) .== 3) # TODO: test
-    # data = IH1JH2{S}(device_zeros(FT,Nij,Nij,Nk,Nf,Nh)); benchmarkcopyto!(device, data, 3); @test all(parent(data) .== 3) # TODO: test
+    # data = IJKFVH{S}(device_zeros(FT,Nij,Nij,Nk,Nf,Nh)); benchmarkcopyto!(bm, device, data, 3); @test all(parent(data) .== 3) # TODO: test
+    # data = IH1JH2{S}(device_zeros(FT,Nij,Nij,Nk,Nf,Nh)); benchmarkcopyto!(bm, device, data, 3); @test all(parent(data) .== 3) # TODO: test
+    tabulate_benchmark(bm)
 end


### PR DESCRIPTION
This PR updates and refactors the benchmarks in a few ways:
 - If a column is the same for all benchmarks, then simply include that information at the table's header and remove the column
 - Starts a dictionary for device specs and uses `CUDA.name(CUDA.device())` to look up the device specs

```julia
function device_info()
    device_specs =
        Dict("NVIDIA A100-SXM4-80GB" => (; device_bandwidth_GBs = 2_039))
    is_cuda = ClimaComms.device() isa ClimaComms.CUDADevice
    if is_cuda && haskey(device_specs, CUDA.name(CUDA.device()))
        (; device_bandwidth_GBs) = device_specs[CUDA.name(CUDA.device())]
        return (;
            device_bandwidth_GBs,
            exists = true,
            name = CUDA.name(CUDA.device()),
        )
    else
        return (;
            device_bandwidth_GBs = 1,
            exists = false,
            name = CUDA.name(CUDA.device()),
        )
    end
end
```
Now, we can add more devices in `device_specs`.

 -  Pass in `kernel_time_s` to `push_info` so that it's decoupled from `nreps`. This is clearer and becomes compatible with benchmarks generated from BenchmarkTools
 - Pass in `problem_size` into `push_info`, so that a benchmark table can have multiple problem sizes (this is helpful for our copyto benchmarks)
 - Use the benchmark utils in the `copyto!` benchmarks.