### PR TITLE
bump Makie dep in ClimaCoreMakie

### DIFF
--- a/lib/ClimaCoreMakie/Project.toml
+++ b/lib/ClimaCoreMakie/Project.toml
@@ -1,11 +1,11 @@
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
 name = "ClimaCoreMakie"
 uuid = "908f55d8-4145-4867-9c14-5dad1a479e4d"
-version = "0.4.5"
+version = "0.4.6"
 
 [compat]
 ClimaCore = "0.11, 0.12, 0.13, 0.14"
-Makie = "0.15, 0.16, 0.17, 0.18, 0.19, 0.20"
+Makie = "0.15, 0.16, 0.17, 0.18, 0.19, 0.20, 0.21"
 julia = "1.7"
 
 [deps]


### PR DESCRIPTION
The current upper bound for Makie at 0.20 makes it not possible to update `ClimaAnalysis` from v0.5.7 to v0.5.8
<!-- Provide a clear description of the content -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
