### PR TITLE
Define CommonSpaces module

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,16 +4,23 @@ ClimaCore.jl Release Notes
 main
 -------
 
+ - We've added new convenience constructors for spaces PR [2082](https://github.com/CliMA/ClimaCore.jl/pull/2082). Here are links to the new constructors:
+   - [ExtrudedCubedSphereSpace]()
+   - [CubedSphereSpace]()
+   - [ColumnSpace]()
+   - [Box3DSpace]()
+   - [SliceXZSpace]()
+   - [RectangleXYSpace]()
+
 v0.14.20
--------
 
  - We've added new convenience constructors for grids PR [1848](https://github.com/CliMA/ClimaCore.jl/pull/1848). Here are links to the new constructors:
-   - [ExtrudedCubedSphereGrid]()
-   - [CubedSphereGrid]()
-   - [ColumnGrid]()
-   - [Box3DGrid]()
-   - [SliceXZGrid]()
-   - [RectangleXYGrid]()
+   - [ExtrudedCubedSphereGrid](https://github.com/CliMA/ClimaCore.jl/blob/cbb193042fac3b4bef33251fbc0f232427bfe506/src/CommonGrids/CommonGrids.jl#L85-L144)
+   - [CubedSphereGrid](https://github.com/CliMA/ClimaCore.jl/blob/cbb193042fac3b4bef33251fbc0f232427bfe506/src/CommonGrids/CommonGrids.jl#L200-L235)
+   - [ColumnGrid](https://github.com/CliMA/ClimaCore.jl/blob/cbb193042fac3b4bef33251fbc0f232427bfe506/src/CommonGrids/CommonGrids.jl#L259-L281)
+   - [Box3DGrid](https://github.com/CliMA/ClimaCore.jl/blob/cbb193042fac3b4bef33251fbc0f232427bfe506/src/CommonGrids/CommonGrids.jl#L303-L378)
+   - [SliceXZGrid](https://github.com/CliMA/ClimaCore.jl/blob/cbb193042fac3b4bef33251fbc0f232427bfe506/src/CommonGrids/CommonGrids.jl#L441-L498)
+   - [RectangleXYGrid](https://github.com/CliMA/ClimaCore.jl/blob/cbb193042fac3b4bef33251fbc0f232427bfe506/src/CommonGrids/CommonGrids.jl#L547-L602)
 
  - A `strict = true` keyword was added to `rcompare`, which checks that the types match. If `strict = false`, then `rcompare` will return `true` for `FieldVector`s and `NamedTuple`s with the same properties but permuted order. For example:
      - `rcompare((;a=1,b=2), (;b=2,a=1); strict = true)` will return `false` and

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -15,7 +15,7 @@
   volume = {271},
   pages = {224-243},
   year = {2014},
-  doi = {https://doi.org/10.1016/j.jcp.2013.11.033},
+  doi = {10.1016/j.jcp.2013.11.033},
   author = {Lei Bao and Ramachandran D. Nair and Henry M. Tufo}
 }
 
@@ -48,7 +48,7 @@
   number = {1},
   pages = {38-69},
   year = {1973},
-  doi = {https://doi.org/10.1016/0021-9991(73)90147-2},
+  doi = {10.1016/0021-9991(73)90147-2},
   author = {Jay P Boris and David L Book}
 }
 
@@ -121,7 +121,7 @@
   volume = {267},
   pages = {176-195},
   year = {2014},
-  doi = {https://doi.org/10.1016/j.jcp.2014.02.029}
+  doi = {10.1016/j.jcp.2014.02.029}
 }
 
 @article{Nair2005,
@@ -166,7 +166,7 @@
       address = {Boston MA, USA},
       volume = {130},
       number = {10},
-      doi = {https://doi.org/10.1175/1520-0493(2002)130<2459:ANTFVC>2.0.CO;2},
+      doi = {10.1175/1520-0493(2002)130<2459:ANTFVC>2.0.CO;2},
       pages= {2459 - 2480},
 }
 
@@ -242,7 +242,7 @@
   number = {1},
   pages = {211-224},
   year = {1992},
-  doi = {https://doi.org/10.1016/S0021-9991(05)80016-6},
+  doi = {10.1016/S0021-9991(05)80016-6},
   author = {David L. Williamson and John B. Drake and James J. Hack and Rüdiger Jakob and Paul N. Swarztrauber}
 }
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -180,6 +180,8 @@ Topologies.ghost_neighboring_elements
 ## Grids
 
 ```@docs
+Grids.CellFace
+Grids.CellCenter
 Grids.ColumnGrid
 Grids.FiniteDifferenceGrid
 Grids.ExtrudedFiniteDifferenceGrid
@@ -227,6 +229,10 @@ the center of each element (also referred to as _cell_) (`CenterFiniteDifference
 or the interfaces (faces in 3D, edges in 2D or points in 1D) between elements
 (`FaceFiniteDifferenceSpace`).
 
+```@docs
+Spaces.FiniteDifferenceSpace
+```
+
 Users should construct either the center or face space from the mesh, then construct
 the other space from the original one: this internally reuses the same data structures, and avoids allocating additional memory.
 
@@ -245,6 +251,24 @@ Spaces.SpectralElementSpaceSlab
 
 ```@docs
 Spaces.node_horizontal_length_scale
+```
+
+### Extruded Finite Difference Spaces
+
+```@docs
+Spaces.ExtrudedFiniteDifferenceSpace
+```
+
+## CommonSpaces
+
+```@docs
+CommonSpaces
+CommonSpaces.ExtrudedCubedSphereSpace
+CommonSpaces.CubedSphereSpace
+CommonSpaces.ColumnSpace
+CommonSpaces.Box3DSpace
+CommonSpaces.SliceXZSpace
+CommonSpaces.RectangleXYSpace
 ```
 
 ### Quadratures

--- a/src/ClimaCore.jl
+++ b/src/ClimaCore.jl
@@ -24,6 +24,7 @@ include("Limiters/Limiters.jl")
 include("InputOutput/InputOutput.jl")
 include("Remapping/Remapping.jl")
 include("CommonGrids/CommonGrids.jl")
+include("CommonSpaces/CommonSpaces.jl")
 
 include("deprecated.jl")
 

--- a/src/Grids/finitedifference.jl
+++ b/src/Grids/finitedifference.jl
@@ -3,8 +3,8 @@ abstract type Staggering end
 
 """
     CellCenter()
-    
-Cell center location 
+
+Cell center location
 """
 struct CellCenter <: Staggering end
 
@@ -23,7 +23,7 @@ abstract type AbstractFiniteDifferenceGrid <: AbstractGrid end
     FiniteDifferenceGrid(device::ClimaComms.AbstractDevice, mesh::Meshes.IntervalMesh)
 
 Construct a `FiniteDifferenceGrid` from an `IntervalTopology` (or an
-`IntervalMesh`). 
+`IntervalMesh`).
 
 This is an object which contains all the necessary geometric information.
 

--- a/src/Spaces/extruded.jl
+++ b/src/Spaces/extruded.jl
@@ -1,5 +1,19 @@
 
+"""
+    ExtrudedFiniteDifferenceSpace(grid, staggering)
 
+    ExtrudedFiniteDifferenceSpace(
+        horizontal_space::AbstractSpace,
+        vertical_space::FiniteDifferenceSpace,
+        hypsography::Grids.HypsographyAdaption = Grids.Flat(),
+    )
+
+An extruded finite-difference space,
+where the extruded direction is _staggered_,
+containing grid information at either
+ - cell centers (where `staggering` is [`Grids.CellCenter`](@ref)) or
+ - cell faces (where `staggering` is [`Grids.CellFace`](@ref))
+"""
 struct ExtrudedFiniteDifferenceSpace{
     G <: Grids.AbstractExtrudedFiniteDifferenceGrid,
     S <: Staggering,

--- a/src/Spaces/finitedifference.jl
+++ b/src/Spaces/finitedifference.jl
@@ -3,11 +3,14 @@ abstract type AbstractFiniteDifferenceSpace <: AbstractSpace end
 """
     FiniteDifferenceSpace(
         grid::Grids.FiniteDifferenceGrid,
-        staggering::Staggering, 
+        staggering::Staggering
     )
 
+A 1D finite-difference space, that lives on
+either:
 
-
+ - cell centers (where `staggering` is [`Grids.CellCenter`](@ref)) or
+ - cell faces (where `staggering` is [`Grids.CellFace`](@ref))
 """
 struct FiniteDifferenceSpace{
     G <: Grids.AbstractFiniteDifferenceGrid,

--- a/test/CommonSpaces/unit_common_spaces.jl
+++ b/test/CommonSpaces/unit_common_spaces.jl
@@ -1,0 +1,137 @@
+#=
+julia --project
+using Revise; include(joinpath("test", "CommonSpaces", "unit_common_spaces.jl"))
+=#
+import ClimaComms
+ClimaComms.@import_required_backends
+using ClimaCore.CommonSpaces
+using ClimaCore:
+    Geometry,
+    Hypsography,
+    Fields,
+    Spaces,
+    Grids,
+    Topologies,
+    Meshes,
+    DataLayouts
+using Test
+
+@testset "Convenience constructors" begin
+    function warp_surface(coord)
+        # sin²(x) form ground elevation
+        x = Geometry.component(coord, 1)
+        FT = eltype(x)
+        hc = FT(500.0)
+        h = hc * FT(sin(π * x / 25000)^2)
+        return h
+    end
+
+    space = ExtrudedCubedSphereSpace(;
+        z_elem = 10,
+        z_min = 0,
+        z_max = 1,
+        radius = 10,
+        h_elem = 10,
+        n_quad_points = 4,
+        horizontal_layout_type = DataLayouts.IJHF,
+        staggering = Grids.CellCenter(),
+    )
+    grid = Spaces.grid(space)
+    @test grid isa Grids.ExtrudedFiniteDifferenceGrid
+    @test grid.horizontal_grid isa Grids.SpectralElementGrid2D
+    @test Grids.topology(grid.horizontal_grid).mesh isa
+          Meshes.EquiangularCubedSphere
+
+    function hypsography_fun(h_grid, z_grid)
+        h_space = Spaces.SpectralElementSpace2D(h_grid)
+        cf = Fields.coordinate_field(h_space)
+        warp_fn = warp_surface # closure
+        z_surface = map(cf) do coord
+            Geometry.ZPoint(warp_fn(coord))
+        end
+        Hypsography.LinearAdaption(z_surface)
+    end
+
+    space = ExtrudedCubedSphereSpace(;
+        z_elem = 10,
+        z_min = 0,
+        z_max = 1,
+        radius = 10,
+        h_elem = 10,
+        n_quad_points = 4,
+        hypsography_fun,
+        staggering = Grids.CellCenter(),
+    )
+    grid = Spaces.grid(space)
+    @test grid isa Grids.ExtrudedFiniteDifferenceGrid
+    @test grid.horizontal_grid isa Grids.SpectralElementGrid2D
+    @test Grids.topology(grid.horizontal_grid).mesh isa
+          Meshes.EquiangularCubedSphere
+    @test Grids.topology(grid.horizontal_grid).mesh isa
+          Meshes.EquiangularCubedSphere
+
+    space = CubedSphereSpace(; radius = 10, n_quad_points = 4, h_elem = 10)
+    grid = Spaces.grid(space)
+    @test grid isa Grids.SpectralElementGrid2D
+    @test Grids.topology(grid).mesh isa Meshes.EquiangularCubedSphere
+
+    space = ColumnSpace(;
+        z_elem = 10,
+        z_min = 0,
+        z_max = 1,
+        staggering = Grids.CellCenter(),
+    )
+    grid = Spaces.grid(space)
+    @test grid isa Grids.FiniteDifferenceGrid
+
+    space = Box3DSpace(;
+        z_elem = 10,
+        x_min = 0,
+        x_max = 1,
+        y_min = 0,
+        y_max = 1,
+        z_min = 0,
+        z_max = 10,
+        periodic_x = false,
+        periodic_y = false,
+        n_quad_points = 4,
+        x_elem = 3,
+        y_elem = 4,
+        staggering = Grids.CellCenter(),
+    )
+    grid = Spaces.grid(space)
+    @test grid isa Grids.ExtrudedFiniteDifferenceGrid
+    @test grid.horizontal_grid isa Grids.SpectralElementGrid2D
+    @test Grids.topology(grid.horizontal_grid).mesh isa Meshes.RectilinearMesh
+
+    space = SliceXZSpace(;
+        z_elem = 10,
+        x_min = 0,
+        x_max = 1,
+        z_min = 0,
+        z_max = 1,
+        periodic_x = false,
+        n_quad_points = 4,
+        x_elem = 4,
+        staggering = Grids.CellCenter(),
+    )
+    grid = Spaces.grid(space)
+    @test grid isa Grids.ExtrudedFiniteDifferenceGrid
+    @test grid.horizontal_grid isa Grids.SpectralElementGrid1D
+    @test Grids.topology(grid.horizontal_grid).mesh isa Meshes.IntervalMesh
+
+    space = RectangleXYSpace(;
+        x_min = 0,
+        x_max = 1,
+        y_min = 0,
+        y_max = 1,
+        periodic_x = false,
+        periodic_y = false,
+        n_quad_points = 4,
+        x_elem = 3,
+        y_elem = 4,
+    )
+    grid = Spaces.grid(space)
+    @test grid isa Grids.SpectralElementGrid2D
+    @test Grids.topology(grid).mesh isa Meshes.RectilinearMesh
+end


### PR DESCRIPTION
This PR extends the `CommonGrids` module with the `CommonSpaces` module, allowing users to construct common spaces. These convenience constructos are a thin layer that simply forward to their convenience grid constructor counterparts and (if necessary) include an additional `staggering` keyword argument.