### PR TITLE
Break down stencil benchmarks

### DIFF
--- a/test/Operators/finitedifference/benchmark_stencils.jl
+++ b/test/Operators/finitedifference/benchmark_stencils.jl
@@ -4,8 +4,14 @@ using Revise; include(joinpath("test", "Operators", "finitedifference", "benchma
 =#
 include("benchmark_stencils_utils.jl")
 
+#! format: off
 @testset "Benchmark operators" begin
-    benchmark_operators(Float64; z_elems = 63, helem = 30, Nq = 4)
+    # benchmark_operators_column(Float64; z_elems = 63, helem = 30, Nq = 4, compile = true)
+    benchmark_operators_column(Float64; z_elems = 63, helem = 30, Nq = 4)
+
+    # benchmark_operators_sphere(Float64; z_elems = 63, helem = 30, Nq = 4, compile = true)
+    benchmark_operators_sphere(Float64; z_elems = 63, helem = 30, Nq = 4)
 end
+#! format: on
 
 nothing


### PR DESCRIPTION
This PR updates the stencil benchmarks:

 - Breaks the benchmarks into column and sphere functions, so that we can more easily target benchmarks
 - Adds a `compile` kwarg, that calls the functions and does not perform the benchmark. This allows us to easily exercise all of the kernels without actually benchmarking them, which is helpful for debugging.