### PR TITLE
Update Makie shading attrib

### DIFF
--- a/lib/ClimaCoreMakie/src/fieldheatmap.jl
+++ b/lib/ClimaCoreMakie/src/fieldheatmap.jl
@@ -6,7 +6,7 @@ Plots a heatmap of a field.
 
 ## Attributes
 
-Inherited from [`Makie.mesh`](https://docs.makie.org/stable/examples/plotting_functions/mesh/index.html#mesh). 
+Inherited from [`Makie.mesh`](https://docs.makie.org/stable/examples/plotting_functions/mesh/index.html#mesh).
 
 - `colormap::Union{Symbol, Vector{<:Colorant}} = :viridis`` sets the colormap that is sampled for numeric colors.
 
@@ -20,7 +20,7 @@ Inherited from [`Makie.mesh`](https://docs.makie.org/stable/examples/plotting_fu
 
 """
 @recipe(FieldHeatmap, field) do scene
-    attrs = Makie.Attributes(; coords = nothing, shading = false)
+    attrs = Makie.Attributes(; coords = nothing, shading = Makie.NoShading)
     return merge(attrs, Makie.default_theme(scene, Makie.Mesh))
 end
 


### PR DESCRIPTION
closes #2093 

In fieldheatmap.jl, the shading attribute for Makie was set to false. This causes a warning stating that:
```
shading = false` is not valid. Use `Makie.automatic`, `NoShading`, `FastShading` or `MultiLightShading`. Defaulting to `NoShading`
```
when  ClimaCoreMakie.fieldheatmap or ClimaCoreMakie.fieldheatmap! is used.

This PR replaces that with "shading = Makie.NoShading". 

<!-- Provide a clear description of the content -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
