### PR TITLE
Fix inference for column broadcasting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@ ClimaCore.jl Release Notes
 main
 -------
 
+v0.14.14
+-------
+
+- Inference was fixed for some broadcast expressions involving columns PR [#1984](https://github.com/CliMA/ClimaCore.jl/pull/1984).
+
 v0.14.13
 -------
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.14.13"
+version = "0.14.14"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/DataLayouts/broadcast.jl
+++ b/src/DataLayouts/broadcast.jl
@@ -252,7 +252,8 @@ Base.@propagate_inbounds function column(
 ) where {Nv, N, DS <: Union{Data1DXStyle{Nv, N}, Data2DXStyle{Nv, N}}}
     _args = column_args(bc.args, inds...)
     _axes = nothing
-    Base.Broadcast.Broadcasted{DataColumnStyle(DS)}(bc.f, _args, _axes)
+    bcc = Base.Broadcast.Broadcasted{DataColumnStyle(DS)}(bc.f, _args, _axes)
+    Base.Broadcast.instantiate(bcc)
 end
 
 @inline function column(

--- a/test/Fields/field_opt.jl
+++ b/test/Fields/field_opt.jl
@@ -390,7 +390,7 @@ using JET
     ρ = Fields.Field(Float64, cspace)
     S = Fields.Field(Float64, cspace)
     ifelsekernel!(S, ρ)
-    @test_opt broken = true ifelsekernel!(S, ρ)
+    @test_opt ifelsekernel!(S, ρ)
 end
 
 nothing


### PR DESCRIPTION
It turns out that what was missing here is that `column` on broadcasted objects passes `nothing` to the axes. So, even though we call `instantiate` on the broadcasted objects in the Fields broadcasting:

```julia
@inline function Base.copyto!(
    dest::Field,
    bc::Base.Broadcast.Broadcasted{<:AbstractFieldStyle},
)
    copyto!(field_values(dest), Base.Broadcast.instantiate(todata(bc)))
    return dest
end
```

We later call `column` inside the datalayouts loop:

```julia
function Base.copyto!(
    dest::VIJFH{S, Nv, Nij, Nh},
    bc::BroadcastedUnionVIJFH{S, Nv, Nij, Nh},
    ::ToCPU,
) where {S, Nv, Nij, Nh}
    # copy contiguous columns
    @inbounds for h in 1:Nh, j in 1:Nij, i in 1:Nij
        col_dest = column(dest, i, j, h)
        col_bc = column(bc, i, j, h)
        copyto!(col_dest, col_bc)
    end
    return dest
end
```
Which then drops the axes and passes in `nothing`. This results in looking up the `axes` inside `getindex` rather than `column`.

I'm kind of surprised that this wasn't a more wide spread issue. Also, it oddly didn't seem to have a performance benefit, but at least it fixes inference and conceptually makes more sense this way.

Closes #1981.