### PR TITLE
Fix CommonSpaces and MPI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -273,6 +273,35 @@ steps:
         agents:
           slurm_gpus: 1
 
+      - label: "Unit: common spaces with CUDA"
+        key: "gpu_common_cuda_spaces"
+        command:
+          - "julia --color=yes --check-bounds=yes --project=.buildkite test/CommonSpaces/unit_common_spaces.jl"
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+        agents:
+          slurm_gpus: 1
+
+      - label: "Unit: common spaces with CUDA and MPI"
+        key: "gpu_common_cuda_mpi_spaces"
+        command:
+          - "srun julia --color=yes --check-bounds=yes --project=.buildkite test/CommonSpaces/unit_common_spaces.jl"
+        env:
+          CLIMACOMMS_CONTEXT: "MPI"
+          CLIMACOMMS_DEVICE: "CUDA"
+        agents:
+          slurm_gpus: 1
+          slurm_ntasks: 2
+
+      - label: "Unit: common spaces with MPI"
+        key: "common_cuda_mpi_spaces"
+        command:
+          - "srun julia --color=yes --check-bounds=yes --project=.buildkite test/CommonSpaces/unit_common_spaces.jl"
+        env:
+          CLIMACOMMS_CONTEXT: "MPI"
+        agents:
+          slurm_ntasks: 2
+
       - label: "Unit: distributed cuda spaces"
         key: "gpu_distributed_extruded_cuda_spaces"
         command:

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,14 @@ ClimaCore.jl Release Notes
 main
 -------
 
+- Prior to this version, `CommonSpaces` could not be created with
+`ClimaComms.MPICommContext`. This is now fixed with PR
+[2176](https://github.com/CliMA/ClimaCore.jl/pull/2176).
+
+
+v0.14.24
+-------
+
  - A new `Adapt` wrapper was added, `to_device`, which allows users to adapt datalayouts, spaces, fields, and fieldvectors between the cpu and gpu. PR [2159](https://github.com/CliMA/ClimaCore.jl/pull/2159).
  - Remap interpolation cuda threading was improved. PR [2159](https://github.com/CliMA/ClimaCore.jl/pull/2159).
  - `center_space` and `face_space` are now exported from `CommonSpaces`. PR [2157](https://github.com/CliMA/ClimaCore.jl/pull/2157).

--- a/src/CommonGrids/CommonGrids.jl
+++ b/src/CommonGrids/CommonGrids.jl
@@ -189,7 +189,10 @@ function ExtrudedCubedSphereGrid(
         horizontal_layout_type,
         enable_bubble,
     )
-    z_topology = Topologies.IntervalTopology(context, z_mesh)
+    z_topology = Topologies.IntervalTopology(
+        ClimaComms.SingletonCommsContext(device),
+        z_mesh,
+    )
     z_grid = Grids.FiniteDifferenceGrid(z_topology)
     return Grids.ExtrudedFiniteDifferenceGrid(
         h_grid,
@@ -307,6 +310,7 @@ function ColumnGrid(
     ),
 ) where {FT}
     @assert ClimaComms.device(context) == device "The given device and context device do not match."
+    @assert context isa ClimaComms.SingletonCommsContext "Columns can only be created on Singleton contextes."
     z_topology = Topologies.IntervalTopology(context, z_mesh)
     return Grids.FiniteDifferenceGrid(z_topology)
 end
@@ -439,7 +443,10 @@ function Box3DGrid(
         horizontal_layout_type,
         enable_bubble,
     )
-    z_topology = Topologies.IntervalTopology(context, z_mesh)
+    z_topology = Topologies.IntervalTopology(
+        ClimaComms.SingletonCommsContext(device),
+        z_mesh,
+    )
     z_grid = Grids.FiniteDifferenceGrid(z_topology)
     return Grids.ExtrudedFiniteDifferenceGrid(
         h_grid,
@@ -542,10 +549,16 @@ function SliceXZGrid(
     @assert horizontal_layout_type <: DataLayouts.AbstractData
     @assert ClimaComms.device(context) == device "The given device and context device do not match."
 
-    h_topology = Topologies.IntervalTopology(context, h_mesh)
+    h_topology = Topologies.IntervalTopology(
+        ClimaComms.SingletonCommsContext(device),
+        h_mesh,
+    )
     h_grid =
         Grids.SpectralElementGrid1D(h_topology, quad; horizontal_layout_type)
-    z_topology = Topologies.IntervalTopology(context, z_mesh)
+    z_topology = Topologies.IntervalTopology(
+        ClimaComms.SingletonCommsContext(device),
+        z_mesh,
+    )
     z_grid = Grids.FiniteDifferenceGrid(z_topology)
     return Grids.ExtrudedFiniteDifferenceGrid(
         h_grid,

--- a/test/CommonSpaces/unit_common_spaces.jl
+++ b/test/CommonSpaces/unit_common_spaces.jl
@@ -37,7 +37,7 @@ ClimaComms.init(ClimaComms.context())
         h_elem = 10,
         n_quad_points = 4,
         horizontal_layout_type = DataLayouts.IJHF,
-        staggering = Grids.CellCenter(),
+        staggering = CellCenter(),
     )
     grid = Spaces.grid(space)
     @test grid isa Grids.ExtrudedFiniteDifferenceGrid
@@ -63,7 +63,7 @@ ClimaComms.init(ClimaComms.context())
         h_elem = 10,
         n_quad_points = 4,
         hypsography_fun,
-        staggering = Grids.CellCenter(),
+        staggering = CellCenter(),
     )
     grid = Spaces.grid(space)
     @test grid isa Grids.ExtrudedFiniteDifferenceGrid
@@ -103,7 +103,7 @@ ClimaComms.init(ClimaComms.context())
         n_quad_points = 4,
         x_elem = 3,
         y_elem = 4,
-        staggering = Grids.CellCenter(),
+        staggering = CellCenter(),
     )
     grid = Spaces.grid(space)
     @test grid isa Grids.ExtrudedFiniteDifferenceGrid
@@ -121,7 +121,7 @@ ClimaComms.init(ClimaComms.context())
             periodic_x = false,
             n_quad_points = 4,
             x_elem = 4,
-            staggering = Grids.CellCenter(),
+            staggering = CellCenter(),
         )
         grid = Spaces.grid(space)
         @test grid isa Grids.ExtrudedFiniteDifferenceGrid


### PR DESCRIPTION
The `CommonGrids` module passes down the context to all the grid it creates. This is a problem for IntervalTopology, because it can only be created with Singletons.

This commit fixes this issue and adds test checking that we can create CommonSpaces with MPI and CUDA

Closes #2175 
