### PR TITLE
Fix DebugOnly docs to work for reduction kernels

### DIFF
--- a/docs/src/debugging.md
+++ b/docs/src/debugging.md
@@ -78,8 +78,8 @@ import ClimaCore
 import Infiltrator # must be in your default environment
 ClimaCore.DebugOnly.call_post_op_callback() = true
 function ClimaCore.DebugOnly.post_op_callback(result, args...; kwargs...)
-    has_nans = any(isnan, parent(result))
-    has_inf = any(isinf, parent(result))
+    has_nans = result isa Number ? isnan(result) : any(isnan, parent(result))
+    has_inf = result isa Number ? isinf(result) : any(isinf, parent(result))
     if has_nans || has_inf
         has_nans && println("NaNs found!")
         has_inf && println("Infs found!")


### PR DESCRIPTION
This PR fixes the docs so that the script works for reduction kernels (e.g., `mean`). I just ran into this when I tried copy-pasting the script.