### PR TITLE
Make 2-proc cuda distributed remap soft-fail

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -366,6 +366,7 @@ steps:
       - label: "Unit: distributed remapping with CUDA (2 processes)"
         key: distributed_remapping_gpu_2procs
         command: "srun julia --color=yes --check-bounds=yes --project=.buildkite test/Remapping/distributed_remapping.jl"
+        soft_fail: true
         env:
           CLIMACOMMS_CONTEXT: "MPI"
           CLIMACOMMS_DEVICE: "CUDA"


### PR DESCRIPTION
This PR makes the `distributed remapping with CUDA (2 processes)` job soft-fail for now, since it's failing pretty consistently.