### PR TITLE
Save the stretch type in the IntervalMesh

### DIFF
--- a/src/InputOutput/writers.jl
+++ b/src/InputOutput/writers.jl
@@ -215,6 +215,15 @@ function write_new!(
             [getfield(mesh.faces[i], 1) for i in 1:length(mesh.faces)],
         )
     end
+    (; stretch) = mesh
+    write_attribute(group, "stretch_type", string(nameof(typeof(stretch))))
+    fns = fieldnames(typeof(stretch))
+    if !isempty(fns)
+        vals = map(fns) do fn
+            getfield(stretch, fn)
+        end
+        write_attribute(group, "stretch_params", [vals...])
+    end
     return name
 end
 


### PR DESCRIPTION
This PR is a first step towards #1790. I think I made this backwards compatible in `InputOutput` by checking which properties are available.

Also, this approach is probably nicer in that we save more information and less data in the HDF5 file, which should result in smaller output files.

The next step will be to define and use a `LazyFace` object in place of `faces` in the `IntervalMesh`. This `LazyFace` should be able to determine any given face, without heap reads/writes.