### PR TITLE
Fix getidx for GradientC2F with SetValue bcs

### DIFF
--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -2845,7 +2845,7 @@ Base.@propagate_inbounds function stencil_right_boundary(
 )
     @assert idx == right_face_boundary_idx(space)
     Geometry.Covariant3Vector(2) ⊗ (
-        getidx(space, bc.val, loc, nothing, idx) ⊟
+        getidx(space, bc.val, loc, nothing, hidx) ⊟
         getidx(space, arg, loc, idx - half, hidx)
     )
 end


### PR DESCRIPTION
Closes #994. cc @kmdeck.

In a followup, we can fix #2089, which would have caught this error.