### PR TITLE
Fix typo in debugging docs

### DIFF
--- a/docs/src/debugging.md
+++ b/docs/src/debugging.md
@@ -14,20 +14,32 @@ this data after any operation that ClimaCore performs.
 
 ## Example
 
-```@example
-import ClimaCore
-using ClimaCore: DataLayouts
-ClimaCore.DebugOnly.call_post_op_callback() = true
-function ClimaCore.DebugOnly.post_op_callback(result, args...; kwargs...)
-  if any(isnan, parent(data))
-    println("NaNs found!")
-  end
-end
+### Print `NaNs` when they are found
 
-FT = Float64;
-data = DataLayouts.VIJFH{FT}(Array{FT}, zeros; Nv=5, Nij=2, Nh=2)
-@. data = NaN
+In this example, we add a callback that simply prints `NaNs found` every
+instance when they are detected in a `ClimaCore` operation.
+
+To do this, we need two ingredients:
+
+First, we need to enable the callback system:
+```@example clima_debug
+import ClimaCore
+ClimaCore.DebugOnly.call_post_op_callback() = true
 ```
+
+The line `ClimaCore.DebugOnly.call_post_op_callback() = true` means that at the
+end of every `ClimaCore` operation, the function
+`ClimaCore.DebugOnly.post_op_callback` is called. By default, this function does
+nothing. So, the second ingredient is to define a method:
+```@example clima_debug
+function ClimaCore.DebugOnly.post_op_callback(result, args...; kwargs...)
+    if any(isnan, parent(result))
+        println("NaNs found!")
+    end
+end
+```
+If needed, `post_op_callback` can be specialized or behave differently in
+different cases, but here, it only checks if `NaN`s are in the given that.
 
 Note that, due to dispatch, `post_op_callback` will likely need a very general
 method signature, and using `post_op_callback
@@ -35,15 +47,78 @@ method signature, and using `post_op_callback
 because `post_op_callback` ends up getting called multiple times with different
 datalayouts.
 
+Now, let us put everything together and demonstrate a complete example:
+
+```@example clima_debug
+import ClimaCore
+ClimaCore.DebugOnly.call_post_op_callback() = true
+function ClimaCore.DebugOnly.post_op_callback(result, args...; kwargs...)
+    if any(isnan, parent(result))
+        println("NaNs found!")
+    end
+end
+
+FT = Float64
+data = ClimaCore.DataLayouts.VIJFH{FT}(Array{FT}, zeros; Nv=5, Nij=2, Nh=2)
+@. data = NaN
+ClimaCore.DebugOnly.call_post_op_callback() = false # hide
+```
+This example should print `NaN` on your standard output.
+
+### Infiltrating
+
+[Infiltrator.jl](https://github.com/JuliaDebug/Infiltrator.jl) is a simple
+debugging tool for Julia packages.
+
+Here is an example, where we can use Infiltrator.jl to find where NaNs is coming
+from interactively.
+
+```julia
+import ClimaCore
+import Infiltrator # must be in your default environment
+ClimaCore.DebugOnly.call_post_op_callback() = true
+function ClimaCore.DebugOnly.post_op_callback(result, args...; kwargs...)
+    if any(isnan, parent(result))
+        println("NaNs found!")
+        # Let's define the stack trace so that we know where this came from
+        st = stacktrace()
+
+        # Let's use Infiltrator.jl to exfiltrate to drop into the REPL.
+        # Now, `Infiltrator.safehouse` will be a NamedTuple
+        # containing `result`, `args` and `kwargs`.
+        Infiltrator.@exfiltrate
+    end
+end
+
+FT = Float64
+data = ClimaCore.DataLayouts.VIJFH{FT}(Array{FT}, zeros; Nv=5, Nij=2, Nh=2)
+@. data = NaN
+# Let's see what happened
+(;result, args, kwargs, st) = Infiltrator.safehouse;
+
+# You can print the stack trace, to see where the NaNs were found:
+ClimaCore.DebugOnly.print_depth_limited_stack_trace(st;maxtypedepth=1)
+
+# Once there, you can see that the call lead you to `copyto!`,
+# Inspecting `args` shows that the `Broadcasted` object used to populate the
+# result was:
+julia> args[2]
+Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}}(identity, (NaN,))
+
+# And there's your problem, NaNs is on the right-hand-side of that assignment.
+```
+
+### Caveats
+
 !!! warn
 
-    While this debugging tool may be helpful, it's not bullet proof. NaNs can
+    While `post_op_callback` may be helpful, it's not bullet proof. NaNs can
     infiltrate user data any time internals are used. For example `parent
     (data) .= NaN` will not be caught by ClimaCore.DebugOnly, and errors can be
     observed later than expected.
 
 !!! note
 
-    This method is called in many places, so this is a performance-critical code
-    path and expensive operations performed in `post_op_callback` may
-    significantly slow down your code.
+    `post_op_callback` is called in many places, so this is a
+    performance-critical code path and expensive operations performed in
+    `post_op_callback` may significantly slow down your code.

--- a/src/DebugOnly/DebugOnly.jl
+++ b/src/DebugOnly/DebugOnly.jl
@@ -46,4 +46,47 @@ function example_debug_post_op_callback(result, args...; kwargs...)
     end
 end
 
+"""
+    depth_limited_stack_trace([io::IO, ]st::Base.StackTraces.StackTrace; maxtypedepth=3)
+
+Given a stacktrace `st`, return a vector of strings containing the trace with
+depth-limited printing.
+"""
+depth_limited_stack_trace(st::Base.StackTraces.StackTrace; maxtypedepth = 3) =
+    depth_limited_stack_trace(stdout, st; maxtypedepth)
+
+function depth_limited_stack_trace(
+    io::IO,
+    st::Base.StackTraces.StackTrace;
+    maxtypedepth = 3,
+)
+    return map(s -> type_depth_limit(io, string(s); maxtypedepth), st)
+end
+
+function type_depth_limit(io::IO, s::String; maxtypedepth::Union{Nothing, Int})
+    sz = get(io, :displaysize, displaysize(io))::Tuple{Int, Int}
+    return Base.type_depth_limit(s, max(sz[2], 120); maxdepth = maxtypedepth)
+end
+
+"""
+    depth_limited_stack_trace([io::IO, ]st::Base.StackTraces.StackTrace; maxtypedepth=3)
+
+Given a stacktrace `st`, return a vector of strings containing the trace with
+depth-limited printing.
+"""
+print_depth_limited_stack_trace(
+    st::Base.StackTraces.StackTrace;
+    maxtypedepth = 3,
+) = print_depth_limited_stack_trace(stdout, st; maxtypedepth)
+
+function print_depth_limited_stack_trace(
+    io::IO,
+    st::Base.StackTraces.StackTrace;
+    maxtypedepth = 3,
+)
+    for t in depth_limited_stack_trace(st; maxtypedepth)
+        println(io, t)
+    end
+end
+
 end


### PR DESCRIPTION
`result` is not defined.

I also updated the indentation so that the block can be copied and pasted without upsetting the formatter