### PR TITLE
Add LevelPlaceholderSpace

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@ ClimaCore.jl Release Notes
 main
 -------
 
+v0.14.15
+-------
+
+- Added support for mixing extruded and horizontal spaces in GPU kernels. PR [#1987](https://github.com/CliMA/ClimaCore.jl/pull/1987).
+
 v0.14.14
 -------
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.14.14"
+version = "0.14.15"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Operators/common.jl
+++ b/src/Operators/common.jl
@@ -69,13 +69,21 @@ end
 
 # Functions for CUDASpectralStyle
 struct PlaceholderSpace <: Spaces.AbstractSpace end
+struct LevelPlaceholderSpace <: Spaces.AbstractSpace end
 struct CenterPlaceholderSpace <: Spaces.AbstractSpace end
 struct FacePlaceholderSpace <: Spaces.AbstractSpace end
 
-
+placeholder_space(current_space, parent_space) = current_space
 placeholder_space(current_space::T, parent_space::T) where {T} =
     PlaceholderSpace()
-placeholder_space(current_space, parent_space) = current_space
+placeholder_space(
+    current_space::Spaces.AbstractPointSpace,
+    parent_space::Spaces.AbstractFiniteDifferenceSpace,
+) = LevelPlaceholderSpace()
+placeholder_space(
+    current_space::Spaces.AbstractSpectralElementSpace,
+    parent_space::Spaces.ExtrudedFiniteDifferenceSpace,
+) = LevelPlaceholderSpace()
 placeholder_space(
     current_space::Spaces.CenterFiniteDifferenceSpace,
     parent_space::Spaces.FaceFiniteDifferenceSpace,
@@ -93,8 +101,12 @@ placeholder_space(
     parent_space::Spaces.CenterExtrudedFiniteDifferenceSpace,
 ) = FacePlaceholderSpace()
 
+@inline reconstruct_placeholder_space(current_space, parent_space) =
+    current_space
 @inline reconstruct_placeholder_space(::PlaceholderSpace, parent_space) =
     parent_space
+@inline reconstruct_placeholder_space(::LevelPlaceholderSpace, parent_space) =
+    Spaces.level(parent_space, left_idx(parent_space)) # extract arbitrary level
 @inline reconstruct_placeholder_space(
     ::CenterPlaceholderSpace,
     parent_space::Spaces.FaceFiniteDifferenceSpace,
@@ -111,9 +123,6 @@ placeholder_space(
     ::FacePlaceholderSpace,
     parent_space::Spaces.CenterExtrudedFiniteDifferenceSpace,
 ) = Spaces.FaceExtrudedFiniteDifferenceSpace(parent_space)
-@inline reconstruct_placeholder_space(current_space, parent_space) =
-    current_space
-
 
 strip_space(obj, parent_space) = obj
 


### PR DESCRIPTION
This PR adds a `LevelPlaceholderSpace`, which is needed to pass mixtures of extruded 3D and level 2D fields onto the GPU. Specifically, this will enable us to perform the column accumulation operation needed for the non-orographic gravity wave parametrization in ClimaAtmos (CliMA/ClimaAtmos.jl#3267).
