### PR TITLE
Add data2array support for DataF layouts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ ClimaCore.jl Release Notes
 main
 -------
 
+ - Added support `data2array` for `DataF` (i.e., `PointField`s). PR [2143](https://github.com/CliMA/ClimaCore.jl/pull/2143).
+
 v0.14.22
 -------
 

--- a/src/DataLayouts/DataLayouts.jl
+++ b/src/DataLayouts/DataLayouts.jl
@@ -2149,6 +2149,7 @@ Also, this assumes that `eltype(data) <: Real`.
 """
 function data2array end
 
+data2array(data::DataF) = reshape(parent(data), :)
 data2array(data::Union{IF, IFH, IHF}) = reshape(parent(data), :)
 data2array(data::Union{IJF, IJFH, IJHF}) = reshape(parent(data), :)
 data2array(

--- a/test/DataLayouts/unit_data2array.jl
+++ b/test/DataLayouts/unit_data2array.jl
@@ -21,6 +21,10 @@ end
     device = ClimaComms.device()
     ArrayType = ClimaComms.array_type(device)
 
+    data = DataF{FT}(ArrayType{FT}, rand)
+    @test DataLayouts.data2array(data) == reshape(parent(data), :)
+    @test is_data2array2data_identity(data)
+
     data = IF{FT}(ArrayType{FT}, rand; Ni)
     @test DataLayouts.data2array(data) == reshape(parent(data), :)
     @test is_data2array2data_identity(data)


### PR DESCRIPTION
Add data2array support for DataF layouts.

This seems to be needed based on [this](https://buildkite.com/clima/climaatmos-ci/builds/22250#01946c62-0b5c-4984-a2ab-49fefe6d062b) build.