### PR TITLE
Fix missing char in matrix_fields docs

### DIFF
--- a/docs/src/matrix_fields.md
+++ b/docs/src/matrix_fields.md
@@ -28,12 +28,12 @@ operator_matrix
 
 ## Vectors and Matrices of Fields
 
-``@docs
+```@docs
 FieldNameDict
 identity_field_matrix
 field_vector_view
 concrete_field_vector
-``
+```
 
 ## Linear Solvers
 


### PR DESCRIPTION
Makes the "Vectors and Matrices of Fields" API display correctly. 
