### PR TITLE
Define `to_device` and `to_cpu`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@ ClimaCore.jl Release Notes
 main
 -------
 
+ - A new `Adapt` wrapper was added, `to_device`, which allows users to adapt datalayouts, spaces, fields, and fieldvectors between the cpu and gpu. PR [2159](https://github.com/CliMA/ClimaCore.jl/pull/2159).
+ - Remap interpolation cuda threading was improved. PR [2159](https://github.com/CliMA/ClimaCore.jl/pull/2159).
+ - `center_space` and `face_space` are now exported from `CommonSpaces`. PR [2157](https://github.com/CliMA/ClimaCore.jl/pull/2157).
+ - Limiter debug printing can now be suppressed, and printed at the end of a simulation, using `Limiters.print_convergence_stats(limiter)`. PR [2152](https://github.com/CliMA/ClimaCore.jl/pull/2152).
+ - Fixed getidx for `GradientC2F` with `SetValue` bcs. PR [2148](https://github.com/CliMA/ClimaCore.jl/pull/2148).
  - Added support `data2array` for `DataF` (i.e., `PointField`s). PR [2143](https://github.com/CliMA/ClimaCore.jl/pull/2143).
  - `HDF5Reader` / `HDF5Writer` now support `do`-syntax. PR [2147](https://github.com/CliMA/ClimaCore.jl/pull/2147).
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -96,6 +96,7 @@ withenv("GKSwstype" => "nul") do
             ],
             "Contributing guide" => "Contributing.md",
             "Code of Conduct" => "code_of_conduct.md",
+            "Frequently asked questions" => "faq.md",
             "references.md",
         ],
     )

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -402,6 +402,13 @@ Remapping.interpolate_array
 Remapping.interpolate
 ```
 
+## Converting between devices
+
+```@docs
+to_device
+to_cpu
+```
+
 ## DebugOnly
 
 ```@docs

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -1,0 +1,27 @@
+# Frequently asked questions
+
+## Moving objects between the CPU and GPU.
+
+Occasionally, it's helpful to move data between the CPU and GPU. ClimaCore
+supports this through a method, [`to_device`](@ref ClimaCore.to_device). We also
+have a specialized version for converting only to the CPU: [`to_cpu`](@ref ClimaCore.to_cpu).
+
+For example, to create a CUDA column space from a CPU space, you can use:
+
+```julia
+using ClimaComms
+using ClimaCore
+using ClimaCore.CommonSpaces
+cpu_space = ColumnSpace(;
+    z_elem = 10,
+    z_min = 0,
+    z_max = 10,
+    staggering = CellCenter()
+)
+cuda_space = ClimaCore.to_device(ClimaComms.CUDADevice(), cpu_space)
+```
+
+Similarly, we can convert back with `to_cpu`:
+```julia
+new_cpu_space = ClimaCore.to_cpu(cuda_space)
+```

--- a/src/ClimaCore.jl
+++ b/src/ClimaCore.jl
@@ -28,5 +28,6 @@ include("CommonGrids/CommonGrids.jl")
 include("CommonSpaces/CommonSpaces.jl")
 
 include("deprecated.jl")
+include("to_device.jl")
 
 end # module

--- a/src/to_device.jl
+++ b/src/to_device.jl
@@ -1,0 +1,60 @@
+import Adapt
+import ClimaComms
+
+"""
+    out = to_device(device, x::Union{
+        DataLayouts.AbstractData,
+        Spaces.AbstractSpace,
+        Fields.Field,
+        Fields.FieldVector,
+    })
+
+Move `x` to the given `device`.
+
+This is particularly useful to move different types of `Space.AbstractSpace`s,
+`Fields.Field`s, and `Fields.FieldVector`s from CPUs to GPUs and viceversa.
+
+If the input is already defined on the target device, returns a copy.
+
+This means that `out === x` will not in general be satisfied.
+"""
+function to_device(
+    device::ClimaComms.AbstractDevice,
+    x::Union{
+        DataLayouts.AbstractData,
+        Spaces.AbstractSpace,
+        Fields.Field,
+        Fields.FieldVector,
+    },
+)
+    return Adapt.adapt(ClimaComms.array_type(device), x)
+end
+
+to_device(::ClimaComms.CPUMultiThreaded, _) = error("Not supported")
+
+
+"""
+    out = to_cpu(x::Union{
+        DataLayouts.AbstractData,
+        Spaces.AbstractSpace,
+        Fields.Field,
+        Fields.FieldVector,
+    })
+
+Move `x` backing data to the CPU.
+
+This is particularly useful for `Space.AbstractSpace`s,
+`Fields.Field`s, and `Fields.FieldVector`s.
+
+Returns a copy.
+
+This means that `out === x` will not in general be satisfied.
+"""
+to_cpu(
+    x::Union{
+        DataLayouts.AbstractData,
+        Spaces.AbstractSpace,
+        Fields.Field,
+        Fields.FieldVector,
+    },
+) = to_device(ClimaComms.CPUSingleThreaded(), x)

--- a/test/Fields/unit_field.jl
+++ b/test/Fields/unit_field.jl
@@ -713,12 +713,26 @@ function test_adapt(cpu_space_in)
     @test parent(Spaces.local_geometry_data(axes(cpu_f_out))) isa Array
     @test parent(Fields.field_values(cpu_f_out)) isa Array
 
+    cpu_f_in = Fields.Field(Float64, cpu_space_in)
+    cpu_f_out = ClimaCore.to_device(ClimaComms.CPUSingleThreaded(), cpu_f_in)
+    @test parent(Spaces.local_geometry_data(axes(cpu_f_out))) isa Array
+    @test parent(Fields.field_values(cpu_f_out)) isa Array
+
     @static if ClimaComms.device() isa ClimaComms.CUDADevice
         # cpu -> gpu
         gpu_f_out = Adapt.adapt(CUDA.CuArray, cpu_f_in)
         @test parent(Fields.field_values(gpu_f_out)) isa CUDA.CuArray
         # gpu -> gpu
         cpu_f_out = Adapt.adapt(Array, gpu_f_out)
+        @test parent(Fields.field_values(cpu_f_out)) isa Array
+
+        # to_device
+        # cpu -> gpu
+        gpu_f_out = ClimaCore.to_device(ClimaComms.CUDADevice(), cpu_f_in)
+        @test parent(Fields.field_values(gpu_f_out)) isa CUDA.CuArray
+        # gpu -> gpu
+        cpu_f_out =
+            ClimaCore.to_device(ClimaComms.CPUSingleThreaded(), gpu_f_out)
         @test parent(Fields.field_values(cpu_f_out)) isa Array
     end
 end


### PR DESCRIPTION
This PR adds `to_device`, which allow users to move data between the CPU and GPU, and `to_cpu`, which allow users to move data to the CPU.