### PR TITLE
Simplify CUDA remapping

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -360,8 +360,6 @@ steps:
         command: "julia --color=yes --check-bounds=yes --project=.buildkite test/Remapping/distributed_remapping.jl"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
-        env:
-          CLIMACOMMS_DEVICE: "CUDA"
         agents:
           slurm_gpus: 1
 


### PR DESCRIPTION
The CUDA kernels for remapping worked in spite of a bug: the kernels used a full 3D launch grid to distribute the work, but only a 1D grid was being launched.

This commit changes three things:
- it removes the additional two dimensions from the kernels. This is the same behavior as in `main`, except for all the dead code being removed
- it reorders some for loops in the kernel so that the outermost loop is the field (in practice, this should not have consequence downstream because we are not using this feature yet)
- it removes a duplicated `env` in a buildkite step
