### PR TITLE
Add shmem for GradientC2F

### DIFF
--- a/ext/cuda/operators_fd_shmem.jl
+++ b/ext/cuda/operators_fd_shmem.jl
@@ -1,6 +1,7 @@
 import ClimaCore: DataLayouts, Spaces, Geometry, RecursiveApply, DataLayouts
 import CUDA
 import ClimaCore.Operators: return_eltype, get_local_geometry
+import ClimaCore.Geometry: ⊗
 
 Base.@propagate_inbounds function fd_operator_shmem(
     space,
@@ -90,5 +91,105 @@ Base.@propagate_inbounds function fd_operator_evaluate(
         Ju³₋ = Ju³[vt]   # corresponds to idx - half
         Ju³₊ = Ju³[vt + 1] # corresponds to idx + half
         return (Ju³₊ ⊟ Ju³₋) ⊠ local_geometry.invJ
+    end
+end
+
+Base.@propagate_inbounds function fd_operator_shmem(
+    space,
+    ::Val{Nvt},
+    op::Operators.GradientC2F,
+    args...,
+) where {Nvt}
+    # allocate temp output
+    RT = return_eltype(op, args...)
+    u = CUDA.CuStaticSharedArray(RT, (Nvt,)) # cell centers
+    lb = CUDA.CuStaticSharedArray(RT, (1,)) # left boundary
+    rb = CUDA.CuStaticSharedArray(RT, (1,)) # right boundary
+    return (u, lb, rb)
+end
+
+Base.@propagate_inbounds function fd_operator_fill_shmem_interior!(
+    op::Operators.GradientC2F,
+    (u, lb, rb),
+    loc, # can be any location
+    space,
+    idx::Integer,
+    hidx,
+    arg,
+)
+    @inbounds begin
+        vt = threadIdx().x
+        cov3 = Geometry.Covariant3Vector(1)
+        u[vt] = cov3 ⊗ Operators.getidx(space, arg, loc, idx, hidx)
+    end
+    return nothing
+end
+
+Base.@propagate_inbounds function fd_operator_fill_shmem_left_boundary!(
+    op::Operators.GradientC2F,
+    bc::Operators.SetValue,
+    (u, lb, rb),
+    loc,
+    space,
+    idx::Integer,
+    hidx,
+    arg,
+)
+    idx == Operators.left_center_boundary_idx(space) ||
+        error("Incorrect left idx")
+    @inbounds begin
+        vt = threadIdx().x
+        cov3 = Geometry.Covariant3Vector(1)
+        u[vt] = cov3 ⊗ Operators.getidx(space, arg, loc, idx, hidx)
+        lb[1] = cov3 ⊗ Operators.getidx(space, bc.val, loc, nothing, hidx)
+    end
+    return nothing
+end
+
+Base.@propagate_inbounds function fd_operator_fill_shmem_right_boundary!(
+    op::Operators.GradientC2F,
+    bc::Operators.SetValue,
+    (u, lb, rb),
+    loc,
+    space,
+    idx::Integer,
+    hidx,
+    arg,
+)
+    # The right boundary is called at `idx + 1`, so we need to subtract 1 from idx (shmem is loaded at vt+1)
+    idx == Operators.right_center_boundary_idx(space) ||
+        error("Incorrect right idx")
+    @inbounds begin
+        vt = threadIdx().x
+        cov3 = Geometry.Covariant3Vector(1)
+        u[vt] = cov3 ⊗ Operators.getidx(space, arg, loc, idx, hidx)
+        rb[1] = cov3 ⊗ Operators.getidx(space, bc.val, loc, nothing, hidx)
+    end
+    return nothing
+end
+
+Base.@propagate_inbounds function fd_operator_evaluate(
+    op::Operators.GradientC2F,
+    (u, lb, rb),
+    loc,
+    space,
+    idx::PlusHalf,
+    hidx,
+    args...,
+)
+    @inbounds begin
+        vt = threadIdx().x
+        # @assert idx.i == vt-1 # assertion passes, but commented to remove potential thrown exception in llvm output
+        if idx == Operators.right_face_boundary_idx(space)
+            u₋ = 2 * u[vt - 1]   # corresponds to idx - half
+            u₊ = 2 * rb[1] # corresponds to idx + half
+        elseif idx == Operators.left_face_boundary_idx(space)
+            u₋ = 2 * lb[1]   # corresponds to idx - half
+            u₊ = 2 * u[vt] # corresponds to idx + half
+        else
+            u₋ = u[vt - 1]   # corresponds to idx - half
+            u₊ = u[vt] # corresponds to idx + half
+        end
+        return u₊ ⊟ u₋
     end
 end

--- a/ext/cuda/operators_fd_shmem_is_supported.jl
+++ b/ext/cuda/operators_fd_shmem_is_supported.jl
@@ -149,6 +149,8 @@ end
 ) = false
 
 # Add cases here where shmem is supported:
+
+##### DivergenceF2C
 @inline Operators.fd_shmem_is_supported(op::Operators.DivergenceF2C) =
     Operators.fd_shmem_is_supported(op, op.bcs)
 @inline Operators.fd_shmem_is_supported(
@@ -157,6 +159,21 @@ end
 ) = true
 @inline Operators.fd_shmem_is_supported(
     op::Operators.DivergenceF2C,
+    bcs::NamedTuple,
+) =
+    all(values(bcs)) do bc
+        all(supported_bc -> bc isa supported_bc, (Operators.SetValue,))
+    end
+
+##### GradientC2F
+@inline Operators.fd_shmem_is_supported(op::Operators.GradientC2F) =
+    Operators.fd_shmem_is_supported(op, op.bcs)
+@inline Operators.fd_shmem_is_supported(
+    op::Operators.GradientC2F,
+    ::@NamedTuple{},
+) = false
+@inline Operators.fd_shmem_is_supported(
+    op::Operators.GradientC2F,
     bcs::NamedTuple,
 ) =
     all(values(bcs)) do bc

--- a/test/Operators/finitedifference/unit_fd_ops_shared_memory.jl
+++ b/test/Operators/finitedifference/unit_fd_ops_shared_memory.jl
@@ -36,6 +36,13 @@ end
     @test Operators.any_fd_shmem_supported(bc)
     @test !ext.any_fd_shmem_style(ext.disable_shmem_style(bc))
     @. c = div(Geometry.WVector(f))
+    ᶠgrad = Operators.GradientC2F(;
+        bottom = Operators.SetValue(FT(0)),
+        top = Operators.SetValue(FT(0)),
+    )
+    bc = @. lazy(ᶠgrad(c))
+    @test Operators.any_fd_shmem_supported(bc)
+    @test Operators.fd_shmem_is_supported(bc)
 end
 
 #! format: off
@@ -66,6 +73,7 @@ end
     @test compare_cpu_gpu(fields_cpu.ᶜout9, fields.ᶜout9); @test !is_trivial(fields_cpu.ᶜout9)
     @test compare_cpu_gpu(fields_cpu.ᶜout10, fields.ᶜout10); @test !is_trivial(fields_cpu.ᶜout10)
     @test compare_cpu_gpu(fields_cpu.ᶜout_uₕ, fields.ᶜout_uₕ); @test !is_trivial(fields_cpu.ᶜout_uₕ)
+    @test compare_cpu_gpu(fields_cpu.ᶠout3_cov, fields.ᶠout3_cov); @test !is_trivial(fields_cpu.ᶠout3_cov)
 end
 
 @testset "Correctness plane" begin


### PR DESCRIPTION
This PR adds FD shmem for `GradientC2F`, and infrastructure needed for all C2F stencil operators (as this was not added in the F2C shmem PR). The new code in [ext/cuda/operators_fd_shmem_common.jl](https://github.com/CliMA/ClimaCore.jl/compare/ck/fd_shmem_with_GradientC2F?expand=1#diff-a0d1b19a17169c7702fd7c699e279b0ffebc12923dd9c4c2b2098edaf553b29b) is exercised in the newly added test.

I think it's worth adding a composite operator test, but hopefully the implementation doesn't need any changes.

Here is a tested [build](https://buildkite.com/clima/climaatmos-ci/builds/23813) in ClimaAtmos.