### PR TITLE
Add matrix-field benchmark

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1404,6 +1404,14 @@ steps:
         agents:
           slurm_gpus: 1
 
+      - label: "Perf: FD operator matrix field operation (example)"
+        key: "perf_fd_ops_mat_field_example"
+        command: "julia --color=yes --project=.buildkite test/Operators/finitedifference/benchmark_fd_ops_shared_memory_matrix_fields.jl"
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+        agents:
+          slurm_mem: 20GB
+
       - label: "Perf: SEM operator benchmarks (cuda Float32)"
         key: "perf_gpu_spectral_ops_cuda_float32"
         command:

--- a/test/Operators/finitedifference/benchmark_fd_ops_shared_memory_matrix_fields.jl
+++ b/test/Operators/finitedifference/benchmark_fd_ops_shared_memory_matrix_fields.jl
@@ -1,0 +1,69 @@
+#=
+julia --project=.buildkite
+using Revise; include("test/Operators/finitedifference/benchmark_fd_ops_shared_memory_matrix_fields.jl")
+=#
+include("utils_fd_ops_shared_memory.jl")
+using ClimaComms
+using LinearAlgebra
+using BenchmarkTools
+ClimaComms.@import_required_backends
+using ClimaCore.CommonSpaces
+using ClimaCore: Operators, Fields, MatrixFields, Geometry, Spaces
+using ClimaCore.Utilities: half
+
+covariant3_unit_vector(lg) =
+    Geometry.Covariant3Vector(
+        1 / Geometry._norm(Geometry.Covariant3Vector(1), lg)
+    )
+
+#! format: off
+function bench_kernels!(L, K, C)
+    space = axes(K)
+    ᶠspace = Spaces.face_space(space)
+    levels = Spaces.nlevels(ᶠspace)
+    ᶠlg_N = Fields.level(
+        Fields.local_geometry_field(ᶠspace),
+        levels - half,
+    )
+    topfluxBC = @. covariant3_unit_vector(ᶠlg_N) * 0
+    topBC_op = Operators.SetBoundaryOperator(
+        top = Operators.SetValue(topfluxBC),
+        bottom = Operators.SetValue(Geometry.Covariant3Vector(0)),
+    )
+    interpc2f_op = Operators.InterpolateC2F(
+        bottom = Operators.Extrapolate(),
+        top = Operators.Extrapolate(),
+    )
+    divf2c_op = Operators.DivergenceF2C()
+    divf2c_matrix = MatrixFields.operator_matrix(divf2c_op)
+    gradc2f_op = Operators.GradientC2F(
+        top = Operators.SetGradient(Geometry.WVector(0)),
+        bottom = Operators.SetGradient(Geometry.WVector(0)),
+    )
+    gradc2f_matrix = MatrixFields.operator_matrix(gradc2f_op)
+    args = (L, K, C, gradc2f_matrix, divf2c_matrix, interpc2f_op, topBC_op)
+    @benchmark CUDA.@sync kernel!($args...)
+end
+
+function kernel!(L, K, C, gradc2f_matrix, divf2c_matrix, interpc2f_op, topBC_op)
+    @. L = (
+        divf2c_matrix() * (
+            MatrixFields.DiagonalMatrixRow(interpc2f_op(K)) *
+            gradc2f_matrix() * MatrixFields.DiagonalMatrixRow(C) +
+            MatrixFields.LowerDiagonalMatrixRow(
+                topBC_op(Geometry.Covariant3Vector(zero(interpc2f_op(K)))),
+            )
+        )
+    ) - (I,)
+end
+
+let FT = Float64
+    ᶜspace =
+        get_space_extruded(ClimaComms.device(), FT; z_elem = 10, h_elem = 30);
+    K = Fields.Field(Float64, ᶜspace);
+    C = Fields.Field(Float64, ᶜspace);
+    L = Fields.Field(MatrixFields.TridiagonalMatrixRow{FT}, ᶜspace);
+    fill!(K, 1);
+    fill!(C, 1);
+    bench_kernels!(L, K, C)
+end


### PR DESCRIPTION
This PR adds a matrix field benchmark that is currently impressively slow on the A100 (on pretty low resolution):

```julia
BenchmarkTools.Trial: 107 samples with 1 evaluation per sample.
 Range (min … max):  43.442 ms … 48.436 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     47.463 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   46.995 ms ±  1.086 ms  ┊ GC (mean ± σ):  0.00% ± 0.00%

                                                 ▄▄▇▃█         
  ▃▁▁▁▃▃▁▁▁▃▁▁▁▁▁▄▁▃▃▄▁▁▁▃▃▄▇▁▄▁▅▃▃▄▁▃▃▁▃▁▁▁▃▃▆▆▇█████▃▇▄▁▁▁▃ ▃
  43.4 ms         Histogram: frequency by time        48.4 ms <

 Memory estimate: 1.22 KiB, allocs estimate: 59.
```
For reference / comparison, pointwise operations for a single assign can be (easily) as low as `100μs`. This benchmark only requires 1 read and 2 reads (+1 boundary read) and 1 write (4 reads+writes total). So, I'd estimate that this should take at most `400μs` (1000x faster).

I'd like to do a couple things:

 - make a utils file, so that we can use this example for running nsight compute, as well as a benchmark
 - make the resolution flexible, so that we can see how this performs with different resolutions
 - make this somehow reusable for our shared memory unit tests, since adding shmem support for these operations should (likely) improve performance.