### PR TITLE
Fix adapt for new limiters, test on gpu

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1454,20 +1454,31 @@ steps:
           - "julia --color=yes --project=.buildkite examples/column/fct_advection.jl"
         artifact_paths:
           - "examples/column/output/fct_advection/*"
-      
+
       - label: ":computer: Column TVD Slope-limited Advection Eq"
         key: "cpu_tvd_column_advect"
         command:
           - "julia --color=yes --project=.buildkite examples/column/tvd_advection.jl"
         artifact_paths:
           - "examples/column/output/tvd_advection/*"
-      
+
       - label: ":computer: Column Lin vanLeer Limiter Advection Eq"
         key: "cpu_lvl_column_advect"
         command:
           - "julia --color=yes --project=.buildkite examples/column/vanleer_advection.jl"
         artifact_paths:
           - "examples/column/output/vanleer_advection/*"
+
+      - label: ":computer: Column Lin vanLeer Limiter Advection Eq cuda"
+        key: "gpu_lvl_column_advect"
+        command:
+          - "julia --color=yes --project=.buildkite examples/column/vanleer_advection.jl"
+        artifact_paths:
+          - "examples/column/output/vanleer_advection/*"
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+        agents:
+          slurm_gpus: 1
 
       - label: ":computer: Column BB FCT Advection Eq"
         key: "cpu_bb_fct_column_advect"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.14.21"
+version = "0.14.22"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.14.22"
+version = "0.14.23"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Discovered [here](https://github.com/CliMA/ClimaAtmos.jl/pull/3485), we're not exercising the new limiters on the gpu, and they're not yet working due to lack of adapt support. This PR fixes this, and tests the limters on the gpu.