### PR TITLE
Add fieldvector unit tests, update `rcompare`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@ ClimaCore.jl Release Notes
 main
 -------
 
+ - A `strict = true` keyword was added to `rcompare`, which checks that the types match. If `strict = false`, then `rcompare` will return `true` for `FieldVector`s and `NamedTuple`s with the same properties but permuted order. For example:
+     - `rcompare((;a=1,b=2), (;b=2,a=1); strict = true)` will return `false` and
+     - `rcompare((;a=1,b=2), (;b=2,a=1); strict = false)` will return `true`
  - We've added new datalayouts: `VIJHF`,`IJHF`,`IHF`,`VIHF`, to explore their performance compared to our existing datalayouts: `VIJFH`,`IJFH`,`IFH`,`VIFH`. PR [#2055](https://github.com/CliMA/ClimaCore.jl/pull/2053), PR [#2052](https://github.com/CliMA/ClimaCore.jl/pull/2055).
  - We've refactored some modules to use less internals. PR [#2053](https://github.com/CliMA/ClimaCore.jl/pull/2053), PR [#2052](https://github.com/CliMA/ClimaCore.jl/pull/2052), [#2051](https://github.com/CliMA/ClimaCore.jl/pull/2051), [#2049](https://github.com/CliMA/ClimaCore.jl/pull/2049).
  - Some work was done in attempt to reduce specializations and compile time. PR [#2042](https://github.com/CliMA/ClimaCore.jl/pull/2042), [#2041](https://github.com/CliMA/ClimaCore.jl/pull/2041)


### PR DESCRIPTION
This PR adds a fieldvector unit test, which was extracted from https://github.com/CliMA/ClimaCore.jl/pull/2070, where the unit tests passed but a test in ClimaLand broke.

It's still not clear to me whether this is exercising broadcasting over different fieldvectors types with the same propertynames, or something different. Either way, we should probably test for that, plus, we could update `rcompare` to handle fieldvectors with different propertyname orders.