### PR TITLE
Remove always_inline = false in fused kernel

### DIFF
--- a/ext/cuda/data_layouts_fused_copyto.jl
+++ b/ext/cuda/data_layouts_fused_copyto.jl
@@ -136,7 +136,6 @@ function launch_fused_copyto!(fmb::FusedMultiBroadcast)
             args;
             threads_s = p.threads,
             blocks_s = p.blocks,
-            always_inline = false,
         )
     else
         args = (fmb, dest1, us)


### PR DESCRIPTION
This PR removes `always_inline = false` in the fused kernel, as this conflicts with the threads specified through the occupancy API call. Found in [this build](https://buildkite.com/clima/climaatmos-target-gpu-simulations/builds/387#01932b17-b36a-4dc2-969f-8d0ac5ad27e4)