### PR TITLE
Tr/fix ci downstream tests

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -46,20 +46,16 @@ jobs:
           repository: 'CliMA/${{ matrix.package }}'
           path: ${{ matrix.package }}
 
-      # The test suite for ClimaTimesteppers depends on ClimaCore, not
-      # ClimaTimesteppers itself. If we dev-ed ClimaCore in ClimaTimesteppers,
-      # the aqua test would fail because we never use ClimaCore.
-      - if: (matrix.package != 'ClimaTimesteppers.jl' && matrix.package != 'ClimaCoupler.jl')
+      # Some of the packages only use ClimaCore in the test suite, so dev-ing ClimaCore
+      # from the package itself would cause the aqua test to fail. Instead, we install
+      # TestEnv into the base environment, activate the test env for the downstream package,
+      # and dev ClimaCore before running the test suite from there.
+      - if: (matrix.package != 'ClimaCoupler.jl')
         run: |
+          julia --color=yes -e 'using Pkg; Pkg.add("TestEnv")'
           julia --color=yes --project=${{ matrix.package }} -e 'using Pkg; Pkg.instantiate()'
-          julia --color=yes --project=${{ matrix.package }} -e 'using Pkg; Pkg.develop(; path = ".")'
-          julia --color=yes --project=${{ matrix.package }} -e 'using Pkg; Pkg.test()'
-
-      - if: matrix.package == 'ClimaTimesteppers.jl'
-        run: |
-          julia --color=yes --project=ClimaTimesteppers.jl/test -e 'using Pkg; Pkg.instantiate()'
-          julia --color=yes --project=ClimaTimesteppers.jl/test -e 'using Pkg; Pkg.develop(; path = ".")'
-          julia --color=yes --project=ClimaTimesteppers.jl/test ClimaTimesteppers.jl/test/runtests.jl
+          julia --color=yes --project=${{ matrix.package }} -e 'using TestEnv; TestEnv.activate();\
+            using Pkg; Pkg.develop(; path = "."); include("${{ matrix.package }}/test/runtests.jl")'
 
       - if: matrix.package == 'ClimaCoupler.jl'
         run: |


### PR DESCRIPTION
<!-- Provide a clear description of the content -->
Previously, there was a special case for ClimaTimeSteppers, where
the environment decsribed by test/Project.toml was used. This caused
errors because the test/Project.toml file was removed. So, the temporary test
environment generated wth Pkg.test() must be used. This does not work,
because it requires dev-ing ClimaCore from the ClimaTimeSteppers project,
which causes an Aqua test to fail.

ClimaUtilities was not passing because dev-ing ClimaCore
caused aqua tests to fail. A possible solution to this is
making a special case, similar to what was done for ClimaTimeSteppers.

I attempted to dev ClimaCore in the temporary test env generated
by Pkg.Test() by passing in `-e using Pkg; Pkg.dev(...)` as a julia
arg to Pkg.test, but that did not work.

Julia 1.11 adds a kwarg to Pkg.add, which specifies the field
inside the Project.toml file that a package should be added to.
If we only used 1.11, we could add the path to ClimaCore and specify
the target as extra or weakdeps, which would allow aqua tests to pass.

Instead, this commit makes the downstream test install TestEnv
into the base julia env, then activate the test env for the downstream
package, then devs ClimaCore, and then run the test suite.

The ClimaTimeSteppers downstream tests still fail. This is an issue with ClimaTimeSteppers because the same test errors when run through the ClimaTimeSteppers CI. See [issue](https://github.com/CliMA/ClimaTimeSteppers.jl/issues/341) and example [here](https://github.com/CliMA/ClimaTimeSteppers.jl/pull/340/checks)

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
