### PR TITLE
add Field sum reproducer

### DIFF
--- a/test/Fields/sum_repro.jl
+++ b/test/Fields/sum_repro.jl
@@ -1,0 +1,24 @@
+import ClimaComms
+ClimaComms.@import_required_backends
+import ClimaCore
+import ClimaCore: Fields
+using Test
+
+include(
+    joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl"),
+)
+import .TestUtilities as TU
+
+@testset "Sum function over field" begin
+    FT = Float32
+    context = ClimaComms.context()
+
+    space = TU.SpectralElementSpace2D(FT; context)
+    field = Fields.zeros(space)
+    f = x -> x + 1
+
+    # Sum of a function applied to a field should be the same as the sum of the
+    # function applied to the parent field, but it isn't
+    @test sum(f, field) != sum(f, parent(field))
+    @test sum(f.(field)) != sum(f.(parent(field)))
+end


### PR DESCRIPTION
In https://github.com/CliMA/ClimaLand.jl/pull/970, I encountered that `sum(f, field) != sum(f, parent(field))`. I'm not sure if this is the expected behavior but it was surprising to me, so I wanted to open a reproducer for it.

@charleskawczynski do you have any insight?
