### PR TITLE
Run documentation on main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,10 @@ name: Documentation
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
+    tags: '*'
 
 jobs:
   docbuild:


### PR DESCRIPTION
The current [documentation page](https://clima.github.io/ClimaCore.jl/dev/) is very much outdated. I think that this is because the "docs" action is run only on pull requests. This means that documentation is not generated and deployed when the commit reaches main, leading to stale github pages. This commit ensures that documentation is also run on main.
