### PR TITLE
Add nodal mask

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -265,8 +265,8 @@ steps:
         key: "gpu_cuda_spaces"
         command:
           - "julia --project=.buildkite -e 'using CUDA; CUDA.versioninfo()'"
-          - "srun julia --color=yes --check-bounds=yes --project=.buildkite test/Spaces/unit_spaces.jl"
-          - "srun julia --color=yes --check-bounds=yes --project=.buildkite test/Spaces/opt_spaces.jl"
+          - "julia --color=yes --check-bounds=yes --project=.buildkite test/Spaces/unit_spaces.jl"
+          - "julia --color=yes --check-bounds=yes --project=.buildkite test/Spaces/opt_spaces.jl"
           - "julia --color=yes --check-bounds=yes --project=.buildkite test/Spaces/unit_high_resolution_space.jl"
         env:
           CLIMACOMMS_DEVICE: "CUDA"

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ ClimaCore.jl Release Notes
 main
 -------
 
+ - `SpectralElementSpace2D` constructors now support nodal masks. PR [2201](https://github.com/CliMA/ClimaCore.jl/pull/2201). See its documentation [here](https://clima.github.io/ClimaCore.jl/dev/masks). Note that it does not yet support restarts.
+
 - Added support for InputOutput with PointSpaces
   PR [2162](https://github.com/CliMA/ClimaCore.jl/pull/2162).
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -86,6 +86,7 @@ withenv("GKSwstype" => "nul") do
                 tutorial in TUTORIALS
             ],
             "Examples" => "examples.md",
+            "Masks" => "masks.md",
             "Debugging" => "debugging.md",
             "Libraries" => [
                 joinpath("lib", "ClimaCorePlots.md"),

--- a/docs/src/masks.md
+++ b/docs/src/masks.md
@@ -1,0 +1,199 @@
+# Masks
+
+## Motivation
+
+ClimaCore spaces, `SpectralElementSpace2D`s in particular, support masks, where
+users can set horizontal nodal locations where operations are skipped.
+
+This is especially helpful for the land model, where they may have degrees of
+freedom over the ocean, but do not want to evaluate expressions in regions where
+data is missing.
+
+Masks in ClimaCore offer a solution to this by, ahead of time prescribing
+regions to skip. This helps both with the ergonomics, as well as performance.
+
+## User interface
+
+There are two user-facing parts for ClimaCore masks:
+
+ - set the `enable_mask = true` keyword in the space constructor (when available),
+   which is currently any constructor that returns/contains a `SpectralElementSpace2D`.
+ - use `set_mask!` to set where the mask is `true` (where compute should occur)
+   and `false` (where compute should be skipped)
+
+Here is an example
+
+```julia
+using ClimaComms
+ClimaComms.@import_required_backends
+import ClimaCore: Spaces, Fields
+using ClimaCore.CommonSpaces
+using Test
+
+FT = Float64
+ᶜspace = ExtrudedCubedSphereSpace(FT;
+    z_elem = 10,
+    z_min = 0,
+    z_max = 1,
+    radius = 10,
+    h_elem = 10,
+    n_quad_points = 4,
+    staggering = CellCenter(),
+    enable_mask = true,
+)
+
+# How to set the mask
+Spaces.set_mask!(ᶜspace) do coords
+    coords.lat > 0.5
+end
+# Or
+mask = Fields.Field(FT, ᶜspace)
+mask .= map(cf -> cf.lat > 0.5 ? 0.0 : 1.0, Fields.coordinate_field(mask))
+Spaces.set_mask!(ᶜspace, mask)
+```
+
+Finally, operations over fields will be skipped where `mask == 0`, and applied
+where `mask == 1`:
+
+```
+@. f = 1 # only applied where the mask is equal to 1
+```
+
+## Example script
+
+Here is a more complex script where the mask is used:
+
+```julia
+using ClimaComms
+ClimaComms.@import_required_backends
+import ClimaCore: Spaces, Fields, DataLayouts, Geometry, Operators
+using ClimaCore.CommonSpaces
+using Test
+
+FT = Float64
+ᶜspace = ExtrudedCubedSphereSpace(FT;
+    z_elem = 10,
+    z_min = 0,
+    z_max = 1,
+    radius = 10,
+    h_elem = 10,
+    n_quad_points = 4,
+    staggering = CellCenter(),
+    enable_mask = true,
+)
+ᶠspace = Spaces.face_space(ᶜspace)
+ᶠcoords = Fields.coordinate_field(ᶠspace)
+
+# How to set the mask
+Spaces.set_mask!(ᶜspace) do coords
+    coords.lat > 0.5
+end
+
+# We also support the syntax `Spaces.set_mask!(::AbstractSpace, ::Field)`
+
+# We can check the mask directly: (internals, only for demonstrative purposes)
+mask = Spaces.get_mask(ᶜspace)
+@test count(parent(mask.is_active)) == 4640
+@test length(parent(mask.is_active)) == 9600
+
+# Let's skip operations that use fill!
+ᶜf = zeros(ᶜspace) # ignores mask
+@. ᶜf = 1 # tests fill! # abides by mask
+
+# Let's show that 4640 columns were impacted:
+@test count(x->x==1, parent(ᶜf)) == 4640 * Spaces.nlevels(axes(ᶜf))
+@test length(parent(ᶜf)) == 9600 * Spaces.nlevels(axes(ᶜf))
+
+# Let's skip operations that use copyto!
+ᶜz = Fields.coordinate_field(ᶜspace).z
+ᶜf = zeros(ᶜspace)
+@. ᶜf = 1 + 0 * ᶜz # tests copyto!
+
+# Let's again show that 4640 columns were impacted:
+@test count(x->x==1, parent(ᶜf)) == 4640 * Spaces.nlevels(axes(ᶜf))
+@test length(parent(ᶜf)) == 9600 * Spaces.nlevels(axes(ᶜf))
+
+# Let's skip operations in FiniteDifference operators
+ᶠf = zeros(ᶠspace)
+c = Fields.Field(FT, ᶜspace)
+div = Operators.DivergenceF2C()
+foo(f, cf) = cf.lat > 0.5 ? zero(f) : sqrt(-1) # results in NaN in masked out regions
+@. c = div(Geometry.WVector(foo(ᶠf, ᶠcoords)))
+
+# Check that this field should never yield NaNs
+@test count(isnan, parent(c)) == 0
+
+# Doing the same thing with a space without a mask will yield NaNs:
+ᶜspace_no_mask = ExtrudedCubedSphereSpace(FT;
+    z_elem = 10,
+    z_min = 0,
+    z_max = 1,
+    radius = 10,
+    h_elem = 10,
+    n_quad_points = 4,
+    staggering = CellCenter(),
+)
+ᶠspace_no_mask = Spaces.face_space(ᶜspace_no_mask)
+ᶠcoords_no_mask = Fields.coordinate_field(ᶠspace_no_mask)
+c_no_mask = Fields.Field(FT, ᶜspace_no_mask)
+ᶠf_no_mask = Fields.Field(FT, ᶠspace_no_mask)
+@. c_no_mask = div(Geometry.WVector(foo(ᶠf_no_mask, ᶠcoords_no_mask)))
+@test count(isnan, parent(c_no_mask)) == 49600
+```
+
+## Supported operations and caveats
+
+Currently, masked _operations_ are only supported for `Fields` (and not
+`DataLayouts`) with `SpectralElementSpace2D`s. We do not yet have support for
+masked `SpectralElement1DSpace`s, and we will likely never offer masked
+operation support for `DataLayouts`, as they do not have the space, and can
+therefore not use the mask.
+
+In addition, some operations with masked fields skip masked regions
+(i.e., mask-aware), and other operations execute everywhere
+(i.e., mask-unaware), effectively ignoring the mask. Here is a list of
+operations of mask-aware and mask-unaware:
+
+ - `DataLayout` operations (`Fields.field_values(f) = 1`) mask-unaware (will likely never be mask-aware).
+ - `fill!` (`@. f = 1`) mask-aware
+ - point-wise `copyto!` (`@. f = 1 + z`) mask-aware
+ - stencil `copyto!` (`@. ᶜf = 1 + DivergenceF2C()(Geometry.WVector(ᶠf))`) mask-aware (vertical derivatives and interpolations interpolations)
+ - spectral element operations `copyto!` (`@. f = 1 + Operators.Divergence()(f)`), where `Operators.Divergence` carries out a divergence operation in horizontal directions. mask-unaware
+ - fieldvector operations `copyto!` (`@. Y += 1`) mask-unaware
+ - reductions:
+   - `sum` (mask-unaware, warning is thrown)
+   - `extrema` (mask-unaware, warning is thrown)
+   - `min` (mask-unaware, warning is thrown)
+   - `max` (mask-unaware, warning is thrown)
+ - field constructors (`copy`, `Fields.Field`, `ones`, `zeros`) are mask-unaware.
+   This was a design implementation detail, users should not generally depend on the results where `mask == 0`, in case this is changed in the future. 
+ - internal array operations (`fill!(parent(field), 0)`) mask-unaware.
+
+## Developer docs
+
+In order to support masks, we define their types in `DataLayouts`, since 
+we need access to them from within kernels in `DataLayouts`. We could have made
+an API and kept them completely orthogonal, but that would have been a bit more
+complicated, also, it was convenient to make the masks themselves data layouts,
+so it seemed most natural for them to live there.
+
+We have a couple types:
+
+ - abstract `AbstractMask` for subtyping masks and use for generic interface
+   methods
+ - `NoMask` (the default), which is a lazy object that should effectively result
+   in a no-op, without any loss of runtime performance
+ - `IJHMask` currently the only supported horizontal mask, which contains
+   `is_active` (defined in `set_mask!`), `N` (the number of active columns),
+   and maps containing indices to the `i, j, h` locations where `is_active` is
+   true. The maps are defined in `set_mask_maps!`, allows us to launch cuda
+   kernels to only target the active columns, and threads are not wasted on
+   non-existent columns. The logic to handle this is relatively thin, and
+   extends our current `ext/cuda/datalayouts_threadblock.jl` api
+   (via `masked_partition` and `masked_universal_index`).
+
+An important note is that when we set the mask maps for active columns, the
+order that they are assigned can be permuted without impacting correctness, but
+this could have a big impact on performance on the gpu. We should investigate
+this.
+

--- a/ext/ClimaCoreCUDAExt.jl
+++ b/ext/ClimaCoreCUDAExt.jl
@@ -13,6 +13,7 @@ import StaticArrays: SVector, SMatrix, SArray
 import ClimaCore.DebugOnly: call_post_op_callback, post_op_callback
 import ClimaCore.DataLayouts: mapreduce_cuda
 import ClimaCore.DataLayouts: ToCUDA
+import ClimaCore.DataLayouts: NoMask, IJHMask
 import ClimaCore.DataLayouts: slab, column
 import ClimaCore.Utilities: half
 import ClimaCore.Utilities: cart_ind, linear_ind

--- a/ext/cuda/adapt.jl
+++ b/ext/cuda/adapt.jl
@@ -30,6 +30,7 @@ Adapt.adapt_structure(
     Adapt.adapt(to, grid.quadrature_style),
     Adapt.adapt(to, grid.global_geometry),
     Adapt.adapt(to, grid.local_geometry),
+    Adapt.adapt(to, grid.mask),
 )
 
 Adapt.adapt_structure(to::CUDA.KernelAdaptor, space::Spaces.PointSpace) =
@@ -53,3 +54,12 @@ Adapt.adapt_structure(
     lim.rtol,
     Limiters.NoConvergenceStats(),
 )
+
+Adapt.adapt_structure(to::CUDA.KernelAdaptor, mask::DataLayouts.IJHMask) =
+    DataLayouts.IJHMask(
+        Adapt.adapt(to, mask.is_active),
+        nothing,
+        Adapt.adapt(to, mask.i_map),
+        Adapt.adapt(to, mask.j_map),
+        Adapt.adapt(to, mask.h_map),
+    )

--- a/ext/cuda/operators_spectral_element.jl
+++ b/ext/cuda/operators_spectral_element.jl
@@ -32,6 +32,7 @@ function Base.copyto!(
         SpectralBroadcasted{CUDASpectralStyle},
         Broadcasted{CUDASpectralStyle},
     },
+    mask = DataLayouts.NoMask(),
 )
     space = axes(out)
     us = UniversalSize(Fields.field_values(out))

--- a/src/CommonGrids/CommonGrids.jl
+++ b/src/CommonGrids/CommonGrids.jl
@@ -102,6 +102,7 @@ import .Helpers.DefaultRectangleXYMesh
         horizontal_layout_type = DataLayouts.IJFH,
         z_mesh::Meshes.IntervalMesh = DefaultZMesh(FT; z_min, z_max, z_elem, stretch),
         enable_bubble::Bool = false
+        enable_mask::Bool = false
     )
 
 A convenience constructor, which builds an
@@ -125,6 +126,8 @@ A convenience constructor, which builds an
  - `horizontal_layout_type` the horizontal DataLayout type (defaults to `DataLayouts.IJFH`). This parameter describes how data is arranged in memory. See [`Grids.SpectralElementGrid2D`](@ref) for its use.
  - `z_mesh` the vertical mesh, defaults to an `Meshes.IntervalMesh` along `z` with given `stretch`
  - `enable_bubble` enables the "bubble correction" for more accurate element areas when computing the spectral element space. See [`Grids.SpectralElementGrid2D`](@ref) for more information.
+ - `enable_mask` enables a horizontal mask, for skipping operations on specified
+                 columns via `set_mask!`.
 
 # Example usage
 
@@ -178,6 +181,7 @@ function ExtrudedCubedSphereGrid(
         stretch,
     ),
     enable_bubble::Bool = false,
+    enable_mask::Bool = false,
 ) where {FT}
     @assert horizontal_layout_type <: DataLayouts.AbstractData
     @assert ClimaComms.device(context) == device "The given device and context device do not match."
@@ -188,6 +192,7 @@ function ExtrudedCubedSphereGrid(
         quad;
         horizontal_layout_type,
         enable_bubble,
+        enable_mask,
     )
     z_topology = Topologies.IntervalTopology(
         ClimaComms.SingletonCommsContext(device),
@@ -214,6 +219,7 @@ end
         h_mesh = Meshes.EquiangularCubedSphere(Domains.SphereDomain{FT}(radius), h_elem),
         h_topology::Topologies.AbstractDistributedTopology = Topologies.Topology2D(context, h_mesh),
         horizontal_layout_type = DataLayouts.IJFH,
+        enable_mask = false,
     )
 
 A convenience constructor, which builds a
@@ -229,6 +235,8 @@ A convenience constructor, which builds a
  - `h_mesh` the horizontal mesh (defaults to `Meshes.EquiangularCubedSphere`)
  - `h_topology` the horizontal topology (defaults to `Topologies.Topology2D`)
  - `horizontal_layout_type` the horizontal DataLayout type (defaults to `DataLayouts.IJFH`). This parameter describes how data is arranged in memory. See [`Grids.SpectralElementGrid2D`](@ref) for its use.
+ - `enable_mask` enables a horizontal mask, for skipping operations on specified
+                 columns via `set_mask!`.
 
 # Example usage
 
@@ -255,10 +263,16 @@ function CubedSphereGrid(
         h_mesh,
     ),
     horizontal_layout_type = DataLayouts.IJFH,
+    enable_mask::Bool = false,
 ) where {FT}
     @assert horizontal_layout_type <: DataLayouts.AbstractData
     @assert ClimaComms.device(context) == device "The given device and context device do not match."
-    return Grids.SpectralElementGrid2D(h_topology, quad; horizontal_layout_type)
+    return Grids.SpectralElementGrid2D(
+        h_topology,
+        quad;
+        horizontal_layout_type,
+        enable_mask,
+    )
 end
 
 """
@@ -340,6 +354,7 @@ end
         [h_topology::Topologies.AbstractDistributedTopology], # optional
         [z_mesh::Meshes.IntervalMesh], # optional
         enable_bubble::Bool = false,
+        enable_mask::Bool = false,
     )
 
 A convenience constructor, which builds a
@@ -369,6 +384,8 @@ A convenience constructor, which builds a
  - `z_mesh` the vertical mesh, defaults to an `Meshes.IntervalMesh` along `z` with given `stretch`
  - `enable_bubble` enables the "bubble correction" for more accurate element areas when computing the spectral element space. See [`Grids.SpectralElementGrid2D`](@ref) for more information.
  - `horizontal_layout_type` the horizontal DataLayout type (defaults to `DataLayouts.IJFH`). This parameter describes how data is arranged in memory. See [`Grids.SpectralElementGrid2D`](@ref) for its use.
+ - `enable_mask` enables a horizontal mask, for skipping operations on specified
+                 columns via `set_mask!`.
 
 # Example usage
 
@@ -434,6 +451,7 @@ function Box3DGrid(
     ),
     enable_bubble::Bool = false,
     horizontal_layout_type = DataLayouts.IJFH,
+    enable_mask::Bool = false,
 ) where {FT}
     @assert horizontal_layout_type <: DataLayouts.AbstractData
     @assert ClimaComms.device(context) == device "The given device and context device do not match."
@@ -442,6 +460,7 @@ function Box3DGrid(
         quad;
         horizontal_layout_type,
         enable_bubble,
+        enable_mask,
     )
     z_topology = Topologies.IntervalTopology(
         ClimaComms.SingletonCommsContext(device),
@@ -585,6 +604,7 @@ end
         hypsography::Grids.HypsographyAdaption = Grids.Flat(),
         global_geometry::Geometry.AbstractGlobalGeometry = Geometry.CartesianGlobalGeometry(),
         quad::Quadratures.QuadratureStyle = Quadratures.GLL{n_quad_points}(),
+        enable_mask::Bool = false,
     )
 
 A convenience constructor, which builds a
@@ -605,6 +625,8 @@ A convenience constructor, which builds a
  - `hypsography_fun` a function or callable object (`hypsography_fun(h_grid, z_grid) -> hypsography`) for constructing the hypsography model.
  - `global_geometry` the global geometry (defaults to [`Geometry.CartesianGlobalGeometry`](@ref))
  - `quad` the quadrature style (defaults to `Quadratures.GLL{n_quad_points}`)
+ - `enable_mask` enables a horizontal mask, for skipping operations on specified
+                 columns via `set_mask!`.
 
 # Example usage
 
@@ -656,6 +678,7 @@ function RectangleXYGrid(
         ),
     ),
     enable_bubble::Bool = false,
+    enable_mask::Bool = false,
 ) where {FT}
     @assert horizontal_layout_type <: DataLayouts.AbstractData
     @assert ClimaComms.device(context) == device "The given device and context device do not match."
@@ -664,6 +687,7 @@ function RectangleXYGrid(
         quad;
         horizontal_layout_type,
         enable_bubble,
+        enable_mask,
     )
 end
 

--- a/src/DataLayouts/fill.jl
+++ b/src/DataLayouts/fill.jl
@@ -1,70 +1,94 @@
-function Base.fill!(dest::AbstractData, val)
+function Base.fill!(dest::AbstractData, val, mask = NoMask())
     dev = device_dispatch(parent(dest))
     if !(VERSION ≥ v"1.11.0-beta") &&
        dest isa EndsWithField &&
-       dev isa ClimaComms.AbstractCPUDevice
+       dev isa ClimaComms.AbstractCPUDevice &&
+       mask isa NoMask
         @inbounds @simd for I in 1:get_N(UniversalSize(dest))
             dest[I] = val
         end
     else
-        Base.fill!(dest, val, dev)
+        Base.fill!(dest, val, dev, mask)
     end
-    call_post_op_callback() && post_op_callback(dest, dest, val)
+    call_post_op_callback() && post_op_callback(dest, dest, val, mask)
     dest
 end
 
-function Base.fill!(data::Union{IJFH, IJHF}, val, ::ToCPU)
-    (_, _, _, _, Nh) = size(data)
-    @inbounds for h in 1:Nh
-        fill!(slab(data, h), val)
+function Base.fill!(data::Union{IJFH, IJHF}, val, ::ToCPU, mask = NoMask())
+    (Ni, Nj, _, _, Nh) = size(data)
+    @inbounds for h in 1:Nh, i in 1:Ni, j in 1:Nj
+        idx = CartesianIndex(i, j, 1, 1, h)
+        should_compute(mask, idx) || continue
+        data[idx] = val
     end
     return data
 end
-function Base.fill!(data::Union{IFH, IHF}, val, ::ToCPU)
-    (_, _, _, _, Nh) = size(data)
-    @inbounds for h in 1:Nh
-        fill!(slab(data, h), val)
+function Base.fill!(data::Union{IFH, IHF}, val, ::ToCPU, mask = NoMask())
+    (Ni, _, _, _, Nh) = size(data)
+    @inbounds for h in 1:Nh, i in 1:Ni
+        idx = CartesianIndex(i, 1, 1, 1, h)
+        should_compute(mask, idx) || continue
+        data[idx] = val
     end
     return data
 end
-function Base.fill!(data::DataF, val, ::ToCPU)
+function Base.fill!(data::DataF, val, ::ToCPU, mask = NoMask())
     @inbounds data[] = val
     return data
 end
 
-function Base.fill!(data::IJF{S, Nij}, val, ::ToCPU) where {S, Nij}
+function Base.fill!(
+    data::IJF{S, Nij},
+    val,
+    ::ToCPU,
+    mask = NoMask(),
+) where {S, Nij}
     @inbounds for j in 1:Nij, i in 1:Nij
-        data[CartesianIndex(i, j, 1, 1, 1)] = val
+        idx = CartesianIndex(i, j, 1, 1, 1)
+        should_compute(mask, idx) || continue
+        data[idx] = val
     end
     return data
 end
 
-function Base.fill!(data::IF{S, Ni}, val, ::ToCPU) where {S, Ni}
+function Base.fill!(
+    data::IF{S, Ni},
+    val,
+    ::ToCPU,
+    mask = NoMask(),
+) where {S, Ni}
     @inbounds for i in 1:Ni
-        data[CartesianIndex(i, 1, 1, 1, 1)] = val
+        idx = CartesianIndex(i, 1, 1, 1, 1)
+        should_compute(mask, idx) || continue
+        data[idx] = val
     end
     return data
 end
 
-function Base.fill!(data::VF, val, ::ToCPU)
+function Base.fill!(data::VF, val, ::ToCPU, mask::NoMask = NoMask())
     Nv = nlevels(data)
+    # we don't need a mask here, since this is for a column
     @inbounds for v in 1:Nv
         data[CartesianIndex(1, 1, 1, v, 1)] = val
     end
     return data
 end
 
-function Base.fill!(data::Union{VIJFH, VIJHF}, val, ::ToCPU)
+function Base.fill!(data::Union{VIJFH, VIJHF}, val, ::ToCPU, mask = NoMask())
     (Ni, Nj, _, Nv, Nh) = size(data)
-    @inbounds for h in 1:Nh, v in 1:Nv
-        fill!(slab(data, v, h), val)
+    @inbounds for h in 1:Nh, i in 1:Ni, j in 1:Nj, v in 1:Nv
+        idx = CartesianIndex(i, j, 1, v, h)
+        should_compute(mask, idx) || continue
+        data[idx] = val
     end
     return data
 end
-function Base.fill!(data::Union{VIFH, VIHF}, val, ::ToCPU)
+function Base.fill!(data::Union{VIFH, VIHF}, val, ::ToCPU, mask = NoMask())
     (Ni, _, _, Nv, Nh) = size(data)
-    @inbounds for h in 1:Nh, v in 1:Nv
-        fill!(slab(data, v, h), val)
+    @inbounds for h in 1:Nh, i in 1:Ni, v in 1:Nv
+        idx = CartesianIndex(i, 1, 1, v, h)
+        should_compute(mask, idx) || continue
+        data[idx] = val
     end
     return data
 end

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -22,6 +22,7 @@ import ..Quadratures
 import ..Grids: ColumnIndex, local_geometry_type
 import ..Spaces: Spaces, AbstractSpace, AbstractPointSpace, cuda_synchronize
 import ..Spaces: nlevels, ncolumns
+import ..Spaces: get_mask, set_mask!
 import ..Geometry: Geometry, Cartesian12Vector
 import ..Utilities: PlusHalf, half
 
@@ -274,9 +275,13 @@ Base.copy(field::Field) = Field(copy(field_values(field)), axes(field))
 Base.deepcopy_internal(field::Field, stackdict::IdDict) =
     Field(Base.deepcopy_internal(field_values(field), stackdict), axes(field))
 
-function Base.copyto!(dest::Field{V, M}, src::Field{V, M}) where {V, M}
+function Base.copyto!(
+    dest::Field{V, M},
+    src::Field{V, M},
+    mask = DataLayouts.NoMask,
+) where {V, M}
     @assert axes(dest) == axes(src)
-    copyto!(field_values(dest), field_values(src))
+    copyto!(field_values(dest), field_values(src), mask)
     return dest
 end
 
@@ -631,5 +636,8 @@ function field2array(field::Field)
     end
     return DataLayouts.data2array(field_values(field))
 end
+
+set_mask!(space::Spaces.AbstractSpace, field::Field) =
+    set_mask!(Spaces.horizontal_space(space), field_values(field))
 
 end # module

--- a/src/Operators/spectralelement.jl
+++ b/src/Operators/spectralelement.jl
@@ -167,6 +167,7 @@ function Base.copyto!(
         SpectralBroadcasted{SlabBlockSpectralStyle},
         Broadcasted{SlabBlockSpectralStyle},
     },
+    mask = DataLayouts.NoMask(),
 )
     Fields.byslab(axes(out)) do slabidx
         Base.@_inline_meta

--- a/src/Spaces/Spaces.jl
+++ b/src/Spaces/Spaces.jl
@@ -38,6 +38,8 @@ import ..Grids:
     local_geometry_data,
     global_geometry,
     dss_weights,
+    set_mask!,
+    get_mask,
     quadrature_style
 
 import ClimaComms
@@ -177,6 +179,11 @@ function ncolumns(space::SpectralElementSpace2D)
     return Nh * Nq * Nq
 end
 
+get_mask(space::AbstractSpace) = get_mask(grid(space))
+get_mask(space::PointSpace) = DataLayouts.NoMask()
+get_mask(space::SpectralElementSpaceSlab) = DataLayouts.NoMask()
+get_mask(space::ExtrudedFiniteDifferenceSpace) =
+    get_mask(horizontal_space(space))
 
 """
     has_vertical(::AbstractSpace)
@@ -198,5 +205,11 @@ has_horizontal(::AbstractSpace) = false
 has_horizontal(::ExtrudedFiniteDifferenceSpace) = true
 has_horizontal(::SpectralElementSpace1D) = true
 has_horizontal(::SpectralElementSpace2D) = true
+
+set_mask!(fn, space::AbstractSpace) = set_mask!(fn, grid(space))
+set_mask!(fn, space::ExtrudedFiniteDifferenceSpace) =
+    set_mask!(fn, grid(horizontal_space(space)))
+set_mask!(space::AbstractSpace, data::DataLayouts.AbstractData) =
+    set_mask!(grid(space), data)
 
 end # module

--- a/src/Spaces/spectralelement.jl
+++ b/src/Spaces/spectralelement.jl
@@ -116,7 +116,6 @@ function issubspace(
     return grid(hspace) === grid(level_space).full_grid.horizontal_grid
 end
 
-
 """
     SpectralElementSpaceSlab <: AbstractSpace
 

--- a/test/Spaces/opt_spaces.jl
+++ b/test/Spaces/opt_spaces.jl
@@ -37,20 +37,20 @@ end
         test_n_failures(91,   TU.PointSpace, context)
         test_n_failures(825,  TU.SpectralElementSpace1D, context)
         test_n_failures(1141, TU.SpectralElementSpace2D, context)
-        test_n_failures(3,  TU.ColumnCenterFiniteDifferenceSpace, context)
-        test_n_failures(4,  TU.ColumnFaceFiniteDifferenceSpace, context)
+        test_n_failures(4,  TU.ColumnCenterFiniteDifferenceSpace, context)
+        test_n_failures(5,  TU.ColumnFaceFiniteDifferenceSpace, context)
         test_n_failures(1147, TU.SphereSpectralElementSpace, context)
         test_n_failures(1146, TU.CenterExtrudedFiniteDifferenceSpace, context)
         test_n_failures(1146, TU.FaceExtrudedFiniteDifferenceSpace, context)
     else
         test_n_failures(0,    TU.PointSpace, context)
         test_n_failures(150,  TU.SpectralElementSpace1D, context)
-        test_n_failures(310,  TU.SpectralElementSpace2D, context)
+        test_n_failures(316,  TU.SpectralElementSpace2D, context)
         test_n_failures(4,  TU.ColumnCenterFiniteDifferenceSpace, context)
         test_n_failures(5,  TU.ColumnFaceFiniteDifferenceSpace, context)
-        test_n_failures(316,  TU.SphereSpectralElementSpace, context)
-        test_n_failures(321,  TU.CenterExtrudedFiniteDifferenceSpace, context)
-        test_n_failures(321,  TU.FaceExtrudedFiniteDifferenceSpace, context)
+        test_n_failures(322,  TU.SphereSpectralElementSpace, context)
+        test_n_failures(327,  TU.CenterExtrudedFiniteDifferenceSpace, context)
+        test_n_failures(327,  TU.FaceExtrudedFiniteDifferenceSpace, context)
 
         # The OBJECT_CACHE causes inference failures that inhibit understanding
         # inference failures in _SpectralElementGrid2D, so let's `@test_opt` those


### PR DESCRIPTION
This PR adds a nodal mask into the `SpectralElementGrid2D`, and allows users to update it with `set_mask!(::Function, space::AbstractSpace)`. This is an initial step towards this [SDI](https://github.com/CliMA/ClimaLand.jl/issues/488).

I imagine that just the pointwise and stencil operations will go a long way, but we may need to iterate to find out what else is needed.

Note to self: I think we also need to thread the mask through in some `materialize!` calls for implicit pieces, assuming that they call `copyto!`

Supersedes #2085

Here is a rough summary of how this works

### Summary

 - We add the mask, in the form of a DataLayout to the horizontal grid, or a `DataLayouts.NoMask` object
   - Using different types like this allows us to dispatch on behavior when the mask is present and absent, effectively becoming a no-op when the mask is absent
 - We then extract and pass that mask to our kernels (i.e., `Base.copyto!`)
 - Inside `Base.copyto!`, if the mask is a datalayout, we check if `mask == 0` for a particular `i, j, f, v, h`, before doing the broadcast assignment (`dest[I] = bc[I]`) then we skip, via `continue` (or `return nothing`, in the case of cuda kernels).