### PR TITLE
Fix JET.test-call failure in get_boundary

### DIFF
--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -185,29 +185,30 @@ boundary_width(
     args...,
 ) = invalid_boundary_condition_error(typeof(op), typeof(bc))
 
+get_boundary(bcs::NamedTuple, name::Symbol) =
+    hasfield(typeof(bcs), name) ? getfield(bcs, name) : NullBoundaryCondition()
+
+get_boundary(bcs::@NamedTuple{}, name::Symbol) = NullBoundaryCondition()
+
 get_boundary(
     op::FiniteDifferenceOperator,
     ::LeftBoundaryWindow{name},
-) where {name} =
-    hasproperty(op.bcs, name) ? getproperty(op.bcs, name) :
-    NullBoundaryCondition()
+) where {name} = get_boundary(op.bcs, name)
 
 get_boundary(
     op::FiniteDifferenceOperator,
     ::RightBoundaryWindow{name},
-) where {name} =
-    hasproperty(op.bcs, name) ? getproperty(op.bcs, name) :
-    NullBoundaryCondition()
+) where {name} = get_boundary(op.bcs, name)
 
 has_boundary(
     op::FiniteDifferenceOperator,
     ::LeftBoundaryWindow{name},
-) where {name} = hasproperty(op.bcs, name)
+) where {name} = hasfield(typeof(op.bcs), name)
 
 has_boundary(
     op::FiniteDifferenceOperator,
     ::RightBoundaryWindow{name},
-) where {name} = hasproperty(op.bcs, name)
+) where {name} = hasfield(typeof(op.bcs), name)
 
 strip_space(op::FiniteDifferenceOperator, parent_space) =
     unionall_type(typeof(op))(


### PR DESCRIPTION
Closes #1755, and adds a test for it. In particular, `JET.@test_call jet_test_f2c_interp2(cfield, ffield)` fails on the main branch without the source code changes.