### PR TITLE
Fix github action ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 [docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
 [docs-dev-url]: https://CliMA.github.io/ClimaCore.jl/dev/
 
-[gha-ci-img]: https://github.com/CliMA/ClimaCore.jl/actions/workflows/OS-UnitTests.yml/badge.svg
-[gha-ci-url]: https://github.com/CliMA/ClimaCore.jl/actions/workflows/OS-UnitTests.yml
+[gha-ci-img]: https://github.com/CliMA/ClimaCore.jl/actions/workflows/UnitTests.yml/badge.svg
+[gha-ci-url]: https://github.com/CliMA/ClimaCore.jl/actions/workflows/UnitTests.yml
 
 [buildkite-ci-img]: https://badge.buildkite.com/2b63d3c49347804f61bd8e99c8b85e05871253b92612cd1af4.svg
 [buildkite-ci-url]: https://buildkite.com/clima/climacore-ci


### PR DESCRIPTION
<!-- Provide a clear description of the content -->

- [X] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [X] Unit tests are included OR N/A.
- [X] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.

This closes #1612. This PR updates the URLs for the GitHub Actions CI badge to reflect the new workflow name.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R19): Updated the GitHub Actions CI badge URLs to point to the new `UnitTests.yml` workflow.