### PR TITLE
Fix InputOutput when enable_bubble is true

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,22 @@ ClimaCore.jl Release Notes
 main
 -------
 
+v0.14.16
+-------
+
+### ![][badge-🐛bugfix] Fix restarting simulations from `Space`s with `enable_bubble = true`
+
+Prior to this change, the `ClimaCore.InputOutput` module did not save whether a
+`Space` was constructed with `enable_bubble = true`. This meant that restarting
+a simulation from a HDF5 file led to inconsistent and incorrect spaces and
+`Field`s. This affected only 2D spectral spaces (and extruded ones that have
+this type of horizontal space).
+
+We now expect `Space`s read from a file to be bitwise identical to the original
+one.
+
+PR [#1999](https://github.com/CliMA/ClimaCore.jl/pull/1999).
+
 v0.14.15
 -------
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.14.15"
+version = "0.14.16"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Grids/spectralelement.jl
+++ b/src/Grids/spectralelement.jl
@@ -129,6 +129,7 @@ mutable struct SpectralElementGrid2D{
     local_dss_weights::D
     internal_surface_geometry::IS
     boundary_surface_geometries::BS
+    enable_bubble::Bool
 end
 
 local_geometry_type(
@@ -467,6 +468,7 @@ function _SpectralElementGrid2D(
         dss_local_weights,
         internal_surface_geometry,
         boundary_surface_geometries,
+        enable_bubble,
     )
 end
 

--- a/src/InputOutput/readers.jl
+++ b/src/InputOutput/readers.jl
@@ -333,10 +333,15 @@ function read_grid_new(reader, name)
         quadrature_style =
             _scan_quadrature_style(attrs(group)["quadrature_type"], npts)
         topology = read_topology(reader, attrs(group)["topology"])
+        enable_bubble = get(attrs(group), "bubble", "false") == "true"
         if type == "SpectralElementGrid1D"
             return Grids.SpectralElementGrid1D(topology, quadrature_style)
         else
-            return Grids.SpectralElementGrid2D(topology, quadrature_style)
+            return Grids.SpectralElementGrid2D(
+                topology,
+                quadrature_style;
+                enable_bubble,
+            )
         end
     elseif type == "FiniteDifferenceGrid"
         topology = read_topology(reader, attrs(group)["topology"])

--- a/src/InputOutput/writers.jl
+++ b/src/InputOutput/writers.jl
@@ -343,6 +343,7 @@ function write_new!(
         "quadrature_num_points",
         Quadratures.degrees_of_freedom(Spaces.quadrature_style(grid)),
     )
+    write_attribute(group, "bubble", grid.enable_bubble ? "true" : "false")
     write_attribute(group, "topology", write!(writer, Spaces.topology(grid)))
     return name
 end


### PR DESCRIPTION
It turns out that we were not saving and restoring a piece of information that is required to fully reconstruct a `2DSpectralSpace`: the bubble correction.

When enabled, the bubble correction recomputes the Jacobian to improve their accuracy. `InputOutput` was not saving this piece of information into the HDF5 file, so spaces read from file always assumed that it was false. This led to discrepancies in the space, and these discrepancies led to problems in the evolution.

Interestingly, for the low-resolution cases we consider in the Atmos CI, `enable_bubble` has very small effects on the value of the Jacobian, with a relative difference compared to the case without bubble smaller than the floating point precision for Float32. In spite of this, it affected the evolution in more noticeable way, in particular in vectors and with hyperdiffusion.

Now, `bubble` is saved as attribute so that it can be read back.

This commit also bumps the version of ClimaCore to 0.14.6
