### PR TITLE
Fix plotting for columns from extruded FD fields

### DIFF
--- a/lib/ClimaCorePlots/src/ClimaCorePlots.jl
+++ b/lib/ClimaCorePlots/src/ClimaCorePlots.jl
@@ -137,7 +137,7 @@ RecipesBase.@recipe function f(field::Fields.FiniteDifferenceField)
     coord_field = Fields.coordinate_field(space)
 
     xdata = parent(field)[:, 1]
-    ydata = parent(Spaces.coordinates_data(space))[:, 1]
+    ydata = parent(Spaces.coordinates_data(space).z)[:, 1]
 
     coord_symbols = propertynames(coord_field)
 


### PR DESCRIPTION
This PR fixes plotting for columns, when extracted from FD fields.

I'm a bit surprised that this was broken (it ran, but the plot was completely wrong).