### PR TITLE
Improve show for spaces, add show for grids

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ ClimaCore.jl Release Notes
 main
 -------
 
+ - Improved `show` for spaces, and added `show` for grids. PR [2202](https://github.com/CliMA/ClimaCore.jl/pull/2202).
+
 v0.14.26
 -------
 

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -35,8 +35,6 @@ Get the topology of a grid.
 """
 function topology end
 
-function vertical_topology end
-
 """
     Grids.local_geometry_data(
         grid       :: AbstractGrid,
@@ -77,6 +75,47 @@ include("extruded.jl")
 include("column.jl")
 include("level.jl")
 
+function Base.show(io::IO, grid::AbstractGrid)
+    indent = get(io, :indent, 0)
+    iio = IOContext(io, :indent => indent + 2)
+    println(io, nameof(typeof(grid)), ":")
+    if has_horizontal(grid)
+        # some reduced spaces (like slab space) do not have topology
+        println(iio, " "^(indent + 2), "horizontal:")
+        print(iio, " "^(indent + 4), "context: ")
+        Topologies.print_context(iio, topology(grid).context)
+        println(iio)
+        println(iio, " "^(indent + 4), "mesh: ", topology(grid).mesh)
+        print(iio, " "^(indent + 4), "quadrature: ", quadrature_style(grid))
+    end
+    if has_vertical(grid)
+        has_horizontal(grid) && println(iio, "")
+        println(iio, " "^(indent + 2), "vertical:")
+        print(iio, " "^(indent + 4), "mesh: ", vertical_topology(grid).mesh)
+    end
+end
+
+"""
+    has_horizontal(::AbstractGrid)
+
+Returns a bool indicating that the grid has a vertical part.
+"""
+function has_horizontal end
+has_horizontal(::AbstractGrid) = false
+has_horizontal(::ExtrudedFiniteDifferenceGrid) = true
+has_horizontal(::DeviceSpectralElementGrid2D) = true
+has_horizontal(::SpectralElementGrid2D) = true
+has_horizontal(::SpectralElementGrid1D) = true
+
+"""
+    has_vertical(::AbstractGrid)
+
+Returns a bool indicating that the space has a vertical part.
+"""
+function has_vertical end
+has_vertical(::AbstractGrid) = false
+has_vertical(::FiniteDifferenceGrid) = true
+has_vertical(::ExtrudedFiniteDifferenceGrid) = true
 
 
 end # module

--- a/src/Spaces/Spaces.jl
+++ b/src/Spaces/Spaces.jl
@@ -178,4 +178,25 @@ function ncolumns(space::SpectralElementSpace2D)
 end
 
 
+"""
+    has_vertical(::AbstractSpace)
+
+Returns a bool indicating that the space has a vertical grid.
+"""
+function has_vertical end
+has_vertical(::AbstractSpace) = false
+has_vertical(::ExtrudedFiniteDifferenceSpace) = true
+has_vertical(::FiniteDifferenceSpace) = false
+
+"""
+    has_horizontal(::AbstractSpace)
+
+Returns a bool indicating that the space has a vertical grid.
+"""
+function has_horizontal end
+has_horizontal(::AbstractSpace) = false
+has_horizontal(::ExtrudedFiniteDifferenceSpace) = true
+has_horizontal(::SpectralElementSpace1D) = true
+has_horizontal(::SpectralElementSpace2D) = true
+
 end # module

--- a/src/Spaces/extruded.jl
+++ b/src/Spaces/extruded.jl
@@ -169,14 +169,32 @@ function Base.show(io::IO, space::ExtrudedFiniteDifferenceSpace)
         ":",
     )
     print(iio, " "^(indent + 2), "context: ")
-    hspace = Spaces.horizontal_space(space)
-    Topologies.print_context(iio, Spaces.topology(hspace).context)
-    println(iio)
-    println(iio, " "^(indent + 2), "horizontal:")
-    println(iio, " "^(indent + 4), "mesh: ", Spaces.topology(hspace).mesh)
-    println(iio, " "^(indent + 4), "quadrature: ", quadrature_style(hspace))
-    println(iio, " "^(indent + 2), "vertical:")
-    print(iio, " "^(indent + 4), "mesh: ", vertical_topology(space).mesh)
+    Topologies.print_context(iio, ClimaComms.context(space))
+    if has_horizontal(space)
+        hspace = Spaces.horizontal_space(space)
+        hmesh = Spaces.topology(hspace).mesh
+        Topologies.print_context(iio, Spaces.topology(hspace).context)
+        println(iio)
+        println(iio, " "^(indent + 2), "horizontal:")
+        println(iio, " "^(indent + 4), "mesh: ", hmesh)
+        println(
+            iio,
+            " "^(indent + 4),
+            "node_horizontal_length_scale: ",
+            Spaces.node_horizontal_length_scale(hspace),
+        )
+        println(
+            iio,
+            " "^(indent + 4),
+            "element_horizontal_length_scale: ",
+            Meshes.element_horizontal_length_scale(hmesh),
+        )
+        println(iio, " "^(indent + 4), "quadrature: ", quadrature_style(hspace))
+    end
+    if has_vertical(space)
+        println(iio, " "^(indent + 2), "vertical:")
+        print(iio, " "^(indent + 4), "mesh: ", vertical_topology(space).mesh)
+    end
 end
 
 quadrature_style(space::ExtrudedFiniteDifferenceSpace) =
@@ -190,16 +208,10 @@ horizontal_space(full_space::ExtrudedFiniteDifferenceSpace) =
 vertical_topology(space::ExtrudedFiniteDifferenceSpace) =
     vertical_topology(grid(space))
 
-
-
 function column(space::ExtrudedFiniteDifferenceSpace, colidx::Grids.ColumnIndex)
     column_grid = column(grid(space), colidx)
     FiniteDifferenceSpace(column_grid, space.staggering)
 end
-
-
-
-
 
 Base.@propagate_inbounds function slab(
     space::ExtrudedFiniteDifferenceSpace,


### PR DESCRIPTION
This PR adds `node_horizontal_length_scale` and `element_horizontal_length_scale` to the `show` method for spaces, and adds a `show` method for grids.