### PR TITLE
Remove unnecessary broadcast type

### DIFF
--- a/ext/cuda/operators_finite_difference.jl
+++ b/ext/cuda/operators_finite_difference.jl
@@ -15,6 +15,11 @@ AbstractStencilStyle(bc, ::ClimaComms.CUDADevice) =
     Operators.any_fd_shmem_supported(bc) ? CUDAWithShmemColumnStencilStyle :
     CUDAColumnStencilStyle
 
+Base.Broadcast.BroadcastStyle(
+    x::Operators.ColumnStencilStyle,
+    y::CUDAColumnStencilStyle,
+) = y
+
 include("operators_fd_shmem_is_supported.jl")
 
 function Base.copyto!(

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -219,9 +219,6 @@ strip_space(op::FiniteDifferenceOperator, parent_space) =
 
 abstract type AbstractStencilStyle <: Fields.AbstractFieldStyle end
 
-# the .f field is an operator
-struct StencilStyle <: AbstractStencilStyle end
-
 struct ColumnStencilStyle <: AbstractStencilStyle end
 
 AbstractStencilStyle(bc, ::ClimaComms.AbstractCPUDevice) = ColumnStencilStyle
@@ -3815,8 +3812,7 @@ Base.@propagate_inbounds function getidx(
     end
 end
 
-
-# broadcasting a StencilStyle gives a CompositeStencilStyle
+# broadcasting a ColumnStencilStyle gives the StencilBroadcasted's style
 Base.Broadcast.BroadcastStyle(
     ::Type{<:StencilBroadcasted{Style}},
 ) where {Style} = Style()
@@ -3945,7 +3941,7 @@ end
 function Base.Broadcast.broadcasted(op::FiniteDifferenceOperator, args...)
     args′ = map(Base.Broadcast.broadcastable, args)
     style = Base.Broadcast.result_style(
-        StencilStyle(),
+        ColumnStencilStyle(),
         Base.Broadcast.combine_styles(args′...),
     )
     Base.Broadcast.broadcasted(style, op, args′...)


### PR DESCRIPTION
It looks like we have two stencil styles, that from what I can tell have no reason to be different: a `StencilStyle` and a `ColumnStencilStyle`. For some reason, `StencilStyle` is used in `result_style` in `broadcasted`, and `ColumnStencilStyle` is used elsewhere.

I ran into an issue:

```julia
ERROR: LoadError: conflicting broadcast rules defined
  Broadcast.BroadcastStyle(::ClimaCore.Operators.StencilStyle, ::ClimaCore.Operators.ColumnStencilStyle) = ClimaCore.Operators.StencilStyle()
  Broadcast.BroadcastStyle(::ClimaCore.Operators.ColumnStencilStyle, ::ClimaCore.Operators.StencilStyle) = ClimaCore.Operators.ColumnStencilStyle()
One of these should be undefined (and thus return Broadcast.Unknown).
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:35
  [2] 
    @ Base.Broadcast ./broadcast.jl:474
  [3] result_style(s1::ClimaCore.Operators.StencilStyle, s2::ClimaCore.Operators.ColumnStencilStyle)
    @ Base.Broadcast ./broadcast.jl:457
  [4] broadcasted(op::ClimaCore.Operators.GradientC2F{…}, args::Base.Broadcast.Broadcasted{…})
    @ ClimaCore.Operators ~/.julia/packages/ClimaCore/7GN1g/src/Operators/finitedifference.jl:3960
```
in a development branch. I think this change fixes this issue.

It looks like these were introduced in these two commits (from a while ago)
 - https://github.com/CliMA/ClimaCore.jl/commit/d2061529740be3e6a89a09f0f4278a0a7a463ab5
 - https://github.com/CliMA/ClimaCore.jl/commit/7645f97c0675920ac4c6dad304639aa4a32c4f2b