### PR TITLE
Use prescribed thread-block configurations

### DIFF
--- a/ext/ClimaCoreCUDAExt.jl
+++ b/ext/ClimaCoreCUDAExt.jl
@@ -17,6 +17,7 @@ import ClimaCore.Utilities: cart_ind, linear_ind
 import ClimaCore.RecursiveApply:
     ⊠, ⊞, ⊟, radd, rmul, rsub, rdiv, rmap, rzero, rmin, rmax
 import ClimaCore.DataLayouts: get_N, get_Nv, get_Nij, get_Nij, get_Nh
+import ClimaCore.DataLayouts: UniversalSize
 
 include(joinpath("cuda", "cuda_utils.jl"))
 include(joinpath("cuda", "data_layouts.jl"))

--- a/ext/cuda/cuda_utils.jl
+++ b/ext/cuda/cuda_utils.jl
@@ -90,6 +90,12 @@ function auto_launch!(
     return nothing
 end
 
+function threads_via_occupancy(f!::F!, args) where {F!}
+    kernel = CUDA.@cuda always_inline = true launch = false f!(args...)
+    config = CUDA.launch_configuration(kernel.fun)
+    return config.threads
+end
+
 """
     thread_index()
 

--- a/ext/cuda/data_layouts.jl
+++ b/ext/cuda/data_layouts.jl
@@ -29,6 +29,7 @@ include("data_layouts_fill.jl")
 include("data_layouts_copyto.jl")
 include("data_layouts_fused_copyto.jl")
 include("data_layouts_mapreduce.jl")
+include("data_layouts_threadblock.jl")
 
 adapt_f(to, f::F) where {F} = Adapt.adapt(to, f)
 adapt_f(to, ::Type{F}) where {F} = (x...) -> F(x...)

--- a/ext/cuda/data_layouts_copyto.jl
+++ b/ext/cuda/data_layouts_copyto.jl
@@ -1,88 +1,9 @@
 DataLayouts._device_dispatch(x::CUDA.CuArray) = ToCUDA()
 
-function knl_copyto!(dest, src)
-
-    i = CUDA.threadIdx().x
-    j = CUDA.threadIdx().y
-
-    h = CUDA.blockIdx().x
-    v = CUDA.blockDim().z * (CUDA.blockIdx().y - 1) + CUDA.threadIdx().z
-
-    if v <= size(dest, 4)
-        I = CartesianIndex((i, j, 1, v, h))
+function knl_copyto!(dest, src, us)
+    I = universal_index(dest)
+    if is_valid_index(dest, I, us)
         @inbounds dest[I] = src[I]
-    end
-    return nothing
-end
-
-function Base.copyto!(
-    dest::IJFH{S, Nij, Nh},
-    bc::DataLayouts.BroadcastedUnionIJFH{S, Nij, Nh},
-    ::ToCUDA,
-) where {S, Nij, Nh}
-    if Nh > 0
-        auto_launch!(
-            knl_copyto!,
-            (dest, bc);
-            threads_s = (Nij, Nij),
-            blocks_s = (Nh, 1),
-        )
-    end
-    return dest
-end
-
-function Base.copyto!(
-    dest::VIJFH{S, Nv, Nij, Nh},
-    bc::DataLayouts.BroadcastedUnionVIJFH{S, Nv, Nij, Nh},
-    ::ToCUDA,
-) where {S, Nv, Nij, Nh}
-    if Nv > 0 && Nh > 0
-        Nv_per_block = min(Nv, fld(256, Nij * Nij))
-        Nv_blocks = cld(Nv, Nv_per_block)
-        auto_launch!(
-            knl_copyto!,
-            (dest, bc);
-            threads_s = (Nij, Nij, Nv_per_block),
-            blocks_s = (Nh, Nv_blocks),
-        )
-    end
-    return dest
-end
-
-function Base.copyto!(
-    dest::VF{S, Nv},
-    bc::DataLayouts.BroadcastedUnionVF{S, Nv},
-    ::ToCUDA,
-) where {S, Nv}
-    if Nv > 0
-        auto_launch!(
-            knl_copyto!,
-            (dest, bc);
-            threads_s = (1, 1),
-            blocks_s = (1, Nv),
-        )
-    end
-    return dest
-end
-
-function Base.copyto!(
-    dest::DataF{S},
-    bc::DataLayouts.BroadcastedUnionDataF{S},
-    ::ToCUDA,
-) where {S}
-    auto_launch!(knl_copyto!, (dest, bc); threads_s = (1, 1), blocks_s = (1, 1))
-    return dest
-end
-
-import ClimaCore.DataLayouts: isascalar
-function knl_copyto_flat!(dest::AbstractData, bc, us)
-    @inbounds begin
-        tidx = thread_index()
-        if tidx ≤ get_N(us)
-            n = size(dest)
-            I = kernel_indexes(tidx, n)
-            dest[I] = bc[I]
-        end
     end
     return nothing
 end
@@ -91,21 +12,27 @@ function cuda_copyto!(dest::AbstractData, bc)
     (_, _, Nv, _, Nh) = DataLayouts.universal_size(dest)
     us = DataLayouts.UniversalSize(dest)
     if Nv > 0 && Nh > 0
-        nitems = prod(DataLayouts.universal_size(dest))
-        auto_launch!(knl_copyto_flat!, (dest, bc, us), nitems; auto = true)
+        args = (dest, bc, us)
+        threads = threads_via_occupancy(knl_copyto!, args)
+        n_max_threads = min(threads, get_N(us))
+        p = partition(dest, n_max_threads)
+        auto_launch!(
+            knl_copyto!,
+            args;
+            threads_s = p.threads,
+            blocks_s = p.blocks,
+        )
     end
     return dest
 end
 
-# TODO: can we use CUDA's luanch configuration for all data layouts?
-# Currently, it seems to have a slight performance degradation.
 #! format: off
-# Base.copyto!(dest::IJFH{S, Nij},          bc::DataLayouts.BroadcastedUnionIJFH{S, Nij, Nh}, ::ToCUDA) where {S, Nij, Nh} = cuda_copyto!(dest, bc)
+Base.copyto!(dest::IJFH{S, Nij},          bc::DataLayouts.BroadcastedUnionIJFH{S, Nij, Nh}, ::ToCUDA) where {S, Nij, Nh} = cuda_copyto!(dest, bc)
 Base.copyto!(dest::IFH{S, Ni, Nh},        bc::DataLayouts.BroadcastedUnionIFH{S, Ni, Nh}, ::ToCUDA) where {S, Ni, Nh} = cuda_copyto!(dest, bc)
 Base.copyto!(dest::IJF{S, Nij},           bc::DataLayouts.BroadcastedUnionIJF{S, Nij}, ::ToCUDA) where {S, Nij} = cuda_copyto!(dest, bc)
 Base.copyto!(dest::IF{S, Ni},             bc::DataLayouts.BroadcastedUnionIF{S, Ni}, ::ToCUDA) where {S, Ni} = cuda_copyto!(dest, bc)
 Base.copyto!(dest::VIFH{S, Nv, Ni, Nh},   bc::DataLayouts.BroadcastedUnionVIFH{S, Nv, Ni, Nh}, ::ToCUDA) where {S, Nv, Ni, Nh} = cuda_copyto!(dest, bc)
-# Base.copyto!(dest::VIJFH{S, Nv, Nij, Nh}, bc::DataLayouts.BroadcastedUnionVIJFH{S, Nv, Nij, Nh}, ::ToCUDA) where {S, Nv, Nij, Nh} = cuda_copyto!(dest, bc)
-# Base.copyto!(dest::VF{S, Nv},             bc::DataLayouts.BroadcastedUnionVF{S, Nv}, ::ToCUDA) where {S, Nv} = cuda_copyto!(dest, bc)
-# Base.copyto!(dest::DataF{S},              bc::DataLayouts.BroadcastedUnionDataF{S}, ::ToCUDA) where {S} = cuda_copyto!(dest, bc)
+Base.copyto!(dest::VIJFH{S, Nv, Nij, Nh}, bc::DataLayouts.BroadcastedUnionVIJFH{S, Nv, Nij, Nh}, ::ToCUDA) where {S, Nv, Nij, Nh} = cuda_copyto!(dest, bc)
+Base.copyto!(dest::VF{S, Nv},             bc::DataLayouts.BroadcastedUnionVF{S, Nv}, ::ToCUDA) where {S, Nv} = cuda_copyto!(dest, bc)
+Base.copyto!(dest::DataF{S},              bc::DataLayouts.BroadcastedUnionDataF{S}, ::ToCUDA) where {S} = cuda_copyto!(dest, bc)
 #! format: on

--- a/ext/cuda/data_layouts_fill.jl
+++ b/ext/cuda/data_layouts_fill.jl
@@ -1,32 +1,27 @@
-function knl_fill_flat!(dest::AbstractData, val, us)
-    @inbounds begin
-        tidx = thread_index()
-        if tidx ≤ get_N(us)
-            n = size(dest)
-            I = kernel_indexes(tidx, n)
-            @inbounds dest[I] = val
-        end
+function knl_fill!(dest, val, us)
+    I = universal_index(dest)
+    if is_valid_index(dest, I, us)
+        @inbounds dest[I] = val
     end
     return nothing
 end
 
-function cuda_fill!(dest::AbstractData, val)
+function cuda_fill!(dest::AbstractData, bc)
     (_, _, Nv, _, Nh) = DataLayouts.universal_size(dest)
     us = DataLayouts.UniversalSize(dest)
     if Nv > 0 && Nh > 0
-        nitems = prod(DataLayouts.universal_size(dest))
-        auto_launch!(knl_fill_flat!, (dest, val, us), nitems; auto = true)
+        args = (dest, bc, us)
+        threads = threads_via_occupancy(knl_fill!, args)
+        n_max_threads = min(threads, get_N(us))
+        p = partition(dest, n_max_threads)
+        auto_launch!(
+            knl_fill!,
+            args;
+            threads_s = p.threads,
+            blocks_s = p.blocks,
+        )
     end
     return dest
 end
 
-#! format: off
-Base.fill!(dest::IJFH{<:Any, <:Any},         val, ::ToCUDA) = cuda_fill!(dest, val)
-Base.fill!(dest::IFH{<:Any, <:Any},          val, ::ToCUDA) = cuda_fill!(dest, val)
-Base.fill!(dest::IJF{<:Any, <:Any},          val, ::ToCUDA) = cuda_fill!(dest, val)
-Base.fill!(dest::IF{<:Any, <:Any},           val, ::ToCUDA) = cuda_fill!(dest, val)
-Base.fill!(dest::VIFH{<:Any, <:Any, <:Any},  val, ::ToCUDA) = cuda_fill!(dest, val)
-Base.fill!(dest::VIJFH{<:Any, <:Any, <:Any}, val, ::ToCUDA) = cuda_fill!(dest, val)
-Base.fill!(dest::VF{<:Any, <:Any},           val, ::ToCUDA) = cuda_fill!(dest, val)
-Base.fill!(dest::DataF{<:Any},               val, ::ToCUDA) = cuda_fill!(dest, val)
-#! format: on
+Base.fill!(dest::AbstractData, val, ::ToCUDA) = cuda_fill!(dest, val)

--- a/ext/cuda/data_layouts_fused_copyto.jl
+++ b/ext/cuda/data_layouts_fused_copyto.jl
@@ -1,106 +1,59 @@
 Base.@propagate_inbounds function rcopyto_at!(
     pair::Pair{<:AbstractData, <:Any},
     I,
-    v,
+    us,
 )
     dest, bc = pair.first, pair.second
-    if 1 ≤ v <= size(dest, 4)
+    if is_valid_index(dest, I, us)
         dest[I] = isascalar(bc) ? bc[] : bc[I]
     end
     return nothing
 end
-Base.@propagate_inbounds function rcopyto_at!(pair::Pair{<:DataF, <:Any}, I, v)
+Base.@propagate_inbounds function rcopyto_at!(pair::Pair{<:DataF, <:Any}, I, us)
     dest, bc = pair.first, pair.second
-    if 1 ≤ v <= size(dest, 4)
+    if is_valid_index(dest, I, us)
         bcI = isascalar(bc) ? bc[] : bc[I]
         dest[] = bcI
     end
     return nothing
 end
-Base.@propagate_inbounds function rcopyto_at!(pairs::Tuple, I, v)
-    rcopyto_at!(first(pairs), I, v)
-    rcopyto_at!(Base.tail(pairs), I, v)
+Base.@propagate_inbounds function rcopyto_at!(pairs::Tuple, I, us)
+    rcopyto_at!(first(pairs), I, us)
+    rcopyto_at!(Base.tail(pairs), I, us)
 end
-Base.@propagate_inbounds rcopyto_at!(pairs::Tuple{<:Any}, I, v) =
-    rcopyto_at!(first(pairs), I, v)
-@inline rcopyto_at!(pairs::Tuple{}, I, v) = nothing
+Base.@propagate_inbounds rcopyto_at!(pairs::Tuple{<:Any}, I, us) =
+    rcopyto_at!(first(pairs), I, us)
+@inline rcopyto_at!(pairs::Tuple{}, I, us) = nothing
 
-function knl_fused_copyto!(fmbc::FusedMultiBroadcast)
-
+function knl_fused_copyto!(fmbc::FusedMultiBroadcast, dest1, us)
     @inbounds begin
-        i = CUDA.threadIdx().x
-        j = CUDA.threadIdx().y
-
-        h = CUDA.blockIdx().x
-        v = CUDA.blockDim().z * (CUDA.blockIdx().y - 1) + CUDA.threadIdx().z
-        (; pairs) = fmbc
-        I = CartesianIndex((i, j, 1, v, h))
-        rcopyto_at!(pairs, I, v)
+        I = universal_index(dest1)
+        if is_valid_index(dest1, I, us)
+            (; pairs) = fmbc
+            rcopyto_at!(pairs, I, us)
+        end
     end
     return nothing
 end
 
 function fused_copyto!(
     fmbc::FusedMultiBroadcast,
-    dest1::VIJFH{S, Nv, Nij, Nh},
+    dest1::DataLayouts.AbstractData,
     ::ToCUDA,
-) where {S, Nv, Nij, Nh}
+)
+    (_, _, Nv, _, Nh) = DataLayouts.universal_size(dest1)
     if Nv > 0 && Nh > 0
-        Nv_per_block = min(Nv, fld(256, Nij * Nij))
-        Nv_blocks = cld(Nv, Nv_per_block)
+        us = DataLayouts.UniversalSize(dest1)
+        args = (fmbc, dest1, us)
+        threads = threads_via_occupancy(knl_fused_copyto!, args)
+        n_max_threads = min(threads, get_N(us))
+        p = partition(dest1, n_max_threads)
         auto_launch!(
             knl_fused_copyto!,
-            (fmbc,);
-            threads_s = (Nij, Nij, Nv_per_block),
-            blocks_s = (Nh, Nv_blocks),
+            args;
+            threads_s = p.threads,
+            blocks_s = p.blocks,
         )
     end
-    return nothing
-end
-
-function fused_copyto!(
-    fmbc::FusedMultiBroadcast,
-    dest1::IJFH{S, Nij},
-    ::ToCUDA,
-) where {S, Nij}
-    _, _, _, _, Nh = size(dest1)
-    if Nh > 0
-        auto_launch!(
-            knl_fused_copyto!,
-            (fmbc,);
-            threads_s = (Nij, Nij),
-            blocks_s = (Nh, 1),
-        )
-    end
-    return nothing
-end
-function fused_copyto!(
-    fmbc::FusedMultiBroadcast,
-    dest1::VF{S, Nv},
-    ::ToCUDA,
-) where {S, Nv}
-    _, _, _, _, Nh = size(dest1)
-    if Nv > 0 && Nh > 0
-        auto_launch!(
-            knl_fused_copyto!,
-            (fmbc,);
-            threads_s = (1, 1),
-            blocks_s = (Nh, Nv),
-        )
-    end
-    return nothing
-end
-
-function fused_copyto!(
-    fmbc::FusedMultiBroadcast,
-    dest1::DataF{S},
-    ::ToCUDA,
-) where {S}
-    auto_launch!(
-        knl_fused_copyto!,
-        (fmbc,);
-        threads_s = (1, 1),
-        blocks_s = (1, 1),
-    )
     return nothing
 end

--- a/ext/cuda/data_layouts_threadblock.jl
+++ b/ext/cuda/data_layouts_threadblock.jl
@@ -1,0 +1,212 @@
+const CI5 = CartesianIndex{5}
+
+maximum_allowable_threads() = (
+    CUDA.attribute(CUDA.device(), CUDA.DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X),
+    CUDA.attribute(CUDA.device(), CUDA.DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y),
+    CUDA.attribute(CUDA.device(), CUDA.DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z),
+)
+
+"""
+    partition(::AbstractData, n_max_threads)
+
+Given `n_max_threads`, which should be determined
+from CUDA's occupancy API, `partition` returns
+a NamedTuple containing:
+
+ - `threads` size of threads to pass to CUDA
+ - `blocks` size of blocks to pass to CUDA
+
+The general pattern followed here, which seems
+to produce good results, is to satisfy a few
+criteria:
+
+ - Maximize the number of (allowable) threads
+   in the thread partition
+ - The order of the thread partition should
+   follow the fastest changing index in the
+   datalayout (e.g., VIJ in VIJFH)
+"""
+function partition end
+
+"""
+    universal_index(::AbstractData)
+
+Returns a universal cartesian index,
+computed from CUDA's `threadIdx`,
+`blockIdx` and `blockDim`.
+"""
+function universal_index end
+
+"""
+    is_valid_index(::AbstractData, I::CartesianIndex, us::UniversalSize)
+
+Check the minimal number of index
+bounds to ensure that the result of
+`universal_index` is valid.
+"""
+function is_valid_index end
+
+##### VIJFH
+@inline function partition(data::DataLayouts.VIJFH, n_max_threads::Integer)
+    (Nij, _, _, Nv, Nh) = DataLayouts.universal_size(data)
+    Nv_thread = min(Int(fld(n_max_threads, Nij * Nij)), Nv)
+    Nv_blocks = cld(Nv, Nv_thread)
+    @assert prod((Nv_thread, Nij, Nij)) ≤ n_max_threads "threads,n_max_threads=($(prod((Nv_thread, Nij, Nij))),$n_max_threads)"
+    return (; threads = (Nv_thread, Nij, Nij), blocks = (Nv_blocks, Nh))
+end
+@inline function universal_index(::DataLayouts.VIJFH)
+    (tv, i, j) = CUDA.threadIdx()
+    (bv, h) = CUDA.blockIdx()
+    v = tv + (bv - 1) * CUDA.blockDim().x
+    return CartesianIndex((i, j, 1, v, h))
+end
+@inline is_valid_index(::DataLayouts.VIJFH, I::CI5, us::UniversalSize) =
+    1 ≤ I[4] ≤ DataLayouts.get_Nv(us)
+
+##### IJFH
+@inline function partition(data::DataLayouts.IJFH, n_max_threads::Integer)
+    (Nij, _, _, _, Nh) = DataLayouts.universal_size(data)
+    Nh_thread = min(
+        Int(fld(n_max_threads, Nij * Nij)),
+        Nh,
+        maximum_allowable_threads()[3],
+    )
+    Nh_blocks = cld(Nh, Nh_thread)
+    @assert prod((Nij, Nij)) ≤ n_max_threads "threads,n_max_threads=($(prod((Nij, Nij))),$n_max_threads)"
+    return (; threads = (Nij, Nij, Nh_thread), blocks = (Nh_blocks,))
+end
+@inline function universal_index(::DataLayouts.IJFH)
+    (i, j, th) = CUDA.threadIdx()
+    (bh,) = CUDA.blockIdx()
+    h = th + (bh - 1) * CUDA.blockDim().z
+    return CartesianIndex((i, j, 1, 1, h))
+end
+@inline is_valid_index(::DataLayouts.IJFH, I::CI5, us::UniversalSize) =
+    1 ≤ I[5] ≤ DataLayouts.get_Nh(us)
+
+##### IFH
+@inline function partition(data::DataLayouts.IFH, n_max_threads::Integer)
+    (Ni, _, _, _, Nh) = DataLayouts.universal_size(data)
+    Nh_thread = min(Int(fld(n_max_threads, Ni)), Nh)
+    Nh_blocks = cld(Nh, Nh_thread)
+    @assert prod((Ni, Nh_thread)) ≤ n_max_threads "threads,n_max_threads=($(prod((Ni, Nh_thread))),$n_max_threads)"
+    return (; threads = (Ni, Nh_thread), blocks = (Nh_blocks,))
+end
+@inline function universal_index(::DataLayouts.IFH)
+    (i, th) = CUDA.threadIdx()
+    (bh,) = CUDA.blockIdx()
+    h = th + (bh - 1) * CUDA.blockDim().y
+    return CartesianIndex((i, 1, 1, 1, h))
+end
+@inline is_valid_index(::DataLayouts.IFH, I::CI5, us::UniversalSize) =
+    1 ≤ I[5] ≤ DataLayouts.get_Nh(us)
+
+##### IJF
+@inline function partition(data::DataLayouts.IJF, n_max_threads::Integer)
+    (Nij, _, _, _, _) = DataLayouts.universal_size(data)
+    @assert prod((Nij, Nij)) ≤ n_max_threads "threads,n_max_threads=($(prod((Nij, Nij))),$n_max_threads)"
+    return (; threads = (Nij, Nij), blocks = (1,))
+end
+@inline function universal_index(::DataLayouts.IJF)
+    (i, j) = CUDA.threadIdx()
+    return CartesianIndex((i, j, 1, 1, 1))
+end
+@inline is_valid_index(::DataLayouts.IJF, I::CI5, us::UniversalSize) = true
+
+##### IF
+@inline function partition(data::DataLayouts.IF, n_max_threads::Integer)
+    (Ni, _, _, _, _) = DataLayouts.universal_size(data)
+    @assert Ni ≤ n_max_threads "threads,n_max_threads=($(Ni),$n_max_threads)"
+    return (; threads = (Ni,), blocks = (1,))
+end
+@inline function universal_index(::DataLayouts.IF)
+    (i,) = CUDA.threadIdx()
+    return CartesianIndex((i, 1, 1, 1, 1))
+end
+@inline is_valid_index(::DataLayouts.IF, I::CI5, us::UniversalSize) = true
+
+##### VIFH
+@inline function partition(data::DataLayouts.VIFH, n_max_threads::Integer)
+    (Ni, _, _, Nv, Nh) = DataLayouts.universal_size(data)
+    Nv_thread = min(Int(fld(n_max_threads, Ni)), Nv)
+    Nv_blocks = cld(Nv, Nv_thread)
+    @assert prod((Nv_thread, Ni)) ≤ n_max_threads "threads,n_max_threads=($(prod((Nv_thread, Ni))),$n_max_threads)"
+    return (; threads = (Nv_thread, Ni), blocks = (Nv_blocks, Nh))
+end
+@inline function universal_index(::DataLayouts.VIFH)
+    (tv, i) = CUDA.threadIdx()
+    (bv, h) = CUDA.blockIdx()
+    v = tv + (bv - 1) * CUDA.blockDim().x
+    return CartesianIndex((i, 1, 1, v, h))
+end
+@inline is_valid_index(::DataLayouts.VIFH, I::CI5, us::UniversalSize) =
+    1 ≤ I[4] ≤ DataLayouts.get_Nv(us)
+
+##### VF
+@inline function partition(data::DataLayouts.VF, n_max_threads::Integer)
+    (_, _, _, Nv, _) = DataLayouts.universal_size(data)
+    Nvt = fld(n_max_threads, Nv)
+    Nv_thread = Nvt == 0 ? n_max_threads : min(Int(Nvt), Nv)
+    Nv_blocks = cld(Nv, Nv_thread)
+    @assert Nv_thread ≤ n_max_threads "threads,n_max_threads=($(Nv_thread),$n_max_threads)"
+    (; threads = (Nv_thread,), blocks = (Nv_blocks,))
+end
+@inline function universal_index(::DataLayouts.VF)
+    (tv,) = CUDA.threadIdx()
+    (bv,) = CUDA.blockIdx()
+    v = tv + (bv - 1) * CUDA.blockDim().x
+    return CartesianIndex((1, 1, 1, v, 1))
+end
+@inline is_valid_index(::DataLayouts.VF, I::CI5, us::UniversalSize) =
+    1 ≤ I[4] ≤ DataLayouts.get_Nv(us)
+
+##### DataF
+@inline partition(data::DataLayouts.DataF, n_max_threads::Integer) =
+    (; threads = 1, blocks = 1)
+@inline universal_index(::DataLayouts.DataF) = CartesianIndex((1, 1, 1, 1, 1))
+@inline is_valid_index(::DataLayouts.DataF, I::CI5, us::UniversalSize) = true
+
+#####
+##### Custom partitions
+#####
+
+##### Column-wise
+@inline function columnwise_partition(
+    us::DataLayouts.UniversalSize,
+    n_max_threads::Integer,
+)
+    (Nij, _, _, _, Nh) = DataLayouts.universal_size(us)
+    Nh_thread = min(Int(fld(n_max_threads, Nij * Nij)), Nh)
+    Nh_blocks = cld(Nh, Nh_thread)
+    @assert prod((Nij, Nij, Nh_thread)) ≤ n_max_threads "threads,n_max_threads=($(prod((Nij, Nij, Nh_thread))),$n_max_threads)"
+    return (; threads = (Nij, Nij, Nh_thread), blocks = (Nh_blocks,))
+end
+@inline function columnwise_universal_index()
+    (i, j, th) = CUDA.threadIdx()
+    (bh,) = CUDA.blockIdx()
+    h = th + (bh - 1) * CUDA.blockDim().z
+    return CartesianIndex((i, j, 1, 1, h))
+end
+@inline columnwise_is_valid_index(I::CI5, us::UniversalSize) =
+    1 ≤ I[5] ≤ DataLayouts.get_Nh(us)
+
+##### Element-wise (e.g., limiters)
+# TODO
+
+##### Multiple-field solve partition
+@inline function multiple_field_solve_partition(
+    us::DataLayouts.UniversalSize,
+    n_max_threads::Integer;
+    Nnames,
+)
+    (Nij, _, _, _, Nh) = DataLayouts.universal_size(us)
+    @assert prod((Nij, Nij, Nnames)) ≤ n_max_threads "threads,n_max_threads=($(prod((Nij, Nij, Nnames))),$n_max_threads)"
+    return (; threads = (Nij, Nij, Nnames), blocks = (Nh,))
+end
+@inline function multiple_field_solve_universal_index()
+    (i, j, iname) = CUDA.threadIdx()
+    (h,) = CUDA.blockIdx()
+    return (CartesianIndex((i, j, 1, 1, h)), iname)
+end
+@inline multiple_field_solve_is_valid_index(I::CI5, us::UniversalSize) =
+    1 ≤ I[5] ≤ DataLayouts.get_Nh(us)

--- a/ext/cuda/matrix_fields_single_field_solve.jl
+++ b/ext/cuda/matrix_fields_single_field_solve.jl
@@ -15,24 +15,24 @@ import ClimaCore.RecursiveApply: ⊠, ⊞, ⊟, rmap, rzero, rdiv
 
 function single_field_solve!(device::ClimaComms.CUDADevice, cache, x, A, b)
     Ni, Nj, _, _, Nh = size(Fields.field_values(A))
+    us = UniversalSize(Fields.field_values(A))
+    args = (device, cache, x, A, b, us)
+    threads = threads_via_occupancy(single_field_solve_kernel!, args)
     nitems = Ni * Nj * Nh
-    nthreads = min(256, nitems)
-    nblocks = cld(nitems, nthreads)
-    args = (device, cache, x, A, b)
+    n_max_threads = min(threads, nitems)
+    p = columnwise_partition(us, n_max_threads)
     auto_launch!(
         single_field_solve_kernel!,
         args;
-        threads_s = nthreads,
-        blocks_s = nblocks,
+        threads_s = p.threads,
+        blocks_s = p.blocks,
     )
 end
 
-function single_field_solve_kernel!(device, cache, x, A, b)
-    idx = CUDA.threadIdx().x + (CUDA.blockIdx().x - 1) * CUDA.blockDim().x
-    Ni, Nj, _, _, Nh = size(Fields.field_values(A))
-    if idx <= Ni * Nj * Nh
-        (i, j, h) = CartesianIndices((1:Ni, 1:Nj, 1:Nh))[idx].I
-
+function single_field_solve_kernel!(device, cache, x, A, b, us)
+    I = columnwise_universal_index()
+    if columnwise_is_valid_index(I, us)
+        (i, j, _, _, h) = I.I
         _single_field_solve!(
             device,
             Spaces.column(cache, i, j, h),

--- a/test/Fields/benchmark_field_multi_broadcast_fusion.jl
+++ b/test/Fields/benchmark_field_multi_broadcast_fusion.jl
@@ -11,8 +11,9 @@ include("utils_field_multi_broadcast_fusion.jl")
     device = ClimaComms.device()
     space = TU.CenterExtrudedFiniteDifferenceSpace(
         FT;
-        zelem = 3,
-        helem = 4,
+        zelem = 63,
+        helem = 30,
+        Nq = 4,
         context = ClimaComms.context(device),
     )
     X = Fields.FieldVector(
@@ -43,8 +44,9 @@ end
     if device isa ClimaComms.CPUSingleThreaded
         space = CenterExtrudedFiniteDifferenceSpaceLineHSpace(
             FT;
-            zelem = 3,
-            helem = 4,
+            zelem = 63,
+            helem = 30,
+            Nq = 4,
             context = ClimaComms.context(device),
         )
         X = Fields.FieldVector(
@@ -101,7 +103,7 @@ end
     device = ClimaComms.device()
     colspace = TU.ColumnCenterFiniteDifferenceSpace(
         FT;
-        zelem = 3,
+        zelem = 63,
         context = ClimaComms.context(device),
     )
     VF_data() = Fields.Field(FT, colspace)


### PR DESCRIPTION
Based on comparing #1963 against our main branch, this PR removes conversions from linear to cartesian indexes, and instead uses partitioned thread-block configurations in order to improve the performance of some kernels. xref: https://github.com/JuliaGPU/KernelAbstractions.jl/issues/470.

Also, these launch configurations all start with using CUDA's occupancy API, in order to get a safer bound on how many threads to use. I've seen some errors due to launching kernels with too many threads on the main branch (in some of the builds from this PR).

I'll try making the comparison easier, but for now I'm going to just paste the results:

## Main

### fill!
```
N reads-writes: 1, N-reps: 10000,  Float_type = Float64, Device_bandwidth_GBs=2039
┌───────┬──────────────────────────────────┬─────────────┬─────────────┬─────────────────────┐
│ funcs │ time per call                    │ bw %        │ achieved bw │ problem size        │
├───────┼──────────────────────────────────┼─────────────┼─────────────┼─────────────────────┤
│ DataF │ 10 microseconds, 651 nanoseconds │ 3.43102e-5  │ 0.000699585 │ (1, 1, 1, 1, 1)     │
│ IJFH  │ 12 microseconds, 51 nanoseconds  │ 2.61999     │ 53.4216     │ (4, 4, 1, 1, 5400)  │
│ IFH   │ 11 microseconds, 310 nanoseconds │ 0.697853    │ 14.2292     │ (4, 1, 1, 1, 5400)  │
│ IJF   │ 10 microseconds, 440 nanoseconds │ 0.000560059 │ 0.0114196   │ (4, 4, 1, 1, 1)     │
│ IF    │ 10 microseconds, 900 nanoseconds │ 0.000134093 │ 0.00273416  │ (4, 1, 1, 1, 1)     │
│ VF    │ 10 microseconds, 960 nanoseconds │ 0.0021004   │ 0.0428272   │ (1, 1, 1, 63, 1)    │
│ VIJFH │ 73 microseconds, 639 nanoseconds │ 27.0097     │ 550.727     │ (4, 4, 1, 63, 5400) │
│ VIFH  │ 18 microseconds, 620 nanoseconds │ 26.7047     │ 544.509     │ (4, 1, 1, 63, 5400) │
└───────┴──────────────────────────────────┴─────────────┴─────────────┴─────────────────────┘
N reads-writes: 1, N-reps: 10000,  Float_type = Float32, Device_bandwidth_GBs=2039
┌───────┬──────────────────────────────────┬────────────┬─────────────┬─────────────────────┐
│ funcs │ time per call                    │ bw %       │ achieved bw │ problem size        │
├───────┼──────────────────────────────────┼────────────┼─────────────┼─────────────────────┤
│ DataF │ 10 microseconds, 710 nanoseconds │ 1.7059e-5  │ 0.000347833 │ (1, 1, 1, 1, 1)     │
│ IJFH  │ 12 microseconds, 251 nanoseconds │ 1.28861    │ 26.2747     │ (4, 4, 1, 1, 5400)  │
│ IFH   │ 11 microseconds, 760 nanoseconds │ 0.335575   │ 6.84237     │ (4, 1, 1, 1, 5400)  │
│ IJF   │ 10 microseconds, 410 nanoseconds │ 0.00028081 │ 0.00572571  │ (4, 4, 1, 1, 1)     │
│ IF    │ 10 microseconds, 410 nanoseconds │ 7.02024e-5 │ 0.00143143  │ (4, 1, 1, 1, 1)     │
│ VF    │ 11 microseconds, 90 nanoseconds  │ 0.00103789 │ 0.0211626   │ (1, 1, 1, 63, 1)    │
│ VIJFH │ 53 microseconds, 541 nanoseconds │ 18.5746    │ 378.736     │ (4, 4, 1, 63, 5400) │
│ VIFH  │ 17 microseconds, 141 nanoseconds │ 14.5053    │ 295.763     │ (4, 1, 1, 63, 5400) │
└───────┴──────────────────────────────────┴────────────┴─────────────┴─────────────────────┘
```
### copyto!
```
N reads-writes: 2, N-reps: 10000,  Float_type = Float64, Device_bandwidth_GBs=2039
┌───────┬───────────────────────────────────┬────────────┬─────────────┬─────────────────────┐
│ funcs │ time per call                     │ bw %       │ achieved bw │ problem size        │
├───────┼───────────────────────────────────┼────────────┼─────────────┼─────────────────────┤
│ DataF │ 11 microseconds, 970 nanoseconds  │ 6.10532e-5 │ 0.00124488  │ (1, 1, 1, 1, 1)     │
│ IJFH  │ 18 microseconds, 459 nanoseconds  │ 3.42065    │ 69.747      │ (4, 4, 1, 1, 5400)  │
│ IFH   │ 13 microseconds, 560 nanoseconds  │ 1.16412    │ 23.7364     │ (4, 1, 1, 1, 5400)  │
│ VF    │ 12 microseconds, 900 nanoseconds  │ 0.00356934 │ 0.0727788   │ (1, 1, 1, 63, 1)    │
│ VIJFH │ 114 microseconds, 770 nanoseconds │ 34.6603    │ 706.724     │ (4, 4, 1, 63, 5400) │
│ VIFH  │ 22 microseconds, 900 nanoseconds  │ 43.4272    │ 885.48      │ (4, 1, 1, 63, 5400) │
└───────┴───────────────────────────────────┴────────────┴─────────────┴─────────────────────┘
N reads-writes: 2, N-reps: 10000,  Float_type = Float32, Device_bandwidth_GBs=2039
┌───────┬──────────────────────────────────┬────────────┬─────────────┬─────────────────────┐
│ funcs │ time per call                    │ bw %       │ achieved bw │ problem size        │
├───────┼──────────────────────────────────┼────────────┼─────────────┼─────────────────────┤
│ DataF │ 12 microseconds, 941 nanoseconds │ 2.82383e-5 │ 0.000575779 │ (1, 1, 1, 1, 1)     │
│ IJFH  │ 18 microseconds, 490 nanoseconds │ 1.70746    │ 34.815      │ (4, 4, 1, 1, 5400)  │
│ IFH   │ 13 microseconds, 329 nanoseconds │ 0.592146   │ 12.0739     │ (4, 1, 1, 1, 5400)  │
│ VF    │ 12 microseconds, 971 nanoseconds │ 0.0017749  │ 0.0361902   │ (1, 1, 1, 63, 1)    │
│ VIJFH │ 68 microseconds, 559 nanoseconds │ 29.011     │ 591.534     │ (4, 4, 1, 63, 5400) │
│ VIFH  │ 21 microseconds, 630 nanoseconds │ 22.9885    │ 468.736     │ (4, 1, 1, 63, 5400) │
└───────┴──────────────────────────────────┴────────────┴─────────────┴─────────────────────┘
```
### stencils
```
Problem size: (1, 1, 1, 63, 1), N-reps: 1,  Float_type = Float64, Device_bandwidth_GBs=2039
┌───────────────────────────────────────────────────────────────┬──────────────────────────────────┬─────────────┬─────────────┬────────────────┐
│ funcs                                                         │ time per call                    │ bw %        │ achieved bw │ N reads-writes │
├───────────────────────────────────────────────────────────────┼──────────────────────────────────┼─────────────┼─────────────┼────────────────┤
│ (op_GradientF2C!, :none)                                      │ 13 microseconds, 451 nanoseconds │ 0.00342311  │ 0.0697973   │ 2              │
│ (op_GradientF2C!, :SetValue, :SetValue)                       │ 14 microseconds, 31 nanoseconds  │ 0.0032816   │ 0.0669118   │ 2              │
│ (op_GradientC2F!, :SetGradient, :SetGradient)                 │ 14 microseconds, 191 nanoseconds │ 0.0032446   │ 0.0661574   │ 2              │
│ (op_GradientC2F!, :SetValue, :SetValue)                       │ 13 microseconds, 801 nanoseconds │ 0.00333629  │ 0.068027    │ 2              │
│ (op_DivergenceF2C!, :none)                                    │ 13 microseconds, 740 nanoseconds │ 0.00502629  │ 0.102486    │ 3              │
│ (op_DivergenceF2C!, :Extrapolate, :Extrapolate)               │ 14 microseconds, 201 nanoseconds │ 0.00486347  │ 0.0991662   │ 3              │
│ (op_DivergenceC2F!, :SetDivergence, :SetDivergence)           │ 13 microseconds, 990 nanoseconds │ 0.00493683  │ 0.100662    │ 3              │
│ (op_InterpolateF2C!, :none)                                   │ 13 microseconds, 580 nanoseconds │ 0.00339034  │ 0.0691291   │ 2              │
│ (op_InterpolateC2F!, :SetValue, :SetValue)                    │ 13 microseconds, 890 nanoseconds │ 0.00331468  │ 0.0675863   │ 2              │
│ (op_InterpolateC2F!, :Extrapolate, :Extrapolate)              │ 13 microseconds, 871 nanoseconds │ 0.00331946  │ 0.0676837   │ 2              │
│ (op_broadcast_example2!, :none)                               │ 12 microseconds, 500 nanoseconds │ 0.00736654  │ 0.150204    │ 4              │
│ (op_LeftBiasedC2F!, :SetValue)                                │ 13 microseconds, 479 nanoseconds │ 0.00341575  │ 0.0696471   │ 2              │
│ (op_LeftBiasedF2C!, :none)                                    │ 13 microseconds, 410 nanoseconds │ 0.00343332  │ 0.0700055   │ 2              │
│ (op_LeftBiasedF2C!, :SetValue)                                │ 13 microseconds, 720 nanoseconds │ 0.00335575  │ 0.0684237   │ 2              │
│ (op_RightBiasedC2F!, :SetValue)                               │ 13 microseconds, 801 nanoseconds │ 0.00333629  │ 0.068027    │ 2              │
│ (op_RightBiasedF2C!, :none)                                   │ 13 microseconds, 631 nanoseconds │ 0.00337791  │ 0.0688755   │ 2              │
│ (op_RightBiasedF2C!, :SetValue)                               │ 13 microseconds, 709 nanoseconds │ 0.00335844  │ 0.0684786   │ 2              │
│ (op_divgrad_CC!, :SetValue, :SetValue, :none)                 │ 14 microseconds, 941 nanoseconds │ 0.00462258  │ 0.0942543   │ 3              │
│ (op_divgrad_FF!, :none, :SetDivergence, :SetDivergence)       │ 13 microseconds, 631 nanoseconds │ 0.00506686  │ 0.103313    │ 3              │
└───────────────────────────────────────────────────────────────┴──────────────────────────────────┴─────────────┴─────────────┴────────────────┘
Problem size: (4, 4, 1, 63, 5400), N-reps: 1,  Float_type = Float64, Device_bandwidth_GBs=2039
┌───────────────────────────────────────────────────────────────┬───────────────────────────────────┬──────────┬─────────────┬────────────────┐
│ funcs                                                         │ time per call                     │ bw %     │ achieved bw │ N reads-writes │
├───────────────────────────────────────────────────────────────┼───────────────────────────────────┼──────────┼─────────────┼────────────────┤
│ (op_GradientF2C!, :none)                                      │ 67 microseconds, 610 nanoseconds  │ 58.8373  │ 1199.69     │ 2              │
│ (op_GradientF2C!, :SetValue, :SetValue)                       │ 93 microseconds, 840 nanoseconds  │ 42.391   │ 864.353     │ 2              │
│ (op_GradientC2F!, :SetGradient, :SetGradient)                 │ 101 microseconds, 220 nanoseconds │ 39.3002  │ 801.332     │ 2              │
│ (op_GradientC2F!, :SetValue, :SetValue)                       │ 87 microseconds, 750 nanoseconds  │ 45.3325  │ 924.33      │ 2              │
│ (op_DivergenceF2C!, :none)                                    │ 202 microseconds, 548 nanoseconds │ 29.4592  │ 600.672     │ 3              │
│ (op_DivergenceF2C!, :Extrapolate, :Extrapolate)               │ 260 microseconds, 169 nanoseconds │ 22.9348  │ 467.64      │ 3              │
│ (op_DivergenceC2F!, :SetDivergence, :SetDivergence)           │ 191 microseconds, 289 nanoseconds │ 31.1931  │ 636.027     │ 3              │
│ (op_InterpolateF2C!, :none)                                   │ 67 microseconds, 570 nanoseconds  │ 58.8713  │ 1200.38     │ 2              │
│ (op_InterpolateC2F!, :SetValue, :SetValue)                    │ 70 microseconds, 140 nanoseconds  │ 56.7141  │ 1156.4      │ 2              │
│ (op_InterpolateC2F!, :Extrapolate, :Extrapolate)              │ 78 microseconds, 459 nanoseconds  │ 50.7008  │ 1033.79     │ 2              │
│ (op_broadcast_example0!, :none)                               │ 129 microseconds, 829 nanoseconds │ 45.9597  │ 937.117     │ 3              │
│ (op_broadcast_example1!, :none)                               │ 248 microseconds, 288 nanoseconds │ 32.0429  │ 653.354     │ 4              │
│ (op_broadcast_example2!, :none)                               │ 248 microseconds, 158 nanoseconds │ 32.0597  │ 653.696     │ 4              │
│ (op_LeftBiasedC2F!, :SetValue)                                │ 66 microseconds, 850 nanoseconds  │ 59.5062  │ 1213.33     │ 2              │
│ (op_LeftBiasedF2C!, :none)                                    │ 66 microseconds, 579 nanoseconds  │ 59.7475  │ 1218.25     │ 2              │
│ (op_LeftBiasedF2C!, :SetValue)                                │ 68 microseconds, 119 nanoseconds  │ 58.3968  │ 1190.71     │ 2              │
│ (op_RightBiasedC2F!, :SetValue)                               │ 67 microseconds, 20 nanoseconds   │ 59.3544  │ 1210.24     │ 2              │
│ (op_RightBiasedF2C!, :none)                                   │ 66 microseconds, 469 nanoseconds  │ 59.8464  │ 1220.27     │ 2              │
│ (op_RightBiasedF2C!, :SetValue)                               │ 68 microseconds, 700 nanoseconds  │ 57.9029  │ 1180.64     │ 2              │
│ (op_divgrad_CC!, :SetValue, :SetValue, :none)                 │ 437 microseconds, 307 nanoseconds │ 13.6446  │ 278.214     │ 3              │
│ (op_divgrad_FF!, :none, :SetDivergence, :SetDivergence)       │ 143 microseconds, 478 nanoseconds │ 41.5875  │ 847.97      │ 3              │
└───────────────────────────────────────────────────────────────┴───────────────────────────────────┴──────────┴─────────────┴────────────────┘
Problem size: (4, 4, 1, 63, 5400), N-reps: 1,  Float_type = Float32, Device_bandwidth_GBs=2039
┌───────────────────────────────────────────────────────────────┬───────────────────────────────────┬──────────┬─────────────┬────────────────┐
│ funcs                                                         │ time per call                     │ bw %     │ achieved bw │ N reads-writes │
├───────────────────────────────────────────────────────────────┼───────────────────────────────────┼──────────┼─────────────┼────────────────┤
│ (op_GradientF2C!, :none)                                      │ 62 microseconds, 569 nanoseconds  │ 31.7883  │ 648.164     │ 2              │
│ (op_GradientF2C!, :SetValue, :SetValue)                       │ 86 microseconds, 931 nanoseconds  │ 22.8801  │ 466.525     │ 2              │
│ (op_GradientC2F!, :SetGradient, :SetGradient)                 │ 92 microseconds, 740 nanoseconds  │ 21.4469  │ 437.303     │ 2              │
│ (op_GradientC2F!, :SetValue, :SetValue)                       │ 81 microseconds, 360 nanoseconds  │ 24.4465  │ 498.464     │ 2              │
│ (op_DivergenceF2C!, :none)                                    │ 119 microseconds, 759 nanoseconds │ 24.9121  │ 507.958     │ 3              │
│ (op_DivergenceF2C!, :Extrapolate, :Extrapolate)               │ 224 microseconds, 729 nanoseconds │ 13.2758  │ 270.694     │ 3              │
│ (op_DivergenceC2F!, :SetDivergence, :SetDivergence)           │ 129 microseconds, 610 nanoseconds │ 23.0188  │ 469.354     │ 3              │
│ (op_InterpolateF2C!, :none)                                   │ 62 microseconds, 160 nanoseconds  │ 31.9975  │ 652.429     │ 2              │
│ (op_InterpolateC2F!, :SetValue, :SetValue)                    │ 64 microseconds, 470 nanoseconds  │ 30.8515  │ 629.062     │ 2              │
│ (op_InterpolateC2F!, :Extrapolate, :Extrapolate)              │ 77 microseconds, 920 nanoseconds  │ 25.5257  │ 520.47      │ 2              │
│ (op_broadcast_example0!, :none)                               │ 75 microseconds, 70 nanoseconds   │ 39.7427  │ 810.354     │ 3              │
│ (op_broadcast_example1!, :none)                               │ 134 microseconds, 119 nanoseconds │ 29.6597  │ 604.761     │ 4              │
│ (op_broadcast_example2!, :none)                               │ 134 microseconds, 769 nanoseconds │ 29.5167  │ 601.845     │ 4              │
│ (op_LeftBiasedC2F!, :SetValue)                                │ 58 microseconds, 701 nanoseconds  │ 33.8836  │ 690.886     │ 2              │
│ (op_LeftBiasedF2C!, :none)                                    │ 60 microseconds, 410 nanoseconds  │ 32.925   │ 671.34      │ 2              │
│ (op_LeftBiasedF2C!, :SetValue)                                │ 62 microseconds, 541 nanoseconds  │ 31.8031  │ 648.465     │ 2              │
│ (op_RightBiasedC2F!, :SetValue)                               │ 61 microseconds, 250 nanoseconds  │ 32.4734  │ 662.133     │ 2              │
│ (op_RightBiasedF2C!, :none)                                   │ 57 microseconds, 510 nanoseconds  │ 34.5847  │ 705.182     │ 2              │
│ (op_RightBiasedF2C!, :SetValue)                               │ 64 microseconds, 330 nanoseconds  │ 30.9182  │ 630.421     │ 2              │
│ (op_divgrad_CC!, :SetValue, :SetValue, :none)                 │ 281 microseconds, 118 nanoseconds │ 10.6128  │ 216.395     │ 3              │
│ (op_divgrad_FF!, :none, :SetDivergence, :SetDivergence)       │ 115 microseconds, 300 nanoseconds │ 25.8757  │ 527.606     │ 3              │
└───────────────────────────────────────────────────────────────┴───────────────────────────────────┴──────────┴─────────────┴────────────────┘
```

## This PR

### fill!
```
N reads-writes: 1, N-reps: 10000,  Float_type = Float64, Device_bandwidth_GBs=2039
┌───────┬──────────────────────────────────┬─────────────┬─────────────┬─────────────────────┐
│ funcs │ time per call                    │ bw %        │ achieved bw │ problem size        │
├───────┼──────────────────────────────────┼─────────────┼─────────────┼─────────────────────┤
│ DataF │ 10 microseconds, 641 nanoseconds │ 3.43424e-5  │ 0.000700243 │ (1, 1, 1, 1, 1)     │
│ IJFH  │ 11 microseconds, 901 nanoseconds │ 2.65301     │ 54.095      │ (4, 4, 1, 1, 5400)  │
│ IFH   │ 11 microseconds, 719 nanoseconds │ 0.673498    │ 13.7326     │ (4, 1, 1, 1, 5400)  │
│ IJF   │ 10 microseconds, 980 nanoseconds │ 0.000532464 │ 0.0108569   │ (4, 4, 1, 1, 1)     │
│ IF    │ 10 microseconds, 930 nanoseconds │ 0.000133725 │ 0.00272665  │ (4, 1, 1, 1, 1)     │
│ VF    │ 10 microseconds, 950 nanoseconds │ 0.00210232  │ 0.0428664   │ (1, 1, 1, 63, 1)    │
│ VIJFH │ 35 microseconds, 270 nanoseconds │ 56.3925     │ 1149.84     │ (4, 4, 1, 63, 5400) │
│ VIFH  │ 15 microseconds, 111 nanoseconds │ 32.9081     │ 670.996     │ (4, 1, 1, 63, 5400) │
└───────┴──────────────────────────────────┴─────────────┴─────────────┴─────────────────────┘
N reads-writes: 1, N-reps: 10000,  Float_type = Float32, Device_bandwidth_GBs=2039
┌───────┬──────────────────────────────────┬─────────────┬─────────────┬─────────────────────┐
│ funcs │ time per call                    │ bw %        │ achieved bw │ problem size        │
├───────┼──────────────────────────────────┼─────────────┼─────────────┼─────────────────────┤
│ DataF │ 11 microseconds, 21 nanoseconds  │ 1.65791e-5  │ 0.000338048 │ (1, 1, 1, 1, 1)     │
│ IJFH  │ 11 microseconds, 820 nanoseconds │ 1.33549     │ 27.2305     │ (4, 4, 1, 1, 5400)  │
│ IFH   │ 11 microseconds, 800 nanoseconds │ 0.334437    │ 6.81918     │ (4, 1, 1, 1, 5400)  │
│ IJF   │ 11 microseconds, 130 nanoseconds │ 0.000262644 │ 0.00535531  │ (4, 4, 1, 1, 1)     │
│ IF    │ 10 microseconds, 861 nanoseconds │ 6.72935e-5  │ 0.00137211  │ (4, 1, 1, 1, 1)     │
│ VF    │ 10 microseconds, 910 nanoseconds │ 0.00105502  │ 0.0215118   │ (1, 1, 1, 63, 1)    │
│ VIJFH │ 31 microseconds, 491 nanoseconds │ 31.5809     │ 643.935     │ (4, 4, 1, 63, 5400) │
│ VIFH  │ 15 microseconds                  │ 16.5747     │ 337.958     │ (4, 1, 1, 63, 5400) │
└───────┴──────────────────────────────────┴─────────────┴─────────────┴─────────────────────┘
```
### copyto!
```
N reads-writes: 2, N-reps: 10000,  Float_type = Float64, Device_bandwidth_GBs=2039
┌───────┬──────────────────────────────────┬────────────┬─────────────┬─────────────────────┐
│ funcs │ time per call                    │ bw %       │ achieved bw │ problem size        │
├───────┼──────────────────────────────────┼────────────┼─────────────┼─────────────────────┤
│ DataF │ 11 microseconds, 840 nanoseconds │ 6.17236e-5 │ 0.00125854  │ (1, 1, 1, 1, 1)     │
│ IJFH  │ 13 microseconds, 631 nanoseconds │ 4.63256    │ 94.4578     │ (4, 4, 1, 1, 5400)  │
│ IFH   │ 12 microseconds, 271 nanoseconds │ 1.28651    │ 26.2319     │ (4, 1, 1, 1, 5400)  │
│ VF    │ 12 microseconds, 560 nanoseconds │ 0.00366567 │ 0.0747431   │ (1, 1, 1, 63, 1)    │
│ VIJFH │ 62 microseconds, 181 nanoseconds │ 63.9744    │ 1304.44     │ (4, 4, 1, 63, 5400) │
│ VIFH  │ 19 microseconds, 409 nanoseconds │ 51.2382    │ 1044.75     │ (4, 1, 1, 63, 5400) │
└───────┴──────────────────────────────────┴────────────┴─────────────┴─────────────────────┘
N reads-writes: 2, N-reps: 10000,  Float_type = Float32, Device_bandwidth_GBs=2039
┌───────┬──────────────────────────────────┬────────────┬─────────────┬─────────────────────┐
│ funcs │ time per call                    │ bw %       │ achieved bw │ problem size        │
├───────┼──────────────────────────────────┼────────────┼─────────────┼─────────────────────┤
│ DataF │ 12 microseconds, 160 nanoseconds │ 3.00496e-5 │ 0.000612712 │ (1, 1, 1, 1, 1)     │
│ IJFH  │ 13 microseconds, 501 nanoseconds │ 2.33858    │ 47.6837     │ (4, 4, 1, 1, 5400)  │
│ IFH   │ 12 microseconds, 111 nanoseconds │ 0.651752   │ 13.2892     │ (4, 1, 1, 1, 5400)  │
│ VF    │ 11 microseconds, 901 nanoseconds │ 0.00193449 │ 0.0394443   │ (1, 1, 1, 63, 1)    │
│ VIJFH │ 47 microseconds, 9 nanoseconds   │ 42.3103    │ 862.707     │ (4, 4, 1, 63, 5400) │
│ VIFH  │ 19 microseconds, 80 nanoseconds  │ 26.0609    │ 531.381     │ (4, 1, 1, 63, 5400) │
└───────┴──────────────────────────────────┴────────────┴─────────────┴─────────────────────┘
```
### stencils
```
Problem size: (1, 1, 1, 63, 1), N-reps: 1,  Float_type = Float64, Device_bandwidth_GBs=2039
┌───────────────────────────────────────────────────────────────┬──────────────────────────────────┬─────────────┬─────────────┬────────────────┐
│ funcs                                                         │ time per call                    │ bw %        │ achieved bw │ N reads-writes │
├───────────────────────────────────────────────────────────────┼──────────────────────────────────┼─────────────┼─────────────┼────────────────┤
│ (op_GradientF2C!, :none)                                      │ 13 microseconds, 321 nanoseconds │ 0.00345652  │ 0.0704785   │ 2              │
│ (op_GradientF2C!, :SetValue, :SetValue)                       │ 13 microseconds, 851 nanoseconds │ 0.00332425  │ 0.0677815   │ 2              │
│ (op_GradientC2F!, :SetGradient, :SetGradient)                 │ 13 microseconds, 960 nanoseconds │ 0.00329806  │ 0.0672474   │ 2              │
│ (op_GradientC2F!, :SetValue, :SetValue)                       │ 14 microseconds, 51 nanoseconds  │ 0.00327693  │ 0.0668166   │ 2              │
│ (op_DivergenceF2C!, :none)                                    │ 13 microseconds, 681 nanoseconds │ 0.00504834  │ 0.102936    │ 3              │
│ (op_DivergenceF2C!, :Extrapolate, :Extrapolate)               │ 13 microseconds, 970 nanoseconds │ 0.00494354  │ 0.100799    │ 3              │
│ (op_DivergenceC2F!, :SetDivergence, :SetDivergence)           │ 13 microseconds, 780 nanoseconds │ 0.0050117   │ 0.102189    │ 3              │
│ (op_InterpolateF2C!, :none)                                   │ 13 microseconds, 331 nanoseconds │ 0.00345393  │ 0.0704256   │ 2              │
│ (op_InterpolateC2F!, :SetValue, :SetValue)                    │ 13 microseconds, 631 nanoseconds │ 0.00337791  │ 0.0688755   │ 2              │
│ (op_InterpolateC2F!, :Extrapolate, :Extrapolate)              │ 13 microseconds, 550 nanoseconds │ 0.00339785  │ 0.0692822   │ 2              │
│ (op_broadcast_example2!, :none)                               │ 13 microseconds, 20 nanoseconds  │ 0.00707233  │ 0.144205    │ 4              │
│ (op_LeftBiasedC2F!, :SetValue)                                │ 13 microseconds, 530 nanoseconds │ 0.00340287  │ 0.0693846   │ 2              │
│ (op_LeftBiasedF2C!, :none)                                    │ 13 microseconds, 370 nanoseconds │ 0.00344359  │ 0.0702149   │ 2              │
│ (op_LeftBiasedF2C!, :SetValue)                                │ 13 microseconds, 450 nanoseconds │ 0.00342337  │ 0.0698025   │ 2              │
│ (op_RightBiasedC2F!, :SetValue)                               │ 13 microseconds, 440 nanoseconds │ 0.00342566  │ 0.0698492   │ 2              │
│ (op_RightBiasedF2C!, :none)                                   │ 12 microseconds, 601 nanoseconds │ 0.00365404  │ 0.0745058   │ 2              │
│ (op_RightBiasedF2C!, :SetValue)                               │ 13 microseconds, 529 nanoseconds │ 0.00340312  │ 0.0693897   │ 2              │
│ (op_divgrad_CC!, :SetValue, :SetValue, :none)                 │ 14 microseconds, 181 nanoseconds │ 0.00487033  │ 0.099306    │ 3              │
│ (op_divgrad_FF!, :none, :SetDivergence, :SetDivergence)       │ 13 microseconds, 710 nanoseconds │ 0.00503729  │ 0.10271     │ 3              │
└───────────────────────────────────────────────────────────────┴──────────────────────────────────┴─────────────┴─────────────┴────────────────┘
Problem size: (4, 4, 1, 63, 5400), N-reps: 1,  Float_type = Float64, Device_bandwidth_GBs=2039
┌───────────────────────────────────────────────────────────────┬───────────────────────────────────┬──────────┬─────────────┬────────────────┐
│ funcs                                                         │ time per call                     │ bw %     │ achieved bw │ N reads-writes │
├───────────────────────────────────────────────────────────────┼───────────────────────────────────┼──────────┼─────────────┼────────────────┤
│ (op_GradientF2C!, :none)                                      │ 68 microseconds, 669 nanoseconds  │ 57.9291  │ 1181.17     │ 2              │
│ (op_GradientF2C!, :SetValue, :SetValue)                       │ 80 microseconds, 229 nanoseconds  │ 49.5822  │ 1010.98     │ 2              │
│ (op_GradientC2F!, :SetGradient, :SetGradient)                 │ 92 microseconds, 329 nanoseconds  │ 43.0843  │ 878.489     │ 2              │
│ (op_GradientC2F!, :SetValue, :SetValue)                       │ 80 microseconds, 90 nanoseconds   │ 49.6683  │ 1012.74     │ 2              │
│ (op_DivergenceF2C!, :none)                                    │ 203 microseconds, 498 nanoseconds │ 29.3216  │ 597.868     │ 3              │
│ (op_DivergenceF2C!, :Extrapolate, :Extrapolate)               │ 216 microseconds, 259 nanoseconds │ 27.5916  │ 562.592     │ 3              │
│ (op_DivergenceC2F!, :SetDivergence, :SetDivergence)           │ 197 microseconds, 838 nanoseconds │ 30.1605  │ 614.973     │ 3              │
│ (op_InterpolateF2C!, :none)                                   │ 68 microseconds, 429 nanoseconds  │ 58.1322  │ 1185.32     │ 2              │
│ (op_InterpolateC2F!, :SetValue, :SetValue)                    │ 71 microseconds, 69 nanoseconds   │ 55.9728  │ 1141.29     │ 2              │
│ (op_InterpolateC2F!, :Extrapolate, :Extrapolate)              │ 74 microseconds, 249 nanoseconds  │ 53.5755  │ 1092.41     │ 2              │
│ (op_broadcast_example0!, :none)                               │ 69 microseconds, 829 nanoseconds  │ 85.4501  │ 1742.33     │ 3              │
│ (op_broadcast_example1!, :none)                               │ 165 microseconds, 438 nanoseconds │ 48.0897  │ 980.549     │ 4              │
│ (op_broadcast_example2!, :none)                               │ 164 microseconds, 739 nanoseconds │ 48.294   │ 984.715     │ 4              │
│ (op_LeftBiasedC2F!, :SetValue)                                │ 67 microseconds, 589 nanoseconds  │ 58.8547  │ 1200.05     │ 2              │
│ (op_LeftBiasedF2C!, :none)                                    │ 68 microseconds, 69 nanoseconds   │ 58.4397  │ 1191.59     │ 2              │
│ (op_LeftBiasedF2C!, :SetValue)                                │ 68 microseconds, 769 nanoseconds  │ 57.8448  │ 1179.46     │ 2              │
│ (op_RightBiasedC2F!, :SetValue)                               │ 67 microseconds, 839 nanoseconds  │ 58.6378  │ 1195.62     │ 2              │
│ (op_RightBiasedF2C!, :none)                                   │ 68 microseconds, 689 nanoseconds  │ 57.9122  │ 1180.83     │ 2              │
│ (op_RightBiasedF2C!, :SetValue)                               │ 69 microseconds, 730 nanoseconds  │ 57.0484  │ 1163.22     │ 2              │
│ (op_divgrad_CC!, :SetValue, :SetValue, :none)                 │ 288 microseconds, 927 nanoseconds │ 20.6519  │ 421.093     │ 3              │
│ (op_divgrad_FF!, :none, :SetDivergence, :SetDivergence)       │ 145 microseconds, 699 nanoseconds │ 40.9536  │ 835.043     │ 3              │
└───────────────────────────────────────────────────────────────┴───────────────────────────────────┴──────────┴─────────────┴────────────────┘
Problem size: (4, 4, 1, 63, 5400), N-reps: 1,  Float_type = Float32, Device_bandwidth_GBs=2039
┌───────────────────────────────────────────────────────────────┬───────────────────────────────────┬──────────┬─────────────┬────────────────┐
│ funcs                                                         │ time per call                     │ bw %     │ achieved bw │ N reads-writes │
├───────────────────────────────────────────────────────────────┼───────────────────────────────────┼──────────┼─────────────┼────────────────┤
│ (op_GradientF2C!, :none)                                      │ 53 microseconds, 300 nanoseconds  │ 37.3164  │ 760.882     │ 2              │
│ (op_GradientF2C!, :SetValue, :SetValue)                       │ 70 microseconds, 899 nanoseconds  │ 28.0535  │ 572.011     │ 2              │
│ (op_GradientC2F!, :SetGradient, :SetGradient)                 │ 80 microseconds, 59 nanoseconds   │ 24.8437  │ 506.564     │ 2              │
│ (op_GradientC2F!, :SetValue, :SetValue)                       │ 72 microseconds, 870 nanoseconds  │ 27.2951  │ 556.547     │ 2              │
│ (op_DivergenceF2C!, :none)                                    │ 114 microseconds, 439 nanoseconds │ 26.0702  │ 531.571     │ 3              │
│ (op_DivergenceF2C!, :Extrapolate, :Extrapolate)               │ 162 microseconds, 79 nanoseconds  │ 18.4075  │ 375.329     │ 3              │
│ (op_DivergenceC2F!, :SetDivergence, :SetDivergence)           │ 124 microseconds, 449 nanoseconds │ 23.9733  │ 488.815     │ 3              │
│ (op_InterpolateF2C!, :none)                                   │ 54 microseconds, 950 nanoseconds  │ 36.1966  │ 738.048     │ 2              │
│ (op_InterpolateC2F!, :SetValue, :SetValue)                    │ 62 microseconds, 750 nanoseconds  │ 31.6972  │ 646.305     │ 2              │
│ (op_InterpolateC2F!, :Extrapolate, :Extrapolate)              │ 71 microseconds, 350 nanoseconds  │ 27.8762  │ 568.395     │ 2              │
│ (op_broadcast_example0!, :none)                               │ 66 microseconds, 101 nanoseconds  │ 45.1354  │ 920.31      │ 3              │
│ (op_broadcast_example1!, :none)                               │ 94 microseconds, 239 nanoseconds  │ 42.2111  │ 860.684     │ 4              │
│ (op_broadcast_example2!, :none)                               │ 93 microseconds, 700 nanoseconds  │ 42.4544  │ 865.644     │ 4              │
│ (op_LeftBiasedC2F!, :SetValue)                                │ 60 microseconds, 90 nanoseconds   │ 33.0998  │ 674.904     │ 2              │
│ (op_LeftBiasedF2C!, :none)                                    │ 51 microseconds, 369 nanoseconds  │ 38.7192  │ 789.484     │ 2              │
│ (op_LeftBiasedF2C!, :SetValue)                                │ 58 microseconds, 879 nanoseconds  │ 33.7806  │ 688.785     │ 2              │
│ (op_RightBiasedC2F!, :SetValue)                               │ 59 microseconds, 200 nanoseconds  │ 33.5974  │ 685.051     │ 2              │
│ (op_RightBiasedF2C!, :none)                                   │ 50 microseconds, 309 nanoseconds  │ 39.535   │ 806.118     │ 2              │
│ (op_RightBiasedF2C!, :SetValue)                               │ 59 microseconds, 49 nanoseconds   │ 33.6833  │ 686.802     │ 2              │
│ (op_divgrad_CC!, :SetValue, :SetValue, :none)                 │ 189 microseconds, 938 nanoseconds │ 15.7075  │ 320.276     │ 3              │
│ (op_divgrad_FF!, :none, :SetDivergence, :SetDivergence)       │ 112 microseconds, 570 nanoseconds │ 26.5033  │ 540.402     │ 3              │
└───────────────────────────────────────────────────────────────┴───────────────────────────────────┴──────────┴─────────────┴────────────────┘
```
