### PR TITLE
Updates to masked spaces

### DIFF
--- a/src/DataLayouts/DataLayouts.jl
+++ b/src/DataLayouts/DataLayouts.jl
@@ -2330,8 +2330,17 @@ function ColumnMask(
     @assert Nq isa Integer
     @assert Nh isa Integer
     T = horizontal_layout_type
-    is_active = replace_basetype(T{FT, Nq}(Array{FT}, Nh), Bool)
-    Nijh = Nq * Nq * Nh
+    is_active = replace_basetype(T{FT, Nq}(DA{FT}, Nh), Bool)
+    parent(is_active) .= true
+    return IJHMask(is_active)
+end
+
+union_all_type(::Type{T}) where {T} = T.name.wrapper
+
+function IJHMask(is_active::Union{IJFH, IJHF})
+    DA = union_all_type(typeof(parent(is_active)))
+    (Ni, Nj, _, _, Nh) = size(is_active)
+    Nijh = Ni * Nj * Nh
     i_map = zeros(Int, Nijh)
     j_map = zeros(Int, Nijh)
     h_map = zeros(Int, Nijh)

--- a/src/Fields/broadcast.jl
+++ b/src/Fields/broadcast.jl
@@ -92,7 +92,7 @@ function Base.copy(
         throw(BroadcastInferenceError(bc))
     end
     # We can trust it and defer to the simpler `copyto!`
-    return copyto!(similar(bc, ElType), bc, DataLayouts.NoMask())
+    return copyto!(similar(bc, ElType), bc, Spaces.get_mask(axes(bc)))
 end
 
 Base.@propagate_inbounds function slab(

--- a/src/Spaces/spectralelement.jl
+++ b/src/Spaces/spectralelement.jl
@@ -20,6 +20,11 @@ function Base.show(io::IO, space::AbstractSpectralElementSpace)
     indent = get(io, :indent, 0)
     iio = IOContext(io, :indent => indent + 2)
     println(io, nameof(typeof(space)), ":")
+    if get_mask(space) isa DataLayouts.NoMask
+        println(iio, " "^(indent + 2), "mask_enabled: false")
+    else
+        println(iio, " "^(indent + 2), "mask_enabled: true")
+    end
     if hasfield(typeof(grid(space)), :topology)
         # some reduced spaces (like slab space) do not have topology
         print(iio, " "^(indent + 2), "context: ")


### PR DESCRIPTION
Closes #2226. This is somewhat of a peel off from #2212.

This PR:
 - initializes masks to true everywhere by default
 - Adds masks to the show method for spaces
 - Extracts the mask from the axes of the broadcasted objects