### PR TITLE
add ClimaCoupler downstream AMIP test

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -31,12 +31,14 @@ jobs:
           - 'KinematicDriver.jl'
           - 'ClimaDiagnostics.jl'
           - 'ClimaUtilities.jl'
+        version:
+          - '1.10'
+          - '1.11'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
-          version: '1.10'
-          version: '1.11'
+          version: ${{ matrix.version }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: actions/checkout@v4
@@ -47,7 +49,7 @@ jobs:
       # The test suite for ClimaTimesteppers depends on ClimaCore, not
       # ClimaTimesteppers itself. If we dev-ed ClimaCore in ClimaTimesteppers,
       # the aqua test would fail because we never use ClimaCore.
-      - if: matrix.package != 'ClimaTimesteppers.jl'
+      - if: (matrix.package != 'ClimaTimesteppers.jl' && matrix.package != 'ClimaCoupler.jl')
         run: |
           julia --color=yes --project=${{ matrix.package }} -e 'using Pkg; Pkg.instantiate()'
           julia --color=yes --project=${{ matrix.package }} -e 'using Pkg; Pkg.develop(; path = ".")'
@@ -58,3 +60,9 @@ jobs:
           julia --color=yes --project=ClimaTimesteppers.jl/test -e 'using Pkg; Pkg.instantiate()'
           julia --color=yes --project=ClimaTimesteppers.jl/test -e 'using Pkg; Pkg.develop(; path = ".")'
           julia --color=yes --project=ClimaTimesteppers.jl/test ClimaTimesteppers.jl/test/runtests.jl
+
+      - if: matrix.package == 'ClimaCoupler.jl'
+        run: |
+          julia --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth -e 'using Pkg; Pkg.instantiate()'
+          julia --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth -e 'using Pkg; Pkg.develop(; path = ".")'
+          julia --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth ClimaCoupler.jl/experiments/ClimaEarth/test/runtests.jl


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
https://github.com/CliMA/ClimaCoupler.jl/pull/1033 added a `test/runtests.jl` file inside of the ClimaCoupler.jl `experiments/ClimaEarth/` directory. This sets up a coarse AMIP simulation and runs it for 2 timesteps. This is meant to be used in upstream packages as a way to ensure downstream compatibility. Note that it doesn't test long-term simulation stability.

This PR adds a downstream test for that environment in this package.

Closes #1959 