### PR TITLE
Fix vertical metric terms, add SEM option for horizontal metric terms

### DIFF
--- a/examples/hybrid/sphere/deformation_flow.jl
+++ b/examples/hybrid/sphere/deformation_flow.jl
@@ -405,7 +405,7 @@ compare_tracer_props(a, b; buffer = 1) = all(
     @test compare_tracer_props(tracer_roughnesses(lim_third_upwind_sol), tracer_roughnesses(third_upwind_sol); buffer = 1.0)
     @test compare_tracer_props(tracer_roughnesses(lim_fct_sol)         , tracer_roughnesses(third_upwind_sol); buffer = 0.93)
     @test compare_tracer_props(tracer_ranges(fct_sol)                  , tracer_ranges(third_upwind_sol); buffer = 1.0)
-    @test compare_tracer_props(tracer_ranges(lim_third_upwind_sol)     , tracer_ranges(third_upwind_sol); buffer = 1.0)
+    @test compare_tracer_props(tracer_ranges(lim_third_upwind_sol)     , tracer_ranges(third_upwind_sol); buffer = 1.2)
     @test compare_tracer_props(tracer_ranges(lim_fct_sol)              , tracer_ranges(third_upwind_sol); buffer = 1.0)
     @test compare_tracer_props(tracer_ranges(lim_first_upwind_sol)     , tracer_ranges(third_upwind_sol); buffer = 0.6)
     @test compare_tracer_props(tracer_ranges(lim_centered_sol)         , tracer_ranges(third_upwind_sol); buffer = 1.3)

--- a/src/Grids/finitedifference.jl
+++ b/src/Grids/finitedifference.jl
@@ -56,13 +56,21 @@ function _FiniteDifferenceGrid(topology::Topologies.IntervalTopology)
     CT = Topologies.coordinate_type(mesh)
     FT = Geometry.float_type(CT)
     Nv_face = length(mesh.faces)
+    Nv_cent = Nv_face - 1
     # construct on CPU, adapt to GPU
+    center_coordinates = DataLayouts.VF{CT, Nv_cent}(Array{FT}, Nv_cent)
     face_coordinates = DataLayouts.VF{CT, Nv_face}(Array{FT}, Nv_face)
+    for v in 1:Nv_cent
+        center_coordinates[vindex(v)] = (mesh.faces[v] + mesh.faces[v + 1]) / 2
+    end
     for v in 1:Nv_face
         face_coordinates[vindex(v)] = mesh.faces[v]
     end
-    center_local_geometry, face_local_geometry =
-        fd_geometry_data(face_coordinates, Val(Topologies.isperiodic(topology)))
+    center_local_geometry, face_local_geometry = fd_geometry_data(
+        center_coordinates,
+        face_coordinates,
+        Val(Topologies.isperiodic(topology)),
+    )
 
     return FiniteDifferenceGrid(
         topology,
@@ -74,84 +82,56 @@ end
 
 # called by the FiniteDifferenceGrid constructor, and the ExtrudedFiniteDifferenceGrid constructor with Hypsography
 function fd_geometry_data(
+    center_coordinates::DataLayouts.AbstractData{Geometry.ZPoint{FT}},
     face_coordinates::DataLayouts.AbstractData{Geometry.ZPoint{FT}},
     ::Val{periodic},
 ) where {FT, periodic}
     CT = Geometry.ZPoint{FT}
     AIdx = (3,)
     LG = Geometry.LocalGeometry{AIdx, CT, FT, SMatrix{1, 1, FT, 1}}
+    ∂x∂ξ_axes = (Geometry.LocalAxis{AIdx}(), Geometry.CovariantAxis{AIdx}())
     (Ni, Nj, Nk, Nv, Nh) = size(face_coordinates)
     Nv_face = Nv - periodic
     Nv_cent = Nv - 1
-    center_local_geometry = similar(face_coordinates, LG, Val(Nv_cent))
+    center_local_geometry = similar(center_coordinates, LG, Val(Nv_cent))
     face_local_geometry = similar(face_coordinates, LG, Val(Nv_face))
-    c1(args...) =
+    cent_coord(args...) =
+        Geometry.component(center_coordinates[CartesianIndex(args...)], 1)
+    face_coord(args...) =
         Geometry.component(face_coordinates[CartesianIndex(args...)], 1)
     for h in 1:Nh, k in 1:Nk, j in 1:Nj, i in 1:Ni
         for v in 1:Nv_cent
-            # centers
-            coord⁻ = c1(i, j, k, v, h)
-            coord⁺ = c1(i, j, k, v + 1, h)
-            # use a "discrete Jacobian"
-            coord = (coord⁺ + coord⁻) / 2
-            Δcoord = coord⁺ - coord⁻
-            J = Δcoord
-            WJ = Δcoord
-            ∂x∂ξ = SMatrix{1, 1}(J)
+            J = face_coord(i, j, k, v + 1, h) - face_coord(i, j, k, v, h)
+            WJ = J
+            x = CT(cent_coord(i, j, k, v, h))
+            ∂x∂ξ = Geometry.AxisTensor(∂x∂ξ_axes, SMatrix{1, 1}(J))
             center_local_geometry[CartesianIndex(i, j, k, v, h)] =
-                Geometry.LocalGeometry(
-                    CT(coord),
-                    J,
-                    WJ,
-                    Geometry.AxisTensor(
-                        (
-                            Geometry.LocalAxis{AIdx}(),
-                            Geometry.CovariantAxis{AIdx}(),
-                        ),
-                        ∂x∂ξ,
-                    ),
-                )
+                Geometry.LocalGeometry(x, J, WJ, ∂x∂ξ)
         end
         for v in 1:Nv_face
-            coord = c1(i, j, k, v, h)
-            if v == 1
+            if periodic && v == 1
+                # periodic boundary face
+                J⁺ = face_coord(i, j, k, 2, h) - face_coord(i, j, k, 1, h)
+                J⁻ = face_coord(i, j, k, Nv, h) - face_coord(i, j, k, Nv - 1, h)
+                J = (J⁺ + J⁻) / 2
+                WJ = J
+            elseif !periodic && v == 1
                 # bottom face
-                if periodic
-                    Δcoord⁺ = c1(i, j, k, 2, h) - c1(i, j, k, 1, h)
-                    Δcoord⁻ = c1(i, j, k, Nv, h) - c1(i, j, k, Nv - 1, h)
-                    J = (Δcoord⁺ + Δcoord⁻) / 2
-                    WJ = J
-                else
-                    coord⁺ = c1(i, j, k, 2, h)
-                    J = coord⁺ - coord
-                    WJ = J / 2
-                end
-            elseif v == Nv_cent + 1
-                @assert !periodic
+                J = face_coord(i, j, k, 2, h) - face_coord(i, j, k, 1, h)
+                WJ = J / 2
+            elseif v == Nv
                 # top face
-                coord⁻ = c1(i, j, k, Nv - 1, h)
-                J = coord - coord⁻
+                @assert !periodic
+                J = face_coord(i, j, k, Nv, h) - face_coord(i, j, k, Nv - 1, h)
                 WJ = J / 2
             else
-                coord⁺ = c1(i, j, k, v + 1, h)
-                coord⁻ = c1(i, j, k, v - 1, h)
-                J = (coord⁺ - coord⁻) / 2
+                J = cent_coord(i, j, k, v, h) - cent_coord(i, j, k, v - 1, h)
                 WJ = J
             end
-            ∂x∂ξ = SMatrix{1, 1}(J)
+            x = CT(face_coord(i, j, k, v, h))
+            ∂x∂ξ = Geometry.AxisTensor(∂x∂ξ_axes, SMatrix{1, 1}(J))
             face_local_geometry[CartesianIndex(i, j, k, v, h)] =
-                Geometry.LocalGeometry(
-                    CT(coord),
-                    J,
-                    WJ,
-                    Geometry.AxisTensor(
-                        (
-                            Geometry.LocalAxis{AIdx}(),
-                            Geometry.CovariantAxis{AIdx}(),
-                        ),
-                        ∂x∂ξ,
-                    ),
-                )
+                Geometry.LocalGeometry(x, J, WJ, ∂x∂ξ)
         end
     end
     return (center_local_geometry, face_local_geometry)

--- a/test/Operators/integrals.jl
+++ b/test/Operators/integrals.jl
@@ -189,8 +189,9 @@ end
     device = ClimaComms.device()
     context = ClimaComms.SingletonCommsContext(device)
     for FT in (Float32, Float64)
-        for topography in (false, true), deep in (false, true)
-            space_kwargs = (; context, topography, deep)
+        bools = (false, true)
+        for topography in bools, deep in bools, autodiff_metric in bools
+            space_kwargs = (; context, topography, deep, autodiff_metric)
             space = TU.CenterExtrudedFiniteDifferenceSpace(FT; space_kwargs...)
             test_fubinis_theorem(space)
         end

--- a/test/Spaces/unit_dss.jl
+++ b/test/Spaces/unit_dss.jl
@@ -126,15 +126,16 @@ function test_dss_conservation(space)
     integral_before_dss = sum(field)
     Spaces.weighted_dss!(field)
     integral_after_dss = sum(field)
-    @test integral_after_dss ≈ integral_before_dss rtol = 14 * eps(FT)
+    @test integral_after_dss ≈ integral_before_dss rtol = 18 * eps(FT)
 end
 
 @testset "DSS Conservation on Cubed Sphere" begin
     device = ClimaComms.device()
     context = ClimaComms.SingletonCommsContext(device)
     for FT in (Float32, Float64)
-        for topography in (false, true), deep in (false, true)
-            space_kwargs = (; context, topography, deep)
+        bools = (false, true)
+        for topography in bools, deep in bools, autodiff_metric in bools
+            space_kwargs = (; context, topography, deep, autodiff_metric)
             center_space =
                 TU.CenterExtrudedFiniteDifferenceSpace(FT; space_kwargs...)
             for space in (center_space, Spaces.face_space(center_space))

--- a/test/TestUtilities/TestUtilities.jl
+++ b/test/TestUtilities/TestUtilities.jl
@@ -113,6 +113,7 @@ function CenterExtrudedFiniteDifferenceSpace(
     Nq = 4,
     deep = false,
     topography = false,
+    autodiff_metric = true,
     horizontal_layout_type = DataLayouts.IJFH,
 ) where {FT}
     radius = FT(128)
@@ -131,8 +132,12 @@ function CenterExtrudedFiniteDifferenceSpace(
     hmesh = Meshes.EquiangularCubedSphere(hdomain, helem)
     htopology = Topologies.Topology2D(context, hmesh)
     quad = Quadratures.GLL{Nq}()
-    hspace =
-        Spaces.SpectralElementSpace2D(htopology, quad; horizontal_layout_type)
+    hspace = Spaces.SpectralElementSpace2D(
+        htopology,
+        quad;
+        autodiff_metric,
+        horizontal_layout_type,
+    )
 
     hypsography = if topography
         # some non-trivial function of latitude and longitude


### PR DESCRIPTION
<!-- Provide a clear description of the content -->
This PR makes our vertical metric terms more consistent, and it adds a new option for our horizontal metric terms.

### Content
- Change the vertical center coordinate of element `n` from `(z(n, 0) + z(n, 1)) / 2` to `z(n, 1/2)`, where `ξ³ = 1/2` represents the center in generalized (unstretched) coordinates, and modify the vertical metric Jacobian to reflect this change. This makes the stretching of center coordinates consistent with the stretching of face coordinates.
- Add an `autodiff_metric` option for `SpectralElementGrid2D` in order to distinguish between metric terms computed with automatic differentiation and metric terms computed with the SEM. The default setting of `autodiff_metric = true` matches what we had previously, while `autodiff_metric = false` is the setting recommended by Paul Ullrich. Both of these exhibit similar performance in ClimaCore unit tests, so we will determine which setting is optimal through testing in ClimaAtmos.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
