### PR TITLE
Unify inclusion pattern of TestUtilities

### DIFF
--- a/test/Fields/benchmark_fieldvectors.jl
+++ b/test/Fields/benchmark_fieldvectors.jl
@@ -16,17 +16,11 @@ if ClimaComms.device() isa ClimaComms.CUDADevice
 else
     device_name = "CPU"
 end
-if !(@isdefined(TU))
-    include(
-        joinpath(
-            pkgdir(ClimaCore),
-            "test",
-            "TestUtilities",
-            "TestUtilities.jl",
-        ),
-    )
-    import .TestUtilities as TU
-end
+@isdefined(TU) || include(
+    joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl"),
+);
+import .TestUtilities as TU;
+
 
 include(joinpath(pkgdir(ClimaCore), "benchmarks/scripts/benchmark_utils.jl"))
 

--- a/test/Fields/convergence_field_integrals.jl
+++ b/test/Fields/convergence_field_integrals.jl
@@ -28,10 +28,10 @@ using LinearAlgebra: norm
 using Statistics: mean
 using ForwardDiff
 
-include(
+@isdefined(TU) || include(
     joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl"),
-)
-import .TestUtilities as TU
+);
+import .TestUtilities as TU;
 
 """
     convergence_rate(err, Δh)

--- a/test/Fields/field_opt.jl
+++ b/test/Fields/field_opt.jl
@@ -25,10 +25,10 @@ using LinearAlgebra: norm
 using Statistics: mean
 using ForwardDiff
 
-include(
+@isdefined(TU) || include(
     joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl"),
-)
-import .TestUtilities as TU
+);
+import .TestUtilities as TU;
 
 # https://github.com/CliMA/ClimaCore.jl/issues/946
 @testset "Allocations with broadcasting Scalars" begin

--- a/test/Fields/unit_field.jl
+++ b/test/Fields/unit_field.jl
@@ -29,10 +29,10 @@ using LinearAlgebra: norm
 using Statistics: mean
 using ForwardDiff
 
-include(
+@isdefined(TU) || include(
     joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl"),
-)
-import .TestUtilities as TU
+);
+import .TestUtilities as TU;
 
 function spectral_space_2D(; n1 = 1, n2 = 1, Nij = 4)
     domain = Domains.RectangleDomain(

--- a/test/Fields/utils_field_multi_broadcast_fusion.jl
+++ b/test/Fields/utils_field_multi_broadcast_fusion.jl
@@ -31,17 +31,10 @@ using LinearAlgebra: norm
 using Statistics: mean
 using ForwardDiff
 
-if !(@isdefined(TU))
-    include(
-        joinpath(
-            pkgdir(ClimaCore),
-            "test",
-            "TestUtilities",
-            "TestUtilities.jl",
-        ),
-    )
-    import .TestUtilities as TU
-end
+@isdefined(TU) || include(
+    joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl"),
+);
+import .TestUtilities as TU;
 
 @show ClimaComms.device()
 

--- a/test/InputOutput/unit_read_type.jl
+++ b/test/InputOutput/unit_read_type.jl
@@ -3,10 +3,10 @@ import ClimaCore
 import ClimaCore: Fields, InputOutput
 using ClimaComms
 ClimaComms.@import_required_backends
-include(
+@isdefined(TU) || include(
     joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl"),
-)
-import .TestUtilities as TU
+);
+import .TestUtilities as TU;
 
 compare_read_type(x) = InputOutput.read_type(string(eltype(x))) == eltype(x)
 @testset "Read field element types" begin

--- a/test/MatrixFields/flat_spaces.jl
+++ b/test/MatrixFields/flat_spaces.jl
@@ -1,8 +1,8 @@
 import ClimaCore
-include(
+@isdefined(TU) || include(
     joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl"),
-)
-import .TestUtilities as TU
+);
+import .TestUtilities as TU;
 
 include("matrix_field_test_utils.jl")
 import ClimaCore.MatrixFields: @name, ⋅

--- a/test/MatrixFields/gpu_compat_bidiag_matrix_row.jl
+++ b/test/MatrixFields/gpu_compat_bidiag_matrix_row.jl
@@ -4,17 +4,10 @@ using Revise; include(joinpath("test", "MatrixFields", "gpu_compat_bidiag_matrix
 import ClimaCore
 import ClimaComms
 ClimaComms.@import_required_backends
-if !(@isdefined(TU))
-    include(
-        joinpath(
-            pkgdir(ClimaCore),
-            "test",
-            "TestUtilities",
-            "TestUtilities.jl",
-        ),
-    )
-end
-import .TestUtilities as TU
+@isdefined(TU) || include(
+    joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl"),
+);
+import .TestUtilities as TU;
 
 import ClimaCore: Spaces, Geometry, Operators, Fields, MatrixFields
 using LinearAlgebra: Adjoint

--- a/test/MatrixFields/matrix_multiplication_recursion.jl
+++ b/test/MatrixFields/matrix_multiplication_recursion.jl
@@ -1,15 +1,9 @@
 import ClimaCore
-if !(@isdefined(TU))
-    include(
-        joinpath(
-            pkgdir(ClimaCore),
-            "test",
-            "TestUtilities",
-            "TestUtilities.jl",
-        ),
-    )
-end
-import .TestUtilities as TU
+@isdefined(TU) || include(
+    joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl"),
+);
+import .TestUtilities as TU;
+
 import ClimaCore: Spaces, Geometry, Operators, Fields, MatrixFields
 import ClimaCore.MatrixFields: ⋅
 import ClimaComms

--- a/test/Operators/finitedifference/benchmark_stencils_utils.jl
+++ b/test/Operators/finitedifference/benchmark_stencils_utils.jl
@@ -10,10 +10,10 @@ using ClimaCore.Geometry: ⊗
 import ClimaCore.DataLayouts
 
 import ClimaCore
-include(
+@isdefined(TU) || include(
     joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl"),
-)
-import .TestUtilities as TU
+);
+import .TestUtilities as TU;
 
 @show ClimaComms.device() isa ClimaComms.CUDADevice
 if ClimaComms.device() isa ClimaComms.CUDADevice

--- a/test/Operators/integrals.jl
+++ b/test/Operators/integrals.jl
@@ -12,10 +12,10 @@ import ClimaCore.Operators:
     column_reduce!,
     column_accumulate!
 
-include(
+@isdefined(TU) || include(
     joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl"),
-)
-import .TestUtilities as TU
+);
+import .TestUtilities as TU;
 
 are_boundschecks_forced = Base.JLOptions().check_bounds == 1
 center_to_face_space(center_space::Spaces.CenterFiniteDifferenceSpace) =

--- a/test/Spaces/extruded_cuda.jl
+++ b/test/Spaces/extruded_cuda.jl
@@ -12,10 +12,10 @@ import ClimaCore:
     Domains, Topologies, Meshes, Spaces, Geometry, column, Fields, Grids
 using Test
 
-include(
+@isdefined(TU) || include(
     joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl"),
-)
-import .TestUtilities as TU
+);
+import .TestUtilities as TU;
 
 compare(cpu, gpu) = all(parent(cpu) .≈ Array(parent(gpu)))
 compare(cpu, gpu, f) = all(parent(f(cpu)) .≈ Array(parent(f(gpu))))

--- a/test/Spaces/opt_spaces.jl
+++ b/test/Spaces/opt_spaces.jl
@@ -6,10 +6,10 @@ using Revise; include(joinpath("test", "Spaces", "opt_spaces.jl"))
 import ClimaCore
 import ClimaCore: Spaces, Grids, Topologies
 using Test
-include(
+@isdefined(TU) || include(
     joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl"),
-)
-import .TestUtilities as TU
+);
+import .TestUtilities as TU;
 import ClimaComms
 ClimaComms.@import_required_backends
 

--- a/test/Spaces/unit_dss.jl
+++ b/test/Spaces/unit_dss.jl
@@ -20,10 +20,10 @@ import ClimaCore:
     Topologies,
     DataLayouts
 
-include(
+@isdefined(TU) || include(
     joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl"),
-)
-import .TestUtilities as TU
+);
+import .TestUtilities as TU;
 
 function get_space_cs(::Type{FT}; context, R = 300.0) where {FT}
     domain = Domains.SphereDomain{FT}(300.0)


### PR DESCRIPTION
This PR unifies the inclusion pattern of the TestUtilities module.

Since including modules in global scope force recompilation, it's convenient to conditionally load them to avoid repaying compilation for every test (assuming we can run our test in a leaky setting).

This is a peel of from #2220.