### PR TITLE
Clean up convenience `interpolate`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,37 @@ ClimaCore.jl Release Notes
 main
 -------
 
+### ![][badge-✨feature/enhancement] Improvements to `Remapping.interpolate` PR [2272](https://github.com/CliMA/ClimaCore.jl/pull/2272)
+
+PR [2272](https://github.com/CliMA/ClimaCore.jl/pull/2272) introduces
+convenience `interpolate` functions that are optimally suited for plotting.
+
+Assuming `field` is a 3D `Field`,
+```julia
+import ClimaCore.Remapping: interpolate
+
+array3D = interpolate(fields)
+```
+
+`array3D` will be an 3D Array with values along the three dimensions. 
+
+By default, no interpolation in the vertical direction is performed. Linear
+interpolation can be obtained by passing `zresolution`
+```julia
+array3D_linear_in_z = interpolate(fields; zresolution)
+```
+
+Controlling the specific interpolation points is also possible, as shown in this
+example:
+```julia
+import ClimaCore.Geometry: LatLongPoint, ZPoint
+import ClimaCore.Remapping: interpolate
+
+target_hcoords = [LatLongPoint(45., 23.)]
+target_zcoords = ZPoint.([100., 200., 1000.])
+
+array3D_specific = interpolate(fields; target_hcoords, target_zcoords)
+```
 
 v0.14.29
 -------

--- a/docs/src/remapping.md
+++ b/docs/src/remapping.md
@@ -45,6 +45,9 @@ given `field`. To obtain such coordinates, you can call the
 functions. These functions return an `Array` with the coordinates over which
 interpolation will occur. These arrays are of type `Geometry.Point`s.
 
+By default, vertical interpolation is switched off and the `field` is evaluated
+directly on the levels.
+
 `ClimaCore.Remapping.interpolate` allocates new output arrays. As such, it is
 not suitable for performance-critical applications.
 `ClimaCore.Remapping.interpolate!` performs interpolation in-place. When using
@@ -80,6 +83,12 @@ If the default target coordinates are being used, it is possible to broadcast
 `ClimaCore.Geometry.components` to extract them as a vector of tuples (and then
 broadcast `getindex` to extract the respective coordinates as vectors).
 
+This also provides the simplest way to plot a `Field`. Suppose `field` is a 2D `Field`:
+```julia
+using CairoMakie
+heatmap(ClimaCore.Remapping.interpolate(field))
+```
+
 ### The `Remapper` object
 
 A `Remapping.Remapper` is an object that is tied to a specified `Space` and can
@@ -88,7 +97,8 @@ The grid does not have to be regular, but it has to be defined as a Cartesian
 product between some horizontal and vertical coordinates (meaning, for each
 horizontal point, there is a fixed column of vertical coordinates).
 
-Let us create our first remapper, assuming we have `space` defined on the surface of the sphere
+Let us create our first remapper, assuming we have `space` defined on the
+surface of the sphere
 ```julia
 import ClimaCore.Geometry: LatLongPoint, ZPoint
 import ClimaCore.Remapping: Remapper
@@ -96,7 +106,8 @@ import ClimaCore.Remapping: Remapper
 hcoords = [Geometry.LatLongPoint(lat, long) for long in -180.:180., lat in -90.:90.]
 remapper = Remapper(space, target_hcoords)
 ```
-This `remapper` object knows can interpolate `Field`s defined on `space` with the same `interpolate` and `interpolate!` functions.
+This `remapper` object knows can interpolate `Field`s defined on `space` with
+the same `interpolate` and `interpolate!` functions.
 ```julia
 import ClimaCore.Fields: coordinate_field
 import ClimaCore.Remapping: interpolate, interpolate!
@@ -118,7 +129,8 @@ When interpolating multiple fields, greater performance can be achieved by
 creating the `Remapper` with a larger internal buffer to store intermediate
 values for interpolation. Effectively, this controls how many fields can be
 remapped simultaneously in `interpolate`. When more fields than `buffer_length`
-are passed, the remapper will batch the work in sizes of `buffer_length`. The optimal number of fields passed is the `buffer_length` of the `remapper`. If
+are passed, the remapper will batch the work in sizes of `buffer_length`. The
+optimal number of fields passed is the `buffer_length` of the `remapper`. If
 more fields are passed, the `remapper` will batch work with size up to its
 `buffer_length`.
 


### PR DESCRIPTION
I don't know if I lost a commit or something in a previous PR, but
`Remapping.interpolate` was missing some methods needed to make it useful. In this commit, I go over the methods for all the spaces and add what is missing (e.g., `interpolate(horizontal_space, target_hcoords)` instead of `interpolate(horizontal_space, target_hcoords, nothing).

I also change the default behavior for `default_target_zcoords` to interpolate on levels instead of linear interpolation. I do this because this is a much more common type of workflow.

With this commit, plotting `Field`s becomes very easy. For example, plotting a surface values of a 3D field:
```julia
using CairoMakie
import ClimaCore.Remapping: interpolate
heatmap(interpolate(field)[:, :, 1])
```

This commit also adds the defaults to the constructors for the `Remapper` too, so that creating a `Remapper` becomes easier:

```julia
import ClimaCore.Remapping: Remapper
remapper = Remapper(space)
```

(If one is fine with the defaults otherwise they can still pass the coordinates)


In the future, it might be nice to incorporate this into a `Makie` extension.