### PR TITLE
Fix column integrals for deep atmosphere

### DIFF
--- a/src/Spaces/extruded.jl
+++ b/src/Spaces/extruded.jl
@@ -5,7 +5,8 @@
     ExtrudedFiniteDifferenceSpace(
         horizontal_space::AbstractSpace,
         vertical_space::FiniteDifferenceSpace,
-        hypsography::Grids.HypsographyAdaption = Grids.Flat(),
+        hypsography::Grids.HypsographyAdaption = Grids.Flat();
+        deep::Bool = false,
     )
 
 An extruded finite-difference space,
@@ -68,12 +69,14 @@ ExtrudedFiniteDifferenceSpace{S}(
 function ExtrudedFiniteDifferenceSpace(
     horizontal_space::AbstractSpace,
     vertical_space::FiniteDifferenceSpace,
-    hypsography::Grids.HypsographyAdaption = Grids.Flat(),
+    hypsography::Grids.HypsographyAdaption = Grids.Flat();
+    deep = false,
 )
     grid_space = Grids.ExtrudedFiniteDifferenceGrid(
         grid(horizontal_space),
         grid(vertical_space),
-        hypsography,
+        hypsography;
+        deep,
     )
     return ExtrudedFiniteDifferenceSpace(grid_space, vertical_space.staggering)
 end


### PR DESCRIPTION
<!-- Provide a clear description of the content -->

This PR modifies the `column_integral_definite!` and `column_integral_indefinite!` functions for deep atmosphere configurations by weighting the discrete lengths `Δz` with discrete areas `ΔA`. Since the values of `ΔA` are constant within each column when using the shallow atmosphere approximation, this change has no effect for shallow atmosphere configurations, and all current unit tests generate the same results.

The purpose of this change is to fix the errors observed in the [deep atmosphere PR's buildkite run](https://buildkite.com/clima/climaatmos-ci/builds/21618), where the vertical integrals for zero-moment microphysics appear to not be conserving water mass.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
