### PR TITLE
extend weighted_dss for FieldVector

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@ ClimaCore.jl Release Notes
 main
 -------
 
+- Extended `create_dss_buffer` and `weighted_dss!` for `FieldVector`s, rather than
+just `Field`s. PR [#2000](https://github.com/CliMA/ClimaCore.jl/pull/2000).
+
 v0.14.16
 -------
 

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -374,7 +374,7 @@ function interpcoord(elemrange, x::Real)
 end
 
 """
-    Spaces.weighted_dss!(f::Field[, ghost_buffer = Spaces.create_dss_buffer(field)])
+    Spaces.weighted_dss!(f::Field, dss_buffer = Spaces.create_dss_buffer(field))
 
 Apply weighted direct stiffness summation (DSS) to `f`. This operates in-place
 (i.e. it modifies the `f`). `ghost_buffer` contains the necessary information


### PR DESCRIPTION
Extend `weighted_dss!` to work for FieldVectors in addition to Fields.

Needed for https://github.com/CliMA/ClimaCoupler.jl/pull/959, and will also be useful for ClimaAtmos.

### To Do
- [x] add method
- [x] add tests
- [x] update NEWS.md


### Code quality
- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
