### PR TITLE
Add FD shmem bug reproducer

### DIFF
--- a/ext/cuda/operators_finite_difference.jl
+++ b/ext/cuda/operators_finite_difference.jl
@@ -51,11 +51,10 @@ function Base.copyto!(
 
     # TODO: Use CUDA.limit(CUDA.LIMIT_SHMEM_SIZE) to determine how much shmem should be used
     # TODO: add shmem support for masked operations
-    # if Operators.any_fd_shmem_supported(bc) &&
-    #    !high_resolution &&
-    #    mask isa NoMask &&
-    #    enough_shmem
-    if false
+    if Operators.any_fd_shmem_supported(bc) &&
+       !high_resolution &&
+       mask isa NoMask &&
+       enough_shmem
         p = fd_stencil_partition(us, n_face_levels)
         args = (
             strip_space(out, space),

--- a/test/Operators/finitedifference/unit_fd_ops_shared_memory.jl
+++ b/test/Operators/finitedifference/unit_fd_ops_shared_memory.jl
@@ -68,6 +68,35 @@ end
     @test compare_cpu_gpu(fields_cpu.ᶜout_uₕ, fields.ᶜout_uₕ); @test !is_trivial(fields_cpu.ᶜout_uₕ)
 end
 
+@testset "Correctness plane" begin
+    ᶜspace_cpu = get_space_plane(ClimaComms.CPUSingleThreaded(), Float64);
+    ᶠspace_cpu = Spaces.face_space(ᶜspace_cpu);
+    fields_cpu = (; get_fields(ᶜspace_cpu)..., get_fields(ᶠspace_cpu)...);
+    kernels!(fields_cpu)
+    @info "Compiled CPU kernels"
+
+    ᶜspace = get_space_plane(ClimaComms.device(), Float64);
+    ClimaComms.device(ᶜspace) isa ClimaComms.CPUSingleThreaded && @warn "Running on the CPU"
+    ᶠspace = Spaces.face_space(ᶜspace);
+    fields = (; get_fields(ᶜspace)..., get_fields(ᶠspace)...);
+    kernels!(fields)
+    @info "Compiled GPU kernels"
+
+    @test compare_cpu_gpu(fields_cpu.ᶜout1, fields.ᶜout1); @test !is_trivial(fields_cpu.ᶜout1)
+    @test compare_cpu_gpu(fields_cpu.ᶜout2, fields.ᶜout2); @test !is_trivial(fields_cpu.ᶜout2)
+    @test compare_cpu_gpu(fields_cpu.ᶜout3, fields.ᶜout3); @test !is_trivial(fields_cpu.ᶜout3)
+    @test compare_cpu_gpu(fields_cpu.ᶜout4, fields.ᶜout4); @test !is_trivial(fields_cpu.ᶜout4)
+    @test compare_cpu_gpu(fields_cpu.ᶜout5, fields.ᶜout5); @test !is_trivial(fields_cpu.ᶜout5)
+    @test compare_cpu_gpu(fields_cpu.ᶜout6, fields.ᶜout6); @test !is_trivial(fields_cpu.ᶜout6)
+    @test compare_cpu_gpu(fields_cpu.ᶜout7, fields.ᶜout7); @test !is_trivial(fields_cpu.ᶜout7)
+    @test compare_cpu_gpu(fields_cpu.ᶜout8, fields.ᶜout8); @test !is_trivial(fields_cpu.ᶜout8)
+    @test compare_cpu_gpu(fields_cpu.ᶠout1_contra, fields.ᶠout1_contra); @test !is_trivial(fields_cpu.ᶠout1_contra)
+    @test compare_cpu_gpu(fields_cpu.ᶠout2_contra, fields.ᶠout2_contra); @test !is_trivial(fields_cpu.ᶠout2_contra)
+    @test compare_cpu_gpu(fields_cpu.ᶜout9, fields.ᶜout9); @test !is_trivial(fields_cpu.ᶜout9)
+    @test compare_cpu_gpu(fields_cpu.ᶜout10, fields.ᶜout10); @test !is_trivial(fields_cpu.ᶜout10)
+    @test compare_cpu_gpu(fields_cpu.ᶜout_uₕ, fields.ᶜout_uₕ); @test !is_trivial(fields_cpu.ᶜout_uₕ)
+end
+
 @testset "Correctness extruded cubed sphere" begin
     ᶜspace_cpu = get_space_extruded(ClimaComms.CPUSingleThreaded(), Float64);
     ᶠspace_cpu = Spaces.face_space(ᶜspace_cpu);

--- a/test/Operators/finitedifference/utils_fd_ops_shared_memory.jl
+++ b/test/Operators/finitedifference/utils_fd_ops_shared_memory.jl
@@ -240,7 +240,7 @@ function compare_cpu_gpu(cpu, gpu; print_diff = true, C_best = 10)
             @show parent(cpu)[(end - 3):end, 1, 1, end]
             @show parent(gpu)[(end - 3):end, 1, 1, end]
         else
-            error("Unsupported type")
+            error("Unsupported type: $(typeof(z))")
         end
     end
     return gpu_matches_cpu
@@ -278,7 +278,7 @@ function compare_cpu_gpu_incremental(cpu, gpu; print_diff = true, C_best = 10)
             @show parent(cpu)[(end - 3):end, 1, 1, end]
             @show parent(gpu)[(end - 3):end, 1, 1, end]
         else
-            error("Unsupported type")
+            error("Unsupported type: $(typeof(z))")
         end
     end
     return true


### PR DESCRIPTION
This PR adds a unit test that reproduces the bug found in the FD shmem implementation, and applies the bugfix.

The bug was due to us grabbing the nodal points using `(Nq, _, _, Nv, Nh) = DataLayouts.universal_size(us)`, and this is wrong for 1D spectral element cases, which is exactly the subset of jobs that were failing.

This was a bit tricky to chase down because most kernels were unaffected, but kernels of the form `@. x += div(f)` broke for 1D SEM cases with sufficiently high horizontal resolution, because there is a race condition on reading and writing `x` between multiple threadblocks.