### PR TITLE
Add function barrier to `diffuse_surface_elevation!`

### DIFF
--- a/src/Hypsography/Hypsography.jl
+++ b/src/Hypsography/Hypsography.jl
@@ -301,6 +301,15 @@ function diffuse_surface_elevation!(
     ghost_buffer = (bf = Spaces.create_dss_buffer(f_z),)
     # Apply smoothing
     χf = @. wdiv(grad(f_z))
+    _diffuse_surface_elevation!(f, κ, maxiter, dt, χf, f_z, ghost_buffer)
+    return f
+end
+
+function _diffuse_surface_elevation!(f, κ, maxiter, dt, χf, f_z, ghost_buffer)
+    # Define required ops
+    wdiv = Operators.WeakDivergence()
+    grad = Operators.Gradient()
+    # Apply smoothing
     for iter in 1:maxiter
         # Euler steps
         if iter ≠ 1


### PR DESCRIPTION
This PR adds a function barrier to `diffuse_surface_elevation!`. This is a step towards #1797. `create_dss_buffer` is type-unstable, and so this function barrier could potentially fix inference failure in a hot loop (inside the Euler loop).