### PR TITLE
Temporarily disable FD shmem

### DIFF
--- a/ext/cuda/operators_finite_difference.jl
+++ b/ext/cuda/operators_finite_difference.jl
@@ -46,10 +46,11 @@ function Base.copyto!(
 
     # TODO: Use CUDA.limit(CUDA.LIMIT_SHMEM_SIZE) to determine how much shmem should be used
     # TODO: add shmem support for masked operations
-    if Operators.any_fd_shmem_supported(bc) &&
-       !high_resolution &&
-       mask isa NoMask &&
-       enough_shmem
+    # if Operators.any_fd_shmem_supported(bc) &&
+    #    !high_resolution &&
+    #    mask isa NoMask &&
+    #    enough_shmem
+    if false
         p = fd_stencil_partition(us, n_face_levels)
         args = (
             strip_space(out, space),


### PR DESCRIPTION
Found in https://github.com/CliMA/ClimaAtmos.jl/pull/3709, the shmem commit breaks some examples. This PR disables it. We can re-enable it once we find out what the issue is.

I'm going to test this branch out before merging / releasing to be sure.