### PR TITLE
Prevent mask from being incorrectly used when Remapping on a non-supported space

### DIFF
--- a/test/Remapping/distributed_remapping.jl
+++ b/test/Remapping/distributed_remapping.jl
@@ -16,7 +16,8 @@ import ClimaCore:
     Quadratures,
     Topologies,
     Remapping,
-    Hypsography
+    Hypsography,
+    CommonSpaces
 using ClimaComms
 ClimaComms.@import_required_backends
 const context = ClimaComms.context()
@@ -923,5 +924,20 @@ end
     @test all(
         Remapping.default_target_hcoords(horzspace) .≈
         [Geometry.XPoint(x) for x in range(-500.0, 500.0, length = 180)],
+    )
+end
+
+@testset "Mask" begin
+    @test_throws ErrorException Remapping.Remapper(
+        CommonSpaces.ExtrudedCubedSphereSpace(;
+            z_elem = 10,
+            z_min = 0,
+            z_max = 1,
+            radius = 10,
+            h_elem = 10,
+            n_quad_points = 4,
+            staggering = CommonSpaces.CellCenter(),
+            enable_mask = true,
+        ),
     )
 end


### PR DESCRIPTION
`Remapping.Remapper` performs spectral interpolation. When interpolating, every point in a given element is used to calculate the target value. As a result, the result is incorrect if one or more of the nodes in an element are masked.

This commit prevents users from accidentally obtaining subtly incorrect results by calling the Remapper on a space that is not supported.

Note that if none of the nodes in an element are masked, the interpolation routine would be fine. A more refined implementation of this check could take this into consideration, but this is deferred to when such need arises.
