### PR TITLE
Add vertical limiter operator docs

### DIFF
--- a/docs/src/operators.md
+++ b/docs/src/operators.md
@@ -60,6 +60,7 @@ UpwindBiasedProductC2F
 Upwind3rdOrderBiasedProductC2F
 FCTBorisBook
 FCTZalesak
+LinVanLeerC2F
 LeftBiasedC2F
 RightBiasedC2F
 LeftBiasedF2C


### PR DESCRIPTION
Adds operator docs (vanleer limiters) to markdown files.
Operator : https://github.com/CliMA/ClimaCore.jl/blob/2623ded20aee049f29065fd9ce3afd6e60f2e755/src/Operators/finitedifference.jl#L1326