### PR TITLE
Fix error messages in DataLayouts

### DIFF
--- a/src/DataLayouts/DataLayouts.jl
+++ b/src/DataLayouts/DataLayouts.jl
@@ -364,9 +364,9 @@ end
 
 @noinline _property_view(
     data::AbstractData{S},
-    ::Val{Nothing},
+    ::Val{nothing},
     name,
-) where {S} = error("Invalid field name $name for type $(S)")
+) where {S} = error("Invalid field name `$name` for type `$(S)`.")
 
 # In the past, we've sometimes needed a generated function
 # for inference and constant propagation:

--- a/test/DataLayouts/data0d.jl
+++ b/test/DataLayouts/data0d.jl
@@ -1,5 +1,5 @@
 #=
-julia --project=test
+julia --project
 using Revise; include(joinpath("test", "DataLayouts", "data0d.jl"))
 =#
 using Test
@@ -63,6 +63,14 @@ end
     @test ret === SA
     @test data[] isa typeof(SA)
     @test_throws MethodError data[] = SB
+end
+
+@testset "DataF error messages" begin
+    SA = (; a = 1.0)
+    data = DataF{typeof(SA)}(ArrayType{Float64})
+    @test_throws ErrorException(
+        "Invalid field name `oops` for type `$(typeof(SA))`.",
+    ) data.oops
 end
 
 @testset "DataF broadcasting between 0D data objects and scalars" begin


### PR DESCRIPTION
I looks like I messed up dispatch in #2034, and perhaps we can have specific error messages afterall. I'm hoping that this closes #2274 without creating new issues. I added the test for the DataF type, but all datalayouts since it's the most lightweight, I didn't add test for other datalayouts because they all use the same `getproperty` methods.