### PR TITLE
Disable GradientC2F shmem, add tests

### DIFF
--- a/ext/cuda/operators_fd_shmem_is_supported.jl
+++ b/ext/cuda/operators_fd_shmem_is_supported.jl
@@ -175,7 +175,7 @@ end
 @inline Operators.fd_shmem_is_supported(
     op::Operators.GradientC2F,
     bcs::NamedTuple,
-) =
-    all(values(bcs)) do bc
-        all(supported_bc -> bc isa supported_bc, (Operators.SetValue,))
-    end
+) = false
+# all(values(bcs)) do bc
+#     all(supported_bc -> bc isa supported_bc, (Operators.SetValue,))
+# end

--- a/test/Operators/finitedifference/unit_fd_ops_shared_memory.jl
+++ b/test/Operators/finitedifference/unit_fd_ops_shared_memory.jl
@@ -40,9 +40,9 @@ end
         bottom = Operators.SetValue(FT(0)),
         top = Operators.SetValue(FT(0)),
     )
-    bc = @. lazy(ᶠgrad(c))
-    @test Operators.any_fd_shmem_supported(bc)
-    @test Operators.fd_shmem_is_supported(bc)
+    # bc = @. lazy(ᶠgrad(c))
+    # @test Operators.any_fd_shmem_supported(bc)
+    # @test Operators.fd_shmem_is_supported(bc)
 end
 
 #! format: off
@@ -72,6 +72,8 @@ end
     @test compare_cpu_gpu(fields_cpu.ᶠout2_contra, fields.ᶠout2_contra); @test !is_trivial(fields_cpu.ᶠout2_contra)
     @test compare_cpu_gpu(fields_cpu.ᶜout9, fields.ᶜout9); @test !is_trivial(fields_cpu.ᶜout9)
     @test compare_cpu_gpu(fields_cpu.ᶜout10, fields.ᶜout10); @test !is_trivial(fields_cpu.ᶜout10)
+    @test compare_cpu_gpu(fields_cpu.ᶜout11, fields.ᶜout11); @test !is_trivial(fields_cpu.ᶜout11)
+    @test compare_cpu_gpu(fields_cpu.ᶜout12, fields.ᶜout12); @test !is_trivial(fields_cpu.ᶜout12)
     @test compare_cpu_gpu(fields_cpu.ᶜout_uₕ, fields.ᶜout_uₕ); @test !is_trivial(fields_cpu.ᶜout_uₕ)
     @test compare_cpu_gpu(fields_cpu.ᶠout3_cov, fields.ᶠout3_cov); @test !is_trivial(fields_cpu.ᶠout3_cov)
 end
@@ -102,6 +104,8 @@ end
     @test compare_cpu_gpu(fields_cpu.ᶠout2_contra, fields.ᶠout2_contra); @test !is_trivial(fields_cpu.ᶠout2_contra)
     @test compare_cpu_gpu(fields_cpu.ᶜout9, fields.ᶜout9); @test !is_trivial(fields_cpu.ᶜout9)
     @test compare_cpu_gpu(fields_cpu.ᶜout10, fields.ᶜout10); @test !is_trivial(fields_cpu.ᶜout10)
+    @test compare_cpu_gpu(fields_cpu.ᶜout11, fields.ᶜout11); @test !is_trivial(fields_cpu.ᶜout11)
+    @test compare_cpu_gpu(fields_cpu.ᶜout12, fields.ᶜout12); @test !is_trivial(fields_cpu.ᶜout12)
     @test compare_cpu_gpu(fields_cpu.ᶜout_uₕ, fields.ᶜout_uₕ); @test !is_trivial(fields_cpu.ᶜout_uₕ)
 end
 
@@ -130,6 +134,8 @@ end
     @test compare_cpu_gpu(fields_cpu.ᶠout2_contra, fields.ᶠout2_contra); @test !is_trivial(fields_cpu.ᶠout2_contra)
     @test compare_cpu_gpu(fields_cpu.ᶜout9, fields.ᶜout9); @test !is_trivial(fields_cpu.ᶜout9)
     @test compare_cpu_gpu(fields_cpu.ᶜout10, fields.ᶜout10); @test !is_trivial(fields_cpu.ᶜout10)
+    @test compare_cpu_gpu(fields_cpu.ᶜout11, fields.ᶜout11); @test !is_trivial(fields_cpu.ᶜout11)
+    @test compare_cpu_gpu(fields_cpu.ᶜout12, fields.ᶜout12); @test !is_trivial(fields_cpu.ᶜout12)
     @test compare_cpu_gpu(fields_cpu.ᶜout_uₕ, fields.ᶜout_uₕ); @test !is_trivial(fields_cpu.ᶜout_uₕ)
 
 end


### PR DESCRIPTION
This PR disables the `GradientC2F` shmem support and adds some tests. It turns out that the new tests are failing due to some sort of composition bug. I'll take a closer look, but for now I'm going to just disable the part that is broken.