### PR TITLE
Add `face/center_space`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,13 @@ main
 - Fixed writing/reading purely vertical spaces. PR [2102](https://github.com/CliMA/ClimaCore.jl/pull/2102)
 - Fixed correctness bug in reductions on GPUs. PR [2106](https://github.com/CliMA/ClimaCore.jl/pull/2106)
 
+### ![][badge-✨feature/enhancement] `face_space`, `center_space` functions
+
+`ClimaCore.Spaces` now comes with two functions, `face_space` and
+`center_space`, to convert a `Space` from being cell-centered to be
+face-centered (and viceversa). These functions only work for vertical and
+extruded spaces.
+
 v0.14.20
 --------
 

--- a/src/CommonSpaces/CommonSpaces.jl
+++ b/src/CommonSpaces/CommonSpaces.jl
@@ -8,15 +8,20 @@ argument, `staggering::Staggering` to construct the desired space.
 module CommonSpaces
 
 export ExtrudedCubedSphereSpace,
-    CubedSphereSpace, ColumnSpace, Box3DSpace, SliceXZSpace, RectangleXYSpace
+    CubedSphereSpace,
+    ColumnSpace,
+    Box3DSpace,
+    SliceXZSpace,
+    RectangleXYSpace,
+    CellCenter,
+    CellFace
 
-export Grids
 import ClimaComms
 
 import ..DataLayouts,
     ..Meshes, ..Topologies, ..Geometry, ..Domains, ..Quadratures, ..Grids
 
-import ..Grids: Staggering
+import ..Grids: Staggering, CellCenter, CellFace
 import ..Spaces
 import ..CommonGrids
 import ..CommonGrids:
@@ -86,10 +91,24 @@ space = ExtrudedCubedSphereSpace(;
     z_max = 1,
     radius = 10,
     h_elem = 10,
-    n_quad_points = 4,
-    staggering = Grids.CellCenter()
+    n_quad_points = 4
+    staggering = CellCenter()
 )
 ```
+This will construct a cell-center space. If you wish to create a face centered space:
+```julia
+using ClimaCore.CommonSpaces
+space = ExtrudedCubedSphereSpace(;
+    z_elem = 10,
+    z_min = 0,
+    z_max = 1,
+    radius = 10,
+    h_elem = 10,
+    n_quad_points = 4,
+    staggering = CellFace()
+)
+```
+alternatively, you can use the `Spaces.face_space` function.
 """
 function ExtrudedCubedSphereSpace end
 
@@ -186,7 +205,7 @@ space = ColumnSpace(;
     z_elem = 10,
     z_min = 0,
     z_max = 10,
-    staggering = Grids.CellCenter()
+    staggering = CellCenter()
 )
 ```
 """
@@ -270,7 +289,7 @@ space = Box3DSpace(;
     n_quad_points = 4,
     x_elem = 3,
     y_elem = 4,
-    staggering = Grids.CellCenter()
+    staggering = CellCenter()
 )
 ```
 """
@@ -319,8 +338,7 @@ configuration, given:
  - `quad` the quadrature style (defaults to `Quadratures.GLL{n_quad_points}`)
  - `staggering` vertical staggering, can be one of [[`Grids.CellFace`](@ref), [`Grids.CellCenter`](@ref)]
 
-Note that these arguments are all the same
-as [`CommonGrids.SliceXZGrid`](@ref),
+Note that these arguments are all the same as [`CommonGrids.SliceXZGrid`](@ref),
 except for `staggering`.
 
 # Example usage
@@ -336,7 +354,7 @@ space = SliceXZSpace(;
     periodic_x = false,
     n_quad_points = 4,
     x_elem = 4,
-    staggering = Grids.CellCenter()
+    staggering = CellCenter()
 )
 ```
 """
@@ -381,9 +399,6 @@ configuration, given:
  - `hypsography_fun` a function or callable object (`hypsography_fun(h_grid, z_grid) -> hypsography`) for constructing the hypsography model.
  - `global_geometry` the global geometry (defaults to [`Geometry.CartesianGlobalGeometry`](@ref))
  - `quad` the quadrature style (defaults to `Quadratures.GLL{n_quad_points}`)
-
-Note that these arguments are all the same as [`CommonGrids.RectangleXYGrid`]
-(@ref), except for `staggering`.
 
 # Example usage
 

--- a/src/Spaces/Spaces.jl
+++ b/src/Spaces/Spaces.jl
@@ -80,10 +80,6 @@ global_geometry(space::AbstractSpace) = global_geometry(grid(space))
 space(refspace::AbstractSpace, staggering::Staggering) =
     space(grid(refspace), staggering)
 
-
-
-
-
 issubspace(::AbstractSpace, ::AbstractSpace) = false
 
 undertype(space::AbstractSpace) =
@@ -102,6 +98,14 @@ include("extruded.jl")
 include("triangulation.jl")
 include("dss.jl")
 
+
+function center_space(space::AbstractSpace)
+    error("`center_space` can only be called with vertical/extruded spaces")
+end
+
+function face_space(space::AbstractSpace)
+    error("`center_space` can only be called with vertical/extruded spaces")
+end
 
 weighted_jacobian(space::Spaces.AbstractSpace) = local_geometry_data(space).WJ
 

--- a/src/Spaces/extruded.jl
+++ b/src/Spaces/extruded.jl
@@ -33,6 +33,29 @@ const FaceExtrudedFiniteDifferenceSpace{G} =
 const CenterExtrudedFiniteDifferenceSpace{G} =
     ExtrudedFiniteDifferenceSpace{G, CellCenter}
 
+"""
+    face_space(space::ExtrudedFiniteDifferenceSpace)
+
+Return face-centered space corresponding to `space`.
+
+If `space` is already face-centered, return itself.
+"""
+function face_space(space::ExtrudedFiniteDifferenceSpace)
+    return ExtrudedFiniteDifferenceSpace(grid(space), CellFace())
+end
+
+"""
+    center_space(space::ExtrudedFiniteDifferenceSpace)
+
+Return center-centered space corresponding to `space`.
+
+If `space` is already center-centered, return itself.
+"""
+function center_space(space::ExtrudedFiniteDifferenceSpace)
+    return ExtrudedFiniteDifferenceSpace(grid(space), CellCenter())
+end
+
+
 #=
 ExtrudedFiniteDifferenceSpace{S}(
     grid::Grids.ExtrudedFiniteDifferenceGrid,

--- a/src/Spaces/finitedifference.jl
+++ b/src/Spaces/finitedifference.jl
@@ -81,7 +81,27 @@ CenterFiniteDifferenceSpace(
 Adapt.adapt_structure(to, space::FiniteDifferenceSpace) =
     FiniteDifferenceSpace(Adapt.adapt(to, grid(space)), staggering(space))
 
+"""
+    face_space(space::FiniteDifferenceSpace)
 
+Return face-centered space corresponding to `space`.
+
+If `space` is already face-centered, return itself.
+"""
+function face_space(space::FiniteDifferenceSpace)
+    return FiniteDifferenceSpace(grid(space), CellFace())
+end
+
+"""
+    center_space(space::FiniteDifferenceSpace)
+
+Return center-centered space corresponding to `space`.
+
+If `space` is already center-centered, return itself.
+"""
+function center_space(space::FiniteDifferenceSpace)
+    return FiniteDifferenceSpace(grid(space), CellCenter())
+end
 
 nlevels(space::FiniteDifferenceSpace) = length(space)
 # TODO: deprecate?


### PR DESCRIPTION
As I started using the `CommonSpaces`, I realized that specifying the staggering was a pain point. It required importing `Grids`, and I pretty much always wanted to build CenterSpaces anyways. In addition to this, I realized that going from center to faces and viceversa was not trivial. This required carrying around both the center and the face space when only one is really needed. In this commit, I add a default staggering to `CommonSpaces` and a function to go from center to face spaces and back.
