### PR TITLE
Use * to denote matrix multiplication

### DIFF
--- a/examples/hybrid/staggered_nonhydrostatic_model.jl
+++ b/examples/hybrid/staggered_nonhydrostatic_model.jl
@@ -331,11 +331,11 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
     #     norm_sqr(C123(ᶜuₕ) + C123(ᶜinterp(ᶠw))) / 2 =
     #     ACT12(ᶜuₕ) * ᶜuₕ / 2 + ACT3(ᶜinterp(ᶠw)) * ᶜinterp(ᶠw) / 2
     # ∂(ᶜK)/∂(ᶠw) = ACT3(ᶜinterp(ᶠw)) * ᶜinterp_matrix()
-    @. ∂ᶜK∂ᶠw = DiagonalMatrixRow(adjoint(CT3(ᶜinterp(ᶠw)))) ⋅ ᶜinterp_matrix()
+    @. ∂ᶜK∂ᶠw = DiagonalMatrixRow(adjoint(CT3(ᶜinterp(ᶠw)))) * ᶜinterp_matrix()
 
     # ᶜρₜ = -ᶜdivᵥ(ᶠinterp(ᶜρ) * ᶠw)
     # ∂(ᶜρₜ)/∂(ᶠw) = -ᶜdivᵥ_matrix() * ᶠinterp(ᶜρ) * ᶠg³³
-    @. ∂ᶜρₜ∂ᶠ𝕄 = -(ᶜdivᵥ_matrix()) ⋅ DiagonalMatrixRow(ᶠinterp(ᶜρ) * g³³(ᶠgⁱʲ))
+    @. ∂ᶜρₜ∂ᶠ𝕄 = -(ᶜdivᵥ_matrix()) * DiagonalMatrixRow(ᶠinterp(ᶜρ) * g³³(ᶠgⁱʲ))
 
     if :ρθ in propertynames(Y.c)
         ᶜρθ = Y.c.ρθ
@@ -349,14 +349,14 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
             # ᶜρθₜ = -ᶜdivᵥ(ᶠinterp(ᶜρθ) * ᶠw)
             # ∂(ᶜρθₜ)/∂(ᶠw) = -ᶜdivᵥ_matrix() * ᶠinterp(ᶜρθ) * ᶠg³³
             @. ∂ᶜ𝔼ₜ∂ᶠ𝕄 =
-                -(ᶜdivᵥ_matrix()) ⋅ DiagonalMatrixRow(ᶠinterp(ᶜρθ) * g³³(ᶠgⁱʲ))
+                -(ᶜdivᵥ_matrix()) * DiagonalMatrixRow(ᶠinterp(ᶜρθ) * g³³(ᶠgⁱʲ))
         else
             # ᶜρθₜ = -ᶜdivᵥ(ᶠinterp(ᶜρ) * ᶠupwind_product(ᶠw, ᶜρθ / ᶜρ))
             # ∂(ᶜρθₜ)/∂(ᶠw) =
             #     -ᶜdivᵥ_matrix() * ᶠinterp(ᶜρ) *
             #     ∂(ᶠupwind_product(ᶠw, ᶜρθ / ᶜρ))/∂(ᶠw)
             @. ∂ᶜ𝔼ₜ∂ᶠ𝕄 =
-                -(ᶜdivᵥ_matrix()) ⋅ DiagonalMatrixRow(
+                -(ᶜdivᵥ_matrix()) * DiagonalMatrixRow(
                     ᶠinterp(ᶜρ) *
                     vec_data(ᶠno_flux(ᶠupwind_product(ᶠw + εw, ᶜρθ / ᶜρ))) /
                     vec_data(CT3(ᶠw + εw)) * g³³(ᶠgⁱʲ),
@@ -381,10 +381,12 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
                 # ∂(ᶜp)/∂(ᶠw) = ∂(ᶜp)/∂(ᶜK) * ∂(ᶜK)/∂(ᶠw)
                 # ∂(ᶜp)/∂(ᶜK) = -ᶜρ * R_d / cv_d
                 @. ∂ᶜ𝔼ₜ∂ᶠ𝕄 =
-                    -(ᶜdivᵥ_matrix()) ⋅ (
+                    -(ᶜdivᵥ_matrix()) * (
                         DiagonalMatrixRow(ᶠinterp(ᶜρe + ᶜp) * g³³(ᶠgⁱʲ)) +
-                        DiagonalMatrixRow(CT3(ᶠw)) ⋅ ᶠinterp_matrix() ⋅
-                        DiagonalMatrixRow(-(ᶜρ * R_d / cv_d)) ⋅ ∂ᶜK∂ᶠw
+                        DiagonalMatrixRow(CT3(ᶠw)) *
+                        ᶠinterp_matrix() *
+                        DiagonalMatrixRow(-(ᶜρ * R_d / cv_d)) *
+                        ∂ᶜK∂ᶠw
                     )
             else
                 # ᶜρeₜ =
@@ -397,7 +399,9 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
                 # ∂(ᶜp)/∂(ᶠw) = ∂(ᶜp)/∂(ᶜK) * ∂(ᶜK)/∂(ᶠw)
                 # ∂(ᶜp)/∂(ᶜK) = -ᶜρ * R_d / cv_d
                 @. ∂ᶜ𝔼ₜ∂ᶠ𝕄 =
-                    -(ᶜdivᵥ_matrix()) ⋅ DiagonalMatrixRow(ᶠinterp(ᶜρ)) ⋅ (
+                    -(ᶜdivᵥ_matrix()) *
+                    DiagonalMatrixRow(ᶠinterp(ᶜρ)) *
+                    (
                         DiagonalMatrixRow(
                             vec_data(
                                 ᶠno_flux(
@@ -405,7 +409,7 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
                                 ),
                             ) / vec_data(CT3(ᶠw + εw)) * g³³(ᶠgⁱʲ),
                         ) +
-                        ᶠno_flux_row(ᶠupwind_product_matrix(ᶠw)) ⋅
+                        ᶠno_flux_row(ᶠupwind_product_matrix(ᶠw)) *
                         (-R_d / cv_d * ∂ᶜK∂ᶠw)
                     )
             end
@@ -414,11 +418,11 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
             # ∂ᶜ𝔼ₜ∂ᶠ𝕄 has 3 diagonals instead of 5
             if isnothing(ᶠupwind_product)
                 @. ∂ᶜ𝔼ₜ∂ᶠ𝕄 =
-                    -(ᶜdivᵥ_matrix()) ⋅
+                    -(ᶜdivᵥ_matrix()) *
                     DiagonalMatrixRow(ᶠinterp(ᶜρe + ᶜp) * g³³(ᶠgⁱʲ))
             else
                 @. ∂ᶜ𝔼ₜ∂ᶠ𝕄 =
-                    -(ᶜdivᵥ_matrix()) ⋅ DiagonalMatrixRow(
+                    -(ᶜdivᵥ_matrix()) * DiagonalMatrixRow(
                         ᶠinterp(ᶜρ) * vec_data(
                             ᶠno_flux(ᶠupwind_product(ᶠw + εw, (ᶜρe + ᶜp) / ᶜρ)),
                         ) / vec_data(CT3(ᶠw + εw)) * g³³(ᶠgⁱʲ),
@@ -443,9 +447,9 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
             #     -ᶜdivᵥ_matrix() * ᶠinterp(ᶜρe_int + ᶜp) * ᶠg³³ +
             #     ᶜinterp_matrix() * adjoint(ᶠgradᵥ(ᶜp)) * ᶠg³³
             @. ∂ᶜ𝔼ₜ∂ᶠ𝕄 =
-                -(ᶜdivᵥ_matrix()) ⋅
+                -(ᶜdivᵥ_matrix()) *
                 DiagonalMatrixRow(ᶠinterp(ᶜρe_int + ᶜp) * g³³(ᶠgⁱʲ)) +
-                ᶜinterp_matrix() ⋅
+                ᶜinterp_matrix() *
                 DiagonalMatrixRow(adjoint(ᶠgradᵥ(ᶜp)) * g³³(ᶠgⁱʲ))
         else
             # ᶜρe_intₜ =
@@ -456,12 +460,12 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
             #     ∂(ᶠupwind_product(ᶠw, (ᶜρe_int + ᶜp) / ᶜρ))/∂(ᶠw) +
             #     ᶜinterp_matrix() * adjoint(ᶠgradᵥ(ᶜp)) * ᶠg³³
             @. ∂ᶜ𝔼ₜ∂ᶠ𝕄 =
-                -(ᶜdivᵥ_matrix()) ⋅ DiagonalMatrixRow(
+                -(ᶜdivᵥ_matrix()) * DiagonalMatrixRow(
                     ᶠinterp(ᶜρ) * vec_data(
                         ᶠno_flux(ᶠupwind_product(ᶠw + εw, (ᶜρe_int + ᶜp) / ᶜρ)),
                     ) / vec_data(CT3(ᶠw + εw)) * g³³(ᶠgⁱʲ),
                 ) +
-                ᶜinterp_matrix() ⋅
+                ᶜinterp_matrix() *
                 DiagonalMatrixRow(adjoint(ᶠgradᵥ(ᶜp)) * g³³(ᶠgⁱʲ))
         end
     end
@@ -480,7 +484,8 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
         # ∂(ᶠgradᵥ(ᶜp))/∂(ᶜρθ) =
         #     ᶠgradᵥ_matrix() * γ * R_d * (ᶜρθ * R_d / p_0)^(γ - 1)
         @. ∂ᶠ𝕄ₜ∂ᶜ𝔼 =
-            -DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) ⋅ ᶠgradᵥ_matrix() ⋅
+            -DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) *
+            ᶠgradᵥ_matrix() *
             DiagonalMatrixRow(γ * R_d * (ᶜρθ * R_d / p_0)^(γ - 1))
 
         if flags.∂ᶠ𝕄ₜ∂ᶜρ_mode == :exact
@@ -489,12 +494,12 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
             # ∂(ᶠwₜ)/∂(ᶠinterp(ᶜρ)) = ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ)^2
             # ∂(ᶠinterp(ᶜρ))/∂(ᶜρ) = ᶠinterp_matrix()
             @. ∂ᶠ𝕄ₜ∂ᶜρ =
-                DiagonalMatrixRow(ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ)^2) ⋅ ᶠinterp_matrix()
+                DiagonalMatrixRow(ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ)^2) * ᶠinterp_matrix()
         elseif flags.∂ᶠ𝕄ₜ∂ᶜρ_mode == :hydrostatic_balance
             # same as above, but we assume that ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ) =
             # -ᶠgradᵥ(ᶜΦ)
             @. ∂ᶠ𝕄ₜ∂ᶜρ =
-                -DiagonalMatrixRow(ᶠgradᵥ(ᶜΦ) / ᶠinterp(ᶜρ)) ⋅ ᶠinterp_matrix()
+                -DiagonalMatrixRow(ᶠgradᵥ(ᶜΦ) / ᶠinterp(ᶜρ)) * ᶠinterp_matrix()
         end
     elseif :ρe in propertynames(Y.c)
         # ᶠwₜ = -ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ) - ᶠgradᵥ(ᶜK + ᶜΦ)
@@ -502,7 +507,7 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
         # ∂(ᶠwₜ)/∂(ᶠgradᵥ(ᶜp)) = -1 / ᶠinterp(ᶜρ)
         # ∂(ᶠgradᵥ(ᶜp))/∂(ᶜρe) = ᶠgradᵥ_matrix() * R_d / cv_d
         @. ∂ᶠ𝕄ₜ∂ᶜ𝔼 =
-            -DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) ⋅ (ᶠgradᵥ_matrix() * R_d / cv_d)
+            -DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) * (ᶠgradᵥ_matrix() * R_d / cv_d)
 
         if flags.∂ᶠ𝕄ₜ∂ᶜρ_mode == :exact
             # ᶠwₜ = -ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ) - ᶠgradᵥ(ᶜK + ᶜΦ)
@@ -515,16 +520,18 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
             # ∂(ᶠwₜ)/∂(ᶠinterp(ᶜρ)) = ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ)^2
             # ∂(ᶠinterp(ᶜρ))/∂(ᶜρ) = ᶠinterp_matrix()
             @. ∂ᶠ𝕄ₜ∂ᶜρ =
-                -DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) ⋅ ᶠgradᵥ_matrix() ⋅
+                -DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) *
+                ᶠgradᵥ_matrix() *
                 DiagonalMatrixRow(R_d * (-(ᶜK + ᶜΦ) / cv_d + T_tri)) +
-                DiagonalMatrixRow(ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ)^2) ⋅ ᶠinterp_matrix()
+                DiagonalMatrixRow(ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ)^2) * ᶠinterp_matrix()
         elseif flags.∂ᶠ𝕄ₜ∂ᶜρ_mode == :hydrostatic_balance
             # same as above, but we assume that ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ) =
             # -ᶠgradᵥ(ᶜΦ) and that ᶜK is negligible compared ot ᶜΦ
             @. ∂ᶠ𝕄ₜ∂ᶜρ =
-                -DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) ⋅ ᶠgradᵥ_matrix() ⋅
+                -DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) *
+                ᶠgradᵥ_matrix() *
                 DiagonalMatrixRow(R_d * (-(ᶜΦ) / cv_d + T_tri)) -
-                DiagonalMatrixRow(ᶠgradᵥ(ᶜΦ) / ᶠinterp(ᶜρ)) ⋅ ᶠinterp_matrix()
+                DiagonalMatrixRow(ᶠgradᵥ(ᶜΦ) / ᶠinterp(ᶜρ)) * ᶠinterp_matrix()
         end
     elseif :ρe_int in propertynames(Y.c)
         # ᶠwₜ = -ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ) - ᶠgradᵥ(ᶜK + ᶜΦ)
@@ -532,7 +539,7 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
         # ∂(ᶠwₜ)/∂(ᶠgradᵥ(ᶜp)) = -1 / ᶠinterp(ᶜρ)
         # ∂(ᶠgradᵥ(ᶜp))/∂(ᶜρe_int) = ᶠgradᵥ_matrix() * R_d / cv_d
         @. ∂ᶠ𝕄ₜ∂ᶜ𝔼 =
-            DiagonalMatrixRow(-1 / ᶠinterp(ᶜρ)) ⋅ (ᶠgradᵥ_matrix() * R_d / cv_d)
+            DiagonalMatrixRow(-1 / ᶠinterp(ᶜρ)) * (ᶠgradᵥ_matrix() * R_d / cv_d)
 
         if flags.∂ᶠ𝕄ₜ∂ᶜρ_mode == :exact
             # ᶠwₜ = -ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ) - ᶠgradᵥ(ᶜK + ᶜΦ)
@@ -544,16 +551,16 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
             # ∂(ᶠwₜ)/∂(ᶠinterp(ᶜρ)) = ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ)^2
             # ∂(ᶠinterp(ᶜρ))/∂(ᶜρ) = ᶠinterp_matrix()
             @. ∂ᶠ𝕄ₜ∂ᶜρ =
-                -DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) ⋅
+                -DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) *
                 (ᶠgradᵥ_matrix() * R_d * T_tri) +
-                DiagonalMatrixRow(ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ)^2) ⋅ ᶠinterp_matrix()
+                DiagonalMatrixRow(ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ)^2) * ᶠinterp_matrix()
         elseif flags.∂ᶠ𝕄ₜ∂ᶜρ_mode == :hydrostatic_balance
             # same as above, but we assume that ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ) =
             # -ᶠgradᵥ(ᶜΦ)
             @. ∂ᶠ𝕄ₜ∂ᶜρ =
-                DiagonalMatrixRow(-1 / ᶠinterp(ᶜρ)) ⋅
+                DiagonalMatrixRow(-1 / ᶠinterp(ᶜρ)) *
                 (ᶠgradᵥ_matrix() * R_d * T_tri) -
-                DiagonalMatrixRow(ᶠgradᵥ(ᶜΦ) / ᶠinterp(ᶜρ)) ⋅ ᶠinterp_matrix()
+                DiagonalMatrixRow(ᶠgradᵥ(ᶜΦ) / ᶠinterp(ᶜρ)) * ᶠinterp_matrix()
         end
     end
 
@@ -571,13 +578,14 @@ function implicit_equation_jacobian!(j, Y, p, δtγ, t)
     # ∂(ᶠwₜ)/∂(ᶠgradᵥ(ᶜK + ᶜΦ)) = -1
     # ∂(ᶠgradᵥ(ᶜK + ᶜΦ))/∂(ᶜK) = ᶠgradᵥ_matrix()
     if :ρθ in propertynames(Y.c) || :ρe_int in propertynames(Y.c)
-        @. ∂ᶠ𝕄ₜ∂ᶠ𝕄 = -(ᶠgradᵥ_matrix()) ⋅ ∂ᶜK∂ᶠw
+        @. ∂ᶠ𝕄ₜ∂ᶠ𝕄 = -(ᶠgradᵥ_matrix()) * ∂ᶜK∂ᶠw
     elseif :ρe in propertynames(Y.c)
         @. ∂ᶠ𝕄ₜ∂ᶠ𝕄 =
             -(
-                DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) ⋅ ᶠgradᵥ_matrix() ⋅
+                DiagonalMatrixRow(1 / ᶠinterp(ᶜρ)) *
+                ᶠgradᵥ_matrix() *
                 DiagonalMatrixRow(-(ᶜρ * R_d / cv_d)) + ᶠgradᵥ_matrix()
-            ) ⋅ ∂ᶜK∂ᶠw
+            ) * ∂ᶜK∂ᶠw
     end
 
     I = one(∂R∂Y)

--- a/src/MatrixFields/field_name_dict.jl
+++ b/src/MatrixFields/field_name_dict.jl
@@ -422,7 +422,7 @@ Base.Broadcast.broadcasted(
     arg3,
     args...,
 ) =
-    foldl((arg1, arg2, arg3, args...)) do arg1′, arg2′
+    unrolled_reduce((arg1, arg2, arg3, args...)) do arg1′, arg2′
         Base.Broadcast.broadcasted(f, arg1′, arg2′)
     end
 
@@ -553,7 +553,7 @@ function Base.Broadcast.broadcasted(
             elseif entry2 isa ScalingFieldMatrixEntry
                 Base.Broadcast.broadcasted(*, entry1, (scaling_value(entry2),))
             else
-                Base.Broadcast.broadcasted(⋅, entry1, entry2)
+                Base.Broadcast.broadcasted(*, entry1, entry2)
             end
         end
         length(summand_bcs) == 1 ? summand_bcs[1] :

--- a/src/MatrixFields/matrix_multiplication.jl
+++ b/src/MatrixFields/matrix_multiplication.jl
@@ -2,8 +2,7 @@
     MultiplyColumnwiseBandMatrixField()
 
 An operator that multiplies a `ColumnwiseBandMatrixField` by another `Field`,
-i.e., matrix-vector or matrix-matrix multiplication. The `⋅` symbol is an alias
-for `MultiplyColumnwiseBandMatrixField()`.
+i.e., matrix-vector or matrix-matrix multiplication.
 
 What follows is a derivation of the algorithm used by this operator with
 single-column `Field`s. For `Field`s on multiple columns, the same computation
@@ -21,7 +20,7 @@ We will also use `outer_indices```(```space```)`` to denote the tuple
 
 From the definition of matrix-vector multiplication,
 ```math
-(M_1 ⋅ V)[i] = \\sum_k M_1[i, k] * V[k].
+(M_1 * V)[i] = \\sum_k M_1[i, k] * V[k].
 ```
 To establish bounds on the values of ``k``, let us define the following values:
 - ``li_1, ri_1 ={}```outer_indices```(```column_axes```(M_1))``
@@ -36,16 +35,16 @@ Combining these into a single inequality gives us
 ```math
 \\text{max}(li_1, i + ld_1) \\leq k \\leq \\text{min}(ri_1, i + ud_1).
 ```
-So, we can rewrite the expression for ``(M_1 ⋅ V)[i]`` as
+So, we can rewrite the expression for ``(M_1 * V)[i]`` as
 ```math
-(M_1 ⋅ V)[i] =
+(M_1 * V)[i] =
     \\sum_{k\\ =\\ \\text{max}(li_1, i + ld_1)}^{\\text{min}(ri_1, i + ud_1)}
     M_1[i, k] * V[k].
 ```
 If we replace the variable ``k`` with ``d = k - i`` and switch from array-like
 indexing to `Field` indexing, we find that
 ```math
-(M_1 ⋅ V)[i] =
+(M_1 * V)[i] =
     \\sum_{d\\ =\\ \\text{max}(li_1 - i, ld_1)}^{\\text{min}(ri_1 - i, ud_1)}
     M_1[i][d] * V[i + d].
 ```
@@ -61,9 +60,9 @@ If this is the case, then the bounds on ``d`` can be simplified to
 \\text{max}(li_1 - i, ld_1) = ld_1 \\quad \\text{and} \\quad
 \\text{min}(ri_1 - i, ud_1) = ud_1.
 ```
-The expression for ``(M_1 ⋅ V)[i]`` then becomes
+The expression for ``(M_1 * V)[i]`` then becomes
 ```math
-(M_1 ⋅ V)[i] = \\sum_{d = ld_1}^{ud_1} M_1[i][d] * V[i + d].
+(M_1 * V)[i] = \\sum_{d = ld_1}^{ud_1} M_1[i][d] * V[i + d].
 ```
 The values of ``i`` in this range are considered to be in the "interior" of the
 operator, while those not in this range (for which we cannot make the above
@@ -73,7 +72,7 @@ simplification) are considered to be on the "boundary".
 
 From the definition of matrix-matrix multiplication,
 ```math
-(M_1 ⋅ M_2)[i, j] = \\sum_k M_1[i, k] * M_2[k, j].
+(M_1 * M_2)[i, j] = \\sum_k M_1[i, k] * M_2[k, j].
 ```
 To establish bounds on the values of ``j`` and ``k``, let us define the
 following values:
@@ -83,7 +82,7 @@ following values:
 - ``ld_2, ud_2 ={}```outer_diagonals```(```eltype```(M_2))``
 
 In addition, let ``ld_{prod}`` and ``ud_{prod}`` denote the outer diagonal
-indices of the product matrix ``M_1 ⋅ M_2``. We will derive the values of
+indices of the product matrix ``M_1 * M_2``. We will derive the values of
 ``ld_{prod}`` and ``ud_{prod}`` in the last section.
 
 Since ``M_1[i, k]`` is only well-defined if ``k`` is a valid column index and
@@ -96,7 +95,7 @@ Since ``M_2[k, j]`` is only well-defined if ``j`` is a valid column index and
 ```math
 li_2 \\leq j \\leq ri_2 \\quad \\text{and} \\quad ld_2 \\leq j - k \\leq ud_2.
 ```
-Finally, ``(M_1 ⋅ M_2)[i, j]`` is only well-defined if ``j - i`` is a valid
+Finally, ``(M_1 * M_2)[i, j]`` is only well-defined if ``j - i`` is a valid
 diagonal index, so
 ```math
 ld_{prod} \\leq j - i \\leq ud_{prod}.
@@ -111,10 +110,10 @@ These inequalities can be combined to obtain
 \\text{min}(ri_1, i + ud_1, j - ld_2).
 \\end{gather*}
 ```
-So, we can rewrite the expression for ``(M_1 ⋅ M_2)[i, j]`` as
+So, we can rewrite the expression for ``(M_1 * M_2)[i, j]`` as
 ```math
 \\begin{gather*}
-(M_1 ⋅ M_2)[i, j] =
+(M_1 * M_2)[i, j] =
     \\sum_{
         k\\ =\\ \\text{max}(li_1, i + ld_1, j - ud_2)
     }^{\\text{min}(ri_1, i + ud_1, j - ld_2)}
@@ -127,7 +126,7 @@ with ``d_{prod} = j - i``, and switch from array-like indexing to `Field`
 indexing, we find that
 ```math
 \\begin{gather*}
-(M_1 ⋅ M_2)[i][d_{prod}] =
+(M_1 * M_2)[i][d_{prod}] =
     \\sum_{
         d\\ =\\ \\text{max}(li_1 - i, ld_1, d_{prod} - ud_2)
     }^{\\text{min}(ri_1 - i, ud_1, d_{prod} - ld_2)}
@@ -154,10 +153,10 @@ Similarly, the bounds on ``d`` can be simplified using the fact that
 \\text{max}(li_1 - i, ld_1) = ld_1 \\quad \\text{and} \\quad
 \\text{min}(ri_1 - i, ud_1) = ud_1.
 ```
-The expression for ``(M_1 ⋅ M_2)[i][d_{prod}]`` then becomes
+The expression for ``(M_1 * M_2)[i][d_{prod}]`` then becomes
 ```math
 \\begin{gather*}
-(M_1 ⋅ M_2)[i][d_{prod}] =
+(M_1 * M_2)[i][d_{prod}] =
     \\sum_{
         d\\ =\\ \\text{max}(ld_1, d_{prod} - ud_2)
     }^{\\text{min}(ud_1, d_{prod} - ld_2)}
@@ -171,7 +170,7 @@ simplifications) are considered to be on the "boundary".
 
 ## 2.2 ``ld_{prod}`` and ``ud_{prod}``
 
-We only need to compute ``(M_1 ⋅ M_2)[i][d_{prod}]`` for values of ``d_{prod}``
+We only need to compute ``(M_1 * M_2)[i][d_{prod}]`` for values of ``d_{prod}``
 that correspond to a nonempty sum in the interior, i.e, those for which
 ```math
 \\text{max}(ld_1, d_{prod} - ud_2) \\leq \\text{min}(ud_1, d_{prod} - ld_2).
@@ -188,7 +187,7 @@ tells us that
 ```math
 ld_1 + ld_2 \\leq d_{prod} \\leq ud_1 + ud_2.
 ```
-In other words, the outer diagonal indices of ``M_1 ⋅ M_2`` are
+In other words, the outer diagonal indices of ``M_1 * M_2`` are
 ```math
 ld_{prod} = ld_1 + ld_2 \\quad \\text{and} \\quad ud_{prod} = ud_1 + ud_2.
 ```
@@ -199,6 +198,8 @@ This means that we can express the bounds on the interior values of ``i`` as
 ```
 """
 struct MultiplyColumnwiseBandMatrixField <: Operators.FiniteDifferenceOperator end
+
+# TODO: Remove this in the next major release of ClimaCore.
 const ⋅ = MultiplyColumnwiseBandMatrixField()
 
 Operators.strip_space(op::MultiplyColumnwiseBandMatrixField, _) = op
@@ -280,8 +281,8 @@ function Operators.return_eltype(
     et_mat1 = eltype(matrix1)
     et_arg = eltype(arg)
     et_mat1 <: BandMatrixRow || error(
-        "The first argument of ⋅ must have elements of type BandMatrixRow, but \
-         the given argument has elements of type $et_mat1",
+        "The first argument of MultiplyColumnwiseBandMatrixField must have
+         elements of type BandMatrixRow, but the given argument has $et_mat1",
     )
     if et_arg <: BandMatrixRow # matrix-matrix multiplication
         matrix2 = arg
@@ -305,8 +306,8 @@ function Operators.return_eltype(
     et_mat1 = eltype(matrix1)
     et_arg = eltype(arg)
     et_mat1 <: BandMatrixRow || error(
-        "The first argument of ⋅ must have elements of type BandMatrixRow, but \
-         the given argument has elements of type $et_mat1",
+        "The first argument of MultiplyColumnwiseBandMatrixField must have
+         elements of type BandMatrixRow, but the given argument has $et_mat1",
     )
     if et_arg <: BandMatrixRow # matrix-matrix multiplication
         matrix2 = arg
@@ -360,7 +361,12 @@ function multiply_matrix_at_index(
 ) where {T <: BandMatrixRow}
     # T = eltype(arg)
     lg = Geometry.LocalGeometry(space, idx, hidx)
-    prod_type = Operators.return_eltype(⋅, matrix1, arg, typeof(lg))
+    prod_type = Operators.return_eltype(
+        MultiplyColumnwiseBandMatrixField(),
+        matrix1,
+        arg,
+        typeof(lg),
+    )
 
     column_space1 = column_axes(matrix1, space)
     ld1, ud1 = outer_diagonals(eltype(matrix1))
@@ -444,7 +450,12 @@ function multiply_matrix_at_index(
 ) where {T}
     # T = eltype(arg)
     lg = Geometry.LocalGeometry(space, idx, hidx)
-    prod_type = Operators.return_eltype(⋅, matrix1, arg, typeof(lg))
+    prod_type = Operators.return_eltype(
+        MultiplyColumnwiseBandMatrixField(),
+        matrix1,
+        arg,
+        typeof(lg),
+    )
 
     column_space1 = column_axes(matrix1, space)
     ld1, ud1 = outer_diagonals(eltype(matrix1))

--- a/src/MatrixFields/operator_matrices.jl
+++ b/src/MatrixFields/operator_matrices.jl
@@ -125,9 +125,9 @@ Base.Broadcast.broadcasted(
 Constructs a new operator (or operator-like object) that generates the matrix
 applied by `op` to its final argument. If `op_matrix = operator_matrix(op)`,
 we can use the following identities:
-- When `op` takes one argument, `@. op(arg) == @. op_matrix() ⋅ arg`.
+- When `op` takes one argument, `@. op(arg) == @. op_matrix() * arg`.
 - When `op` takes multiple arguments,
-    `@. op(args..., arg) == @. op_matrix(args...) ⋅ arg`.
+    `@. op(args..., arg) == @. op_matrix(args...) * arg`.
 
 When `op` takes more than one argument, `operator_matrix(op)` constructs a
 `FiniteDifferenceOperator` that generates the operator matrix. When `op` only
@@ -147,7 +147,7 @@ centers applies an ``n \\times (n + 1)`` bidiagonal matrix:
 \\vdots & \\vdots & \\vdots & \\ddots & \\vdots & \\vdots & \\vdots \\\\
       0 &       0 &       0 & \\cdots &     0.5 &     0.5 &       0 \\\\
       0 &       0 &       0 & \\cdots &       0 &     0.5 &     0.5
-\\end{bmatrix} ⋅ arg
+\\end{bmatrix} * arg
 ```
 The `GradientF2C()` operator applies a similar matrix, but with different
 entries:
@@ -159,7 +159,7 @@ entries:
        \\vdots &        \\vdots &        \\vdots & \\ddots &        \\vdots &        \\vdots &       \\vdots \\\\
              0 &              0 &              0 & \\cdots & -\\textbf{e}^3 &  \\textbf{e}^3 &             0 \\\\
              0 &              0 &              0 & \\cdots &              0 & -\\textbf{e}^3 & \\textbf{e}^3
-\\end{bmatrix} ⋅ arg
+\\end{bmatrix} * arg
 ```
 The unit vector ``\\textbf{e}^3``, which can also be thought of as the
 differential along the third coordinate axis (``\\textrm{d}\\xi^3``), is
@@ -179,7 +179,7 @@ grad_b \\\\ 0 \\\\ 0 \\\\ \\vdots \\\\ 0 \\\\ 0 \\\\ grad_t
              0 &              0 &              0 & \\cdots &  \\textbf{e}^3 &             0 \\\\
              0 &              0 &              0 & \\cdots & -\\textbf{e}^3 & \\textbf{e}^3 \\\\
              0 &              0 &              0 & \\cdots &              0 &             0
-\\end{bmatrix} ⋅ arg
+\\end{bmatrix} * arg
 ```
 However, this simplifies to a linear transformation when ``grad_b`` and
 ``grad_t`` are both 0:
@@ -192,7 +192,7 @@ However, this simplifies to a linear transformation when ``grad_b`` and
              0 &              0 &              0 & \\cdots &  \\textbf{e}^3 &             0 \\\\
              0 &              0 &              0 & \\cdots & -\\textbf{e}^3 & \\textbf{e}^3 \\\\
              0 &              0 &              0 & \\cdots &              0 &             0
-\\end{bmatrix} ⋅ arg
+\\end{bmatrix} * arg
 ```
 In general, when `op` has nonzero boundary conditions that make it apply an
 affine transformation, `operator_matrix(op)` will print out a warning and zero
@@ -203,8 +203,8 @@ nonlinear transformations to their arguments; that is, transformations which
 cannot be accurately approximated without using more terms of the form
 ```math
 \\textrm{op}(\\textbf{0}) +
-\\textrm{op}'(\\textbf{0}) ⋅ arg +
-\\textrm{op}''(\\textbf{0}) ⋅ arg ⋅ arg +
+\\textrm{op}'(\\textbf{0}) * arg +
+\\textrm{op}''(\\textbf{0}) * arg * arg +
 \\ldots.
 ```
 When `op` is such an operator, `operator_matrix(op)` will throw an error. In the

--- a/test/MatrixFields/flat_spaces.jl
+++ b/test/MatrixFields/flat_spaces.jl
@@ -5,7 +5,7 @@ import ClimaCore
 import .TestUtilities as TU;
 
 include("matrix_field_test_utils.jl")
-import ClimaCore.MatrixFields: @name, ⋅
+import ClimaCore.MatrixFields: @name
 
 @testset "Matrix Fields with Spectral Element and Point Spaces" begin
     get_j_field(space, FT) = fill(MatrixFields.DiagonalMatrixRow(FT(1)), space)

--- a/test/MatrixFields/gpu_compat_bidiag_matrix_row.jl
+++ b/test/MatrixFields/gpu_compat_bidiag_matrix_row.jl
@@ -18,8 +18,7 @@ using ClimaCore.MatrixFields:
     DiagonalMatrixRow,
     BidiagonalMatrixRow,
     TridiagonalMatrixRow,
-    MultiplyColumnwiseBandMatrixField,
-    ⋅
+    MultiplyColumnwiseBandMatrixField
 const C3 = Geometry.Covariant3Vector
 const CT3 = Geometry.Contravariant3Vector
 GFT = Float64
@@ -82,14 +81,14 @@ function foo(c, f)
     dtγ = FT(1)
 
     @. ∂ᶠu₃ʲ_err_∂ᶠu₃ʲ =
-        dtγ * ᶠtridiagonal_matrix_c3 ⋅ DiagonalMatrixRow(adjoint(CT3(ᶠu₃))) -
+        dtγ * ᶠtridiagonal_matrix_c3 * DiagonalMatrixRow(adjoint(CT3(ᶠu₃))) -
         (I_u₃,)
 
-    @. ∂ᶠu₃ʲ_err_∂ᶠu₃ʲ = dtγ * ᶠtridiagonal_matrix_c3 ⋅ adj_u₃ - (I_u₃,)
+    @. ∂ᶠu₃ʲ_err_∂ᶠu₃ʲ = dtγ * ᶠtridiagonal_matrix_c3 * adj_u₃ - (I_u₃,)
 
     # Fails on gpu
     @. ᶠtridiagonal_matrix_c3 =
-        -(ᶠgradᵥ_matrix()) ⋅ ifelse(
+        -(ᶠgradᵥ_matrix()) * ifelse(
             ᶜu₃ʲ.components.data.:1 > 0,
             convert(BidiagonalMatrixRow{FT}, ᶜleft_bias_matrix()),
             convert(BidiagonalMatrixRow{FT}, ᶜright_bias_matrix()),
@@ -100,7 +99,7 @@ function foo(c, f)
     @. bdmr_l = convert(BidiagonalMatrixRow{FT}, ᶜleft_bias_matrix())
     @. bdmr_r = convert(BidiagonalMatrixRow{FT}, ᶜright_bias_matrix())
     @. bdmr = ifelse(ᶜu₃ʲ.components.data.:1 > 0, bdmr_l, bdmr_r)
-    @. ᶠtridiagonal_matrix_c3 = -(ᶠgradᵥ_matrix()) ⋅ bdmr
+    @. ᶠtridiagonal_matrix_c3 = -(ᶠgradᵥ_matrix()) * bdmr
 
     return nothing
 end

--- a/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_1.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_1.jl
@@ -11,14 +11,14 @@ end
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "matrix of covectors times matrix of vectors" begin
 
-    bc = @lazy @. ᶜᶠmat_AC1 ⋅ ᶠᶜmat_C12
+    bc = @lazy @. ᶜᶠmat_AC1 * ᶠᶜmat_C12
     result = materialize(bc)
 
     ref_set_result! =
         result -> (@. result =
-            ᶜᶠmat ⋅ (
-                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:1) ⋅ ᶠᶜmat2 +
-                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:2) ⋅ ᶠᶜmat3
+            ᶜᶠmat * (
+                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:1) * ᶠᶜmat2 +
+                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:2) * ᶠᶜmat3
             ))
 
     unit_test_field_broadcast(

--- a/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_2.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_2.jl
@@ -13,17 +13,21 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
                  of numbers times matrix of covectors times matrix of \
                  vectors" begin
 
-    bc = @lazy @. ᶜᶠmat_AC1 ⋅ ᶠᶜmat_C12 ⋅ ᶜᶠmat ⋅ ᶠᶜmat_AC1 ⋅ ᶜᶠmat_C12
+    bc = @lazy @. ᶜᶠmat_AC1 * ᶠᶜmat_C12 * ᶜᶠmat * ᶠᶜmat_AC1 * ᶜᶠmat_C12
     result = materialize(bc)
 
     ref_set_result! =
         result -> (@. result =
-            ᶜᶠmat ⋅ (
-                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:1) ⋅ ᶠᶜmat2 +
-                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:2) ⋅ ᶠᶜmat3
-            ) ⋅ ᶜᶠmat ⋅ ᶠᶜmat ⋅ (
-                DiagonalMatrixRow(ᶜlg.gⁱʲ.components.data.:1) ⋅ ᶜᶠmat2 +
-                DiagonalMatrixRow(ᶜlg.gⁱʲ.components.data.:2) ⋅ ᶜᶠmat3
+            ᶜᶠmat *
+            (
+                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:1) * ᶠᶜmat2 +
+                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:2) * ᶠᶜmat3
+            ) *
+            ᶜᶠmat *
+            ᶠᶜmat *
+            (
+                DiagonalMatrixRow(ᶜlg.gⁱʲ.components.data.:1) * ᶜᶠmat2 +
+                DiagonalMatrixRow(ᶜlg.gⁱʲ.components.data.:2) * ᶜᶠmat3
             ))
 
     unit_test_field_broadcast(

--- a/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_3.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_3.jl
@@ -13,19 +13,25 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
                  and covectors times matrix of numbers and vectors times \
                  vector of numbers" begin
 
-    bc = @lazy @. ᶜᶠmat_AC1_num ⋅ ᶠᶜmat_C12_AC1 ⋅ ᶜᶠmat_num_C12 ⋅ ᶠvec
+    bc = @lazy @. ᶜᶠmat_AC1_num * ᶠᶜmat_C12_AC1 * ᶜᶠmat_num_C12 * ᶠvec
     result = materialize(bc)
 
     ref_set_result! =
         result -> (@. result = tuple(
-            ᶜᶠmat ⋅ (
-                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:1) ⋅ ᶠᶜmat2 +
-                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:2) ⋅ ᶠᶜmat3
-            ) ⋅ ᶜᶠmat ⋅ ᶠvec,
-            ᶜᶠmat ⋅ ᶠᶜmat ⋅ (
-                DiagonalMatrixRow(ᶜlg.gⁱʲ.components.data.:1) ⋅ ᶜᶠmat2 +
-                DiagonalMatrixRow(ᶜlg.gⁱʲ.components.data.:2) ⋅ ᶜᶠmat3
-            ) ⋅ ᶠvec,
+            ᶜᶠmat *
+            (
+                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:1) * ᶠᶜmat2 +
+                DiagonalMatrixRow(ᶠlg.gⁱʲ.components.data.:2) * ᶠᶜmat3
+            ) *
+            ᶜᶠmat *
+            ᶠvec,
+            ᶜᶠmat *
+            ᶠᶜmat *
+            (
+                DiagonalMatrixRow(ᶜlg.gⁱʲ.components.data.:1) * ᶜᶠmat2 +
+                DiagonalMatrixRow(ᶜlg.gⁱʲ.components.data.:2) * ᶜᶠmat3
+            ) *
+            ᶠvec,
         ))
 
     unit_test_field_broadcast(

--- a/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_4.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_4.jl
@@ -13,14 +13,14 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
                  times matrix of numbers times matrix of numbers times \
                  vector of nested values" begin
 
-    bc = @lazy @. ᶜᶠmat_NT ⋅ ᶠᶜmat ⋅ ᶜᶠmat ⋅ ᶠᶜmat_NT ⋅ ᶜvec_NT
+    bc = @lazy @. ᶜᶠmat_NT * ᶠᶜmat * ᶜᶠmat * ᶠᶜmat_NT * ᶜvec_NT
     result = materialize(bc)
 
     ref_set_result! =
         result -> (@. result = nested_type(
-            ᶜᶠmat ⋅ ᶠᶜmat ⋅ ᶜᶠmat ⋅ ᶠᶜmat ⋅ ᶜvec,
-            ᶜᶠmat2 ⋅ ᶠᶜmat ⋅ ᶜᶠmat ⋅ ᶠᶜmat2 ⋅ ᶜvec,
-            ᶜᶠmat3 ⋅ ᶠᶜmat ⋅ ᶜᶠmat ⋅ ᶠᶜmat3 ⋅ ᶜvec,
+            ᶜᶠmat * ᶠᶜmat * ᶜᶠmat * ᶠᶜmat * ᶜvec,
+            ᶜᶠmat2 * ᶠᶜmat * ᶜᶠmat * ᶠᶜmat2 * ᶜvec,
+            ᶜᶠmat3 * ᶠᶜmat * ᶜᶠmat * ᶠᶜmat3 * ᶜvec,
         ))
 
     unit_test_field_broadcast(

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_1.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_1.jl
@@ -9,7 +9,7 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "diagonal matrix times vector" begin
-    bc = @lazy @. ᶜᶜmat ⋅ ᶜvec
+    bc = @lazy @. ᶜᶜmat * ᶜvec
     result = materialize(bc)
 
     input_fields = (ᶜᶜmat, ᶜvec)

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_10.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_10.jl
@@ -10,7 +10,7 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "diagonal matrix times bi-diagonal matrix times \
                  tri-diagonal matrix times quad-diagonal matrix times \
                  vector, but with forced right-associativity" begin
-    bc = @lazy @. ᶜᶜmat ⋅ (ᶜᶠmat ⋅ (ᶠᶠmat ⋅ (ᶠᶜmat ⋅ ᶜvec)))
+    bc = @lazy @. ᶜᶜmat * (ᶜᶠmat * (ᶠᶠmat * (ᶠᶜmat * ᶜvec)))
     if using_cuda
         @test_throws invalid_ir_error materialize(bc)
         @warn "cuda is broken for this test, exiting."
@@ -20,9 +20,9 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
 
     input_fields = (ᶜᶜmat, ᶜᶠmat, ᶠᶠmat, ᶠᶜmat, ᶜvec)
     temp_value_fields = (
-        (@. ᶠᶜmat ⋅ ᶜvec),
-        (@. ᶠᶠmat ⋅ (ᶠᶜmat ⋅ ᶜvec)),
-        (@. ᶜᶠmat ⋅ (ᶠᶠmat ⋅ (ᶠᶜmat ⋅ ᶜvec))),
+        (@. ᶠᶜmat * ᶜvec),
+        (@. ᶠᶠmat * (ᶠᶜmat * ᶜvec)),
+        (@. ᶜᶠmat * (ᶠᶠmat * (ᶠᶜmat * ᶜvec))),
     )
     ref_set_result! =
         (

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_11.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_11.jl
@@ -8,15 +8,15 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "linear combination of matrix products and LinearAlgebra.I" begin
-    bc = @lazy @. 2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat + ᶠᶠmat ⋅ ᶠᶠmat / 3 - (4I,)
+    bc = @lazy @. 2 * ᶠᶜmat * ᶜᶜmat * ᶜᶠmat + ᶠᶠmat * ᶠᶠmat / 3 - (4I,)
     result = materialize(bc)
 
     input_fields = (ᶜᶜmat, ᶜᶠmat, ᶠᶠmat, ᶠᶜmat)
     temp_value_fields = (
         (@. 2 * ᶠᶜmat),
-        (@. 2 * ᶠᶜmat ⋅ ᶜᶜmat),
-        (@. 2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat),
-        (@. ᶠᶠmat ⋅ ᶠᶠmat),
+        (@. 2 * ᶠᶜmat * ᶜᶜmat),
+        (@. 2 * ᶠᶜmat * ᶜᶜmat * ᶜᶠmat),
+        (@. ᶠᶠmat * ᶠᶠmat),
     )
     ref_set_result! =
         (

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_12.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_12.jl
@@ -9,15 +9,15 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "another linear combination of matrix products and \
                  LinearAlgebra.I" begin
-    bc = @lazy @. ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat * 2 - (ᶠᶠmat / 3) ⋅ ᶠᶠmat + (4I,)
+    bc = @lazy @. ᶠᶜmat * ᶜᶜmat * ᶜᶠmat * 2 - (ᶠᶠmat / 3) * ᶠᶠmat + (4I,)
     result = materialize(bc)
 
     input_fields = (ᶜᶜmat, ᶜᶠmat, ᶠᶠmat, ᶠᶜmat)
     temp_value_fields = (
-        (@. ᶠᶜmat ⋅ ᶜᶜmat),
-        (@. ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat),
+        (@. ᶠᶜmat * ᶜᶜmat),
+        (@. ᶠᶜmat * ᶜᶜmat * ᶜᶠmat),
         (@. ᶠᶠmat / 3),
-        (@. (ᶠᶠmat / 3) ⋅ ᶠᶠmat),
+        (@. (ᶠᶠmat / 3) * ᶠᶠmat),
     )
     ref_set_result! =
         (

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_13.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_13.jl
@@ -9,16 +9,16 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "matrix times linear combination" begin
     bc =
-        @lazy @. ᶜᶠmat ⋅ (2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat + ᶠᶠmat ⋅ ᶠᶠmat / 3 - (4I,))
+        @lazy @. ᶜᶠmat * (2 * ᶠᶜmat * ᶜᶜmat * ᶜᶠmat + ᶠᶠmat * ᶠᶠmat / 3 - (4I,))
     result = materialize(bc)
 
     input_fields = (ᶜᶜmat, ᶜᶠmat, ᶠᶠmat, ᶠᶜmat)
     temp_value_fields = (
         (@. 2 * ᶠᶜmat),
-        (@. 2 * ᶠᶜmat ⋅ ᶜᶜmat),
-        (@. 2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat),
-        (@. ᶠᶠmat ⋅ ᶠᶠmat),
-        (@. 2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat + ᶠᶠmat ⋅ ᶠᶠmat / 3 - (4I,)),
+        (@. 2 * ᶠᶜmat * ᶜᶜmat),
+        (@. 2 * ᶠᶜmat * ᶜᶜmat * ᶜᶠmat),
+        (@. ᶠᶠmat * ᶠᶠmat),
+        (@. 2 * ᶠᶜmat * ᶜᶜmat * ᶜᶠmat + ᶠᶠmat * ᶠᶠmat / 3 - (4I,)),
     )
     ref_set_result! =
         (

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_14.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_14.jl
@@ -8,8 +8,8 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "linear combination times another linear combination" begin
-    bc = @lazy @. (2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat + ᶠᶠmat ⋅ ᶠᶠmat / 3 - (4I,)) ⋅
-             (ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat * 2 - (ᶠᶠmat / 3) ⋅ ᶠᶠmat + (4I,))
+    bc = @lazy @. (2 * ᶠᶜmat * ᶜᶜmat * ᶜᶠmat + ᶠᶠmat * ᶠᶠmat / 3 - (4I,)) *
+             (ᶠᶜmat * ᶜᶜmat * ᶜᶠmat * 2 - (ᶠᶠmat / 3) * ᶠᶠmat + (4I,))
     result = materialize(bc)
 
     input_fields = (ᶜᶜmat, ᶜᶠmat, ᶠᶠmat, ᶠᶜmat)
@@ -49,15 +49,15 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
 
     temp_value_fields = (
         (@. 2 * ᶠᶜmat),
-        (@. 2 * ᶠᶜmat ⋅ ᶜᶜmat),
-        (@. 2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat),
-        (@. ᶠᶠmat ⋅ ᶠᶠmat),
-        (@. 2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat + ᶠᶠmat ⋅ ᶠᶠmat / 3 - (4I,)),
-        (@. ᶠᶜmat ⋅ ᶜᶜmat),
-        (@. ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat),
+        (@. 2 * ᶠᶜmat * ᶜᶜmat),
+        (@. 2 * ᶠᶜmat * ᶜᶜmat * ᶜᶠmat),
+        (@. ᶠᶠmat * ᶠᶠmat),
+        (@. 2 * ᶠᶜmat * ᶜᶜmat * ᶜᶠmat + ᶠᶠmat * ᶠᶠmat / 3 - (4I,)),
+        (@. ᶠᶜmat * ᶜᶜmat),
+        (@. ᶠᶜmat * ᶜᶜmat * ᶜᶠmat),
         (@. ᶠᶠmat / 3),
-        (@. (ᶠᶠmat / 3) ⋅ ᶠᶠmat),
-        (@. ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat * 2 - (ᶠᶠmat / 3) ⋅ ᶠᶠmat + (4I,)),
+        (@. (ᶠᶠmat / 3) * ᶠᶠmat),
+        (@. ᶠᶜmat * ᶜᶜmat * ᶜᶠmat * 2 - (ᶠᶠmat / 3) * ᶠᶠmat + (4I,)),
     )
 
     unit_test_field_broadcast_vs_array_reference(

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_15.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_15.jl
@@ -9,10 +9,11 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "matrix times matrix times linear combination times matrix \
                  times another linear combination times matrix" begin
-    bc = @lazy @. ᶠᶜmat ⋅ ᶜᶠmat ⋅
-             (2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat + ᶠᶠmat ⋅ ᶠᶠmat / 3 - (4I,)) ⋅
-             ᶠᶠmat ⋅
-             (ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat * 2 - (ᶠᶠmat / 3) ⋅ ᶠᶠmat + (4I,)) ⋅
+    bc = @lazy @. ᶠᶜmat *
+             ᶜᶠmat *
+             (2 * ᶠᶜmat * ᶜᶜmat * ᶜᶠmat + ᶠᶠmat * ᶠᶠmat / 3 - (4I,)) *
+             ᶠᶠmat *
+             (ᶠᶜmat * ᶜᶜmat * ᶜᶠmat * 2 - (ᶠᶠmat / 3) * ᶠᶠmat + (4I,)) *
              ᶠᶠmat
     result = materialize(bc)
 
@@ -60,26 +61,29 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
         end
 
     temp_value_fields = (
-        (@. ᶠᶜmat ⋅ ᶜᶠmat),
+        (@. ᶠᶜmat * ᶜᶠmat),
         (@. 2 * ᶠᶜmat),
-        (@. 2 * ᶠᶜmat ⋅ ᶜᶜmat),
-        (@. 2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat),
-        (@. ᶠᶠmat ⋅ ᶠᶠmat),
-        (@. 2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat + ᶠᶠmat ⋅ ᶠᶠmat / 3 - (4I,)),
-        (@. ᶠᶜmat ⋅ ᶜᶠmat ⋅
-            (2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat + ᶠᶠmat ⋅ ᶠᶠmat / 3 - (4I,))),
-        (@. ᶠᶜmat ⋅ ᶜᶠmat ⋅
-            (2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat + ᶠᶠmat ⋅ ᶠᶠmat / 3 - (4I,)) ⋅
+        (@. 2 * ᶠᶜmat * ᶜᶜmat),
+        (@. 2 * ᶠᶜmat * ᶜᶜmat * ᶜᶠmat),
+        (@. ᶠᶠmat * ᶠᶠmat),
+        (@. 2 * ᶠᶜmat * ᶜᶜmat * ᶜᶠmat + ᶠᶠmat * ᶠᶠmat / 3 - (4I,)),
+        (@. ᶠᶜmat *
+            ᶜᶠmat *
+            (2 * ᶠᶜmat * ᶜᶜmat * ᶜᶠmat + ᶠᶠmat * ᶠᶠmat / 3 - (4I,))),
+        (@. ᶠᶜmat *
+            ᶜᶠmat *
+            (2 * ᶠᶜmat * ᶜᶜmat * ᶜᶠmat + ᶠᶠmat * ᶠᶠmat / 3 - (4I,)) *
             ᶠᶠmat),
-        (@. ᶠᶜmat ⋅ ᶜᶜmat),
-        (@. ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat),
+        (@. ᶠᶜmat * ᶜᶜmat),
+        (@. ᶠᶜmat * ᶜᶜmat * ᶜᶠmat),
         (@. ᶠᶠmat / 3),
-        (@. (ᶠᶠmat / 3) ⋅ ᶠᶠmat),
-        (@. ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat * 2 - (ᶠᶠmat / 3) ⋅ ᶠᶠmat + (4I,)),
-        (@. ᶠᶜmat ⋅ ᶜᶠmat ⋅
-            (2 * ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat + ᶠᶠmat ⋅ ᶠᶠmat / 3 - (4I,)) ⋅
-            ᶠᶠmat ⋅
-            (ᶠᶜmat ⋅ ᶜᶜmat ⋅ ᶜᶠmat * 2 - (ᶠᶠmat / 3) ⋅ ᶠᶠmat + (4I,))),
+        (@. (ᶠᶠmat / 3) * ᶠᶠmat),
+        (@. ᶠᶜmat * ᶜᶜmat * ᶜᶠmat * 2 - (ᶠᶠmat / 3) * ᶠᶠmat + (4I,)),
+        (@. ᶠᶜmat *
+            ᶜᶠmat *
+            (2 * ᶠᶜmat * ᶜᶜmat * ᶜᶠmat + ᶠᶠmat * ᶠᶠmat / 3 - (4I,)) *
+            ᶠᶠmat *
+            (ᶠᶜmat * ᶜᶜmat * ᶜᶠmat * 2 - (ᶠᶠmat / 3) * ᶠᶠmat + (4I,))),
     )
 
     unit_test_field_broadcast_vs_array_reference(

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_16.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_16.jl
@@ -8,9 +8,10 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "matrix constructions and multiplications" begin
-    bc = @lazy @. BidiagonalMatrixRow(ᶜᶠmat ⋅ ᶠvec, ᶜᶜmat ⋅ ᶜvec) ⋅
-             TridiagonalMatrixRow(ᶠvec, ᶠᶜmat ⋅ ᶜvec, 1) ⋅ ᶠᶠmat ⋅
-             DiagonalMatrixRow(DiagonalMatrixRow(ᶠvec) ⋅ ᶠvec)
+    bc = @lazy @. BidiagonalMatrixRow(ᶜᶠmat * ᶠvec, ᶜᶜmat * ᶜvec) *
+             TridiagonalMatrixRow(ᶠvec, ᶠᶜmat * ᶜvec, 1) *
+             ᶠᶠmat *
+             DiagonalMatrixRow(DiagonalMatrixRow(ᶠvec) * ᶠvec)
     result = materialize(bc)
 
     input_fields = (ᶜᶜmat, ᶜᶠmat, ᶠᶠmat, ᶠᶜmat, ᶜvec, ᶠvec)
@@ -44,14 +45,15 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
         end
 
     temp_value_fields = (
-        (@. BidiagonalMatrixRow(ᶜᶠmat ⋅ ᶠvec, ᶜᶜmat ⋅ ᶜvec)),
-        (@. TridiagonalMatrixRow(ᶠvec, ᶠᶜmat ⋅ ᶜvec, 1)),
-        (@. BidiagonalMatrixRow(ᶜᶠmat ⋅ ᶠvec, ᶜᶜmat ⋅ ᶜvec) ⋅
-            TridiagonalMatrixRow(ᶠvec, ᶠᶜmat ⋅ ᶜvec, 1)),
-        (@. BidiagonalMatrixRow(ᶜᶠmat ⋅ ᶠvec, ᶜᶜmat ⋅ ᶜvec) ⋅
-            TridiagonalMatrixRow(ᶠvec, ᶠᶜmat ⋅ ᶜvec, 1) ⋅ ᶠᶠmat),
+        (@. BidiagonalMatrixRow(ᶜᶠmat * ᶠvec, ᶜᶜmat * ᶜvec)),
+        (@. TridiagonalMatrixRow(ᶠvec, ᶠᶜmat * ᶜvec, 1)),
+        (@. BidiagonalMatrixRow(ᶜᶠmat * ᶠvec, ᶜᶜmat * ᶜvec) *
+            TridiagonalMatrixRow(ᶠvec, ᶠᶜmat * ᶜvec, 1)),
+        (@. BidiagonalMatrixRow(ᶜᶠmat * ᶠvec, ᶜᶜmat * ᶜvec) *
+            TridiagonalMatrixRow(ᶠvec, ᶠᶜmat * ᶜvec, 1) *
+            ᶠᶠmat),
         (@. DiagonalMatrixRow(ᶠvec)),
-        (@. DiagonalMatrixRow(DiagonalMatrixRow(ᶠvec) ⋅ ᶠvec)),
+        (@. DiagonalMatrixRow(DiagonalMatrixRow(ᶠvec) * ᶠvec)),
     )
     unit_test_field_broadcast_vs_array_reference(
         result,

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_2.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_2.jl
@@ -8,7 +8,7 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "tri-diagonal matrix times vector" begin
-    bc = @lazy @. ᶠᶠmat ⋅ ᶠvec
+    bc = @lazy @. ᶠᶠmat * ᶠvec
     result = materialize(bc)
 
     input_fields = (ᶠᶠmat, ᶠvec)

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_3.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_3.jl
@@ -8,7 +8,7 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "quad-diagonal matrix times vector" begin
-    bc = @lazy @. ᶠᶜmat ⋅ ᶜvec
+    bc = @lazy @. ᶠᶜmat * ᶜvec
     result = materialize(bc)
 
     input_fields = (ᶠᶜmat, ᶜvec)

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_4.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_4.jl
@@ -8,7 +8,7 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "diagonal matrix times bi-diagonal matrix" begin
-    bc = @lazy @. ᶜᶜmat ⋅ ᶜᶠmat
+    bc = @lazy @. ᶜᶜmat * ᶜᶠmat
     result = materialize(bc)
 
     input_fields = (ᶜᶜmat, ᶜᶠmat)

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_5.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_5.jl
@@ -8,7 +8,7 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "tri-diagonal matrix times tri-diagonal matrix" begin
-    bc = @lazy @. ᶠᶠmat ⋅ ᶠᶠmat
+    bc = @lazy @. ᶠᶠmat * ᶠᶠmat
     result = materialize(bc)
 
     input_fields = (ᶠᶠmat,)

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_6.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_6.jl
@@ -8,7 +8,7 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 #! format: on
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "quad-diagonal matrix times diagonal matrix" begin
-    bc = @lazy @. ᶠᶜmat ⋅ ᶜᶜmat
+    bc = @lazy @. ᶠᶜmat * ᶜᶜmat
     result = materialize(bc)
 
     input_fields = (ᶠᶜmat, ᶜᶜmat)

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_7.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_7.jl
@@ -9,11 +9,11 @@ include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcas
 test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "diagonal matrix times bi-diagonal matrix times \
                  tri-diagonal matrix times quad-diagonal matrix" begin
-    bc = @lazy @. ᶜᶜmat ⋅ ᶜᶠmat ⋅ ᶠᶠmat ⋅ ᶠᶜmat
+    bc = @lazy @. ᶜᶜmat * ᶜᶠmat * ᶠᶠmat * ᶠᶜmat
     result = materialize(bc)
 
     input_fields = (ᶜᶜmat, ᶜᶠmat, ᶠᶠmat, ᶠᶜmat)
-    temp_value_fields = ((@. ᶜᶜmat ⋅ ᶜᶠmat), (@. ᶜᶜmat ⋅ ᶜᶠmat ⋅ ᶠᶠmat))
+    temp_value_fields = ((@. ᶜᶜmat * ᶜᶠmat), (@. ᶜᶜmat * ᶜᶠmat * ᶠᶠmat))
     ref_set_result! =
         (_result, _ᶜᶜmat, _ᶜᶠmat, _ᶠᶠmat, _ᶠᶜmat, _temp1, _temp2) -> begin
             mul!(_temp1, _ᶜᶜmat, _ᶜᶠmat)

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_8.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_8.jl
@@ -10,7 +10,7 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "diagonal matrix times bi-diagonal matrix times \
                  tri-diagonal matrix times quad-diagonal matrix, but with \
                  forced right-associativity" begin
-    bc = @lazy @. ᶜᶜmat ⋅ (ᶜᶠmat ⋅ (ᶠᶠmat ⋅ ᶠᶜmat))
+    bc = @lazy @. ᶜᶜmat * (ᶜᶠmat * (ᶠᶠmat * ᶠᶜmat))
     if using_cuda
         @test_throws invalid_ir_error materialize(bc)
         @warn "cuda is broken for this test, exiting."
@@ -19,7 +19,7 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
     result = materialize(bc)
 
     input_fields = (ᶜᶜmat, ᶜᶠmat, ᶠᶠmat, ᶠᶜmat)
-    temp_value_fields = ((@. ᶠᶠmat ⋅ ᶠᶜmat), (@. ᶜᶠmat ⋅ (ᶠᶠmat ⋅ ᶠᶜmat)))
+    temp_value_fields = ((@. ᶠᶠmat * ᶠᶜmat), (@. ᶜᶠmat * (ᶠᶠmat * ᶠᶜmat)))
     ref_set_result! =
         (_result, _ᶜᶜmat, _ᶜᶠmat, _ᶠᶠmat, _ᶠᶜmat, _temp1, _temp2) -> begin
             mul!(_temp1, _ᶠᶠmat, _ᶠᶜmat)

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_9.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_9.jl
@@ -10,14 +10,14 @@ test_opt = get(ENV, "BUILDKITE", "") == "true"
 @testset "diagonal matrix times bi-diagonal matrix times \
                  tri-diagonal matrix times quad-diagonal matrix times \
                  vector" begin
-    bc = @lazy @. ᶜᶜmat ⋅ ᶜᶠmat ⋅ ᶠᶠmat ⋅ ᶠᶜmat ⋅ ᶜvec
+    bc = @lazy @. ᶜᶜmat * ᶜᶠmat * ᶠᶠmat * ᶠᶜmat * ᶜvec
     result = materialize(bc)
 
     input_fields = (ᶜᶜmat, ᶜᶠmat, ᶠᶠmat, ᶠᶜmat, ᶜvec)
     temp_value_fields = (
-        (@. ᶜᶜmat ⋅ ᶜᶠmat),
-        (@. ᶜᶜmat ⋅ ᶜᶠmat ⋅ ᶠᶠmat),
-        (@. ᶜᶜmat ⋅ ᶜᶠmat ⋅ ᶠᶠmat ⋅ ᶠᶜmat),
+        (@. ᶜᶜmat * ᶜᶠmat),
+        (@. ᶜᶜmat * ᶜᶠmat * ᶠᶠmat),
+        (@. ᶜᶜmat * ᶜᶠmat * ᶠᶠmat * ᶠᶜmat),
     )
     ref_set_result! =
         (

--- a/test/MatrixFields/matrix_multiplication_at_boundaries.jl
+++ b/test/MatrixFields/matrix_multiplication_at_boundaries.jl
@@ -42,7 +42,7 @@ end
     nan_outside_entries!(ᶠᶜmatrix_with_outside_entries)
 
     # Test all possible products of matrix fields that include outside entries.
-    # Ensure that ⋅ never makes use of the outside entries.
+    # Ensure that matrix multiplication never makes use of the outside entries.
     for (matrix_field1, matrix_field2) in (
         (ᶜᶜmatrix_with_outside_entries, ᶜᶜmatrix_with_outside_entries),
         (ᶜᶜmatrix_with_outside_entries, ᶜᶠmatrix_with_outside_entries),
@@ -65,6 +65,6 @@ end
         (ᶠᶠmatrix_without_outside_entries, ᶠᶠmatrix_with_outside_entries),
         (ᶠᶠmatrix_without_outside_entries, ᶠᶜmatrix_with_outside_entries),
     )
-        @test !any(isnan, parent(@. matrix_field1 ⋅ matrix_field2))
+        @test !any(isnan, parent(@. matrix_field1 * matrix_field2))
     end
 end

--- a/test/MatrixFields/matrix_multiplication_recursion.jl
+++ b/test/MatrixFields/matrix_multiplication_recursion.jl
@@ -5,7 +5,6 @@ import ClimaCore
 import .TestUtilities as TU;
 
 import ClimaCore: Spaces, Geometry, Operators, Fields, MatrixFields
-import ClimaCore.MatrixFields: ⋅
 import ClimaComms
 ClimaComms.@import_required_backends
 
@@ -68,9 +67,10 @@ fill!(parent(dest_field), NaN)
 # Test field update with multiple nested operations
 function update_field!(dest_field, K, dψdϑ_res)
     @. dest_field =
-        divf2c_matrix() ⋅ (
-            MatrixFields.DiagonalMatrixRow(interpc2f_op(-K)) ⋅
-            gradc2f_matrix() ⋅ MatrixFields.DiagonalMatrixRow(dψdϑ_res) +
+        divf2c_matrix() * (
+            MatrixFields.DiagonalMatrixRow(interpc2f_op(-K)) *
+            gradc2f_matrix() *
+            MatrixFields.DiagonalMatrixRow(dψdϑ_res) +
             MatrixFields.LowerDiagonalMatrixRow(
                 topBC_op(Geometry.Covariant3Vector(zero(interpc2f_op(K)))),
             )

--- a/test/MatrixFields/operator_matrices.jl
+++ b/test/MatrixFields/operator_matrices.jl
@@ -41,13 +41,13 @@ import ClimaCore.Operators:
 
 include("matrix_field_test_utils.jl")
 
-apply_op_matrix(::Nothing, op_matrix, arg) = @lazy @. op_matrix() ⋅ arg
+apply_op_matrix(::Nothing, op_matrix, arg) = @lazy @. op_matrix() * arg
 apply_op_matrix(boundary_op, op_matrix, arg) =
-    @lazy @. boundary_op(op_matrix() ⋅ arg)
+    @lazy @. boundary_op(op_matrix() * arg)
 apply_op_matrix(::Nothing, op_matrix, arg1, arg2) =
-    @lazy @. op_matrix(arg1) ⋅ arg2
+    @lazy @. op_matrix(arg1) * arg2
 apply_op_matrix(boundary_op, op_matrix, arg1, arg2) =
-    @lazy @. boundary_op(op_matrix(arg1) ⋅ arg2)
+    @lazy @. boundary_op(op_matrix(arg1) * arg2)
 
 apply_op(::Nothing, op, args...) = @lazy @. op(args...)
 apply_op(boundary_op, op, args...) = @lazy @. boundary_op(op(args...))
@@ -225,36 +225,42 @@ end
     ᶜdiv_matrix = MatrixFields.operator_matrix(ᶜdiv)
     ᶠcurl_matrix = MatrixFields.operator_matrix(ᶠcurl)
 
-    @test_throws "does not contain any Fields" @. ᶜlbias_matrix() ⋅
+    @test_throws "does not contain any Fields" @. ᶜlbias_matrix() *
                                                   ᶠinterp_matrix()
 
     ᶜ0 = @. zero(ᶜscalar)
     ᶜ1 = @. one(ᶜscalar)
     ᶠ1 = @. one(ᶠscalar)
     for get_result in (
-        @lazy(@. ᶜlbias_matrix() ⋅ ᶠinterp_matrix() + DiagonalMatrixRow(ᶜ0)),
-        @lazy(@. DiagonalMatrixRow(ᶜ0) + ᶜlbias_matrix() ⋅ ᶠinterp_matrix()),
-        @lazy(@. ᶜlbias_matrix() ⋅ ᶠinterp_matrix() ⋅ DiagonalMatrixRow(ᶜ1)),
-        @lazy(@. ᶜlbias_matrix() ⋅ DiagonalMatrixRow(ᶠ1) ⋅ ᶠinterp_matrix()),
-        @lazy(@. DiagonalMatrixRow(ᶜ1) ⋅ ᶜlbias_matrix() ⋅ ᶠinterp_matrix()),
+        @lazy(@. ᶜlbias_matrix() * ᶠinterp_matrix() + DiagonalMatrixRow(ᶜ0)),
+        @lazy(@. DiagonalMatrixRow(ᶜ0) + ᶜlbias_matrix() * ᶠinterp_matrix()),
+        @lazy(@. ᶜlbias_matrix() * ᶠinterp_matrix() * DiagonalMatrixRow(ᶜ1)),
+        @lazy(@. ᶜlbias_matrix() * DiagonalMatrixRow(ᶠ1) * ᶠinterp_matrix()),
+        @lazy(@. DiagonalMatrixRow(ᶜ1) * ᶜlbias_matrix() * ᶠinterp_matrix()),
     )
         test_field_broadcast(;
             test_name = "product of two lazy operator matrices",
             get_result,
-            set_result = @lazy(@. ᶜlbias_matrix() ⋅ ᶠinterp_matrix()),
+            set_result = @lazy(@. ᶜlbias_matrix() * ᶠinterp_matrix()),
         )
     end
 
     test_field_broadcast(;
         test_name = "product of six operator matrices",
         get_result = @lazy(
-            @. ᶜflux_correct_matrix(ᶠuvw) ⋅ ᶜadvect_matrix(ᶠuvw) ⋅
-               ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠrbias_matrix() ⋅ ᶜlbias_matrix() ⋅
+            @. ᶜflux_correct_matrix(ᶠuvw) *
+               ᶜadvect_matrix(ᶠuvw) *
+               ᶜwinterp_matrix(ᶠscalar) *
+               ᶠrbias_matrix() *
+               ᶜlbias_matrix() *
                ᶠinterp_matrix()
         ),
         set_result = @lazy(
-            @. ᶜflux_correct_matrix(ᶠuvw) ⋅ ᶜadvect_matrix(ᶠuvw) ⋅
-               ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠrbias_matrix() ⋅ ᶜlbias_matrix() ⋅
+            @. ᶜflux_correct_matrix(ᶠuvw) *
+               ᶜadvect_matrix(ᶠuvw) *
+               ᶜwinterp_matrix(ᶠscalar) *
+               ᶠrbias_matrix() *
+               ᶜlbias_matrix() *
                ᶠinterp_matrix()
         ),
     )
@@ -263,14 +269,22 @@ end
         test_name = "applying six operators to a nested field using operator \
                      matrices",
         get_result = @lazy(
-            @. ᶜflux_correct_matrix(ᶠuvw) ⋅ ᶜadvect_matrix(ᶠuvw) ⋅
-               ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠrbias_matrix() ⋅ ᶜlbias_matrix() ⋅
-               ᶠinterp_matrix() ⋅ ᶜnested
+            @. ᶜflux_correct_matrix(ᶠuvw) *
+               ᶜadvect_matrix(ᶠuvw) *
+               ᶜwinterp_matrix(ᶠscalar) *
+               ᶠrbias_matrix() *
+               ᶜlbias_matrix() *
+               ᶠinterp_matrix() *
+               ᶜnested
         ),
         set_result = @lazy(
-            @. ᶜflux_correct_matrix(ᶠuvw) ⋅ ᶜadvect_matrix(ᶠuvw) ⋅
-               ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠrbias_matrix() ⋅ ᶜlbias_matrix() ⋅
-               ᶠinterp_matrix() ⋅ ᶜnested
+            @. ᶜflux_correct_matrix(ᶠuvw) *
+               ᶜadvect_matrix(ᶠuvw) *
+               ᶜwinterp_matrix(ᶠscalar) *
+               ᶠrbias_matrix() *
+               ᶜlbias_matrix() *
+               ᶠinterp_matrix() *
+               ᶜnested
         ),
         ref_set_result = @lazy(
             @. ᶜflux_correct(
@@ -287,21 +301,21 @@ end
         test_name = "applying six operators to a nested field using operator \
                      matrices, but with forced right associativity",
         get_result = @lazy(
-            @. ᶜflux_correct_matrix(ᶠuvw) ⋅ (
-                ᶜadvect_matrix(ᶠuvw) ⋅ (
-                    ᶜwinterp_matrix(ᶠscalar) ⋅ (
-                        ᶠrbias_matrix() ⋅
-                        (ᶜlbias_matrix() ⋅ (ᶠinterp_matrix() ⋅ ᶜnested))
+            @. ᶜflux_correct_matrix(ᶠuvw) * (
+                ᶜadvect_matrix(ᶠuvw) * (
+                    ᶜwinterp_matrix(ᶠscalar) * (
+                        ᶠrbias_matrix() *
+                        (ᶜlbias_matrix() * (ᶠinterp_matrix() * ᶜnested))
                     )
                 )
             )
         ),
         set_result = @lazy(
-            @. ᶜflux_correct_matrix(ᶠuvw) ⋅ (
-                ᶜadvect_matrix(ᶠuvw) ⋅ (
-                    ᶜwinterp_matrix(ᶠscalar) ⋅ (
-                        ᶠrbias_matrix() ⋅
-                        (ᶜlbias_matrix() ⋅ (ᶠinterp_matrix() ⋅ ᶜnested))
+            @. ᶜflux_correct_matrix(ᶠuvw) * (
+                ᶜadvect_matrix(ᶠuvw) * (
+                    ᶜwinterp_matrix(ᶠscalar) * (
+                        ᶠrbias_matrix() *
+                        (ᶜlbias_matrix() * (ᶠinterp_matrix() * ᶜnested))
                     )
                 )
             )
@@ -325,16 +339,23 @@ end
     # false positive, a compiler issue, or a sign that the code can be improved?
     for get_result in (
         @lazy(
-            @. (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠcurl_matrix() *
+            @. (c12_b',) *
+               ᶜwinterp_matrix(ᶠscalar) *
+               ᶠcurl_matrix() *
                (c12_a,) +
                (DiagonalMatrixRow(ᶜdiv(ᶠuvw)) - ᶜadvect_matrix(ᶠuvw)) / 5
         ),
         @lazy(
-            @. ᶜdiv_matrix() ⋅ DiagonalMatrixRow(ᶠscalar) ⋅ ᶠgrad_matrix() ⋅ (
-                (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠcurl_matrix() *
-                (c12_a,) +
-                (DiagonalMatrixRow(ᶜdiv(ᶠuvw)) - ᶜadvect_matrix(ᶠuvw)) / 5
-            )
+            @. ᶜdiv_matrix() *
+               DiagonalMatrixRow(ᶠscalar) *
+               ᶠgrad_matrix() *
+               (
+                   (c12_b',) *
+                   ᶜwinterp_matrix(ᶠscalar) *
+                   ᶠcurl_matrix() *
+                   (c12_a,) +
+                   (DiagonalMatrixRow(ᶜdiv(ᶠuvw)) - ᶜadvect_matrix(ᶠuvw)) / 5
+               )
         ),
     )
         materialize(get_result)
@@ -345,20 +366,28 @@ end
         test_name = "non-trivial combination of operator matrices and other \
                      matrix fields",
         get_result = @lazy(
-            @. ᶠupwind_matrix(ᶠuvw) ⋅ (
-                ᶜdiv_matrix() ⋅ DiagonalMatrixRow(ᶠscalar) ⋅ ᶠgrad_matrix() ⋅
+            @. ᶠupwind_matrix(ᶠuvw) * (
+                ᶜdiv_matrix() *
+                DiagonalMatrixRow(ᶠscalar) *
+                ᶠgrad_matrix() *
                 (
-                    (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠcurl_matrix() *
+                    (c12_b',) *
+                    ᶜwinterp_matrix(ᶠscalar) *
+                    ᶠcurl_matrix() *
                     (c12_a,) +
                     (DiagonalMatrixRow(ᶜdiv(ᶠuvw)) - ᶜadvect_matrix(ᶠuvw)) / 5
                 ) - (2I,)
             )
         ),
         set_result = @lazy(
-            @. ᶠupwind_matrix(ᶠuvw) ⋅ (
-                ᶜdiv_matrix() ⋅ DiagonalMatrixRow(ᶠscalar) ⋅ ᶠgrad_matrix() ⋅
+            @. ᶠupwind_matrix(ᶠuvw) * (
+                ᶜdiv_matrix() *
+                DiagonalMatrixRow(ᶠscalar) *
+                ᶠgrad_matrix() *
                 (
-                    (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠcurl_matrix() *
+                    (c12_b',) *
+                    ᶜwinterp_matrix(ᶠscalar) *
+                    ᶠcurl_matrix() *
                     (c12_a,) +
                     (DiagonalMatrixRow(ᶜdiv(ᶠuvw)) - ᶜadvect_matrix(ᶠuvw)) / 5
                 ) - (2I,)
@@ -368,31 +397,45 @@ end
 
     # TODO: This case's reference function takes too long to compile on both
     # CPUs and GPUs (more than half an hour), as of Julia 1.9. This might be
-    # happening because of excessive inlining---aside from ⋅, all other finite
+    # happening because of excessive inlining---aside from *, all other finite
     # difference operators use @propagate_inbounds. So, the reference function
     # is currently disabled, although the test does pass when it is enabled.
     test_field_broadcast(;
         test_name = "applying a non-trivial sequence of operations to a scalar \
                      field using operator matrices and other matrix fields",
         get_result = @lazy(
-            @. ᶠupwind_matrix(ᶠuvw) ⋅ (
-                ᶜdiv_matrix() ⋅ DiagonalMatrixRow(ᶠscalar) ⋅ ᶠgrad_matrix() ⋅
-                (
-                    (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠcurl_matrix() *
-                    (c12_a,) +
-                    (DiagonalMatrixRow(ᶜdiv(ᶠuvw)) - ᶜadvect_matrix(ᶠuvw)) / 5
-                ) - (2I,)
-            ) ⋅ ᶜscalar
+            @. ᶠupwind_matrix(ᶠuvw) *
+               (
+                   ᶜdiv_matrix() *
+                   DiagonalMatrixRow(ᶠscalar) *
+                   ᶠgrad_matrix() *
+                   (
+                       (c12_b',) *
+                       ᶜwinterp_matrix(ᶠscalar) *
+                       ᶠcurl_matrix() *
+                       (c12_a,) +
+                       (DiagonalMatrixRow(ᶜdiv(ᶠuvw)) - ᶜadvect_matrix(ᶠuvw)) /
+                       5
+                   ) - (2I,)
+               ) *
+               ᶜscalar
         ),
         set_result = @lazy(
-            @. ᶠupwind_matrix(ᶠuvw) ⋅ (
-                ᶜdiv_matrix() ⋅ DiagonalMatrixRow(ᶠscalar) ⋅ ᶠgrad_matrix() ⋅
-                (
-                    (c12_b',) * ᶜwinterp_matrix(ᶠscalar) ⋅ ᶠcurl_matrix() *
-                    (c12_a,) +
-                    (DiagonalMatrixRow(ᶜdiv(ᶠuvw)) - ᶜadvect_matrix(ᶠuvw)) / 5
-                ) - (2I,)
-            ) ⋅ ᶜscalar
+            @. ᶠupwind_matrix(ᶠuvw) *
+               (
+                   ᶜdiv_matrix() *
+                   DiagonalMatrixRow(ᶠscalar) *
+                   ᶠgrad_matrix() *
+                   (
+                       (c12_b',) *
+                       ᶜwinterp_matrix(ᶠscalar) *
+                       ᶠcurl_matrix() *
+                       (c12_a,) +
+                       (DiagonalMatrixRow(ᶜdiv(ᶠuvw)) - ᶜadvect_matrix(ᶠuvw)) /
+                       5
+                   ) - (2I,)
+               ) *
+               ᶜscalar
         ),
         # ref_set_result = @lazy(@. ᶠupwind(
         #     ᶠuvw,


### PR DESCRIPTION
<!-- Provide a clear description of the content -->

This PR removes the alias `const ⋅ = MultiplyColumnwiseBandMatrixField()` and allows us to use the standard `*` symbol to denote matrix multiplication. All internal uses of `⋅` have been replaced with `*`, and the exported `⋅` symbol has been replaced with `const ⋅ = *`. This export is necessary to avoid breaking ClimaAtmos for now, but it should be removed before the next major release of ClimaCore. (The `⋅` symbol cannot be marked as deprecated because `@deprecate` only works for function calls.)

This PR supersedes #2229 and closes #1774.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
