### PR TITLE
Add DataLayouts convenience constructors

### DIFF
--- a/test/DataLayouts/benchmark_copyto.jl
+++ b/test/DataLayouts/benchmark_copyto.jl
@@ -40,38 +40,37 @@ end
 
 @testset "copyto! with Nf = 1" begin
     device = ClimaComms.device()
-    device_zeros(args...) = ClimaComms.array_type(device)(zeros(args...))
+    ArrayType = ClimaComms.array_type(device)
     FT = Float64
     S = FT
-    Nf = 1
     Nv = 63
-    Nij = 4
+    Ni = Nij = 4
     Nh = 30 * 30 * 6
     Nk = 6
     bm = Benchmark(; float_type = FT, device_name)
-    data = DataF{S}(device_zeros(FT, Nf))
+    data = DataF{S}(ArrayType{FT}, zeros)
     benchmarkcopyto!(bm, device, data, 3)
     @test all(parent(data) .== 3)
-    data = IJFH{S, Nij}(device_zeros(FT, Nij, Nij, Nf, Nh))
+    data = IJFH{S}(ArrayType{FT}, zeros; Nij, Nh)
     benchmarkcopyto!(bm, device, data, 3)
     @test all(parent(data) .== 3)
-    data = IFH{S, Nij}(device_zeros(FT, Nij, Nf, Nh))
+    data = IFH{S}(ArrayType{FT}, zeros; Ni, Nh)
     benchmarkcopyto!(bm, device, data, 3)
     @test all(parent(data) .== 3)
     # The parent array of IJF and IF datalayouts are MArrays, and can therefore not bm, be passed into CUDA kernels on the RHS.
-    # data = IJF{S, Nij}(device_zeros(FT,Nij,Nij,Nf));             benchmarkcopyto!(bm, device, data, 3); @test all(parent(data) .== 3)
-    # data = IF{S, Nij}(device_zeros(FT,Nij,Nf));                  benchmarkcopyto!(bm, device, data, 3); @test all(parent(data) .== 3)
-    data = VF{S, Nv}(device_zeros(FT, Nv, Nf))
+    # data = IJF{S}(ArrayType{FT}, zeros; Nij);             benchmarkcopyto!(bm, device, data, 3); @test all(parent(data) .== 3)
+    # data = IF{S}(ArrayType{FT}, zeros; Ni);               benchmarkcopyto!(bm, device, data, 3); @test all(parent(data) .== 3)
+    data = VF{S}(ArrayType{FT}, zeros; Nv)
     benchmarkcopyto!(bm, device, data, 3)
     @test all(parent(data) .== 3)
-    data = VIJFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nij, Nf, Nh))
+    data = VIJFH{S}(ArrayType{FT}, zeros; Nv, Nij, Nh)
     benchmarkcopyto!(bm, device, data, 3)
     @test all(parent(data) .== 3)
-    data = VIFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nf, Nh))
+    data = VIFH{S}(ArrayType{FT}, zeros; Nv, Ni, Nh)
     benchmarkcopyto!(bm, device, data, 3)
     @test all(parent(data) .== 3)
 
-    # data = IJKFVH{S}(device_zeros(FT,Nij,Nij,Nk,Nf,Nh)); benchmarkcopyto!(bm, device, data, 3); @test all(parent(data) .== 3) # TODO: test
-    # data = IH1JH2{S}(device_zeros(FT,Nij,Nij,Nk,Nf,Nh)); benchmarkcopyto!(bm, device, data, 3); @test all(parent(data) .== 3) # TODO: test
+    # data = IJKFVH{S}(ArrayType{FT}, zeros; Nij,Nk,Nh); benchmarkcopyto!(bm, device, data, 3); @test all(parent(data) .== 3) # TODO: test
+    # data = IH1JH2{S}(ArrayType{FT}, zeros; Nij,Nk,Nh); benchmarkcopyto!(bm, device, data, 3); @test all(parent(data) .== 3) # TODO: test
     tabulate_benchmark(bm)
 end

--- a/test/DataLayouts/benchmark_fill.jl
+++ b/test/DataLayouts/benchmark_fill.jl
@@ -18,7 +18,7 @@ end
 
 include(joinpath(pkgdir(ClimaCore), "benchmarks/scripts/benchmark_utils.jl"))
 
-function benchmarkfill!(bm, device, data, val, name)
+function benchmarkfill!(bm, device, data, val)
     caller = string(nameof(typeof(data)))
     @info "Benchmarking $caller..."
     trial = @benchmark ClimaComms.@cuda_sync $device fill!($data, $val)
@@ -37,41 +37,40 @@ end
 
 @testset "fill! with Nf = 1" begin
     device = ClimaComms.device()
-    device_zeros(args...) = ClimaComms.array_type(device)(zeros(args...))
+    ArrayType = ClimaComms.array_type(device)
     FT = Float64
     S = FT
-    Nf = 1
     Nv = 63
-    Nij = 4
+    Ni = Nij = 4
     Nh = 30 * 30 * 6
     Nk = 6
     bm = Benchmark(; float_type = FT, device_name)
-    data = DataF{S}(device_zeros(FT, Nf))
-    benchmarkfill!(bm, device, data, 3, "DataF")
+    data = DataF{S}(ArrayType{FT}, zeros)
+    benchmarkfill!(bm, device, data, 3)
     @test all(parent(data) .== 3)
-    data = IJFH{S, Nij}(device_zeros(FT, Nij, Nij, Nf, Nh))
-    benchmarkfill!(bm, device, data, 3, "IJFH")
+    data = IJFH{S}(ArrayType{FT}, zeros; Nij, Nh)
+    benchmarkfill!(bm, device, data, 3)
     @test all(parent(data) .== 3)
-    data = IFH{S, Nij}(device_zeros(FT, Nij, Nf, Nh))
-    benchmarkfill!(bm, device, data, 3, "IFH")
+    data = IFH{S}(ArrayType{FT}, zeros; Ni, Nh)
+    benchmarkfill!(bm, device, data, 3)
     @test all(parent(data) .== 3)
-    data = IJF{S, Nij}(device_zeros(FT, Nij, Nij, Nf))
-    benchmarkfill!(bm, device, data, 3, "IJF")
+    data = IJF{S}(ArrayType{FT}, zeros; Nij)
+    benchmarkfill!(bm, device, data, 3)
     @test all(parent(data) .== 3)
-    data = IF{S, Nij}(device_zeros(FT, Nij, Nf))
-    benchmarkfill!(bm, device, data, 3, "IF")
+    data = IF{S}(ArrayType{FT}, zeros; Ni)
+    benchmarkfill!(bm, device, data, 3)
     @test all(parent(data) .== 3)
-    data = VF{S, Nv}(device_zeros(FT, Nv, Nf))
-    benchmarkfill!(bm, device, data, 3, "VF")
+    data = VF{S}(ArrayType{FT}, zeros; Nv)
+    benchmarkfill!(bm, device, data, 3)
     @test all(parent(data) .== 3)
-    data = VIJFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nij, Nf, Nh))
-    benchmarkfill!(bm, device, data, 3, "VIJFH")
+    data = VIJFH{S}(ArrayType{FT}, zeros; Nv, Nij, Nh)
+    benchmarkfill!(bm, device, data, 3)
     @test all(parent(data) .== 3)
-    data = VIFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nf, Nh))
-    benchmarkfill!(bm, device, data, 3, "VIFH")
+    data = VIFH{S}(ArrayType{FT}, zeros; Nv, Ni, Nh)
+    benchmarkfill!(bm, device, data, 3)
     @test all(parent(data) .== 3)
 
-    # data = IJKFVH{S}(device_zeros(FT,Nij,Nij,Nk,Nf,Nh)); benchmarkfill!(bm, device, data, 3); @test all(parent(data) .== 3) # TODO: test
-    # data = IH1JH2{S}(device_zeros(FT,Nij,Nij,Nk,Nf,Nh)); benchmarkfill!(bm, device, data, 3); @test all(parent(data) .== 3) # TODO: test
+    # data = DataLayouts.IJKFVH{S}(ArrayType{FT}, zeros; Nij,Nk,Nv,Nh); benchmarkfill!(bm, device, data, 3); @test all(parent(data) .== 3) # TODO: test
+    # data = DataLayouts.IH1JH2{S}(ArrayType{FT}, zeros; Nij);          benchmarkfill!(bm, device, data, 3); @test all(parent(data) .== 3) # TODO: test
     tabulate_benchmark(bm)
 end

--- a/test/DataLayouts/cuda.jl
+++ b/test/DataLayouts/cuda.jl
@@ -32,8 +32,8 @@ end
     device = ClimaComms.device()
     ArrayType = ClimaComms.array_type(device)
     Nh = 10
-    src = IJFH{S, 4}(ArrayType(rand(4, 4, 3, Nh)))
-    dst = IJFH{S, 4}(ArrayType(zeros(4, 4, 3, Nh)))
+    src = IJFH{S}(ArrayType{Float64}, rand; Nij = 4, Nh)
+    dst = IJFH{S}(ArrayType{Float64}, zeros; Nij = 4, Nh)
 
     test_copy!(dst, src)
 
@@ -47,10 +47,8 @@ end
     Nh = 2
     device = ClimaComms.device()
     ArrayType = ClimaComms.array_type(device)
-    data_arr1 = ArrayType(ones(FT, 2, 2, 3, Nh))
-    data_arr2 = ArrayType(ones(FT, 2, 2, 1, Nh))
-    data1 = IJFH{S1, 2}(data_arr1)
-    data2 = IJFH{S2, 2}(data_arr2)
+    data1 = IJFH{S1}(ArrayType{FT}, ones; Nij = 2, Nh)
+    data2 = IJFH{S2}(ArrayType{FT}, ones; Nij = 2, Nh)
 
     f1(a1, a2) = a1.a.re * a2 + a1.b
     res = f1.(data1, data2)
@@ -58,10 +56,8 @@ end
     @test Array(parent(res)) == FT[2 for i in 1:2, j in 1:2, f in 1:1, h in 1:2]
 
     Nv = 33
-    data_arr1 = ArrayType(ones(FT, Nv, 4, 4, 3, 2))
-    data_arr2 = ArrayType(ones(FT, Nv, 4, 4, 1, 2))
-    data1 = VIJFH{S1, Nv, 4}(data_arr1)
-    data2 = VIJFH{S2, Nv, 4}(data_arr2)
+    data1 = VIJFH{S1}(ArrayType{FT}, ones; Nv, Nij = 4, Nh = 2)
+    data2 = VIJFH{S2}(ArrayType{FT}, ones; Nv, Nij = 4, Nh = 2)
 
     f2(a1, a2) = a1.a.re * a2 + a1.b
     res = f2.(data1, data2)
@@ -77,14 +73,13 @@ end
     Nh = 3
     device = ClimaComms.device()
     ArrayType = ClimaComms.array_type(device)
-    array = similar(ArrayType{FT}, 2, 2, 2, Nh)
-    data = IJFH{S, 2}(array)
+    data = IJFH{S}(ArrayType{FT}; Nij = 2, Nh)
     data .= Complex(1.0, 2.0)
     @test Array(parent(data)) ==
           FT[f == 1 ? 1 : 2 for i in 1:2, j in 1:2, f in 1:2, h in 1:3]
 
     Nv = 33
-    data = VIJFH{S, Nv, 4}(ArrayType{FT}(undef, Nv, 4, 4, 2, Nh))
+    data = VIJFH{S}(ArrayType{FT}; Nv, Nij = 4, Nh)
     data .= Complex(1.0, 2.0)
     @test Array(parent(data)) == FT[
         f == 1 ? 1 : 2 for v in 1:Nv, i in 1:4, j in 1:4, f in 1:2, h in 1:3

--- a/test/DataLayouts/data1d.jl
+++ b/test/DataLayouts/data1d.jl
@@ -5,19 +5,21 @@ using Revise; include(joinpath("test", "DataLayouts", "data1d.jl"))
 using Test
 using JET
 
+using ClimaComms
 using ClimaCore.DataLayouts
 using StaticArrays
 using ClimaCore.DataLayouts: get_struct, set_struct!, vindex
 
 TestFloatTypes = (Float32, Float64)
+device = ClimaComms.device()
+ArrayType = ClimaComms.array_type(device)
 
 @testset "VF" begin
     for FT in TestFloatTypes
         S = Tuple{Complex{FT}, FT}
         Nv = 4
-        array = rand(FT, Nv, 3)
-
-        data = VF{S, Nv}(array)
+        data = VF{S}(ArrayType{FT}, rand; Nv)
+        array = parent(data)
         @test getfield(data.:1, :array) == @view(array[:, 1:2])
 
         # test tuple assignment
@@ -35,19 +37,18 @@ TestFloatTypes = (Float32, Float64)
     end
     FT = Float64
     Nv = 4
-    array = rand(FT, Nv, 1)
-    data = VF{FT, Nv}(array)
+    data = VF{FT}(ArrayType{FT}, rand; Nv)
     @test DataLayouts.data2array(data) ==
           reshape(parent(data), DataLayouts.nlevels(data), :)
     @test DataLayouts.array2data(DataLayouts.data2array(data), data) == data
 end
 
 @testset "VF boundscheck" begin
-    S = Tuple{Complex{Float64}, Float64}
+    FT = Float64
+    S = Tuple{Complex{FT}, FT}
     Nv = 4
-    array = zeros(Float64, Nv, 3)
-    data = VF{S, Nv}(array)
-    @test data[vindex(1)][2] == zero(Float64)
+    data = VF{S}(ArrayType{FT}, zeros; Nv)
+    @test data[vindex(1)][2] == zero(FT)
     @test_throws BoundsError data[vindex(-1)]
     @test_throws BoundsError data[vindex(5)]
 end
@@ -59,8 +60,7 @@ end
     SA = (a = 1.0, b = 2.0)
     SB = (c = 1.0, d = 2.0)
 
-    array = zeros(Float64, Nv, 2)
-    data = VF{typeof(SA), Nv}(array)
+    data = VF{typeof(SA)}(ArrayType{Float64}, zeros; Nv)
 
     ret = begin
         data[vindex(1)] = SA
@@ -73,9 +73,8 @@ end
 @testset "VF broadcasting between 1D data objects and scalars" begin
     for FT in TestFloatTypes
         Nv = 2
-        data1 = ones(FT, Nv, 2)
         S = Complex{FT}
-        data1 = VF{S, Nv}(data1)
+        data1 = VF{S}(ArrayType{FT}, ones; Nv)
         res = data1 .+ 1
         @test res isa VF
         @test parent(res) == FT[2.0 1.0; 2.0 1.0]
@@ -89,7 +88,7 @@ end
     for FT in TestFloatTypes
         Nv = 3
         S = Complex{FT}
-        data = VF{S, Nv}(Array{FT}, Nv)
+        data = VF{S}(ArrayType{FT}; Nv)
         data .= Complex{FT}(1.0, 2.0)
         @test parent(data) == FT[1.0 2.0; 1.0 2.0; 1.0 2.0]
         data .= 1
@@ -100,12 +99,10 @@ end
 @testset "VF broadcasting between 1D data objects" begin
     for FT in TestFloatTypes
         Nv = 2
-        data1 = ones(FT, Nv, 2)
-        data2 = ones(FT, Nv, 1)
         S1 = Complex{FT}
         S2 = FT
-        data1 = VF{S1, Nv}(data1)
-        data2 = VF{S2, Nv}(data2)
+        data1 = VF{S1}(ArrayType{FT}, ones; Nv)
+        data2 = VF{S2}(ArrayType{FT}, ones; Nv)
         res = data1 .+ data2
         @test res isa VF{S1}
         @test parent(res) == FT[2.0 1.0; 2.0 1.0]
@@ -119,12 +116,11 @@ end
         for FT in TestFloatTypes
             Nv = 2
             S1 = NamedTuple{(:a, :b), Tuple{Complex{FT}, FT}}
-            data1 = ones(FT, Nv, 3)
             S2 = NamedTuple{(:c,), Tuple{FT}}
-            data2 = ones(FT, Nv, 1)
 
-            dl1 = VF{S1, Nv}(data1)
-            dl2 = VF{S2, Nv}(data2)
+            dl1 = VF{S1}(ArrayType{FT}, ones; Nv)
+            dl2 = VF{S2}(ArrayType{FT}, ones; Nv)
+            data1 = parent(dl1)
 
             f(a1, a2) = a1.a.re * a2.c + a1.b
 

--- a/test/DataLayouts/opt_similar.jl
+++ b/test/DataLayouts/opt_similar.jl
@@ -28,30 +28,29 @@ end
 
 @testset "similar" begin
     device = ClimaComms.device()
-    device_zeros(args...) = ClimaComms.array_type(device)(zeros(args...))
+    ArrayType = ClimaComms.array_type(device)
     FT = Float64
     S = FT
-    Nf = 1
     Nv = 4
-    Nij = 3
+    Ni = Nij = 3
     Nh = 5
     Nk = 6
-    data = DataF{S}(device_zeros(FT, Nf))
+    data = DataF{S}(ArrayType{FT}, zeros)
     test_similar!(data)
-    data = IJFH{S, Nij}(device_zeros(FT, Nij, Nij, Nf, Nh))
+    data = IJFH{S}(ArrayType{FT}, zeros; Nij, Nh)
     test_similar!(data)
-    data = IFH{S, Nij}(device_zeros(FT, Nij, Nf, Nh))
+    data = IFH{S}(ArrayType{FT}, zeros; Ni, Nh)
     test_similar!(data)
-    data = IJF{S, Nij}(device_zeros(FT, Nij, Nij, Nf))
+    data = IJF{S}(ArrayType{FT}, zeros; Nij)
     test_similar!(data)
-    data = IF{S, Nij}(device_zeros(FT, Nij, Nf))
+    data = IF{S}(ArrayType{FT}, zeros; Ni)
     test_similar!(data)
-    data = VF{S, Nv}(device_zeros(FT, Nv, Nf))
+    data = VF{S}(ArrayType{FT}, zeros; Nv)
     test_similar!(data)
-    data = VIJFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nij, Nf, Nh))
+    data = VIJFH{S}(ArrayType{FT}, zeros; Nv, Nij, Nh)
     test_similar!(data)
-    data = VIFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nf, Nh))
+    data = VIFH{S}(ArrayType{FT}, zeros; Nv, Ni, Nh)
     test_similar!(data)
-    # data = DataLayouts.IJKFVH{S, Nij, Nk, Nv}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); test_similar!(data) # TODO: test
-    # data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));                     test_similar!(data) # TODO: test
+    # data = DataLayouts.IJKFVH{S}(ArrayType{FT}, zeros; Nij,Nk,Nv,Nh); test_similar!(data) # TODO: test
+    # data = DataLayouts.IH1JH2{S}(ArrayType{FT}, zeros; Nij);          test_similar!(data) # TODO: test
 end

--- a/test/DataLayouts/opt_universal_size.jl
+++ b/test/DataLayouts/opt_universal_size.jl
@@ -50,30 +50,29 @@ end
 
 @testset "UniversalSize" begin
     device = ClimaComms.device()
-    device_zeros(args...) = ClimaComms.array_type(device)(zeros(args...))
+    ArrayType = ClimaComms.array_type(device)
     FT = Float64
     S = FT
-    Nf = 1
     Nv = 4
-    Nij = 3
+    Ni = Nij = 3
     Nh = 5
     Nk = 6
-    data = DataF{S}(device_zeros(FT, Nf))
+    data = DataF{S}(ArrayType{FT}, zeros)
     test_universal_size(data)
-    data = IJFH{S, Nij}(device_zeros(FT, Nij, Nij, Nf, Nh))
+    data = IJFH{S}(ArrayType{FT}, zeros; Nij, Nh)
     test_universal_size(data)
-    data = IFH{S, Nij}(device_zeros(FT, Nij, Nf, Nh))
+    data = IFH{S}(ArrayType{FT}, zeros; Ni, Nh)
     test_universal_size(data)
-    data = IJF{S, Nij}(device_zeros(FT, Nij, Nij, Nf))
+    data = IJF{S}(ArrayType{FT}, zeros; Nij)
     test_universal_size(data)
-    data = IF{S, Nij}(device_zeros(FT, Nij, Nf))
+    data = IF{S}(ArrayType{FT}, zeros; Ni)
     test_universal_size(data)
-    data = VF{S, Nv}(device_zeros(FT, Nv, Nf))
+    data = VF{S}(ArrayType{FT}, zeros; Nv)
     test_universal_size(data)
-    data = VIJFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nij, Nf, Nh))
+    data = VIJFH{S}(ArrayType{FT}, zeros; Nv, Nij, Nh)
     test_universal_size(data)
-    data = VIFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nf, Nh))
+    data = VIFH{S}(ArrayType{FT}, zeros; Nv, Ni, Nh)
     test_universal_size(data)
-    # data = DataLayouts.IJKFVH{S, Nij, Nk, Nv}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); test_universal_size(data) # TODO: test
-    # data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));                     test_universal_size(data) # TODO: test
+    # data = DataLayouts.IJKFVH{S}(ArrayType{FT}, zeros; Nij,Nk,Nv,Nh);  test_universal_size(data) # TODO: test
+    # data = DataLayouts.IH1JH2{S}(ArrayType{FT}, zeros; Nij);           test_universal_size(data) # TODO: test
 end

--- a/test/DataLayouts/unit_copyto.jl
+++ b/test/DataLayouts/unit_copyto.jl
@@ -43,68 +43,66 @@ end
 
 @testset "copyto! with Nf = 1" begin
     device = ClimaComms.device()
-    device_zeros(args...) = ClimaComms.array_type(device)(zeros(args...))
+    ArrayType = ClimaComms.array_type(device)
     FT = Float64
     S = FT
-    Nf = 1
     Nv = 4
-    Nij = 3
+    Ni = Nij = 3
     Nh = 5
     Nk = 6
-    data = DataF{S}(device_zeros(FT, Nf))
+    data = DataF{S}(ArrayType{FT}, zeros)
     test_copyto_float!(data)
-    data = IJFH{S, Nij}(device_zeros(FT, Nij, Nij, Nf, Nh))
+    data = IJFH{S}(ArrayType{FT}, zeros; Nij, Nh)
     test_copyto_float!(data)
-    data = IFH{S, Nij}(device_zeros(FT, Nij, Nf, Nh))
+    data = IFH{S}(ArrayType{FT}, zeros; Ni, Nh)
     test_copyto_float!(data)
-    data = IJF{S, Nij}(device_zeros(FT, Nij, Nij, Nf))
+    data = IJF{S}(ArrayType{FT}, zeros; Nij)
     test_copyto_float!(data)
-    data = IF{S, Nij}(device_zeros(FT, Nij, Nf))
+    data = IF{S}(ArrayType{FT}, zeros; Ni)
     test_copyto_float!(data)
-    data = VF{S, Nv}(device_zeros(FT, Nv, Nf))
+    data = VF{S}(ArrayType{FT}, zeros; Nv)
     test_copyto_float!(data)
-    data = VIJFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nij, Nf, Nh))
+    data = VIJFH{S}(ArrayType{FT}, zeros; Nv, Nij, Nh)
     test_copyto_float!(data)
-    data = VIFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nf, Nh))
+    data = VIFH{S}(ArrayType{FT}, zeros; Nv, Ni, Nh)
     test_copyto_float!(data)
-    # data = DataLayouts.IJKFVH{S, Nij, Nk}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); test_copyto_float!(data) # TODO: test
-    # data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));             test_copyto_float!(data) # TODO: test
+    # data = DataLayouts.IJKFVH{S}(ArrayType{FT}, zeros; Nij,Nk,Nv,Nh); test_copyto_float!(data) # TODO: test
+    # data = DataLayouts.IH1JH2{S}(ArrayType{FT}, zeros; Nij);          test_copyto_float!(data) # TODO: test
 end
 
 @testset "copyto! with Nf > 1" begin
     device = ClimaComms.device()
-    device_zeros(args...) = ClimaComms.array_type(device)(zeros(args...))
+    ArrayType = ClimaComms.array_type(device)
     FT = Float64
     S = Tuple{FT, FT}
-    Nf = 2
     Nv = 4
-    Nij = 3
+    Ni = Nij = 3
     Nh = 5
     Nk = 6
-    data = DataF{S}(device_zeros(FT, Nf))
+    data = DataF{S}(ArrayType{FT}, zeros)
     test_copyto!(data)
-    data = IJFH{S, Nij}(device_zeros(FT, Nij, Nij, Nf, Nh))
+    data = IJFH{S}(ArrayType{FT}, zeros; Nij, Nh)
     test_copyto!(data)
-    data = IFH{S, Nij}(device_zeros(FT, Nij, Nf, Nh))
+    data = IFH{S}(ArrayType{FT}, zeros; Ni, Nh)
     test_copyto!(data)
-    data = IJF{S, Nij}(device_zeros(FT, Nij, Nij, Nf))
+    data = IJF{S}(ArrayType{FT}, zeros; Nij)
     test_copyto!(data)
-    data = IF{S, Nij}(device_zeros(FT, Nij, Nf))
+    data = IF{S}(ArrayType{FT}, zeros; Ni)
     test_copyto!(data)
-    data = VF{S, Nv}(device_zeros(FT, Nv, Nf))
+    data = VF{S}(ArrayType{FT}, zeros; Nv)
     test_copyto!(data)
-    data = VIJFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nij, Nf, Nh))
+    data = VIJFH{S}(ArrayType{FT}, zeros; Nv, Nij, Nh)
     test_copyto!(data)
-    data = VIFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nf, Nh))
+    data = VIFH{S}(ArrayType{FT}, zeros; Nv, Ni, Nh)
     test_copyto!(data)
     # TODO: test this
-    # data = DataLayouts.IJKFVH{S, Nij, Nk}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); test_copyto!(data) # TODO: test
-    # data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));             test_copyto!(data) # TODO: test
+    # data = DataLayouts.IJKFVH{S}(ArrayType{FT}, zeros; Nij,Nk,Nv,Nh); test_copyto!(data) # TODO: test
+    # data = DataLayouts.IH1JH2{S}(ArrayType{FT}, zeros; Nij);          test_copyto!(data) # TODO: test
 end
 
 @testset "copyto! views with Nf > 1" begin
     device = ClimaComms.device()
-    device_zeros(args...) = ClimaComms.array_type(device)(zeros(args...))
+    ArrayType = ClimaComms.array_type(device)
     data_view(data) = DataLayouts.rebuild(
         data,
         SubArray(
@@ -117,28 +115,27 @@ end
     )
     FT = Float64
     S = Tuple{FT, FT}
-    Nf = 2
     Nv = 4
-    Nij = 3
+    Ni = Nij = 3
     Nh = 5
     Nk = 6
     # Rather than using level/slab/column, let's just make views/SubArrays
     # directly so that we can easily test all cases:
-    data = IJFH{S, Nij}(device_zeros(FT, Nij, Nij, Nf, Nh))
+    data = IJFH{S}(ArrayType{FT}, zeros; Nij, Nh)
     test_copyto!(data_view(data))
-    data = IFH{S, Nij}(device_zeros(FT, Nij, Nf, Nh))
+    data = IFH{S}(ArrayType{FT}, zeros; Ni, Nh)
     test_copyto!(data_view(data))
-    data = IJF{S, Nij}(device_zeros(FT, Nij, Nij, Nf))
+    data = IJF{S}(ArrayType{FT}, zeros; Nij)
     test_copyto!(data_view(data))
-    data = IF{S, Nij}(device_zeros(FT, Nij, Nf))
+    data = IF{S}(ArrayType{FT}, zeros; Ni)
     test_copyto!(data_view(data))
-    data = VF{S, Nv}(device_zeros(FT, Nv, Nf))
+    data = VF{S}(ArrayType{FT}, zeros; Nv)
     test_copyto!(data_view(data))
-    data = VIJFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nij, Nf, Nh))
+    data = VIJFH{S}(ArrayType{FT}, zeros; Nv, Nij, Nh)
     test_copyto!(data_view(data))
-    data = VIFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nf, Nh))
+    data = VIFH{S}(ArrayType{FT}, zeros; Nv, Ni, Nh)
     test_copyto!(data_view(data))
     # TODO: test this
-    # data = DataLayouts.IJKFVH{S, Nij, Nk}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); test_copyto!(data) # TODO: test
-    # data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));             test_copyto!(data) # TODO: test
+    # data = DataLayouts.IJKFVH{S}(ArrayType{FT}, zeros; Nij,Nk,Nv,Nh); test_copyto!(data) # TODO: test
+    # data = DataLayouts.IH1JH2{S}(ArrayType{FT}, zeros; Nij);          test_copyto!(data) # TODO: test
 end

--- a/test/DataLayouts/unit_data2array.jl
+++ b/test/DataLayouts/unit_data2array.jl
@@ -4,6 +4,7 @@ using Revise; include(joinpath("test", "DataLayouts", "unit_data2array.jl"))
 =#
 using Test
 using ClimaCore.DataLayouts
+using ClimaComms
 
 function is_data2array2data_identity(data)
     all(
@@ -15,36 +16,32 @@ end
 @testset "data2array & array2data" begin
     FT = Float64
     Nv = 10 # number of vertical levels
-    Nij = 4  # number of nodal points
+    Ni = Nij = 4  # number of nodal points
     Nh = 10 # number of elements
+    device = ClimaComms.device()
+    ArrayType = ClimaComms.array_type(device)
 
-    array = rand(FT, 2, 1)
-    data = IF{FT, 2}(array)
+    data = IF{FT}(ArrayType{FT}, rand; Ni)
     @test DataLayouts.data2array(data) == reshape(parent(data), :)
     @test is_data2array2data_identity(data)
 
-    array = rand(FT, 2, 1, Nh)
-    data = IFH{FT, 2}(array)
+    data = IFH{FT}(ArrayType{FT}, rand; Ni, Nh)
     @test DataLayouts.data2array(data) == reshape(parent(data), :)
     @test is_data2array2data_identity(data)
 
-    array = rand(FT, 2, 2, 1)
-    data = IJF{FT, 2}(array)
+    data = IJF{FT}(ArrayType{FT}, rand; Nij)
     @test DataLayouts.data2array(data) == reshape(parent(data), :)
     @test is_data2array2data_identity(data)
 
-    array = rand(FT, Nij, Nij, 1, Nh)
-    data = IJFH{FT, Nij}(array)
+    data = IJFH{FT}(ArrayType{FT}, rand; Nij, Nh)
     @test DataLayouts.data2array(data) == reshape(parent(data), :)
     @test is_data2array2data_identity(data)
 
-    array = rand(FT, Nv, Nij, 1, Nh)
-    data = VIFH{FT, Nv, Nij}(array)
+    data = VIFH{FT}(ArrayType{FT}, rand; Nv, Ni, Nh)
     @test DataLayouts.data2array(data) == reshape(parent(data), Nv, :)
     @test is_data2array2data_identity(data)
 
-    array = rand(FT, Nv, Nij, Nij, 1, Nh)
-    data = VIJFH{FT, Nv, Nij}(array)
+    data = VIJFH{FT}(ArrayType{FT}, rand; Nv, Nij, Nh)
     @test DataLayouts.data2array(data) == reshape(parent(data), Nv, :)
     @test is_data2array2data_identity(data)
 end

--- a/test/DataLayouts/unit_fill.jl
+++ b/test/DataLayouts/unit_fill.jl
@@ -19,72 +19,70 @@ end
 
 @testset "fill! with Nf = 1" begin
     device = ClimaComms.device()
-    device_zeros(args...) = ClimaComms.array_type(device)(zeros(args...))
+    ArrayType = ClimaComms.array_type(device)
     FT = Float64
     S = FT
-    Nf = 1
     Nv = 4
-    Nij = 3
+    Ni = Nij = 3
     Nh = 5
     Nk = 6
 
-    data = DataF{S}(device_zeros(FT, Nf))
+    data = DataF{S}(ArrayType{FT}, zeros)
     test_fill!(data, 3)
-    data = IJFH{S, Nij}(device_zeros(FT, Nij, Nij, Nf, Nh))
+    data = IJFH{S}(ArrayType{FT}, zeros; Nij, Nh)
     test_fill!(data, 3)
-    data = IFH{S, Nij}(device_zeros(FT, Nij, Nf, Nh))
+    data = IFH{S}(ArrayType{FT}, zeros; Ni, Nh)
     test_fill!(data, 3)
-    data = IJF{S, Nij}(device_zeros(FT, Nij, Nij, Nf))
+    data = IJF{S}(ArrayType{FT}, zeros; Nij)
     test_fill!(data, 3)
-    data = IF{S, Nij}(device_zeros(FT, Nij, Nf))
+    data = IF{S}(ArrayType{FT}, zeros; Ni)
     test_fill!(data, 3)
-    data = VF{S, Nv}(device_zeros(FT, Nv, Nf))
+    data = VF{S}(ArrayType{FT}, zeros; Nv)
     test_fill!(data, 3)
-    data = VIJFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nij, Nf, Nh))
+    data = VIJFH{S}(ArrayType{FT}, zeros; Nv, Nij, Nh)
     test_fill!(data, 3)
-    data = VIFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nf, Nh))
+    data = VIFH{S}(ArrayType{FT}, zeros; Nv, Ni, Nh)
     test_fill!(data, 3)
 
-    # data = DataLayouts.IJKFVH{S, Nij, Nk}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); test_fill!(data, 3) # TODO: test
-    # data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));             test_fill!(data, 3) # TODO: test
+    # data = DataLayouts.IJKFVH{S}(ArrayType{FT}, zeros; Nij,Nk,Nv,Nh); test_fill!(data, 3) # TODO: test
+    # data = DataLayouts.IH1JH2{S}(ArrayType{FT}, zeros; Nij);          test_fill!(data, 3) # TODO: test
 end
 
 @testset "fill! with Nf > 1" begin
     device = ClimaComms.device()
-    device_zeros(args...) = ClimaComms.array_type(device)(zeros(args...))
+    ArrayType = ClimaComms.array_type(device)
     FT = Float64
     S = Tuple{FT, FT}
-    Nf = 2
     Nv = 4
-    Nij = 3
+    Ni = Nij = 3
     Nh = 5
     Nk = 6
 
-    data = DataF{S}(device_zeros(FT, Nf))
+    data = DataF{S}(ArrayType{FT}, zeros)
     test_fill!(data, (2, 3))
-    data = IJFH{S, Nij}(device_zeros(FT, Nij, Nij, Nf, Nh))
+    data = IJFH{S}(ArrayType{FT}, zeros; Nij, Nh)
     test_fill!(data, (2, 3))
-    data = IFH{S, Nij}(device_zeros(FT, Nij, Nf, Nh))
+    data = IFH{S}(ArrayType{FT}, zeros; Ni, Nh)
     test_fill!(data, (2, 3))
-    data = IJF{S, Nij}(device_zeros(FT, Nij, Nij, Nf))
+    data = IJF{S}(ArrayType{FT}, zeros; Nij)
     test_fill!(data, (2, 3))
-    data = IF{S, Nij}(device_zeros(FT, Nij, Nf))
+    data = IF{S}(ArrayType{FT}, zeros; Ni)
     test_fill!(data, (2, 3))
-    data = VF{S, Nv}(device_zeros(FT, Nv, Nf))
+    data = VF{S}(ArrayType{FT}, zeros; Nv)
     test_fill!(data, (2, 3))
-    data = VIJFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nij, Nf, Nh))
+    data = VIJFH{S}(ArrayType{FT}, zeros; Nv, Nij, Nh)
     test_fill!(data, (2, 3))
-    data = VIFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nf, Nh))
+    data = VIFH{S}(ArrayType{FT}, zeros; Nv, Ni, Nh)
     test_fill!(data, (2, 3))
 
     # TODO: test this
-    # data = DataLayouts.IJKFVH{S, Nij, Nk}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); test_fill!(data, (2,3)) # TODO: test
-    # data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));             test_fill!(data, (2,3)) # TODO: test
+    # data = DataLayouts.IJKFVH{S}(ArrayType{FT}, zeros; Nij,Nk,Nv,Nh); test_fill!(data, (2,3)) # TODO: test
+    # data = DataLayouts.IH1JH2{S}(ArrayType{FT}, zeros; Nij);          test_fill!(data, (2,3)) # TODO: test
 end
 
 @testset "fill! views with Nf > 1" begin
     device = ClimaComms.device()
-    device_zeros(args...) = ClimaComms.array_type(device)(zeros(args...))
+    ArrayType = ClimaComms.array_type(device)
     data_view(data) = DataLayouts.rebuild(
         data,
         SubArray(
@@ -97,37 +95,36 @@ end
     )
     FT = Float64
     S = Tuple{FT, FT}
-    Nf = 2
     Nv = 4
-    Nij = 3
+    Ni = Nij = 3
     Nh = 5
     Nk = 6
     # Rather than using level/slab/column, let's just make views/SubArrays
     # directly so that we can easily test all cases:
 
-    data = IJFH{S, Nij}(device_zeros(FT, Nij, Nij, Nf, Nh))
+    data = IJFH{S}(ArrayType{FT}, zeros; Nij, Nh)
     test_fill!(data_view(data), (2, 3))
-    data = IFH{S, Nij}(device_zeros(FT, Nij, Nf, Nh))
+    data = IFH{S}(ArrayType{FT}, zeros; Ni, Nh)
     test_fill!(data_view(data), (2, 3))
-    data = IJF{S, Nij}(device_zeros(FT, Nij, Nij, Nf))
+    data = IJF{S}(ArrayType{FT}, zeros; Nij)
     test_fill!(data_view(data), (2, 3))
-    data = IF{S, Nij}(device_zeros(FT, Nij, Nf))
+    data = IF{S}(ArrayType{FT}, zeros; Ni)
     test_fill!(data_view(data), (2, 3))
-    data = VF{S, Nv}(device_zeros(FT, Nv, Nf))
+    data = VF{S}(ArrayType{FT}, zeros; Nv)
     test_fill!(data_view(data), (2, 3))
-    data = VIJFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nij, Nf, Nh))
+    data = VIJFH{S}(ArrayType{FT}, zeros; Nv, Nij, Nh)
     test_fill!(data_view(data), (2, 3))
-    data = VIFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nf, Nh))
+    data = VIFH{S}(ArrayType{FT}, zeros; Nv, Ni, Nh)
     test_fill!(data_view(data), (2, 3))
 
     # TODO: test this
-    # data = DataLayouts.IJKFVH{S, Nij, Nk}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); test_fill!(data, (2,3)) # TODO: test
-    # data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));             test_fill!(data, (2,3)) # TODO: test
+    # data = DataLayouts.IJKFVH{S}(ArrayType{FT}, zeros; Nij,Nk,Nv,Nh); test_fill!(data, (2,3)) # TODO: test
+    # data = DataLayouts.IH1JH2{S}(ArrayType{FT}, zeros; Nij);          test_fill!(data, (2,3)) # TODO: test
 end
 
 @testset "Reshaped Arrays" begin
     device = ClimaComms.device()
-    device_zeros(args...) = ClimaComms.array_type(device)(zeros(args...))
+    ArrayType = ClimaComms.array_type(device)
     function reshaped_array(data2)
         # `reshape` does not always return a `ReshapedArray`, which
         # we need to specialize on to correctly dispatch when its
@@ -160,26 +157,25 @@ end
     end
     FT = Float64
     S = Tuple{FT, FT} # need at least 2 components to make a SubArray
-    Nf = 2
     Nv = 4
-    Nij = 3
+    Ni = Nij = 3
     Nh = 5
     Nk = 6
     # directly so that we can easily test all cases:
 
-    data = IJFH{S, Nij}(device_zeros(FT, Nij, Nij, Nf, Nh))
+    data = IJFH{S}(ArrayType{FT}, zeros; Nij, Nh)
     test_fill!(reshaped_array(data), 2)
-    data = IFH{S, Nij}(device_zeros(FT, Nij, Nf, Nh))
+    data = IFH{S}(ArrayType{FT}, zeros; Ni, Nh)
     test_fill!(reshaped_array(data), 2)
-    # data = IJF{S, Nij}(device_zeros(FT,Nij,Nij,Nf));             test_fill!(reshaped_array(data), 2)
-    # data = IF{S, Nij}(device_zeros(FT,Nij,Nf));                  test_fill!(reshaped_array(data), 2)
-    # data = VF{S, Nv}(device_zeros(FT,Nv,Nf));                    test_fill!(reshaped_array(data), 2)
-    data = VIJFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nij, Nf, Nh))
+    # data = IJF{S}(ArrayType{FT}, zeros; Nij);          test_fill!(reshaped_array(data), 2)
+    # data = IF{S}(ArrayType{FT}, zeros; Ni);            test_fill!(reshaped_array(data), 2)
+    # data = VF{S}(ArrayType{FT}, zeros; Nv);            test_fill!(reshaped_array(data), 2)
+    data = VIJFH{S}(ArrayType{FT}, zeros; Nv, Nij, Nh)
     test_fill!(reshaped_array(data), 2)
-    data = VIFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nf, Nh))
+    data = VIFH{S}(ArrayType{FT}, zeros; Nv, Ni, Nh)
     test_fill!(reshaped_array(data), 2)
 
     # TODO: test this
-    # data = DataLayouts.IJKFVH{S, Nij, Nk}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); test_fill!(reshaped_array(data), 2) # TODO: test
-    # data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));             test_fill!(reshaped_array(data), 2) # TODO: test
+    # data = DataLayouts.IJKFVH{S}(ArrayType{FT}, zeros; Nij,Nk,Nv,Nh); test_fill!(reshaped_array(data), 2) # TODO: test
+    # data = DataLayouts.IH1JH2{S}(ArrayType{FT}, zeros; Nij);          test_fill!(reshaped_array(data), 2) # TODO: test
 end

--- a/test/DataLayouts/unit_mapreduce.jl
+++ b/test/DataLayouts/unit_mapreduce.jl
@@ -66,58 +66,56 @@ function test_mapreduce_2!(context, data)
 end
 
 @testset "mapreduce with Nf = 1" begin
-    device_zeros(args...) = ClimaComms.array_type(device)(zeros(args...))
+    ArrayType = ClimaComms.array_type(device)
     FT = Float64
     S = FT
-    Nf = 1
     Nv = 4
-    Nij = 3
+    Ni = Nij = 3
     Nh = 5
     Nk = 6
-    data = DataF{S}(device_zeros(FT, Nf))
+    data = DataF{S}(ArrayType{FT}, zeros)
     test_mapreduce_1!(context, data)
-    data = IJFH{S, Nij}(device_zeros(FT, Nij, Nij, Nf, Nh))
+    data = IJFH{S}(ArrayType{FT}, zeros; Nij, Nh)
     test_mapreduce_1!(context, data)
-    # data = IFH{S, Nij}(device_zeros(FT,Nij,Nf,Nh));              test_mapreduce_1!(context, data)
-    # data = IJF{S, Nij}(device_zeros(FT,Nij,Nij,Nf));                 test_mapreduce_1!(context, data)
-    # data = IF{S, Nij}(device_zeros(FT,Nij,Nf));                      test_mapreduce_1!(context, data)
-    data = VF{S, Nv}(device_zeros(FT, Nv, Nf))
+    # data = IFH{S}(ArrayType{FT}, zeros; Ni,Nh);               test_mapreduce_1!(context, data)
+    # data = IJF{S}(ArrayType{FT}, zeros; Nij);                 test_mapreduce_1!(context, data)
+    # data = IF{S}(ArrayType{FT}, zeros; Ni);                   test_mapreduce_1!(context, data)
+    data = VF{S}(ArrayType{FT}, zeros; Nv)
     test_mapreduce_1!(context, data)
-    data = VIJFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nij, Nf, Nh))
+    data = VIJFH{S}(ArrayType{FT}, zeros; Nv, Nij, Nh)
     test_mapreduce_1!(context, data)
-    # data = VIFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nf,Nh));      test_mapreduce_1!(context, data)
-    # data = DataLayouts.IJKFVH{S, Nij, Nk}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); test_mapreduce_1!(context, data) # TODO: test
-    # data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));                 test_mapreduce_1!(context, data) # TODO: test
+    # data = VIFH{S}(ArrayType{FT}, zeros; Nv,Nij,Nh);                  test_mapreduce_1!(context, data)
+    # data = DataLayouts.IJKFVH{S}(ArrayType{FT}, zeros; Nij,Nk,Nv,Nh); test_mapreduce_1!(context, data) # TODO: test
+    # data = DataLayouts.IH1JH2{S}(ArrayType{FT}, zeros; Nij);             test_mapreduce_1!(context, data) # TODO: test
 end
 
 @testset "mapreduce with Nf > 1" begin
-    device_zeros(args...) = ClimaComms.array_type(device)(zeros(args...))
+    ArrayType = ClimaComms.array_type(device)
     FT = Float64
     S = Tuple{FT, FT}
-    Nf = 2
     Nv = 4
-    Nij = 3
+    Ni = Nij = 3
     Nh = 5
     Nk = 6
-    data = DataF{S}(device_zeros(FT, Nf))
+    data = DataF{S}(ArrayType{FT}, zeros)
     test_mapreduce_2!(context, data)
-    data = IJFH{S, Nij}(device_zeros(FT, Nij, Nij, Nf, Nh))
+    data = IJFH{S}(ArrayType{FT}, zeros; Nij, Nh)
     test_mapreduce_2!(context, data)
-    # data = IFH{S, Nij}(device_zeros(FT,Nij,Nf,Nh));              test_mapreduce_2!(context, data)
-    # data = IJF{S, Nij}(device_zeros(FT,Nij,Nij,Nf));                 test_mapreduce_2!(context, data)
-    # data = IF{S, Nij}(device_zeros(FT,Nij,Nf));                      test_mapreduce_2!(context, data)
-    data = VF{S, Nv}(device_zeros(FT, Nv, Nf))
+    # data = IFH{S}(ArrayType{FT}, zeros; Ni,Nh);               test_mapreduce_2!(context, data)
+    # data = IJF{S}(ArrayType{FT}, zeros; Nij);                 test_mapreduce_2!(context, data)
+    # data = IF{S}(ArrayType{FT}, zeros; Ni);                   test_mapreduce_2!(context, data)
+    data = VF{S}(ArrayType{FT}, zeros; Nv)
     test_mapreduce_2!(context, data)
-    data = VIJFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nij, Nf, Nh))
+    data = VIJFH{S}(ArrayType{FT}, zeros; Nv, Nij, Nh)
     test_mapreduce_2!(context, data)
-    # data = VIFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nf,Nh));      test_mapreduce_2!(context, data)
+    # data = VIFH{S}(ArrayType{FT}, zeros; Nv,Nij,Nh);                  test_mapreduce_2!(context, data)
     # TODO: test this
-    # data = DataLayouts.IJKFVH{S, Nij, Nk}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); test_mapreduce_2!(context, data) # TODO: test
-    # data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));                 test_mapreduce_2!(context, data) # TODO: test
+    # data = DataLayouts.IJKFVH{S}(ArrayType{FT}, zeros; Nij,Nk,Nv,Nh); test_mapreduce_2!(context, data) # TODO: test
+    # data = DataLayouts.IH1JH2{S}(ArrayType{FT}, zeros; Nij);             test_mapreduce_2!(context, data) # TODO: test
 end
 
 @testset "mapreduce views with Nf > 1" begin
-    device_zeros(args...) = ClimaComms.array_type(device)(zeros(args...))
+    ArrayType = ClimaComms.array_type(device)
     data_view(data) = DataLayouts.rebuild(
         data,
         SubArray(
@@ -130,26 +128,25 @@ end
     )
     FT = Float64
     S = Tuple{FT, FT}
-    Nf = 2
     Nv = 4
-    Nij = 3
+    Ni = Nij = 3
     Nh = 5
     Nk = 6
     # Rather than using level/slab/column, let's just make views/SubArrays
     # directly so that we can easily test all cases:
-    data = DataF{S}(device_zeros(FT, Nf))
+    data = DataF{S}(ArrayType{FT}, zeros)
     test_mapreduce_2!(context, data_view(data))
-    data = IJFH{S, Nij}(device_zeros(FT, Nij, Nij, Nf, Nh))
+    data = IJFH{S}(ArrayType{FT}, zeros; Nij, Nh)
     test_mapreduce_2!(context, data_view(data))
-    # data = IFH{S, Nij}(device_zeros(FT,Nij,Nf,Nh));              test_mapreduce_2!(context, data_view(data))
-    # data = IJF{S, Nij}(device_zeros(FT,Nij,Nij,Nf));                 test_mapreduce_2!(context, data_view(data))
-    # data = IF{S, Nij}(device_zeros(FT,Nij,Nf));                      test_mapreduce_2!(context, data_view(data))
-    data = VF{S, Nv}(device_zeros(FT, Nv, Nf))
+    # data = IFH{S}(ArrayType{FT}, zeros; Ni,Nh);               test_mapreduce_2!(context, data_view(data))
+    # data = IJF{S}(ArrayType{FT}, zeros; Nij);                 test_mapreduce_2!(context, data_view(data))
+    # data = IF{S}(ArrayType{FT}, zeros; Ni);                   test_mapreduce_2!(context, data_view(data))
+    data = VF{S}(ArrayType{FT}, zeros; Nv)
     test_mapreduce_2!(context, data_view(data))
-    data = VIJFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nij, Nf, Nh))
+    data = VIJFH{S}(ArrayType{FT}, zeros; Nv, Nij, Nh)
     test_mapreduce_2!(context, data_view(data))
-    # data = VIFH{S, Nv, Nij}(device_zeros(FT,Nv,Nij,Nf,Nh));      test_mapreduce_2!(context, data_view(data))
+    # data = VIFH{S}(ArrayType{FT}, zeros; Nv,Nij,Nh);                  test_mapreduce_2!(context, data_view(data))
     # TODO: test this
-    # data = DataLayouts.IJKFVH{S, Nij, Nk}(device_zeros(FT,Nij,Nij,Nk,Nf,Nv,Nh)); test_mapreduce_2!(context, data_view(data)) # TODO: test
-    # data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT,2*Nij,3*Nij));                 test_mapreduce_2!(context, data_view(data)) # TODO: test
+    # data = DataLayouts.IJKFVH{S}(ArrayType{FT}, zeros; Nij,Nk,Nv,Nh); test_mapreduce_2!(context, data_view(data)) # TODO: test
+    # data = DataLayouts.IH1JH2{S}(ArrayType{FT}, zeros; Nij);             test_mapreduce_2!(context, data_view(data)) # TODO: test
 end

--- a/test/DataLayouts/unit_ndims.jl
+++ b/test/DataLayouts/unit_ndims.jl
@@ -9,44 +9,42 @@ ClimaComms.@import_required_backends
 
 @testset "Base.ndims" begin
     device = ClimaComms.device()
-    device_zeros(args...) = ClimaComms.array_type(device)(zeros(args...))
+    ArrayType = ClimaComms.array_type(device)
     FT = Float64
     S = FT
-    Nf = 1
     Nv = 4
-    Nij = 3
+    Ni = Nij = 3
     Nh = 5
     Nk = 6
-    data = DataF{S}(device_zeros(FT, Nf))
+
+    data = DataF{S}(ArrayType{FT}, zeros)
     @test ndims(data) == 1
     @test ndims(typeof(data)) == 1
-    data = IF{S, Nij}(device_zeros(FT, Nij, Nf))
+    data = IF{S}(ArrayType{FT}, zeros; Ni)
     @test ndims(data) == 2
     @test ndims(typeof(data)) == 2
-    data = VF{S, Nv}(device_zeros(FT, Nv, Nf))
+    data = VF{S}(ArrayType{FT}, zeros; Nv)
     @test ndims(data) == 2
     @test ndims(typeof(data)) == 2
-    data = IFH{S, Nij}(device_zeros(FT, Nij, Nf, Nh))
+    data = IFH{S}(ArrayType{FT}, zeros; Ni, Nh)
     @test ndims(data) == 3
     @test ndims(typeof(data)) == 3
-    data = IJF{S, Nij}(device_zeros(FT, Nij, Nij, Nf))
+    data = IJF{S}(ArrayType{FT}, zeros; Nij)
     @test ndims(data) == 3
     @test ndims(typeof(data)) == 3
-    data = IJFH{S, Nij}(device_zeros(FT, Nij, Nij, Nf, Nh))
+    data = IJFH{S}(ArrayType{FT}, zeros; Nij, Nh)
     @test ndims(data) == 4
     @test ndims(typeof(data)) == 4
-    data = VIFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nf, Nh))
+    data = VIFH{S}(ArrayType{FT}, zeros; Nv, Ni, Nh)
     @test ndims(data) == 4
     @test ndims(typeof(data)) == 4
-    data = VIJFH{S, Nv, Nij}(device_zeros(FT, Nv, Nij, Nij, Nf, Nh))
+    data = VIJFH{S}(ArrayType{FT}, zeros; Nv, Nij, Nh)
     @test ndims(data) == 5
     @test ndims(typeof(data)) == 5
-    data = DataLayouts.IJKFVH{S, Nij, Nk, Nv}(
-        device_zeros(FT, Nij, Nij, Nk, Nf, Nv, Nh),
-    )
+    data = DataLayouts.IJKFVH{S}(ArrayType{FT}, zeros; Nij, Nk, Nv, Nh)
     @test ndims(data) == 6
     @test ndims(typeof(data)) == 6
-    data = DataLayouts.IH1JH2{S, Nij}(device_zeros(FT, 2 * Nij, 3 * Nij))
+    data = DataLayouts.IH1JH2{S}(ArrayType{FT}, zeros; Nij)
     @test ndims(data) == 2
     @test ndims(typeof(data)) == 2
 end


### PR DESCRIPTION
I've found myself churning a lot of code in the test suite, related to construction of datalayouts.

This PR adds new convenience constructors for datalayouts, meant to be used at the top-level (as they are not inferable).

They have a few advantages over the existing way we construct them. Concretely, they:
 - Require less code duplication
 - Infer `Nf`
 - Use keywords for clarity, and are therefore order-agnostic

So, instead of writing

```julia
array = rand(FT, Nv, Nij, Nij, 3, Nh)
data = VIJFH{S, Nv, Nij}(array)
```

We can write:

```julia
data = VIJFH{S}(ArrayType{FT}, rand; Nv, Nij, Nh)
array = parent(data) # (if you still need `array`)
```

So, this will hopefully reduce the surface area of these constructors if we use them consistently in the test suite.