### PR TITLE
Use new MultiplyColumnwiseBandMatrixField alias

### DIFF
--- a/examples/hybrid/implicit_equation_jacobian.jl
+++ b/examples/hybrid/implicit_equation_jacobian.jl
@@ -2,6 +2,7 @@ import LinearAlgebra: ldiv!
 using ClimaCore: Spaces, Fields, Operators
 using ClimaCore.Utilities: half
 using ClimaCore.MatrixFields
+import ClimaCore.MatrixFields: ⋆
 using ClimaCore.MatrixFields: @name
 
 """

--- a/examples/hybrid/staggered_nonhydrostatic_model.jl
+++ b/examples/hybrid/staggered_nonhydrostatic_model.jl
@@ -331,11 +331,11 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
     #     norm_sqr(C123(ᶜuₕ) + C123(ᶜinterp(ᶠw))) / 2 =
     #     ACT12(ᶜuₕ) * ᶜuₕ / 2 + ACT3(ᶜinterp(ᶠw)) * ᶜinterp(ᶠw) / 2
     # ∂(ᶜK)/∂(ᶠw) = ACT3(ᶜinterp(ᶠw)) * ᶜinterp_matrix()
-    @. ∂ᶜK∂ᶠw = DiagonalMatrixRow(adjoint(CT3(ᶜinterp(ᶠw)))) ⋅ ᶜinterp_matrix()
+    @. ∂ᶜK∂ᶠw = DiagonalMatrixRow(adjoint(CT3(ᶜinterp(ᶠw)))) ⋆ ᶜinterp_matrix()
 
     # ᶜρₜ = -ᶜdivᵥ(ᶠinterp(ᶜρ) * ᶠw)
     # ∂(ᶜρₜ)/∂(ᶠw) = -ᶜdivᵥ_matrix() * ᶠinterp(ᶜρ) * ᶠg³³
-    @. ∂ᶜρₜ∂ᶠ𝕄 = -(ᶜdivᵥ_matrix()) ⋅ DiagonalMatrixRow(ᶠinterp(ᶜρ) * g³³(ᶠgⁱʲ))
+    @. ∂ᶜρₜ∂ᶠ𝕄 = -(ᶜdivᵥ_matrix()) ⋆ DiagonalMatrixRow(ᶠinterp(ᶜρ) * g³³(ᶠgⁱʲ))
 
     if :ρθ in propertynames(Y.c)
         ᶜρθ = Y.c.ρθ
@@ -349,14 +349,14 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
             # ᶜρθₜ = -ᶜdivᵥ(ᶠinterp(ᶜρθ) * ᶠw)
             # ∂(ᶜρθₜ)/∂(ᶠw) = -ᶜdivᵥ_matrix() * ᶠinterp(ᶜρθ) * ᶠg³³
             @. ∂ᶜ𝔼ₜ∂ᶠ𝕄 =
-                -(ᶜdivᵥ_matrix()) ⋅ DiagonalMatrixRow(ᶠinterp(ᶜρθ) * g³³(ᶠgⁱʲ))
+                -(ᶜdivᵥ_matrix()) ⋆ DiagonalMatrixRow(ᶠinterp(ᶜρθ) * g³³(ᶠgⁱʲ))
         else
             # ᶜρθₜ = -ᶜdivᵥ(ᶠinterp(ᶜρ) * ᶠupwind_product(ᶠw, ᶜρθ / ᶜρ))
             # ∂(ᶜρθₜ)/∂(ᶠw) =
             #     -ᶜdivᵥ_matrix() * ᶠinterp(ᶜρ) *
             #     ∂(ᶠupwind_product(ᶠw, ᶜρθ / ᶜρ))/∂(ᶠw)
             @. ∂ᶜ𝔼ₜ∂ᶠ𝕄 =
-                -(ᶜdivᵥ_matrix()) ⋅ DiagonalMatrixRow(
+                -(ᶜdivᵥ_matrix()) ⋆ DiagonalMatrixRow(
                     ᶠinterp(ᶜρ) *
                     vec_data(ᶠno_flux(ᶠupwind_product(ᶠw + εw, ᶜρθ / ᶜρ))) /
                     vec_data(CT3(ᶠw + εw)) * g³³(ᶠgⁱʲ),
@@ -381,10 +381,10 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
                 # ∂(ᶜp)/∂(ᶠw) = ∂(ᶜp)/∂(ᶜK) * ∂(ᶜK)/∂(ᶠw)
                 # ∂(ᶜp)/∂(ᶜK) = -ᶜρ * R_d / cv_d
                 @. ∂ᶜ𝔼ₜ∂ᶠ𝕄 =
-                    -(ᶜdivᵥ_matrix()) ⋅ (
+                    -(ᶜdivᵥ_matrix()) ⋆ (
                         DiagonalMatrixRow(ᶠinterp(ᶜρe + ᶜp) * g³³(ᶠgⁱʲ)) +
-                        DiagonalMatrixRow(CT3(ᶠw)) ⋅ ᶠinterp_matrix() ⋅
-                        DiagonalMatrixRow(-(ᶜρ * R_d / cv_d)) ⋅ ∂ᶜK∂ᶠw
+                        DiagonalMatrixRow(CT3(ᶠw)) ⋆ ᶠinterp_matrix() ⋆
+                        DiagonalMatrixRow(-(ᶜρ * R_d / cv_d)) ⋆ ∂ᶜK∂ᶠw
                     )
             else
                 # ᶜρeₜ =
@@ -397,7 +397,7 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
                 # ∂(ᶜp)/∂(ᶠw) = ∂(ᶜp)/∂(ᶜK) * ∂(ᶜK)/∂(ᶠw)
                 # ∂(ᶜp)/∂(ᶜK) = -ᶜρ * R_d / cv_d
                 @. ∂ᶜ𝔼ₜ∂ᶠ𝕄 =
-                    -(ᶜdivᵥ_matrix()) ⋅ DiagonalMatrixRow(ᶠinterp(ᶜρ)) ⋅ (
+                    -(ᶜdivᵥ_matrix()) ⋆ DiagonalMatrixRow(ᶠinterp(ᶜρ)) ⋆ (
                         DiagonalMatrixRow(
                             vec_data(
                                 ᶠno_flux(
@@ -405,7 +405,7 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
                                 ),
                             ) / vec_data(CT3(ᶠw + εw)) * g³³(ᶠgⁱʲ),
                         ) +
-                        ᶠno_flux_row(ᶠupwind_product_matrix(ᶠw)) ⋅
+                        ᶠno_flux_row(ᶠupwind_product_matrix(ᶠw)) ⋆
                         (-R_d / cv_d * ∂ᶜK∂ᶠw)
                     )
             end
@@ -414,11 +414,11 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
             # ∂ᶜ𝔼ₜ∂ᶠ𝕄 has 3 diagonals instead of 5
             if isnothing(ᶠupwind_product)
                 @. ∂ᶜ𝔼ₜ∂ᶠ𝕄 =
-                    -(ᶜdivᵥ_matrix()) ⋅
+                    -(ᶜdivᵥ_matrix()) ⋆
                     DiagonalMatrixRow(ᶠinterp(ᶜρe + ᶜp) * g³³(ᶠgⁱʲ))
             else
                 @. ∂ᶜ𝔼ₜ∂ᶠ𝕄 =
-                    -(ᶜdivᵥ_matrix()) ⋅ DiagonalMatrixRow(
+                    -(ᶜdivᵥ_matrix()) ⋆ DiagonalMatrixRow(
                         ᶠinterp(ᶜρ) * vec_data(
                             ᶠno_flux(ᶠupwind_product(ᶠw + εw, (ᶜρe + ᶜp) / ᶜρ)),
                         ) / vec_data(CT3(ᶠw + εw)) * g³³(ᶠgⁱʲ),
@@ -443,9 +443,9 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
             #     -ᶜdivᵥ_matrix() * ᶠinterp(ᶜρe_int + ᶜp) * ᶠg³³ +
             #     ᶜinterp_matrix() * adjoint(ᶠgradᵥ(ᶜp)) * ᶠg³³
             @. ∂ᶜ𝔼ₜ∂ᶠ𝕄 =
-                -(ᶜdivᵥ_matrix()) ⋅
+                -(ᶜdivᵥ_matrix()) ⋆
                 DiagonalMatrixRow(ᶠinterp(ᶜρe_int + ᶜp) * g³³(ᶠgⁱʲ)) +
-                ᶜinterp_matrix() ⋅
+                ᶜinterp_matrix() ⋆
                 DiagonalMatrixRow(adjoint(ᶠgradᵥ(ᶜp)) * g³³(ᶠgⁱʲ))
         else
             # ᶜρe_intₜ =
@@ -456,12 +456,12 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
             #     ∂(ᶠupwind_product(ᶠw, (ᶜρe_int + ᶜp) / ᶜρ))/∂(ᶠw) +
             #     ᶜinterp_matrix() * adjoint(ᶠgradᵥ(ᶜp)) * ᶠg³³
             @. ∂ᶜ𝔼ₜ∂ᶠ𝕄 =
-                -(ᶜdivᵥ_matrix()) ⋅ DiagonalMatrixRow(
+                -(ᶜdivᵥ_matrix()) ⋆ DiagonalMatrixRow(
                     ᶠinterp(ᶜρ) * vec_data(
                         ᶠno_flux(ᶠupwind_product(ᶠw + εw, (ᶜρe_int + ᶜp) / ᶜρ)),
                     ) / vec_data(CT3(ᶠw + εw)) * g³³(ᶠgⁱʲ),
                 ) +
-                ᶜinterp_matrix() ⋅
+                ᶜinterp_matrix() ⋆
                 DiagonalMatrixRow(adjoint(ᶠgradᵥ(ᶜp)) * g³³(ᶠgⁱʲ))
         end
     end
@@ -480,7 +480,7 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
         # ∂(ᶠgradᵥ(ᶜp))/∂(ᶜρθ) =
         #     ᶠgradᵥ_matrix() * γ * R_d * (ᶜρθ * R_d / p_0)^(γ - 1)
         @. ∂ᶠ𝕄ₜ∂ᶜ𝔼 =
-            -DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) ⋅ ᶠgradᵥ_matrix() ⋅
+            -DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) ⋆ ᶠgradᵥ_matrix() ⋆
             DiagonalMatrixRow(γ * R_d * (ᶜρθ * R_d / p_0)^(γ - 1))
 
         if flags.∂ᶠ𝕄ₜ∂ᶜρ_mode == :exact
@@ -489,12 +489,12 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
             # ∂(ᶠwₜ)/∂(ᶠinterp(ᶜρ)) = ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ)^2
             # ∂(ᶠinterp(ᶜρ))/∂(ᶜρ) = ᶠinterp_matrix()
             @. ∂ᶠ𝕄ₜ∂ᶜρ =
-                DiagonalMatrixRow(ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ)^2) ⋅ ᶠinterp_matrix()
+                DiagonalMatrixRow(ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ)^2) ⋆ ᶠinterp_matrix()
         elseif flags.∂ᶠ𝕄ₜ∂ᶜρ_mode == :hydrostatic_balance
             # same as above, but we assume that ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ) =
             # -ᶠgradᵥ(ᶜΦ)
             @. ∂ᶠ𝕄ₜ∂ᶜρ =
-                -DiagonalMatrixRow(ᶠgradᵥ(ᶜΦ) / ᶠinterp(ᶜρ)) ⋅ ᶠinterp_matrix()
+                -DiagonalMatrixRow(ᶠgradᵥ(ᶜΦ) / ᶠinterp(ᶜρ)) ⋆ ᶠinterp_matrix()
         end
     elseif :ρe in propertynames(Y.c)
         # ᶠwₜ = -ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ) - ᶠgradᵥ(ᶜK + ᶜΦ)
@@ -502,7 +502,7 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
         # ∂(ᶠwₜ)/∂(ᶠgradᵥ(ᶜp)) = -1 / ᶠinterp(ᶜρ)
         # ∂(ᶠgradᵥ(ᶜp))/∂(ᶜρe) = ᶠgradᵥ_matrix() * R_d / cv_d
         @. ∂ᶠ𝕄ₜ∂ᶜ𝔼 =
-            -DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) ⋅ (ᶠgradᵥ_matrix() * R_d / cv_d)
+            -DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) ⋆ (ᶠgradᵥ_matrix() * R_d / cv_d)
 
         if flags.∂ᶠ𝕄ₜ∂ᶜρ_mode == :exact
             # ᶠwₜ = -ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ) - ᶠgradᵥ(ᶜK + ᶜΦ)
@@ -515,16 +515,16 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
             # ∂(ᶠwₜ)/∂(ᶠinterp(ᶜρ)) = ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ)^2
             # ∂(ᶠinterp(ᶜρ))/∂(ᶜρ) = ᶠinterp_matrix()
             @. ∂ᶠ𝕄ₜ∂ᶜρ =
-                -DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) ⋅ ᶠgradᵥ_matrix() ⋅
+                -DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) ⋆ ᶠgradᵥ_matrix() ⋆
                 DiagonalMatrixRow(R_d * (-(ᶜK + ᶜΦ) / cv_d + T_tri)) +
-                DiagonalMatrixRow(ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ)^2) ⋅ ᶠinterp_matrix()
+                DiagonalMatrixRow(ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ)^2) ⋆ ᶠinterp_matrix()
         elseif flags.∂ᶠ𝕄ₜ∂ᶜρ_mode == :hydrostatic_balance
             # same as above, but we assume that ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ) =
             # -ᶠgradᵥ(ᶜΦ) and that ᶜK is negligible compared ot ᶜΦ
             @. ∂ᶠ𝕄ₜ∂ᶜρ =
-                -DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) ⋅ ᶠgradᵥ_matrix() ⋅
+                -DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) ⋆ ᶠgradᵥ_matrix() ⋆
                 DiagonalMatrixRow(R_d * (-(ᶜΦ) / cv_d + T_tri)) -
-                DiagonalMatrixRow(ᶠgradᵥ(ᶜΦ) / ᶠinterp(ᶜρ)) ⋅ ᶠinterp_matrix()
+                DiagonalMatrixRow(ᶠgradᵥ(ᶜΦ) / ᶠinterp(ᶜρ)) ⋆ ᶠinterp_matrix()
         end
     elseif :ρe_int in propertynames(Y.c)
         # ᶠwₜ = -ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ) - ᶠgradᵥ(ᶜK + ᶜΦ)
@@ -532,7 +532,7 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
         # ∂(ᶠwₜ)/∂(ᶠgradᵥ(ᶜp)) = -1 / ᶠinterp(ᶜρ)
         # ∂(ᶠgradᵥ(ᶜp))/∂(ᶜρe_int) = ᶠgradᵥ_matrix() * R_d / cv_d
         @. ∂ᶠ𝕄ₜ∂ᶜ𝔼 =
-            DiagonalMatrixRow(-1 / ᶠinterp(ᶜρ)) ⋅ (ᶠgradᵥ_matrix() * R_d / cv_d)
+            DiagonalMatrixRow(-1 / ᶠinterp(ᶜρ)) ⋆ (ᶠgradᵥ_matrix() * R_d / cv_d)
 
         if flags.∂ᶠ𝕄ₜ∂ᶜρ_mode == :exact
             # ᶠwₜ = -ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ) - ᶠgradᵥ(ᶜK + ᶜΦ)
@@ -544,16 +544,16 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
             # ∂(ᶠwₜ)/∂(ᶠinterp(ᶜρ)) = ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ)^2
             # ∂(ᶠinterp(ᶜρ))/∂(ᶜρ) = ᶠinterp_matrix()
             @. ∂ᶠ𝕄ₜ∂ᶜρ =
-                -DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) ⋅
+                -DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) ⋆
                 (ᶠgradᵥ_matrix() * R_d * T_tri) +
-                DiagonalMatrixRow(ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ)^2) ⋅ ᶠinterp_matrix()
+                DiagonalMatrixRow(ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ)^2) ⋆ ᶠinterp_matrix()
         elseif flags.∂ᶠ𝕄ₜ∂ᶜρ_mode == :hydrostatic_balance
             # same as above, but we assume that ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ) =
             # -ᶠgradᵥ(ᶜΦ)
             @. ∂ᶠ𝕄ₜ∂ᶜρ =
-                DiagonalMatrixRow(-1 / ᶠinterp(ᶜρ)) ⋅
+                DiagonalMatrixRow(-1 / ᶠinterp(ᶜρ)) ⋆
                 (ᶠgradᵥ_matrix() * R_d * T_tri) -
-                DiagonalMatrixRow(ᶠgradᵥ(ᶜΦ) / ᶠinterp(ᶜρ)) ⋅ ᶠinterp_matrix()
+                DiagonalMatrixRow(ᶠgradᵥ(ᶜΦ) / ᶠinterp(ᶜρ)) ⋆ ᶠinterp_matrix()
         end
     end
 
@@ -571,13 +571,13 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
     # ∂(ᶠwₜ)/∂(ᶠgradᵥ(ᶜK + ᶜΦ)) = -1
     # ∂(ᶠgradᵥ(ᶜK + ᶜΦ))/∂(ᶜK) = ᶠgradᵥ_matrix()
     if :ρθ in propertynames(Y.c) || :ρe_int in propertynames(Y.c)
-        @. ∂ᶠ𝕄ₜ∂ᶠ𝕄 = -(ᶠgradᵥ_matrix()) ⋅ ∂ᶜK∂ᶠw
+        @. ∂ᶠ𝕄ₜ∂ᶠ𝕄 = -(ᶠgradᵥ_matrix()) ⋆ ∂ᶜK∂ᶠw
     elseif :ρe in propertynames(Y.c)
         @. ∂ᶠ𝕄ₜ∂ᶠ𝕄 =
             -(
-                DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) ⋅ ᶠgradᵥ_matrix() ⋅
+                DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) ⋆ ᶠgradᵥ_matrix() ⋆
                 DiagonalMatrixRow(-(ᶜρ * R_d / cv_d)) + ᶠgradᵥ_matrix()
-            ) ⋅ ∂ᶜK∂ᶠw
+            ) ⋆ ∂ᶜK∂ᶠw
     end
 
     I = one(∂R∂Y)

--- a/src/MatrixFields/MatrixFields.jl
+++ b/src/MatrixFields/MatrixFields.jl
@@ -78,6 +78,7 @@ export DiagonalMatrixRow,
     QuaddiagonalMatrixRow,
     PentadiagonalMatrixRow
 export FieldVectorKeys, FieldMatrixKeys, FieldVectorView, FieldMatrix
+# TODO: deprecate exporting ⋅
 export FieldMatrixWithSolver, ⋅
 
 include("band_matrix_row.jl")

--- a/src/MatrixFields/matrix_multiplication.jl
+++ b/src/MatrixFields/matrix_multiplication.jl
@@ -200,6 +200,7 @@ This means that we can express the bounds on the interior values of ``i`` as
 """
 struct MultiplyColumnwiseBandMatrixField <: Operators.FiniteDifferenceOperator end
 const ⋅ = MultiplyColumnwiseBandMatrixField()
+const ⋆ = MultiplyColumnwiseBandMatrixField()
 
 Operators.strip_space(op::MultiplyColumnwiseBandMatrixField, _) = op
 

--- a/test/MatrixFields/flat_spaces.jl
+++ b/test/MatrixFields/flat_spaces.jl
@@ -5,7 +5,8 @@ import ClimaCore
 import .TestUtilities as TU;
 
 include("matrix_field_test_utils.jl")
-import ClimaCore.MatrixFields: @name, ⋅
+import ClimaCore.MatrixFields: @name
+import ClimaCore.MatrixFields: ⋆
 
 @testset "Matrix Fields with Spectral Element and Point Spaces" begin
     get_j_field(space, FT) = fill(MatrixFields.DiagonalMatrixRow(FT(1)), space)

--- a/test/MatrixFields/gpu_compat_bidiag_matrix_row.jl
+++ b/test/MatrixFields/gpu_compat_bidiag_matrix_row.jl
@@ -13,13 +13,13 @@ import ClimaCore: Spaces, Geometry, Operators, Fields, MatrixFields
 using LinearAlgebra: Adjoint
 import StaticArrays: SArray
 import ClimaCore.Geometry: AxisTensor, CovariantAxis, ContravariantAxis
+import ClimaCore.MatrixFields: ⋆
 using ClimaCore.MatrixFields:
     BandMatrixRow,
     DiagonalMatrixRow,
     BidiagonalMatrixRow,
-    TridiagonalMatrixRow,
-    MultiplyColumnwiseBandMatrixField,
-    ⋅
+    TridiagonalMatrixRow
+
 const C3 = Geometry.Covariant3Vector
 const CT3 = Geometry.Contravariant3Vector
 GFT = Float64
@@ -82,14 +82,14 @@ function foo(c, f)
     dtγ = FT(1)
 
     @. ∂ᶠu₃ʲ_err_∂ᶠu₃ʲ =
-        dtγ * ᶠtridiagonal_matrix_c3 ⋅ DiagonalMatrixRow(adjoint(CT3(ᶠu₃))) -
+        dtγ * ᶠtridiagonal_matrix_c3 ⋆ DiagonalMatrixRow(adjoint(CT3(ᶠu₃))) -
         (I_u₃,)
 
-    @. ∂ᶠu₃ʲ_err_∂ᶠu₃ʲ = dtγ * ᶠtridiagonal_matrix_c3 ⋅ adj_u₃ - (I_u₃,)
+    @. ∂ᶠu₃ʲ_err_∂ᶠu₃ʲ = dtγ * ᶠtridiagonal_matrix_c3 ⋆ adj_u₃ - (I_u₃,)
 
     # Fails on gpu
     @. ᶠtridiagonal_matrix_c3 =
-        -(ᶠgradᵥ_matrix()) ⋅ ifelse(
+        -(ᶠgradᵥ_matrix()) ⋆ ifelse(
             ᶜu₃ʲ.components.data.:1 > 0,
             convert(BidiagonalMatrixRow{FT}, ᶜleft_bias_matrix()),
             convert(BidiagonalMatrixRow{FT}, ᶜright_bias_matrix()),
@@ -100,7 +100,7 @@ function foo(c, f)
     @. bdmr_l = convert(BidiagonalMatrixRow{FT}, ᶜleft_bias_matrix())
     @. bdmr_r = convert(BidiagonalMatrixRow{FT}, ᶜright_bias_matrix())
     @. bdmr = ifelse(ᶜu₃ʲ.components.data.:1 > 0, bdmr_l, bdmr_r)
-    @. ᶠtridiagonal_matrix_c3 = -(ᶠgradᵥ_matrix()) ⋅ bdmr
+    @. ᶠtridiagonal_matrix_c3 = -(ᶠgradᵥ_matrix()) ⋆ bdmr
 
     return nothing
 end

--- a/test/MatrixFields/matrix_field_test_utils.jl
+++ b/test/MatrixFields/matrix_field_test_utils.jl
@@ -21,6 +21,7 @@ import ClimaCore:
     Operators,
     Quadratures
 using ClimaCore.MatrixFields
+import ClimaCore.MatrixFields: ⋆
 
 # Test that an expression is true and that it is also type-stable.
 macro test_all(expression)

--- a/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_1.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_1.jl
@@ -3,6 +3,7 @@ julia --project
 using Revise; include(joinpath("test", "MatrixFields", "matrix_fields_broadcasting", "test_non_scalar_1.jl"))
 =#
 import ClimaCore
+import ClimaCore.MatrixFields: ⋆
 #! format: off
 if !(@isdefined(unit_test_field_broadcast))
     include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_non_scalar_utils.jl"))
@@ -11,14 +12,14 @@ end
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "matrix of covectors times matrix of vectors" begin
 
-    bc = @lazy @. ᶜᶠmat_AC1 ⋅ ᶠᶜmat_C12
+    bc = @lazy @. ᶜᶠmat_AC1 ⋆ ᶠᶜmat_C12
     result = materialize(bc)
 
     ref_set_result! =
         result -> (@. result =
-            ᶜᶠmat ⋅ (
-                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:1) ⋅ ᶠᶜmat2 +
-                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:2) ⋅ ᶠᶜmat3
+            ᶜᶠmat ⋆ (
+                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:1) ⋆ ᶠᶜmat2 +
+                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:2) ⋆ ᶠᶜmat3
             ))
 
     unit_test_field_broadcast(

--- a/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_2.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_2.jl
@@ -13,17 +13,17 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
                  of numbers times matrix of covectors times matrix of \
                  vectors" begin
 
-    bc = @lazy @. ᶜᶠmat_AC1 ⋅ ᶠᶜmat_C12 ⋅ ᶜᶠmat ⋅ ᶠᶜmat_AC1 ⋅ ᶜᶠmat_C12
+    bc = @lazy @. ᶜᶠmat_AC1 ⋆ ᶠᶜmat_C12 ⋆ ᶜᶠmat ⋆ ᶠᶜmat_AC1 ⋆ ᶜᶠmat_C12
     result = materialize(bc)
 
     ref_set_result! =
         result -> (@. result =
-            ᶜᶠmat ⋅ (
-                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:1) ⋅ ᶠᶜmat2 +
-                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:2) ⋅ ᶠᶜmat3
-            ) ⋅ ᶜᶠmat ⋅ ᶠᶜmat ⋅ (
-                DiagonalMatrixRow(ᶜlg.gⁱʲ.components.data.:1) ⋅ ᶜᶠmat2 +
-                DiagonalMatrixRow(ᶜlg.gⁱʲ.components.data.:2) ⋅ ᶜᶠmat3
+            ᶜᶠmat ⋆ (
+                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:1) ⋆ ᶠᶜmat2 +
+                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:2) ⋆ ᶠᶜmat3
+            ) ⋆ ᶜᶠmat ⋆ ᶠᶜmat ⋆ (
+                DiagonalMatrixRow(ᶜlg.gⁱʲ.components.data.:1) ⋆ ᶜᶠmat2 +
+                DiagonalMatrixRow(ᶜlg.gⁱʲ.components.data.:2) ⋆ ᶜᶠmat3
             ))
 
     unit_test_field_broadcast(

--- a/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_3.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_3.jl
@@ -13,19 +13,19 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
                  and covectors times matrix of numbers and vectors times \
                  vector of numbers" begin
 
-    bc = @lazy @. ᶜᶠmat_AC1_num ⋅ ᶠᶜmat_C12_AC1 ⋅ ᶜᶠmat_num_C12 ⋅ ᶠvec
+    bc = @lazy @. ᶜᶠmat_AC1_num ⋆ ᶠᶜmat_C12_AC1 ⋆ ᶜᶠmat_num_C12 ⋆ ᶠvec
     result = materialize(bc)
 
     ref_set_result! =
         result -> (@. result = tuple(
-            ᶜᶠmat ⋅ (
-                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:1) ⋅ ᶠᶜmat2 +
-                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:2) ⋅ ᶠᶜmat3
-            ) ⋅ ᶜᶠmat ⋅ ᶠvec,
-            ᶜᶠmat ⋅ ᶠᶜmat ⋅ (
-                DiagonalMatrixRow(ᶜlg.gⁱʲ.components.data.:1) ⋅ ᶜᶠmat2 +
-                DiagonalMatrixRow(ᶜlg.gⁱʲ.components.data.:2) ⋅ ᶜᶠmat3
-            ) ⋅ ᶠvec,
+            ᶜᶠmat ⋆ (
+                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:1) ⋆ ᶠᶜmat2 +
+                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:2) ⋆ ᶠᶜmat3
+            ) ⋆ ᶜᶠmat ⋆ ᶠvec,
+            ᶜᶠmat ⋆ ᶠᶜmat ⋆ (
+                DiagonalMatrixRow(ᶜlg.gⁱʲ.components.data.:1) ⋆ ᶜᶠmat2 +
+                DiagonalMatrixRow(ᶜlg.gⁱʲ.components.data.:2) ⋆ ᶜᶠmat3
+            ) ⋆ ᶠvec,
         ))
 
     unit_test_field_broadcast(

--- a/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_4.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_4.jl
@@ -13,14 +13,14 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
                  times matrix of numbers times matrix of numbers times \
                  vector of nested values" begin
 
-    bc = @lazy @. ᶜᶠmat_NT ⋅ ᶠᶜmat ⋅ ᶜᶠmat ⋅ ᶠᶜmat_NT ⋅ ᶜvec_NT
+    bc = @lazy @. ᶜᶠmat_NT ⋆ ᶠᶜmat ⋆ ᶜᶠmat ⋆ ᶠᶜmat_NT ⋆ ᶜvec_NT
     result = materialize(bc)
 
     ref_set_result! =
         result -> (@. result = nested_type(
-            ᶜᶠmat ⋅ ᶠᶜmat ⋅ ᶜᶠmat ⋅ ᶠᶜmat ⋅ ᶜvec,
-            ᶜᶠmat2 ⋅ ᶠᶜmat ⋅ ᶜᶠmat ⋅ ᶠᶜmat2 ⋅ ᶜvec,
-            ᶜᶠmat3 ⋅ ᶠᶜmat ⋅ ᶜᶠmat ⋅ ᶠᶜmat3 ⋅ ᶜvec,
+            ᶜᶠmat ⋆ ᶠᶜmat ⋆ ᶜᶠmat ⋆ ᶠᶜmat ⋆ ᶜvec,
+            ᶜᶠmat2 ⋆ ᶠᶜmat ⋆ ᶜᶠmat ⋆ ᶠᶜmat2 ⋆ ᶜvec,
+            ᶜᶠmat3 ⋆ ᶠᶜmat ⋆ ᶜᶠmat ⋆ ᶠᶜmat3 ⋆ ᶜvec,
         ))
 
     unit_test_field_broadcast(

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_1.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_1.jl
@@ -9,7 +9,7 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "diagonal matrix times vector" begin
-    bc = @lazy @. ᶜᶜmat ⋅ ᶜvec
+    bc = @lazy @. ᶜᶜmat ⋆ ᶜvec
     result = materialize(bc)
 
     input_fields = (ᶜᶜmat, ᶜvec)

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_10.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_10.jl
@@ -10,7 +10,7 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "diagonal matrix times bi-diagonal matrix times \
                  tri-diagonal matrix times quad-diagonal matrix times \
                  vector, but with forced right-associativity" begin
-    bc = @lazy @. ᶜᶜmat ⋅ (ᶜᶠmat ⋅ (ᶠᶠmat ⋅ (ᶠᶜmat ⋅ ᶜvec)))
+    bc = @lazy @. ᶜᶜmat ⋆ (ᶜᶠmat ⋆ (ᶠᶠmat ⋆ (ᶠᶜmat ⋆ ᶜvec)))
     if using_cuda
         @test_throws invalid_ir_error materialize(bc)
         @warn "cuda is broken for this test, exiting."
@@ -20,9 +20,9 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
 
     input_fields = (ᶜᶜmat, ᶜᶠmat, ᶠᶠmat, ᶠᶜmat, ᶜvec)
     temp_value_fields = (
-        (@. ᶠᶜmat ⋅ ᶜvec),
-        (@. ᶠᶠmat ⋅ (ᶠᶜmat ⋅ ᶜvec)),
-        (@. ᶜᶠmat ⋅ (ᶠᶠmat ⋅ (ᶠᶜmat ⋅ ᶜvec))),
+        (@. ᶠᶜmat ⋆ ᶜvec),
+        (@. ᶠᶠmat ⋆ (ᶠᶜmat ⋆ ᶜvec)),
+        (@. ᶜᶠmat ⋆ (ᶠᶠmat ⋆ (ᶠᶜmat ⋆ ᶜvec))),
     )
     ref_set_result! =
         (

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_11.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_11.jl
@@ -8,15 +8,15 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "linear combination of matrix products and LinearAlgebra.I" begin
-    bc = @lazy @. 2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat + ᶠᶠmat ⋅ ᶠᶠmat / 3 - (4I,)
+    bc = @lazy @. 2 * ᶠᶜmat ⋆ ᶜᶜmat ⋆ ᶜᶠmat + ᶠᶠmat ⋆ ᶠᶠmat / 3 - (4I,)
     result = materialize(bc)
 
     input_fields = (ᶜᶜmat, ᶜᶠmat, ᶠᶠmat, ᶠᶜmat)
     temp_value_fields = (
         (@. 2 * ᶠᶜmat),
-        (@. 2 * ᶠᶜmat ⋅ ᶜᶜmat),
-        (@. 2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat),
-        (@. ᶠᶠmat ⋅ ᶠᶠmat),
+        (@. 2 * ᶠᶜmat ⋆ ᶜᶜmat),
+        (@. 2 * ᶠᶜmat ⋆ ᶜᶜmat ⋆ ᶜᶠmat),
+        (@. ᶠᶠmat ⋆ ᶠᶠmat),
     )
     ref_set_result! =
         (

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_12.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_12.jl
@@ -9,15 +9,15 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "another linear combination of matrix products and \
                  LinearAlgebra.I" begin
-    bc = @lazy @. ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat * 2 - (ᶠᶠmat / 3) ⋅ ᶠᶠmat + (4I,)
+    bc = @lazy @. ᶠᶜmat ⋆ ᶜᶜmat ⋆ ᶜᶠmat * 2 - (ᶠᶠmat / 3) ⋆ ᶠᶠmat + (4I,)
     result = materialize(bc)
 
     input_fields = (ᶜᶜmat, ᶜᶠmat, ᶠᶠmat, ᶠᶜmat)
     temp_value_fields = (
-        (@. ᶠᶜmat ⋅ ᶜᶜmat),
-        (@. ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat),
+        (@. ᶠᶜmat ⋆ ᶜᶜmat),
+        (@. ᶠᶜmat ⋆ ᶜᶜmat ⋆ ᶜᶠmat),
         (@. ᶠᶠmat / 3),
-        (@. (ᶠᶠmat / 3) ⋅ ᶠᶠmat),
+        (@. (ᶠᶠmat / 3) ⋆ ᶠᶠmat),
     )
     ref_set_result! =
         (

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_13.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_13.jl
@@ -9,16 +9,16 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "matrix times linear combination" begin
     bc =
-        @lazy @. ᶜᶠmat ⋅ (2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat + ᶠᶠmat ⋅ ᶠᶠmat / 3 - (4I,))
+        @lazy @. ᶜᶠmat ⋆ (2 * ᶠᶜmat ⋆ ᶜᶜmat ⋆ ᶜᶠmat + ᶠᶠmat ⋆ ᶠᶠmat / 3 - (4I,))
     result = materialize(bc)
 
     input_fields = (ᶜᶜmat, ᶜᶠmat, ᶠᶠmat, ᶠᶜmat)
     temp_value_fields = (
         (@. 2 * ᶠᶜmat),
-        (@. 2 * ᶠᶜmat ⋅ ᶜᶜmat),
-        (@. 2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat),
-        (@. ᶠᶠmat ⋅ ᶠᶠmat),
-        (@. 2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat + ᶠᶠmat ⋅ ᶠᶠmat / 3 - (4I,)),
+        (@. 2 * ᶠᶜmat ⋆ ᶜᶜmat),
+        (@. 2 * ᶠᶜmat ⋆ ᶜᶜmat ⋆ ᶜᶠmat),
+        (@. ᶠᶠmat ⋆ ᶠᶠmat),
+        (@. 2 * ᶠᶜmat ⋆ ᶜᶜmat ⋆ ᶜᶠmat + ᶠᶠmat ⋆ ᶠᶠmat / 3 - (4I,)),
     )
     ref_set_result! =
         (

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_14.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_14.jl
@@ -8,8 +8,8 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "linear combination times another linear combination" begin
-    bc = @lazy @. (2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat + ᶠᶠmat ⋅ ᶠᶠmat / 3 - (4I,)) ⋅
-             (ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat * 2 - (ᶠᶠmat / 3) ⋅ ᶠᶠmat + (4I,))
+    bc = @lazy @. (2 * ᶠᶜmat ⋆ ᶜᶜmat ⋆ ᶜᶠmat + ᶠᶠmat ⋆ ᶠᶠmat / 3 - (4I,)) ⋆
+             (ᶠᶜmat ⋆ ᶜᶜmat ⋆ ᶜᶠmat * 2 - (ᶠᶠmat / 3) ⋆ ᶠᶠmat + (4I,))
     result = materialize(bc)
 
     input_fields = (ᶜᶜmat, ᶜᶠmat, ᶠᶠmat, ᶠᶜmat)
@@ -49,15 +49,15 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
 
     temp_value_fields = (
         (@. 2 * ᶠᶜmat),
-        (@. 2 * ᶠᶜmat ⋅ ᶜᶜmat),
-        (@. 2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat),
-        (@. ᶠᶠmat ⋅ ᶠᶠmat),
-        (@. 2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat + ᶠᶠmat ⋅ ᶠᶠmat / 3 - (4I,)),
-        (@. ᶠᶜmat ⋅ ᶜᶜmat),
-        (@. ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat),
+        (@. 2 * ᶠᶜmat ⋆ ᶜᶜmat),
+        (@. 2 * ᶠᶜmat ⋆ ᶜᶜmat ⋆ ᶜᶠmat),
+        (@. ᶠᶠmat ⋆ ᶠᶠmat),
+        (@. 2 * ᶠᶜmat ⋆ ᶜᶜmat ⋆ ᶜᶠmat + ᶠᶠmat ⋆ ᶠᶠmat / 3 - (4I,)),
+        (@. ᶠᶜmat ⋆ ᶜᶜmat),
+        (@. ᶠᶜmat ⋆ ᶜᶜmat ⋆ ᶜᶠmat),
         (@. ᶠᶠmat / 3),
-        (@. (ᶠᶠmat / 3) ⋅ ᶠᶠmat),
-        (@. ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat * 2 - (ᶠᶠmat / 3) ⋅ ᶠᶠmat + (4I,)),
+        (@. (ᶠᶠmat / 3) ⋆ ᶠᶠmat),
+        (@. ᶠᶜmat ⋆ ᶜᶜmat ⋆ ᶜᶠmat * 2 - (ᶠᶠmat / 3) ⋆ ᶠᶠmat + (4I,)),
     )
 
     unit_test_field_broadcast_vs_array_reference(

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_15.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_15.jl
@@ -9,10 +9,10 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "matrix times matrix times linear combination times matrix \
                  times another linear combination times matrix" begin
-    bc = @lazy @. ᶠᶜmat ⋅ ᶜᶠmat ⋅
-             (2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat + ᶠᶠmat ⋅ ᶠᶠmat / 3 - (4I,)) ⋅
-             ᶠᶠmat ⋅
-             (ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat * 2 - (ᶠᶠmat / 3) ⋅ ᶠᶠmat + (4I,)) ⋅
+    bc = @lazy @. ᶠᶜmat ⋆ ᶜᶠmat ⋆
+             (2 * ᶠᶜmat ⋆ ᶜᶜmat ⋆ ᶜᶠmat + ᶠᶠmat ⋆ ᶠᶠmat / 3 - (4I,)) ⋆
+             ᶠᶠmat ⋆
+             (ᶠᶜmat ⋆ ᶜᶜmat ⋆ ᶜᶠmat * 2 - (ᶠᶠmat / 3) ⋆ ᶠᶠmat + (4I,)) ⋆
              ᶠᶠmat
     result = materialize(bc)
 
@@ -60,26 +60,26 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
         end
 
     temp_value_fields = (
-        (@. ᶠᶜmat ⋅ ᶜᶠmat),
+        (@. ᶠᶜmat ⋆ ᶜᶠmat),
         (@. 2 * ᶠᶜmat),
-        (@. 2 * ᶠᶜmat ⋅ ᶜᶜmat),
-        (@. 2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat),
-        (@. ᶠᶠmat ⋅ ᶠᶠmat),
-        (@. 2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat + ᶠᶠmat ⋅ ᶠᶠmat / 3 - (4I,)),
-        (@. ᶠᶜmat ⋅ ᶜᶠmat ⋅
-            (2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat + ᶠᶠmat ⋅ ᶠᶠmat / 3 - (4I,))),
-        (@. ᶠᶜmat ⋅ ᶜᶠmat ⋅
-            (2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat + ᶠᶠmat ⋅ ᶠᶠmat / 3 - (4I,)) ⋅
+        (@. 2 * ᶠᶜmat ⋆ ᶜᶜmat),
+        (@. 2 * ᶠᶜmat ⋆ ᶜᶜmat ⋆ ᶜᶠmat),
+        (@. ᶠᶠmat ⋆ ᶠᶠmat),
+        (@. 2 * ᶠᶜmat ⋆ ᶜᶜmat ⋆ ᶜᶠmat + ᶠᶠmat ⋆ ᶠᶠmat / 3 - (4I,)),
+        (@. ᶠᶜmat ⋆ ᶜᶠmat ⋆
+            (2 * ᶠᶜmat ⋆ ᶜᶜmat ⋆ ᶜᶠmat + ᶠᶠmat ⋆ ᶠᶠmat / 3 - (4I,))),
+        (@. ᶠᶜmat ⋆ ᶜᶠmat ⋆
+            (2 * ᶠᶜmat ⋆ ᶜᶜmat ⋆ ᶜᶠmat + ᶠᶠmat ⋆ ᶠᶠmat / 3 - (4I,)) ⋆
             ᶠᶠmat),
-        (@. ᶠᶜmat ⋅ ᶜᶜmat),
-        (@. ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat),
+        (@. ᶠᶜmat ⋆ ᶜᶜmat),
+        (@. ᶠᶜmat ⋆ ᶜᶜmat ⋆ ᶜᶠmat),
         (@. ᶠᶠmat / 3),
-        (@. (ᶠᶠmat / 3) ⋅ ᶠᶠmat),
-        (@. ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat * 2 - (ᶠᶠmat / 3) ⋅ ᶠᶠmat + (4I,)),
-        (@. ᶠᶜmat ⋅ ᶜᶠmat ⋅
-            (2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat + ᶠᶠmat ⋅ ᶠᶠmat / 3 - (4I,)) ⋅
-            ᶠᶠmat ⋅
-            (ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat * 2 - (ᶠᶠmat / 3) ⋅ ᶠᶠmat + (4I,))),
+        (@. (ᶠᶠmat / 3) ⋆ ᶠᶠmat),
+        (@. ᶠᶜmat ⋆ ᶜᶜmat ⋆ ᶜᶠmat * 2 - (ᶠᶠmat / 3) ⋆ ᶠᶠmat + (4I,)),
+        (@. ᶠᶜmat ⋆ ᶜᶠmat ⋆
+            (2 * ᶠᶜmat ⋆ ᶜᶜmat ⋆ ᶜᶠmat + ᶠᶠmat ⋆ ᶠᶠmat / 3 - (4I,)) ⋆
+            ᶠᶠmat ⋆
+            (ᶠᶜmat ⋆ ᶜᶜmat ⋆ ᶜᶠmat * 2 - (ᶠᶠmat / 3) ⋆ ᶠᶠmat + (4I,))),
     )
 
     unit_test_field_broadcast_vs_array_reference(

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_16.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_16.jl
@@ -8,9 +8,9 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "matrix constructions and multiplications" begin
-    bc = @lazy @. BidiagonalMatrixRow(ᶜᶠmat ⋅ ᶠvec, ᶜᶜmat ⋅ ᶜvec) ⋅
-             TridiagonalMatrixRow(ᶠvec, ᶠᶜmat ⋅ ᶜvec, 1) ⋅ ᶠᶠmat ⋅
-             DiagonalMatrixRow(DiagonalMatrixRow(ᶠvec) ⋅ ᶠvec)
+    bc = @lazy @. BidiagonalMatrixRow(ᶜᶠmat ⋆ ᶠvec, ᶜᶜmat ⋆ ᶜvec) ⋆
+             TridiagonalMatrixRow(ᶠvec, ᶠᶜmat ⋆ ᶜvec, 1) ⋆ ᶠᶠmat ⋆
+             DiagonalMatrixRow(DiagonalMatrixRow(ᶠvec) ⋆ ᶠvec)
     result = materialize(bc)
 
     input_fields = (ᶜᶜmat, ᶜᶠmat, ᶠᶠmat, ᶠᶜmat, ᶜvec, ᶠvec)
@@ -44,14 +44,14 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
         end
 
     temp_value_fields = (
-        (@. BidiagonalMatrixRow(ᶜᶠmat ⋅ ᶠvec, ᶜᶜmat ⋅ ᶜvec)),
-        (@. TridiagonalMatrixRow(ᶠvec, ᶠᶜmat ⋅ ᶜvec, 1)),
-        (@. BidiagonalMatrixRow(ᶜᶠmat ⋅ ᶠvec, ᶜᶜmat ⋅ ᶜvec) ⋅
-            TridiagonalMatrixRow(ᶠvec, ᶠᶜmat ⋅ ᶜvec, 1)),
-        (@. BidiagonalMatrixRow(ᶜᶠmat ⋅ ᶠvec, ᶜᶜmat ⋅ ᶜvec) ⋅
-            TridiagonalMatrixRow(ᶠvec, ᶠᶜmat ⋅ ᶜvec, 1) ⋅ ᶠᶠmat),
+        (@. BidiagonalMatrixRow(ᶜᶠmat ⋆ ᶠvec, ᶜᶜmat ⋆ ᶜvec)),
+        (@. TridiagonalMatrixRow(ᶠvec, ᶠᶜmat ⋆ ᶜvec, 1)),
+        (@. BidiagonalMatrixRow(ᶜᶠmat ⋆ ᶠvec, ᶜᶜmat ⋆ ᶜvec) ⋆
+            TridiagonalMatrixRow(ᶠvec, ᶠᶜmat ⋆ ᶜvec, 1)),
+        (@. BidiagonalMatrixRow(ᶜᶠmat ⋆ ᶠvec, ᶜᶜmat ⋆ ᶜvec) ⋆
+            TridiagonalMatrixRow(ᶠvec, ᶠᶜmat ⋆ ᶜvec, 1) ⋆ ᶠᶠmat),
         (@. DiagonalMatrixRow(ᶠvec)),
-        (@. DiagonalMatrixRow(DiagonalMatrixRow(ᶠvec) ⋅ ᶠvec)),
+        (@. DiagonalMatrixRow(DiagonalMatrixRow(ᶠvec) ⋆ ᶠvec)),
     )
     unit_test_field_broadcast_vs_array_reference(
         result,

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_2.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_2.jl
@@ -8,7 +8,7 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "tri-diagonal matrix times vector" begin
-    bc = @lazy @. ᶠᶠmat ⋅ ᶠvec
+    bc = @lazy @. ᶠᶠmat ⋆ ᶠvec
     result = materialize(bc)
 
     input_fields = (ᶠᶠmat, ᶠvec)

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_3.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_3.jl
@@ -8,7 +8,7 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "quad-diagonal matrix times vector" begin
-    bc = @lazy @. ᶠᶜmat ⋅ ᶜvec
+    bc = @lazy @. ᶠᶜmat ⋆ ᶜvec
     result = materialize(bc)
 
     input_fields = (ᶠᶜmat, ᶜvec)

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_4.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_4.jl
@@ -8,7 +8,7 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "diagonal matrix times bi-diagonal matrix" begin
-    bc = @lazy @. ᶜᶜmat ⋅ ᶜᶠmat
+    bc = @lazy @. ᶜᶜmat ⋆ ᶜᶠmat
     result = materialize(bc)
 
     input_fields = (ᶜᶜmat, ᶜᶠmat)

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_5.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_5.jl
@@ -8,7 +8,7 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "tri-diagonal matrix times tri-diagonal matrix" begin
-    bc = @lazy @. ᶠᶠmat ⋅ ᶠᶠmat
+    bc = @lazy @. ᶠᶠmat ⋆ ᶠᶠmat
     result = materialize(bc)
 
     input_fields = (ᶠᶠmat,)

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_6.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_6.jl
@@ -8,7 +8,7 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "quad-diagonal matrix times diagonal matrix" begin
-    bc = @lazy @. ᶠᶜmat ⋅ ᶜᶜmat
+    bc = @lazy @. ᶠᶜmat ⋆ ᶜᶜmat
     result = materialize(bc)
 
     input_fields = (ᶠᶜmat, ᶜᶜmat)

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_7.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_7.jl
@@ -9,11 +9,11 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "diagonal matrix times bi-diagonal matrix times \
                  tri-diagonal matrix times quad-diagonal matrix" begin
-    bc = @lazy @. ᶜᶜmat ⋅ ᶜᶠmat ⋅ ᶠᶠmat ⋅ ᶠᶜmat
+    bc = @lazy @. ᶜᶜmat ⋆ ᶜᶠmat ⋆ ᶠᶠmat ⋆ ᶠᶜmat
     result = materialize(bc)
 
     input_fields = (ᶜᶜmat, ᶜᶠmat, ᶠᶠmat, ᶠᶜmat)
-    temp_value_fields = ((@. ᶜᶜmat ⋅ ᶜᶠmat), (@. ᶜᶜmat ⋅ ᶜᶠmat ⋅ ᶠᶠmat))
+    temp_value_fields = ((@. ᶜᶜmat ⋆ ᶜᶠmat), (@. ᶜᶜmat ⋆ ᶜᶠmat ⋆ ᶠᶠmat))
     ref_set_result! =
         (_result, _ᶜᶜmat, _ᶜᶠmat, _ᶠᶠmat, _ᶠᶜmat, _temp1, _temp2) -> begin
             mul!(_temp1, _ᶜᶜmat, _ᶜᶠmat)

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_8.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_8.jl
@@ -10,7 +10,7 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "diagonal matrix times bi-diagonal matrix times \
                  tri-diagonal matrix times quad-diagonal matrix, but with \
                  forced right-associativity" begin
-    bc = @lazy @. ᶜᶜmat ⋅ (ᶜᶠmat ⋅ (ᶠᶠmat ⋅ ᶠᶜmat))
+    bc = @lazy @. ᶜᶜmat ⋆ (ᶜᶠmat ⋆ (ᶠᶠmat ⋆ ᶠᶜmat))
     if using_cuda
         @test_throws invalid_ir_error materialize(bc)
         @warn "cuda is broken for this test, exiting."
@@ -19,7 +19,7 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
     result = materialize(bc)
 
     input_fields = (ᶜᶜmat, ᶜᶠmat, ᶠᶠmat, ᶠᶜmat)
-    temp_value_fields = ((@. ᶠᶠmat ⋅ ᶠᶜmat), (@. ᶜᶠmat ⋅ (ᶠᶠmat ⋅ ᶠᶜmat)))
+    temp_value_fields = ((@. ᶠᶠmat ⋆ ᶠᶜmat), (@. ᶜᶠmat ⋆ (ᶠᶠmat ⋆ ᶠᶜmat)))
     ref_set_result! =
         (_result, _ᶜᶜmat, _ᶜᶠmat, _ᶠᶠmat, _ᶠᶜmat, _temp1, _temp2) -> begin
             mul!(_temp1, _ᶠᶠmat, _ᶠᶜmat)

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_9.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_9.jl
@@ -10,14 +10,14 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "diagonal matrix times bi-diagonal matrix times \
                  tri-diagonal matrix times quad-diagonal matrix times \
                  vector" begin
-    bc = @lazy @. ᶜᶜmat ⋅ ᶜᶠmat ⋅ ᶠᶠmat ⋅ ᶠᶜmat ⋅ ᶜvec
+    bc = @lazy @. ᶜᶜmat ⋆ ᶜᶠmat ⋆ ᶠᶠmat ⋆ ᶠᶜmat ⋆ ᶜvec
     result = materialize(bc)
 
     input_fields = (ᶜᶜmat, ᶜᶠmat, ᶠᶠmat, ᶠᶜmat, ᶜvec)
     temp_value_fields = (
-        (@. ᶜᶜmat ⋅ ᶜᶠmat),
-        (@. ᶜᶜmat ⋅ ᶜᶠmat ⋅ ᶠᶠmat),
-        (@. ᶜᶜmat ⋅ ᶜᶠmat ⋅ ᶠᶠmat ⋅ ᶠᶜmat),
+        (@. ᶜᶜmat ⋆ ᶜᶠmat),
+        (@. ᶜᶜmat ⋆ ᶜᶠmat ⋆ ᶠᶠmat),
+        (@. ᶜᶜmat ⋆ ᶜᶠmat ⋆ ᶠᶠmat ⋆ ᶠᶜmat),
     )
     ref_set_result! =
         (

--- a/test/MatrixFields/matrix_multiplication_at_boundaries.jl
+++ b/test/MatrixFields/matrix_multiplication_at_boundaries.jl
@@ -65,6 +65,6 @@ end
         (ᶠᶠmatrix_without_outside_entries, ᶠᶠmatrix_with_outside_entries),
         (ᶠᶠmatrix_without_outside_entries, ᶠᶜmatrix_with_outside_entries),
     )
-        @test !any(isnan, parent(@. matrix_field1 ⋅ matrix_field2))
+        @test !any(isnan, parent(@. matrix_field1 ⋆ matrix_field2))
     end
 end

--- a/test/MatrixFields/matrix_multiplication_recursion.jl
+++ b/test/MatrixFields/matrix_multiplication_recursion.jl
@@ -5,7 +5,8 @@ import ClimaCore
 import .TestUtilities as TU;
 
 import ClimaCore: Spaces, Geometry, Operators, Fields, MatrixFields
-import ClimaCore.MatrixFields: ⋅
+import ClimaCore.MatrixFields: ⋆
+
 import ClimaComms
 ClimaComms.@import_required_backends
 
@@ -68,9 +69,9 @@ fill!(parent(dest_field), NaN)
 # Test field update with multiple nested operations
 function update_field!(dest_field, K, dψdϑ_res)
     @. dest_field =
-        divf2c_matrix() ⋅ (
-            MatrixFields.DiagonalMatrixRow(interpc2f_op(-K)) ⋅
-            gradc2f_matrix() ⋅ MatrixFields.DiagonalMatrixRow(dψdϑ_res) +
+        divf2c_matrix() ⋆ (
+            MatrixFields.DiagonalMatrixRow(interpc2f_op(-K)) ⋆
+            gradc2f_matrix() ⋆ MatrixFields.DiagonalMatrixRow(dψdϑ_res) +
             MatrixFields.LowerDiagonalMatrixRow(
                 topBC_op(Geometry.Covariant3Vector(zero(interpc2f_op(K)))),
             )

--- a/test/MatrixFields/operator_matrices.jl
+++ b/test/MatrixFields/operator_matrices.jl
@@ -7,6 +7,7 @@ import LinearAlgebra: I
 
 import ClimaCore.RecursiveApply: rzero
 import ClimaCore
+import ClimaCore.MatrixFields: ⋆
 import ClimaCore.Operators:
     SetValue,
     SetGradient,
@@ -41,13 +42,13 @@ import ClimaCore.Operators:
 
 include("matrix_field_test_utils.jl")
 
-apply_op_matrix(::Nothing, op_matrix, arg) = @lazy @. op_matrix() ⋅ arg
+apply_op_matrix(::Nothing, op_matrix, arg) = @lazy @. op_matrix() ⋆ arg
 apply_op_matrix(boundary_op, op_matrix, arg) =
-    @lazy @. boundary_op(op_matrix() ⋅ arg)
+    @lazy @. boundary_op(op_matrix() ⋆ arg)
 apply_op_matrix(::Nothing, op_matrix, arg1, arg2) =
-    @lazy @. op_matrix(arg1) ⋅ arg2
+    @lazy @. op_matrix(arg1) ⋆ arg2
 apply_op_matrix(boundary_op, op_matrix, arg1, arg2) =
-    @lazy @. boundary_op(op_matrix(arg1) ⋅ arg2)
+    @lazy @. boundary_op(op_matrix(arg1) ⋆ arg2)
 
 apply_op(::Nothing, op, args...) = @lazy @. op(args...)
 apply_op(boundary_op, op, args...) = @lazy @. boundary_op(op(args...))
@@ -225,36 +226,36 @@ end
     ᶜdiv_matrix = MatrixFields.operator_matrix(ᶜdiv)
     ᶠcurl_matrix = MatrixFields.operator_matrix(ᶠcurl)
 
-    @test_throws "does not contain any Fields" @. ᶜlbias_matrix() ⋅
+    @test_throws "does not contain any Fields" @. ᶜlbias_matrix() ⋆
                                                   ᶠinterp_matrix()
 
     ᶜ0 = @. zero(ᶜscalar)
     ᶜ1 = @. one(ᶜscalar)
     ᶠ1 = @. one(ᶠscalar)
     for get_result in (
-        @lazy(@. ᶜlbias_matrix() ⋅ ᶠinterp_matrix() + DiagonalMatrixRow(ᶜ0)),
-        @lazy(@. DiagonalMatrixRow(ᶜ0) + ᶜlbias_matrix() ⋅ ᶠinterp_matrix()),
-        @lazy(@. ᶜlbias_matrix() ⋅ ᶠinterp_matrix() ⋅ DiagonalMatrixRow(ᶜ1)),
-        @lazy(@. ᶜlbias_matrix() ⋅ DiagonalMatrixRow(ᶠ1) ⋅ ᶠinterp_matrix()),
-        @lazy(@. DiagonalMatrixRow(ᶜ1) ⋅ ᶜlbias_matrix() ⋅ ᶠinterp_matrix()),
+        @lazy(@. ᶜlbias_matrix() ⋆ ᶠinterp_matrix() + DiagonalMatrixRow(ᶜ0)),
+        @lazy(@. DiagonalMatrixRow(ᶜ0) + ᶜlbias_matrix() ⋆ ᶠinterp_matrix()),
+        @lazy(@. ᶜlbias_matrix() ⋆ ᶠinterp_matrix() ⋆ DiagonalMatrixRow(ᶜ1)),
+        @lazy(@. ᶜlbias_matrix() ⋆ DiagonalMatrixRow(ᶠ1) ⋆ ᶠinterp_matrix()),
+        @lazy(@. DiagonalMatrixRow(ᶜ1) ⋆ ᶜlbias_matrix() ⋆ ᶠinterp_matrix()),
     )
         test_field_broadcast(;
             test_name = "product of two lazy operator matrices",
             get_result,
-            set_result = @lazy(@. ᶜlbias_matrix() ⋅ ᶠinterp_matrix()),
+            set_result = @lazy(@. ᶜlbias_matrix() ⋆ ᶠinterp_matrix()),
         )
     end
 
     test_field_broadcast(;
         test_name = "product of six operator matrices",
         get_result = @lazy(
-            @. ᶜflux_correct_matrix(ᶠuvw) ⋅ ᶜadvect_matrix(ᶠuvw) ⋅
-               ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠrbias_matrix() ⋅ ᶜlbias_matrix() ⋅
+            @. ᶜflux_correct_matrix(ᶠuvw) ⋆ ᶜadvect_matrix(ᶠuvw) ⋆
+               ᶜwinterp_matrix(ᶠscalar) ⋆ ᶠrbias_matrix() ⋆ ᶜlbias_matrix() ⋆
                ᶠinterp_matrix()
         ),
         set_result = @lazy(
-            @. ᶜflux_correct_matrix(ᶠuvw) ⋅ ᶜadvect_matrix(ᶠuvw) ⋅
-               ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠrbias_matrix() ⋅ ᶜlbias_matrix() ⋅
+            @. ᶜflux_correct_matrix(ᶠuvw) ⋆ ᶜadvect_matrix(ᶠuvw) ⋆
+               ᶜwinterp_matrix(ᶠscalar) ⋆ ᶠrbias_matrix() ⋆ ᶜlbias_matrix() ⋆
                ᶠinterp_matrix()
         ),
     )
@@ -263,14 +264,14 @@ end
         test_name = "applying six operators to a nested field using operator \
                      matrices",
         get_result = @lazy(
-            @. ᶜflux_correct_matrix(ᶠuvw) ⋅ ᶜadvect_matrix(ᶠuvw) ⋅
-               ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠrbias_matrix() ⋅ ᶜlbias_matrix() ⋅
-               ᶠinterp_matrix() ⋅ ᶜnested
+            @. ᶜflux_correct_matrix(ᶠuvw) ⋆ ᶜadvect_matrix(ᶠuvw) ⋆
+               ᶜwinterp_matrix(ᶠscalar) ⋆ ᶠrbias_matrix() ⋆ ᶜlbias_matrix() ⋆
+               ᶠinterp_matrix() ⋆ ᶜnested
         ),
         set_result = @lazy(
-            @. ᶜflux_correct_matrix(ᶠuvw) ⋅ ᶜadvect_matrix(ᶠuvw) ⋅
-               ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠrbias_matrix() ⋅ ᶜlbias_matrix() ⋅
-               ᶠinterp_matrix() ⋅ ᶜnested
+            @. ᶜflux_correct_matrix(ᶠuvw) ⋆ ᶜadvect_matrix(ᶠuvw) ⋆
+               ᶜwinterp_matrix(ᶠscalar) ⋆ ᶠrbias_matrix() ⋆ ᶜlbias_matrix() ⋆
+               ᶠinterp_matrix() ⋆ ᶜnested
         ),
         ref_set_result = @lazy(
             @. ᶜflux_correct(
@@ -287,21 +288,21 @@ end
         test_name = "applying six operators to a nested field using operator \
                      matrices, but with forced right associativity",
         get_result = @lazy(
-            @. ᶜflux_correct_matrix(ᶠuvw) ⋅ (
-                ᶜadvect_matrix(ᶠuvw) ⋅ (
-                    ᶜwinterp_matrix(ᶠscalar) ⋅ (
-                        ᶠrbias_matrix() ⋅
-                        (ᶜlbias_matrix() ⋅ (ᶠinterp_matrix() ⋅ ᶜnested))
+            @. ᶜflux_correct_matrix(ᶠuvw) ⋆ (
+                ᶜadvect_matrix(ᶠuvw) ⋆ (
+                    ᶜwinterp_matrix(ᶠscalar) ⋆ (
+                        ᶠrbias_matrix() ⋆
+                        (ᶜlbias_matrix() ⋆ (ᶠinterp_matrix() ⋆ ᶜnested))
                     )
                 )
             )
         ),
         set_result = @lazy(
-            @. ᶜflux_correct_matrix(ᶠuvw) ⋅ (
-                ᶜadvect_matrix(ᶠuvw) ⋅ (
-                    ᶜwinterp_matrix(ᶠscalar) ⋅ (
-                        ᶠrbias_matrix() ⋅
-                        (ᶜlbias_matrix() ⋅ (ᶠinterp_matrix() ⋅ ᶜnested))
+            @. ᶜflux_correct_matrix(ᶠuvw) ⋆ (
+                ᶜadvect_matrix(ᶠuvw) ⋆ (
+                    ᶜwinterp_matrix(ᶠscalar) ⋆ (
+                        ᶠrbias_matrix() ⋆
+                        (ᶜlbias_matrix() ⋆ (ᶠinterp_matrix() ⋆ ᶜnested))
                     )
                 )
             )
@@ -325,13 +326,13 @@ end
     # false positive, a compiler issue, or a sign that the code can be improved?
     for get_result in (
         @lazy(
-            @. (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠcurl_matrix() *
+            @. (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋆ ᶠcurl_matrix() *
                (c12_a,) +
                (DiagonalMatrixRow(ᶜdiv(ᶠuvw)) - ᶜadvect_matrix(ᶠuvw)) / 5
         ),
         @lazy(
-            @. ᶜdiv_matrix() ⋅ DiagonalMatrixRow(ᶠscalar) ⋅ ᶠgrad_matrix() ⋅ (
-                (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠcurl_matrix() *
+            @. ᶜdiv_matrix() ⋆ DiagonalMatrixRow(ᶠscalar) ⋆ ᶠgrad_matrix() ⋆ (
+                (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋆ ᶠcurl_matrix() *
                 (c12_a,) +
                 (DiagonalMatrixRow(ᶜdiv(ᶠuvw)) - ᶜadvect_matrix(ᶠuvw)) / 5
             )
@@ -345,20 +346,20 @@ end
         test_name = "non-trivial combination of operator matrices and other \
                      matrix fields",
         get_result = @lazy(
-            @. ᶠupwind_matrix(ᶠuvw) ⋅ (
-                ᶜdiv_matrix() ⋅ DiagonalMatrixRow(ᶠscalar) ⋅ ᶠgrad_matrix() ⋅
+            @. ᶠupwind_matrix(ᶠuvw) ⋆ (
+                ᶜdiv_matrix() ⋆ DiagonalMatrixRow(ᶠscalar) ⋆ ᶠgrad_matrix() ⋆
                 (
-                    (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠcurl_matrix() *
+                    (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋆ ᶠcurl_matrix() *
                     (c12_a,) +
                     (DiagonalMatrixRow(ᶜdiv(ᶠuvw)) - ᶜadvect_matrix(ᶠuvw)) / 5
                 ) - (2I,)
             )
         ),
         set_result = @lazy(
-            @. ᶠupwind_matrix(ᶠuvw) ⋅ (
-                ᶜdiv_matrix() ⋅ DiagonalMatrixRow(ᶠscalar) ⋅ ᶠgrad_matrix() ⋅
+            @. ᶠupwind_matrix(ᶠuvw) ⋆ (
+                ᶜdiv_matrix() ⋆ DiagonalMatrixRow(ᶠscalar) ⋆ ᶠgrad_matrix() ⋆
                 (
-                    (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠcurl_matrix() *
+                    (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋆ ᶠcurl_matrix() *
                     (c12_a,) +
                     (DiagonalMatrixRow(ᶜdiv(ᶠuvw)) - ᶜadvect_matrix(ᶠuvw)) / 5
                 ) - (2I,)
@@ -368,31 +369,31 @@ end
 
     # TODO: This case's reference function takes too long to compile on both
     # CPUs and GPUs (more than half an hour), as of Julia 1.9. This might be
-    # happening because of excessive inlining---aside from ⋅, all other finite
+    # happening because of excessive inlining---aside from ⋆, all other finite
     # difference operators use @propagate_inbounds. So, the reference function
     # is currently disabled, although the test does pass when it is enabled.
     test_field_broadcast(;
         test_name = "applying a non-trivial sequence of operations to a scalar \
                      field using operator matrices and other matrix fields",
         get_result = @lazy(
-            @. ᶠupwind_matrix(ᶠuvw) ⋅ (
-                ᶜdiv_matrix() ⋅ DiagonalMatrixRow(ᶠscalar) ⋅ ᶠgrad_matrix() ⋅
+            @. ᶠupwind_matrix(ᶠuvw) ⋆ (
+                ᶜdiv_matrix() ⋆ DiagonalMatrixRow(ᶠscalar) ⋆ ᶠgrad_matrix() ⋆
                 (
-                    (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠcurl_matrix() *
+                    (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋆ ᶠcurl_matrix() *
                     (c12_a,) +
                     (DiagonalMatrixRow(ᶜdiv(ᶠuvw)) - ᶜadvect_matrix(ᶠuvw)) / 5
                 ) - (2I,)
-            ) ⋅ ᶜscalar
+            ) ⋆ ᶜscalar
         ),
         set_result = @lazy(
-            @. ᶠupwind_matrix(ᶠuvw) ⋅ (
-                ᶜdiv_matrix() ⋅ DiagonalMatrixRow(ᶠscalar) ⋅ ᶠgrad_matrix() ⋅
+            @. ᶠupwind_matrix(ᶠuvw) ⋆ (
+                ᶜdiv_matrix() ⋆ DiagonalMatrixRow(ᶠscalar) ⋆ ᶠgrad_matrix() ⋆
                 (
-                    (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠcurl_matrix() *
+                    (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋆ ᶠcurl_matrix() *
                     (c12_a,) +
                     (DiagonalMatrixRow(ᶜdiv(ᶠuvw)) - ᶜadvect_matrix(ᶠuvw)) / 5
                 ) - (2I,)
-            ) ⋅ ᶜscalar
+            ) ⋆ ᶜscalar
         ),
         # ref_set_result = @lazy(@. ᶠupwind(
         #     ᶠuvw,


### PR DESCRIPTION
The `\cdot` alias for `MultiplyColumnwiseBandMatrixField` is a pain-- it collides with LinearAlgebra's `\cdot`, and it's exported by `ClimaCore.MatrixFields`.

This PR doesn't fix this issue per-say, but I would like to at least isolate where we are doing this and fix collisions for the ClimaCore examples.

I think we unfortunately can't remove the export from `ClimaCore.MatrixFields`, as this will technically be a breaking change. Perhaps we can deprecate this change and phase it out.

I spoke with @dennisYatunin, and he believes that we can replace all of these `\cdot`s with `*`. This PR applies these changes to all of the appropriate places, but instead replacing it with `\star`. This will allow us to do a replace-all once we are ready to apply this fix.