### PR TITLE
Improve limiter debug info, update deformation flow example and buffers

### DIFF
--- a/ext/ClimaCoreCUDAExt.jl
+++ b/ext/ClimaCoreCUDAExt.jl
@@ -1,6 +1,7 @@
 module ClimaCoreCUDAExt
 
 import NVTX
+import ClimaCore.Limiters
 import ClimaComms
 import ClimaCore: DataLayouts, Grids, Spaces, Fields
 import ClimaCore: Geometry

--- a/ext/cuda/adapt.jl
+++ b/ext/cuda/adapt.jl
@@ -42,3 +42,14 @@ Adapt.adapt_structure(
     to::CUDA.KernelAdaptor,
     topology::Topologies.IntervalTopology,
 ) = Topologies.DeviceIntervalTopology(topology.boundaries)
+
+Adapt.adapt_structure(
+    to::CUDA.KernelAdaptor,
+    lim::Limiters.QuasiMonotoneLimiter,
+) = Limiters.QuasiMonotoneLimiter(
+    Adapt.adapt(to, lim.q_bounds),
+    Adapt.adapt(to, lim.q_bounds_nbr),
+    Adapt.adapt(to, lim.ghost_buffer),
+    lim.rtol,
+    Limiters.NoConvergenceStats(),
+)

--- a/ext/cuda/limiters.jl
+++ b/ext/cuda/limiters.jl
@@ -127,7 +127,8 @@ function apply_limiter!(
     ρq::Fields.Field,
     ρ::Fields.Field,
     limiter::QuasiMonotoneLimiter,
-    dev::ClimaComms.CUDADevice,
+    dev::ClimaComms.CUDADevice;
+    warn::Bool = true,
 )
     ρq_data = Fields.field_values(ρq)
     us = DataLayouts.UniversalSize(ρq_data)


### PR DESCRIPTION
This PR debugs the deformation flow example, which broke in this [build](https://buildkite.com/clima/climacore-ci/builds/5020) (and is broken on main). So, this PR is effectively fixing CI. Closes #2151.

I've updated the way that the logging works for the limiters:

 - This PR collects convergence statistics in the QuasimonotoneLimiter, and provides users with functions to print that information. This will alleviate log bloat, and give users better information for debugging.
 - The convergence stats are only supported for cpu jobs, since this requires using mutable structs. Perhaps there's a way we can still do this for gpu jobs, but that will require a very different looking solution, which is not the purpose of this PR.

This test has been somewhat flaky for a while, and debugging has been challenging because the log is very bloated with false-positive warnings. The flakiness could be related to https://github.com/CliMA/ClimaTimeSteppers.jl/issues/283, but I'm not sure. Ultimately, I think we need to add more precise / granular unit tests.

This PR should not be behavior changing, but I would like to, at some point, short-circuit the iteration loop in the limiters when the tracer mass (and some other variables) are zero, which results in relative error of NaNs / non-convergence warnings.