### PR TITLE
Add FieldVector microbenchmarks and improve fieldvector broadcast performance

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -486,6 +486,7 @@ steps:
         key: unit_field
         command:
           - "julia --color=yes --check-bounds=yes --project=.buildkite test/Fields/unit_field.jl"
+          - "julia --color=yes --check-bounds=yes --project=.buildkite test/Fields/benchmark_fieldvectors.jl"
           - "julia --color=yes --check-bounds=yes --project=.buildkite test/Fields/benchmark_field_multi_broadcast_fusion.jl"
           - "julia --color=yes --check-bounds=yes --project=.buildkite test/Fields/convergence_field_integrals.jl"
           - "julia --color=yes --check-bounds=yes --project=.buildkite test/Fields/inference_repro.jl"
@@ -495,6 +496,7 @@ steps:
         command:
           - "julia --project=.buildkite -e 'using CUDA; CUDA.versioninfo()'"
           - "julia --color=yes --check-bounds=yes --project=.buildkite test/Fields/unit_field.jl"
+          - "julia --color=yes --check-bounds=yes --project=.buildkite test/Fields/benchmark_fieldvectors.jl"
           - "julia --color=yes --check-bounds=yes --project=.buildkite test/Fields/benchmark_field_multi_broadcast_fusion.jl"
           - "julia --color=yes --check-bounds=yes --project=.buildkite test/Fields/convergence_field_integrals.jl"
           - "julia --color=yes --check-bounds=yes --project=.buildkite test/Fields/inference_repro.jl"

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -10,7 +10,11 @@ import ..DataLayouts:
     FusedMultiBroadcast,
     @fused_direct,
     isascalar,
-    check_fused_broadcast_axes
+    check_fused_broadcast_axes,
+    ToCPU,
+    ToCUDA,
+    copyto_per_field!,
+    copyto_per_field_scalar!
 import ..Domains
 import ..Topologies
 import ..Quadratures

--- a/test/Fields/benchmark_fieldvectors.jl
+++ b/test/Fields/benchmark_fieldvectors.jl
@@ -1,0 +1,137 @@
+#=
+julia --project
+ENV["CLIMACOMMS_DEVICE"] = "CPU"; using Revise; include(joinpath("test", "Fields", "benchmark_fieldvectors.jl"))
+ENV["CLIMACOMMS_DEVICE"] = "CUDA"; using Revise; include(joinpath("test", "Fields", "benchmark_fieldvectors.jl"))
+=#
+using Test
+using ClimaCore.DataLayouts
+using ClimaCore: Spaces, Fields, Geometry
+using BenchmarkTools
+import ClimaComms
+import ClimaCore
+@static pkgversion(ClimaComms) >= v"0.6" && ClimaComms.@import_required_backends
+if ClimaComms.device() isa ClimaComms.CUDADevice
+    import CUDA
+    device_name = CUDA.name(CUDA.device()) # Move to ClimaComms
+else
+    device_name = "CPU"
+end
+if !(@isdefined(TU))
+    include(
+        joinpath(
+            pkgdir(ClimaCore),
+            "test",
+            "TestUtilities",
+            "TestUtilities.jl",
+        ),
+    )
+    import .TestUtilities as TU
+end
+
+include(joinpath(pkgdir(ClimaCore), "benchmarks/scripts/benchmark_utils.jl"))
+
+function benchmarkcopyto!(bm, device, data, val)
+    caller = string(nameof(typeof(data)))
+    @info "Benchmarking $caller..."
+    data_rhs_1 = similar(data)
+    data_rhs_2 = similar(data)
+    data_rhs_3 = similar(data)
+    data_rhs_4 = similar(data)
+    T = eltype(parent(data))
+    dt = T(0)
+    bc1 = Base.Broadcast.broadcasted(+, data_rhs_2, data_rhs_3, data_rhs_4)
+    bc2 = Base.Broadcast.broadcasted(*, dt, bc1)
+    bc = Base.Broadcast.broadcasted(+, data_rhs_1, bc2)
+    trial = @benchmark ClimaComms.@cuda_sync $device Base.copyto!($data, $bc)
+    t_min = minimum(trial.times) * 1e-9 # to seconds
+    nreps = length(trial.times)
+    n_reads_writes = 1 + 4
+    push_info(
+        bm;
+        kernel_time_s = t_min,
+        nreps = nreps,
+        caller,
+        problem_size = size(parent(data)),
+        n_reads_writes,
+    )
+end
+
+function fv_state(cspace, fspace)
+    FT = Spaces.undertype(cspace)
+    return Fields.FieldVector(
+        c = fill(
+            (;
+                ρ = FT(0),
+                uₕ = zero(Geometry.Covariant12Vector{FT}),
+                e_int = FT(0),
+                q_tot = FT(0),
+            ),
+            cspace,
+        ),
+        f = fill((; w = Geometry.Covariant3Vector(FT(0))), fspace),
+    )
+end
+
+@testset "FieldVector FH" begin
+    FT = Float64
+    device = ClimaComms.device()
+
+    bm = Benchmark(; float_type = FT, device_name)
+    cspace = TU.CenterExtrudedFiniteDifferenceSpace(
+        FT;
+        zelem = 63,
+        helem = 30,
+        Nq = 4,
+        context = ClimaComms.context(device),
+    )
+    fspace = Spaces.FaceExtrudedFiniteDifferenceSpace(cspace)
+    X = fv_state(cspace, fspace)
+    benchmarkcopyto!(bm, device, X, 3)
+
+    cspace = TU.CenterExtrudedFiniteDifferenceSpace(
+        FT;
+        zelem = 63,
+        helem = 15,
+        Nq = 4,
+        context = ClimaComms.context(device),
+    )
+    fspace = Spaces.FaceExtrudedFiniteDifferenceSpace(cspace)
+    X = fv_state(cspace, fspace)
+    benchmarkcopyto!(bm, device, X, 3)
+
+    tabulate_benchmark(bm)
+    nothing
+end
+
+@testset "FieldVector HF" begin
+    FT = Float64
+    device = ClimaComms.device()
+
+    bm = Benchmark(; float_type = FT, device_name)
+    cspace = TU.CenterExtrudedFiniteDifferenceSpace(
+        FT;
+        zelem = 63,
+        helem = 30,
+        Nq = 4,
+        context = ClimaComms.context(device),
+        horizontal_layout_type = DataLayouts.IJHF,
+    )
+    fspace = Spaces.FaceExtrudedFiniteDifferenceSpace(cspace)
+    X = fv_state(cspace, fspace)
+    benchmarkcopyto!(bm, device, X, 3)
+
+    cspace = TU.CenterExtrudedFiniteDifferenceSpace(
+        FT;
+        zelem = 63,
+        helem = 15,
+        Nq = 4,
+        context = ClimaComms.context(device),
+        horizontal_layout_type = DataLayouts.IJHF,
+    )
+    fspace = Spaces.FaceExtrudedFiniteDifferenceSpace(cspace)
+    X = fv_state(cspace, fspace)
+    benchmarkcopyto!(bm, device, X, 3)
+
+    tabulate_benchmark(bm)
+    nothing
+end

--- a/test/Fields/unit_field.jl
+++ b/test/Fields/unit_field.jl
@@ -388,6 +388,8 @@ end
     Y3 = Fields.FieldVector(; x = cx, y = cy)
     Y4 = Fields.FieldVector(; x = cx, y = cy)
     Z = Fields.FieldVector(; x = fx, y = fy)
+    Base.copyto!(Y1, Y2)
+    Base.copyto!(Y1, 0)
     function test_fv_allocations!(X1, X2, X3, X4)
         @. X1 += X2 * X3 + X4
         return nothing


### PR DESCRIPTION
Closes #2067. This turned out to be pretty easy: any fieldvector operation is embarrassingly parallel. We can leverage `NonExtrudedBroadcasted`, forward everything to the backing arrays, and just linearly index everywhere. This puts us in a pretty good shape for fieldvector operations, and it'll be even better at lower resolution since we parallelize across field variables.

## GPU
#### main
```julia
N reads-writes: 5,  Float_type = Float64, Device_bandwidth_GBs=2039
┌─────────────┬───────────────────────────────────┬─────────┬─────────────┬──────────────┬────────┐
│ funcs       │ time per call                     │ bw %    │ achieved bw │ problem size │ n-reps │
├─────────────┼───────────────────────────────────┼─────────┼─────────────┼──────────────┼────────┤
│ FieldVector │ 1 millisecond, 104 microseconds   │ 54.161  │ 1104.34     │ (32745600,)  │ 4475   │
│ FieldVector │ 307 microseconds, 597 nanoseconds │ 48.6243 │ 991.45      │ (8186400,)   │ 10000  │
└─────────────┴───────────────────────────────────┴─────────┴─────────────┴──────────────┴────────┘
```
#### this PR
```julia
N reads-writes: 5,  Float_type = Float64, Device_bandwidth_GBs=2039
┌─────────────┬───────────────────────────────────┬─────────┬─────────────┬──────────────┬────────┐
│ funcs       │ time per call                     │ bw %    │ achieved bw │ problem size │ n-reps │
├─────────────┼───────────────────────────────────┼─────────┼─────────────┼──────────────┼────────┤
│ FieldVector │ 757 microseconds, 513 nanoseconds │ 78.9779 │ 1610.36     │ (32745600,)  │ 6491   │
│ FieldVector │ 202 microseconds, 849 nanoseconds │ 73.7335 │ 1503.43     │ (8186400,)   │ 10000  │
└─────────────┴───────────────────────────────────┴─────────┴─────────────┴──────────────┴────────┘
```

## CPU
#### main
```julia
N reads-writes: 5,  Float_type = Float64,
┌─────────────┬──────────────────────────────────┬─────────────┬──────────────┬────────┐
│ funcs       │ time per call                    │ achieved bw │ problem size │ n-reps │
├─────────────┼──────────────────────────────────┼─────────────┼──────────────┼────────┤
│ FieldVector │ 32 milliseconds, 45 microseconds │ 38.0674     │ (32745600,)  │ 33     │
│ FieldVector │ 7 milliseconds, 792 microseconds │ 39.1372     │ (8186400,)   │ 529    │
└─────────────┴──────────────────────────────────┴─────────────┴──────────────┴────────┘
```

#### This PR

```julia
N reads-writes: 5,  Float_type = Float64,
┌─────────────┬───────────────────────────────────┬─────────────┬──────────────┬────────┐
│ funcs       │ time per call                     │ achieved bw │ problem size │ n-reps │
├─────────────┼───────────────────────────────────┼─────────────┼──────────────┼────────┤
│ FieldVector │ 23 milliseconds, 218 microseconds │ 52.5398     │ (32745600,)  │ 43     │
│ FieldVector │ 5 milliseconds, 752 microseconds  │ 53.0143     │ (8186400,)   │ 828    │
└─────────────┴───────────────────────────────────┴─────────────┴──────────────┴────────┘
```