### PR TITLE
Remove unnecessary method specializations for Numbers

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -895,6 +895,11 @@ steps:
         key: unit_matrix_field_broadcasting_cpu_non_scalar_4
         command: "julia --color=yes --check-bounds=yes --project=.buildkite test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_4.jl"
 
+      - label: "Unit: matrix field broadcasting (CPU)"
+        key: unit_matrix_field_broadcasting_cpu_non_scalar_5
+        command: "julia --color=yes --check-bounds=yes --project=.buildkite test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_5.jl"
+        soft_fail: true
+
   - group: "Unit: MatrixFields - broadcasting (GPU)"
     steps:
 
@@ -1078,6 +1083,15 @@ steps:
       - label: "Unit: matrix field broadcasting (GPU)"
         key: unit_matrix_field_broadcasting_gpu_non_scalar_4
         command: "julia --color=yes --check-bounds=yes --project=.buildkite test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_4.jl"
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+        agents:
+          slurm_gpus: 1
+          slurm_mem: 10GB
+
+      - label: "Unit: matrix field broadcasting (GPU)"
+        key: unit_matrix_field_broadcasting_gpu_non_scalar_5
+        command: "julia --color=yes --check-bounds=yes --project=.buildkite test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_5.jl"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:

--- a/src/RecursiveApply/RecursiveApply.jl
+++ b/src/RecursiveApply/RecursiveApply.jl
@@ -167,9 +167,6 @@ Recursively add elements of `X` and `Y`.
 """
 radd(X) = X
 radd(X, Y) = rmap(+, X, Y)
-radd(w::Number, X) = rmap(x -> w + x, X)
-radd(X, w::Number) = rmap(x -> x + w, X)
-radd(w1::Number, w2::Number) = w1 + w2
 const ⊞ = radd
 
 # Adapted from Base/operators.jl for general nary operator fallbacks
@@ -187,9 +184,6 @@ Recursively subtract elements of `Y` from `X`.
 """
 rsub(X) = rmap(-, X)
 rsub(X, Y) = rmap(-, X, Y)
-rsub(X, w::Number) = rmap(x -> x - w, X)
-rsub(w::Number, X) = rmap(x -> w - x, X)
-rsub(w1::Number, w2::Number) = w1 - w2
 const ⊟ = rsub
 
 """
@@ -198,9 +192,6 @@ const ⊟ = rsub
 Recursively divide each element of `X` by `Y`
 """
 rdiv(X, Y) = rmap(/, X, Y)
-rdiv(X, w::Number) = rmap(x -> x / w, X)
-rdiv(w::Number, X) = rmap(x -> w / x, X)
-rdiv(w1::Number, w2::Number) = w1 / w2
 
 """
     rmuladd(w, X, Y)
@@ -209,7 +200,6 @@ Recursively add elements of `w * X + Y`.
 """
 rmuladd(w::Number, X, Y) = rmap((x, y) -> muladd(w, x, y), X, Y)
 rmuladd(X, w::Number, Y) = rmap((x, y) -> muladd(x, w, y), X, Y)
-rmuladd(X::Number, w::Number, Y) = rmap((x, y) -> muladd(x, w, y), X, Y)
-rmuladd(w::Number, x::Number, y::Number) = muladd(w, x, y)
+rmuladd(x::Number, w::Number, Y) = rmap(y -> muladd(x, w, y), Y)
 
 end # module

--- a/test/MatrixFields/matrix_field_broadcasting.jl
+++ b/test/MatrixFields/matrix_field_broadcasting.jl
@@ -56,6 +56,7 @@ end
     GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_non_scalar_2.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
     GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_non_scalar_3.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
     GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_non_scalar_4.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
+    GC.gc(); include(joinpath("matrix_fields_broadcasting", "test_non_scalar_5.jl")); print_mem && @info "mem usage: rss = $(Sys.maxrss() / 2^30)"
     GC.gc()
 end
 #! format: on

--- a/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_5.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_5.jl
@@ -1,0 +1,30 @@
+#=
+julia --project
+using Revise; include(joinpath("test", "MatrixFields", "matrix_fields_broadcasting", "test_non_scalar_1.jl"))
+=#
+import ClimaCore
+#! format: off
+if !(@isdefined(unit_test_field_broadcast))
+    include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_non_scalar_utils.jl"))
+end
+#! format: on
+test_opt = get(ENV, "BUILDKITE", "") == "true"
+@testset "matrix of vectors divided by scalar" begin
+
+    bc = @lazy @. ᶜᶠmat_C12 / 2
+    result = materialize(bc)
+
+    ref_set_result! =
+        result -> (@. result =
+            map(Geometry.Covariant12Vector, ᶜᶠmat2 / 2, ᶜᶠmat3 / 2))
+
+    unit_test_field_broadcast(
+        result,
+        bc;
+        ref_set_result!,
+        allowed_max_eps_error = 0,
+    )
+
+    test_opt && opt_test_field_broadcast(result, bc; ref_set_result!)
+    test_opt && !using_cuda && perf_getidx(bc)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,6 +86,7 @@ UnitTest("MatrixFields - non-scalar broadcasting (1)" ,"MatrixFields/matrix_fiel
 UnitTest("MatrixFields - non-scalar broadcasting (2)" ,"MatrixFields/matrix_fields_broadcasting/test_non_scalar_2.jl"),
 UnitTest("MatrixFields - non-scalar broadcasting (3)" ,"MatrixFields/matrix_fields_broadcasting/test_non_scalar_3.jl"),
 UnitTest("MatrixFields - non-scalar broadcasting (4)" ,"MatrixFields/matrix_fields_broadcasting/test_non_scalar_4.jl"),
+UnitTest("MatrixFields - non-scalar broadcasting (5)" ,"MatrixFields/matrix_fields_broadcasting/test_non_scalar_5.jl"),
 UnitTest("MatrixFields - flat spaces" ,"MatrixFields/flat_spaces.jl"),
     
 # UnitTest("MatrixFields - matrix field broadcast"   ,"MatrixFields/matrix_field_broadcasting.jl"), # too long


### PR DESCRIPTION
There appear to be inference issues arising from unnecessary specializations on `Number` types in several `RecursiveApply` methods. Specifically, the specializations for `rdiv` (but not for `rmul`) are the source of the first bug described in #1983, and removing them fixes that error. Removing these specializations may also fix other inference problems for operations on complex fields (e.g., matrix fields of non-scalar values).

Several specializations of `rmuladd` are not removed in this PR because `rmap` does not currently support 3 input arguments (only 1 or 2). This can be fixed in the future, especially if we end up rewriting `rmap` in terms of `unrolled_map`.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
