### PR TITLE
Tr/spectral broadcast with finite difference spaces

### DIFF
--- a/src/DataLayouts/DataLayouts.jl
+++ b/src/DataLayouts/DataLayouts.jl
@@ -850,6 +850,11 @@ function DataF(x::T) where {T}
     end
 end
 
+function SArray(data::DataF{S, A}) where {S, A<:AbstractArray}
+    Nf = typesize(eltype(A), S)
+    DataF{S}(SArray{Tuple{Nf}, eltype(A), 1, Nf}(parent(data)))
+end
+
 Base.@propagate_inbounds function Base.getindex(data::DataF{S}) where {S}
     @inbounds get_struct(
         parent(data),

--- a/src/Fields/indices.jl
+++ b/src/Fields/indices.jl
@@ -252,7 +252,7 @@ function byslab(
         end
     end
 end
-
+# TODO: This is not correct when the space is horizontal
 function byslab(
     fn,
     ::ClimaComms.CPUSingleThreaded,

--- a/src/Fields/indices.jl
+++ b/src/Fields/indices.jl
@@ -252,3 +252,59 @@ function byslab(
         end
     end
 end
+
+function byslab(
+    fn,
+    ::ClimaComms.CPUSingleThreaded,
+    space::Spaces.CenterFiniteDifferenceSpace,
+)
+    Nh = Topologies.nlocalelems(Spaces.topology(space))
+    Nv = Spaces.nlevels(space)
+    @inbounds begin
+        for v in 1:Nv
+            fn(SlabIndex(v, 1))
+        end
+    end
+end
+
+function byslab(
+    fn,
+    ::ClimaComms.CPUMultiThreaded,
+    space::Spaces.CenterFiniteDifferenceSpace,
+)
+    Nh = Topologies.nlocalelems(Spaces.topology(space))
+    Nv = Spaces.nlevels(space)
+    @inbounds begin
+        Threads.@threads for v in 1:Nv
+            fn(SlabIndex(v, 1))
+        end
+    end
+end
+
+function byslab(
+    fn,
+    ::ClimaComms.CPUSingleThreaded,
+    space::Spaces.FaceFiniteDifferenceSpace,
+)
+    Nh = Topologies.nlocalelems(Spaces.topology(space))
+    Nv = Spaces.nlevels(space)
+    @inbounds begin
+        for v in 1:Nv
+            fn(SlabIndex(v - half, 1))
+        end
+    end
+end
+
+function byslab(
+    fn,
+    ::ClimaComms.CPUMultiThreaded,
+    space::Spaces.FaceFiniteDifferenceSpace,
+)
+    Nh = Topologies.nlocalelems(Spaces.topology(space))
+    Nv = Spaces.nlevels(space)
+    @inbounds begin
+        Threads.@threads for v in 1:Nv
+            fn(SlabIndex(v - half, 1))
+        end
+    end
+end

--- a/src/Geometry/conversions.jl
+++ b/src/Geometry/conversions.jl
@@ -580,6 +580,9 @@ Curl is only defined for `CovariantVector`` field input types.
 
 | Input Vector | Operator direction | Curl output vector |
 | ------------ | ------------------ | -------------- |
+|  Covariant1Vector | ()     | Contravariant12Vector |
+|  Covariant12Vector | ()     | Contravariant3Vector |
+|  Covariant123Vector | ()     | Contravariant123Vector |
 |  Covariant12Vector | (1,2) | Contravariant3Vector |
 |  Covariant3Vector | (1,2) | Contravariant12Vector |
 |  Covariant123Vector | (1,2) | Contravariant123Vector |

--- a/src/Geometry/conversions.jl
+++ b/src/Geometry/conversions.jl
@@ -547,7 +547,14 @@ Required for statically infering the result type of the divergence operation for
 The return type when taking the gradient along dimension `I` of a field `V`.
 
 Required for statically infering the result type of the gradient operation for `AxisVector` subtypes.
-    """
+When `I` is an empty tuple, the gradient result type is assumed to be a Covariant12Vector.
+"""
+@inline function gradient_result_type(
+    ::Val{()},
+    ::Type{V},
+) where {V <: Number}
+    AxisVector{V, CovariantAxis{(1,2)}, SVector{2, V}}
+end
 @inline function gradient_result_type(
     ::Val{I},
     ::Type{V},
@@ -594,6 +601,20 @@ Curl is only defined for `CovariantVector`` field input types.
 ) where {FT} = Contravariant3Vector{FT}
 @inline curl_result_type(
     ::Val{(1, 2)},
+    ::Type{Covariant123Vector{FT}},
+) where {FT} = Contravariant123Vector{FT}
+
+# TODO: this is wrong, but replicates behavior of if a column represented by a box
+@inline curl_result_type(
+    ::Val{()},
+    ::Type{Covariant3Vector{FT}},
+) where {FT} = Contravariant12Vector{FT}
+@inline curl_result_type(
+    ::Val{()},
+    ::Type{Covariant12Vector{FT}},
+) where {FT} = Contravariant3Vector{FT}
+@inline curl_result_type(
+    ::Val{()},
     ::Type{Covariant123Vector{FT}},
 ) where {FT} = Contravariant123Vector{FT}
 

--- a/src/Operators/spectralelement.jl
+++ b/src/Operators/spectralelement.jl
@@ -1394,6 +1394,14 @@ struct Interpolate{I, S} <: TensorOperator
 end
 Interpolate(space) = Interpolate{operator_axes(space), typeof(space)}(space)
 
+function apply_operator(op::Interpolate{()}, space, slabidx, arg)
+    # TODO: How would interpolation be done with no horizontal space?
+    # this returns the value at the (1,1) node. Maybe it should be some sort of weighted mean
+    space_in = axes(arg)
+    out = DataF(get_node(space_in, arg, CartesianIndex(), slabidx))
+    return Field(SArray(out), space)
+end
+
 function apply_operator(op::Interpolate{(1,)}, space_out, slabidx, arg)
     FT = Spaces.undertype(space_out)
     space_in = axes(arg)
@@ -1482,6 +1490,13 @@ struct Restrict{I, S} <: TensorOperator
     space::S
 end
 Restrict(space) = Restrict{operator_axes(space), typeof(space)}(space)
+
+function apply_operator(op::Restrict{()}, space, slabidx, arg)
+    # TODO: How would this be done with no horizontal space?
+    space_in = axes(arg)
+    out = DataF(get_node(space_in, arg, CartesianIndex(), slabidx))
+    return Field(SArray(out), space)
+end
 
 function apply_operator(op::Restrict{(1,)}, space_out, slabidx, arg)
     FT = Spaces.undertype(space_out)

--- a/src/Spaces/finitedifference.jl
+++ b/src/Spaces/finitedifference.jl
@@ -135,6 +135,12 @@ function Δz_data(space::AbstractSpace)
     )
 end
 
+horizontal_space(space::FiniteDifferenceSpace) = nothing
+
+node_horizontal_length_scale(space::Nothing) = 0
+
+quadrature_style(space::Nothing) = nothing
+
 function left_boundary_name(space::AbstractSpace)
     boundaries = Topologies.boundaries(Spaces.vertical_topology(space))
     propertynames(boundaries)[1]

--- a/src/Spaces/finitedifference.jl
+++ b/src/Spaces/finitedifference.jl
@@ -134,7 +134,8 @@ function Δz_data(space::AbstractSpace)
         Δz_metric_component(data_layout_type),
     )
 end
-
+# TODO: Not true if defined on horizontal mesh?
+# TODO:Maybe this should just be taken care of in ClimaAtmos
 horizontal_space(space::FiniteDifferenceSpace) = nothing
 
 node_horizontal_length_scale(space::Nothing) = 0


### PR DESCRIPTION
<!-- Provide a clear description of the content -->
Adds methods to `Operators/spectrealelement.jl` to support spectral operators on columns, which have no vertical space. Also adds the following methods to simplify using single column in atmos:

```
# TODO: Not true if defined on horizontal mesh?
horizontal_space(space::FiniteDifferenceSpace) = nothing

node_horizontal_length_scale(space::Nothing) = 0

quadrature_style(space::Nothing) = nothing
```
A `apply_operator` method on empty axis is added for the following operations 

- Divergence/WeakDivergence: results in zeros
- Gradient/WeakGradient: results in Covariant12Vectors filled with zero
- Curl/WeakCurl: results in  the same type of contravariant as the operation on the (1,2) axis, but filled with zero
- Interpolate: results in the value at the (1,1) node (maybe should be some sort of weighted mean)
- Restrict: results in the value at the (1,1) node 

The Interpolate and Restrict operators do not need to be added to support a single column run in Atmos.
- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
