### PR TITLE
Improve inference in `dss_transform`

### DIFF
--- a/src/Topologies/dss_transform.jl
+++ b/src/Topologies/dss_transform.jl
@@ -44,6 +44,11 @@ end
         dss_transform(Base.tail(arg), local_geometry, weight)...,
     )
 end
+@inline dss_transform(
+    arg::Tuple{Any},
+    local_geometry::Geometry.LocalGeometry,
+    weight,
+) = (dss_transform(first(arg), local_geometry, weight),)
 @inline function dss_transform(
     arg::NamedTuple{names},
     local_geometry::Geometry.LocalGeometry,


### PR DESCRIPTION
I suspect that this method is needed to catch the case when `arg` has a single element.

I'm hoping that this fixes the wide yellow platform in https://github.com/CliMA/ClimaAtmos.jl/issues/3295.