### PR TITLE
Try avoid reconstructing space in getidx

### DIFF
--- a/src/MatrixFields/field_name_dict.jl
+++ b/src/MatrixFields/field_name_dict.jl
@@ -107,7 +107,10 @@ end
 function Operators.strip_space(dict::FieldNameDict)
     vals = unrolled_map(values(dict)) do val
         if val isa Fields.Field
-            Fields.Field(Fields.field_values(val), Operators.PlaceholderSpace())
+            Fields.Field(
+                Fields.field_values(val),
+                Operators.PlaceholderSpace(axes(val)),
+            )
         else
             val
         end

--- a/src/MatrixFields/matrix_shape.jl
+++ b/src/MatrixFields/matrix_shape.jl
@@ -48,10 +48,10 @@ column_axes(matrix_field, matrix_space = axes(matrix_field)) =
 
 _column_axes(::Square, space) = space
 _column_axes(::FaceToCenter, space) = Operators.reconstruct_placeholder_space(
-    Operators.FacePlaceholderSpace(),
+    Operators.FacePlaceholderSpace(space),
     space,
 )
 _column_axes(::CenterToFace, space) = Operators.reconstruct_placeholder_space(
-    Operators.CenterPlaceholderSpace(),
+    Operators.CenterPlaceholderSpace(space),
     space,
 )

--- a/src/Operators/common.jl
+++ b/src/Operators/common.jl
@@ -68,38 +68,57 @@ end
 # the GPU, which is quite limited (~4kB).
 
 # Functions for CUDASpectralStyle
-struct PlaceholderSpace <: Spaces.AbstractSpace end
-struct LevelPlaceholderSpace <: Spaces.AbstractSpace end
-struct CenterPlaceholderSpace <: Spaces.AbstractSpace end
-struct FacePlaceholderSpace <: Spaces.AbstractSpace end
+struct PlaceholderSpace{N, IP} <: Spaces.AbstractSpace end
+struct LevelPlaceholderSpace{N, IP} <: Spaces.AbstractSpace end
+struct CenterPlaceholderSpace{N, IP} <: Spaces.AbstractSpace end
+struct FacePlaceholderSpace{N, IP} <: Spaces.AbstractSpace end
+Spaces.nlevels(::FacePlaceholderSpace{N}) where {N} = N
+Spaces.nlevels(::CenterPlaceholderSpace{N}) where {N} = N
+
+PlaceholderSpace(space) = PlaceholderSpace{
+    Spaces.nlevels(space),
+    Topologies.isperiodic(Spaces.vertical_topology(space)),
+}()
+LevelPlaceholderSpace(space) = LevelPlaceholderSpace{
+    Spaces.nlevels(space),
+    Topologies.isperiodic(Spaces.vertical_topology(space)),
+}()
+CenterPlaceholderSpace(space) = CenterPlaceholderSpace{
+    Spaces.nlevels(space),
+    Topologies.isperiodic(Spaces.vertical_topology(space)),
+}()
+FacePlaceholderSpace(space) = FacePlaceholderSpace{
+    Spaces.nlevels(space),
+    Topologies.isperiodic(Spaces.vertical_topology(space)),
+}()
 
 placeholder_space(current_space, parent_space) = current_space
 placeholder_space(current_space::T, parent_space::T) where {T} =
-    PlaceholderSpace()
+    PlaceholderSpace(current_space)
 placeholder_space(
     current_space::Spaces.AbstractPointSpace,
     parent_space::Spaces.AbstractFiniteDifferenceSpace,
-) = LevelPlaceholderSpace()
+) = LevelPlaceholderSpace(current_space)
 placeholder_space(
     current_space::Spaces.AbstractSpectralElementSpace,
     parent_space::Spaces.ExtrudedFiniteDifferenceSpace,
-) = LevelPlaceholderSpace()
+) = LevelPlaceholderSpace(current_space)
 placeholder_space(
     current_space::Spaces.CenterFiniteDifferenceSpace,
     parent_space::Spaces.FaceFiniteDifferenceSpace,
-) = CenterPlaceholderSpace()
+) = CenterPlaceholderSpace(current_space)
 placeholder_space(
     current_space::Spaces.CenterExtrudedFiniteDifferenceSpace,
     parent_space::Spaces.FaceExtrudedFiniteDifferenceSpace,
-) = CenterPlaceholderSpace()
+) = CenterPlaceholderSpace(current_space)
 placeholder_space(
     current_space::Spaces.FaceFiniteDifferenceSpace,
     parent_space::Spaces.CenterFiniteDifferenceSpace,
-) = FacePlaceholderSpace()
+) = FacePlaceholderSpace(current_space)
 placeholder_space(
     current_space::Spaces.FaceExtrudedFiniteDifferenceSpace,
     parent_space::Spaces.CenterExtrudedFiniteDifferenceSpace,
-) = FacePlaceholderSpace()
+) = FacePlaceholderSpace(current_space)
 
 @inline reconstruct_placeholder_space(current_space, parent_space) =
     current_space

--- a/src/Operators/common.jl
+++ b/src/Operators/common.jl
@@ -68,10 +68,11 @@ end
 # the GPU, which is quite limited (~4kB).
 
 # Functions for CUDASpectralStyle
-struct PlaceholderSpace{N, IP} <: Spaces.AbstractSpace end
-struct LevelPlaceholderSpace{N, IP} <: Spaces.AbstractSpace end
-struct CenterPlaceholderSpace{N, IP} <: Spaces.AbstractSpace end
-struct FacePlaceholderSpace{N, IP} <: Spaces.AbstractSpace end
+abstract type AbstractPlaceHolderSpace <: Spaces.AbstractSpace end
+struct PlaceholderSpace{N, IP} <: AbstractPlaceHolderSpace end
+struct LevelPlaceholderSpace{N, IP} <: AbstractPlaceHolderSpace end
+struct CenterPlaceholderSpace{N, IP} <: AbstractPlaceHolderSpace end
+struct FacePlaceholderSpace{N, IP} <: AbstractPlaceHolderSpace end
 Spaces.nlevels(::FacePlaceholderSpace{N}) where {N} = N
 Spaces.nlevels(::CenterPlaceholderSpace{N}) where {N} = N
 

--- a/src/Operators/common.jl
+++ b/src/Operators/common.jl
@@ -93,6 +93,15 @@ FacePlaceholderSpace(space) = FacePlaceholderSpace{
 }()
 
 placeholder_space(current_space, parent_space) = current_space
+placeholder_space(current_space::T, parent_space::T) where {T <: Spaces.CenterFiniteDifferenceSpace} =
+    CenterPlaceholderSpace(current_space)
+placeholder_space(current_space::T, parent_space::T) where {T <: Spaces.FaceFiniteDifferenceSpace} =
+    FacePlaceholderSpace(current_space)
+placeholder_space(current_space::T, parent_space::T) where {T <: Spaces.FaceExtrudedFiniteDifferenceSpace} =
+    FacePlaceholderSpace(current_space)
+placeholder_space(current_space::T, parent_space::T) where {T <: Spaces.CenterExtrudedFiniteDifferenceSpace} =
+    CenterPlaceholderSpace(current_space)
+
 placeholder_space(current_space::T, parent_space::T) where {T} =
     PlaceholderSpace(current_space)
 placeholder_space(

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -50,6 +50,7 @@ right_face_boundary_idx(space::AllFiniteDifferenceSpace⁺) =
 
 vertically_periodic(space) =
     Topologies.isperiodic(Spaces.vertical_topology(space))
+vertically_periodic(space::Spaces.AbstractSpectralElementSpace) = false
 vertically_periodic(::FacePlaceholderSpace{N, IP}) where {N, IP} = IP
 vertically_periodic(::CenterPlaceholderSpace{N, IP}) where {N, IP} = IP
 


### PR DESCRIPTION
This is an experimental PR, which tries to avoid reconstructing the space in `getidx`.

The basic idea is: under the assumption that compiling methods with big types is expensive, can we reduce the number of methods that we compile with big types (i.e., spaces)?

To achieve this, I think we need two pieces of information in the placeholder space from the original space:
 - is the vertical topology periodic?
 - number of levels in the space