### PR TITLE
Use more unique values in InputOutput hybrid box tests

### DIFF
--- a/test/InputOutput/unit_hybrid2dbox.jl
+++ b/test/InputOutput/unit_hybrid2dbox.jl
@@ -105,7 +105,7 @@ end
         coords,
     )
     uₕ = map(coord -> Geometry.Covariant1Vector(coord.x * 0.1), coords)
-    w = map(coord -> Geometry.Covariant3Vector(coord.x * 0.2), face_coords)
+    w = map(coord -> Geometry.Covariant3Vector(coord.z * 0.2), face_coords)
     Y = Fields.FieldVector(Yc = Yc, uₕ = uₕ, w = w)
 
     # write field vector to hdf5 file

--- a/test/InputOutput/unit_hybrid2dbox.jl
+++ b/test/InputOutput/unit_hybrid2dbox.jl
@@ -104,8 +104,8 @@ end
         coord -> init_dry_rising_bubble_2d(coord.x, coord.z, params),
         coords,
     )
-    uₕ = map(_ -> Geometry.Covariant1Vector(0.0), coords)
-    w = map(_ -> Geometry.Covariant3Vector(0.0), face_coords)
+    uₕ = map(coord -> Geometry.Covariant1Vector(coord.x * 0.1), coords)
+    w = map(coord -> Geometry.Covariant3Vector(coord.x * 0.2), face_coords)
     Y = Fields.FieldVector(Yc = Yc, uₕ = uₕ, w = w)
 
     # write field vector to hdf5 file

--- a/test/InputOutput/unit_hybrid2dbox_stretched.jl
+++ b/test/InputOutput/unit_hybrid2dbox_stretched.jl
@@ -105,8 +105,8 @@ end
         coord -> init_dry_rising_bubble_2d(coord.x, coord.z, params),
         coords,
     )
-    uₕ = map(_ -> Geometry.Covariant1Vector(0.0), coords)
-    w = map(_ -> Geometry.Covariant3Vector(0.0), face_coords)
+    uₕ = map(coord -> Geometry.Covariant1Vector(coord.x * 0.1), coords)
+    w = map(coord -> Geometry.Covariant3Vector(coord.z * 0.2), face_coords)
     Y = Fields.FieldVector(Yc = Yc, uₕ = uₕ, w = w)
 
     # write field vector to hdf5 file

--- a/test/InputOutput/unit_hybrid2dbox_topography.jl
+++ b/test/InputOutput/unit_hybrid2dbox_topography.jl
@@ -116,8 +116,8 @@ end
         coord -> init_dry_rising_bubble_2d(coord.x, coord.z, params),
         coords,
     )
-    uₕ = map(_ -> Geometry.Covariant1Vector(0.0), coords)
-    w = map(_ -> Geometry.Covariant3Vector(0.0), face_coords)
+    uₕ = map(coord -> Geometry.Covariant1Vector(coord.x * 0.11), coords)
+    w = map(coord -> Geometry.Covariant3Vector(coord.z * 0.25), face_coords)
     Y = Fields.FieldVector(Yc = Yc, uₕ = uₕ, w = w)
 
     # write field vector to hdf5 file

--- a/test/InputOutput/unit_hybrid3dbox.jl
+++ b/test/InputOutput/unit_hybrid3dbox.jl
@@ -116,8 +116,11 @@ end
             init_dry_rising_bubble_3d(coord.x, coord.y, coord.z, params),
         coords,
     )
-    uₕ = map(_ -> Geometry.Covariant12Vector(0.0, 0.0), coords)
-    w = map(_ -> Geometry.Covariant3Vector(0.0), face_coords)
+    uₕ = map(
+        coord -> Geometry.Covariant12Vector(coord.x * 0.1, coord.y * 0.15),
+        coords,
+    )
+    w = map(coord -> Geometry.Covariant3Vector(coord.z * 0.3), face_coords)
     Y = Fields.FieldVector(Yc = Yc, uₕ = uₕ, w = w)
 
     # write field vector to hdf5 file


### PR DESCRIPTION
<!-- Provide a clear description of the content -->

Instead of using vectors that are all zeroes, this change uses the coordinates themselves to create more unique values so the tests are more specific.

Resolves #1996 

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
