### PR TITLE
Add missing `post_op_callback` calls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,14 @@ ClimaCore.jl Release Notes
 main
 -------
 
+### ![][badge-✨feature/enhancement] A new DebugOnly module can help find where
+     NaNs/Inf come from. PRs [2115](https://github.com/CliMA/ClimaCore.jl/pull/2115) and
+     [2139](https://github.com/CliMA/ClimaCore.jl/pull/2139)
+
+A new `ClimaCore.DebugOnly` module was added, which can help users find where
+NaNs or Infs come from in a simulation, interactively. Documentation, with a
+simple representative example can be found [here](https://clima.github.io/ClimaCore.jl/dev/debugging/#Infiltrating).
+
 ### ![][badge-✨feature/enhancement] Various improvements to `Remapper` [2060](https://github.com/CliMA/ClimaCore.jl/pull/2060)
 
 The `ClimaCore.Remapping` module received two improvements. First, `Remapper` is

--- a/src/CommonSpaces/CommonSpaces.jl
+++ b/src/CommonSpaces/CommonSpaces.jl
@@ -91,7 +91,7 @@ space = ExtrudedCubedSphereSpace(;
     z_max = 1,
     radius = 10,
     h_elem = 10,
-    n_quad_points = 4
+    n_quad_points = 4,
     staggering = CellCenter()
 )
 ```


### PR DESCRIPTION
Closes #2138.

I decided to add these calls to the high-level functions, and not the low-level ones, because we don't have access to any name information at the leaf level, since we convert everything to arrays. But since there's only one assignment per variable, calling the post-op callback after the full fieldvector is assigned is safe while also giving users the name information in the FieldVector.

By the way, I think that this is an excellent workflow so far, I was able to reproduce the issue, and while I did have to trace through to find where we missed a calls to `post_op_callback`, I was able to find it from everything in the stack trace.