### PR TITLE
Fix fill with mask

### DIFF
--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -23,6 +23,7 @@ import ..Grids: ColumnIndex, local_geometry_type
 import ..Spaces: Spaces, AbstractSpace, AbstractPointSpace, cuda_synchronize
 import ..Spaces: nlevels, ncolumns
 import ..Spaces: get_mask, set_mask!
+import ..DataLayouts: AbstractMask
 import ..Geometry: Geometry, Cartesian12Vector
 import ..Utilities: PlusHalf, half
 
@@ -285,7 +286,7 @@ Base.deepcopy_internal(field::Field, stackdict::IdDict) =
 function Base.copyto!(
     dest::Field{V, M},
     src::Field{V, M},
-    mask = DataLayouts.NoMask,
+    mask = DataLayouts.NoMask(),
 ) where {V, M}
     @assert axes(dest) == axes(src)
     copyto!(field_values(dest), field_values(src), mask)
@@ -293,12 +294,17 @@ function Base.copyto!(
 end
 
 """
-    fill!(field::Field, value)
+    fill!(field::Field, value, mask = get_mask(axes(field)))
 
-Fill `field` with `value`.
+Fill `field` with `value`. The mask is extracted from the field's space,
+and `fill!` is only applied where the `mask` is true.
 """
-function Base.fill!(field::Field, value)
-    fill!(field_values(field), value)
+function Base.fill!(
+    field::Field,
+    value,
+    mask::AbstractMask = get_mask(axes(field)),
+)
+    fill!(field_values(field), value, mask)
     return field
 end
 """

--- a/test/Spaces/unit_spaces.jl
+++ b/test/Spaces/unit_spaces.jl
@@ -1,5 +1,5 @@
 #=
-julia --project
+julia --project=.buildkite
 using Revise; include(joinpath("test", "Spaces", "unit_spaces.jl"))
 =#
 using Test
@@ -70,8 +70,9 @@ on_gpu = ClimaComms.device() isa ClimaComms.CUDADevice
 
     f = Fields.Field(FT, hspace)
     fill!(parent(f), 0)
-    @. f = 1 # tests fill!
+    fill!(f, 1)
     @test count(iszero, parent(f)) == 2
+    @test count(x -> x == 1, parent(f)) == 2
     ᶜx = Fields.coordinate_field(hspace).x
     @. f = 1 + ᶜx * 0 # tests copyto!
     @test count(iszero, parent(f)) == 2
@@ -109,7 +110,7 @@ on_gpu = ClimaComms.device() isa ClimaComms.CUDADevice
     @test count(parent(mask.is_active)) == 4640
     @test length(parent(mask.is_active)) == 9600
     ᶜf = zeros(ᶜspace)
-    @. ᶜf = 1 # tests fill!
+    fill!(ᶜf, 1)
     @test count(x -> x == 1, parent(ᶜf)) == 4640 * Spaces.nlevels(axes(ᶜf))
     @test length(parent(ᶜf)) == 9600 * Spaces.nlevels(axes(ᶜf))
     ᶜz = Fields.coordinate_field(ᶜspace).z


### PR DESCRIPTION
This PR fixes an observed issue with the masked `fill!` implementation, which was incorrectly mask-unaware. (found by @kmdeck)