### PR TITLE
Try to fix Undefined Behavior in DataLayouts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ ClimaCore.jl Release Notes
 main
 -------
 
+ - Fixed world-age issue on Julia 1.11 issue [Julia#54780](https://github.com/JuliaLang/julia/issues/54780), PR [#2034](https://github.com/CliMA/ClimaCore.jl/pull/2034).
+
 v0.14.18
 -------
 


### PR DESCRIPTION
Per https://github.com/JuliaLang/julia/issues/54780#issuecomment-2269928520, this PR attempts to remove `string(::Type)` inside a generated function.

It seems to me like this code could be type-unstable, unless things are constant-propagated.