### PR TITLE
Add UniversalSize to spaces

### DIFF
--- a/src/Grids/finitedifference.jl
+++ b/src/Grids/finitedifference.jl
@@ -34,11 +34,13 @@ mutable struct FiniteDifferenceGrid{
     GG,
     CLG,
     FLG,
+    US,
 } <: AbstractFiniteDifferenceGrid
     topology::T
     global_geometry::GG
     center_local_geometry::CLG
     face_local_geometry::FLG
+    universal_sizes::US
 end
 
 
@@ -64,11 +66,16 @@ function _FiniteDifferenceGrid(topology::Topologies.IntervalTopology)
     center_local_geometry, face_local_geometry =
         fd_geometry_data(face_coordinates, Val(Topologies.isperiodic(topology)))
 
+    universal_sizes = (;
+        center = DataLayouts.UniversalSize(center_local_geometry),
+        face = DataLayouts.UniversalSize(face_local_geometry),
+    )
     return FiniteDifferenceGrid(
         topology,
         global_geometry,
         Adapt.adapt(ArrayType, center_local_geometry),
         Adapt.adapt(ArrayType, face_local_geometry),
+        universal_sizes,
     )
 end
 

--- a/src/Grids/level.jl
+++ b/src/Grids/level.jl
@@ -6,6 +6,9 @@ struct LevelGrid{
     level::L
 end
 
+universal_size(levelgrid::LevelGrid) = universal_size(levelgrid.full_grid)
+universal_sizes(levelgrid::LevelGrid) = universal_sizes(levelgrid.full_grid)
+
 quadrature_style(levelgrid::LevelGrid) =
     quadrature_style(levelgrid.full_grid.horizontal_grid)
 


### PR DESCRIPTION
It seems that compile times are due to `Nh`. I would argue that adding a type parameter that has a single value for an entire simulation shouldn't be an issue. However, in the light of https://github.com/JuliaLang/julia/issues/55807, it's possible that this isn't the case. I'd like to make progress on alleviating long compile times--I've observed that a job in ClimaAtmos took about 26 minutes to complete the first timestep, and each subsequent step is on the order of, or less than, one second.

This PR adds universal sizes to the spaces. The hope is that we can preserve the performance benefit of knowing static array dimensions (https://github.com/CliMA/ClimaCore.jl/issues/11) for most broadcast expressions, while reducing compile times. Here are some trade-offs with this PR:

 - We can remove `Nh` (and `Nv`) from the type domain, and instead grab them from the space for broadcast operations for field-style expressions
 - For DataLayout broadcast expressions we won't have a space to grab the universal size (containing `Nh`, `Nv`) from, so those kernels will revert to using runtime `Nh`/`Nv`.

Unfortunately, this means that diagnostic edmf, which performs lost of level operations on DataLayouts, will fall back to a somewhat slower kernel (as it was before `Nh`/`Nv` was static).