### PR TITLE
Tune kernels for use with FastCartesianIndices

### DIFF
--- a/ext/cuda/data_layouts.jl
+++ b/ext/cuda/data_layouts.jl
@@ -27,6 +27,12 @@ Base.similar(
     dims::Dims{N},
 ) where {T, N, B} = similar(CUDA.CuArray{T, N, B}, dims)
 
+unval(::Val{CI}) where {CI} = CI
+unval(CI) = CI
+
+@inline linear_thread_idx() =
+    threadIdx().x + (blockIdx().x - Int32(1)) * blockDim().x
+
 include("data_layouts_fill.jl")
 include("data_layouts_copyto.jl")
 include("data_layouts_fused_copyto.jl")

--- a/ext/cuda/data_layouts_threadblock.jl
+++ b/ext/cuda/data_layouts_threadblock.jl
@@ -1,32 +1,12 @@
 const CI5 = CartesianIndex{5}
+# using ClimaCartesianIndices: FastCartesianIndices
+FastCartesianIndices(x) = CartesianIndices(x)
 
 maximum_allowable_threads() = (
     CUDA.attribute(CUDA.device(), CUDA.DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X),
     CUDA.attribute(CUDA.device(), CUDA.DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y),
     CUDA.attribute(CUDA.device(), CUDA.DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z),
 )
-
-"""
-    partition(::AbstractData, n_max_threads)
-
-Given `n_max_threads`, which should be determined
-from CUDA's occupancy API, `partition` returns
-a NamedTuple containing:
-
- - `threads` size of threads to pass to CUDA
- - `blocks` size of blocks to pass to CUDA
-
-The general pattern followed here, which seems
-to produce good results, is to satisfy a few
-criteria:
-
- - Maximize the number of (allowable) threads
-   in the thread partition
- - The order of the thread partition should
-   follow the fastest changing index in the
-   datalayout (e.g., VIJ in VIJFH)
-"""
-function partition end
 
 """
     universal_index(::AbstractData)
@@ -37,182 +17,35 @@ computed from CUDA's `threadIdx`,
 """
 function universal_index end
 
-"""
-    is_valid_index(::AbstractData, I::CartesianIndex, us::UniversalSize)
-
-Check the minimal number of index
-bounds to ensure that the result of
-`universal_index` is valid.
-"""
-function is_valid_index end
-
-##### VIJFH
-@inline function partition(
-    data::Union{DataLayouts.VIJFH, DataLayouts.VIJHF},
-    n_max_threads::Integer,
-)
-    (Nij, _, _, Nv, Nh) = DataLayouts.universal_size(data)
-    Nv_thread = min(Int(fld(n_max_threads, Nij * Nij)), Nv)
-    Nv_blocks = cld(Nv, Nv_thread)
-    @assert prod((Nv_thread, Nij, Nij)) ≤ n_max_threads "threads,n_max_threads=($(prod((Nv_thread, Nij, Nij))),$n_max_threads)"
-    return (; threads = (Nv_thread, Nij, Nij), blocks = (Nh, Nv_blocks))
-end
-@inline function universal_index(::Union{DataLayouts.VIJFH, DataLayouts.VIJHF})
-    (tv, i, j) = CUDA.threadIdx()
-    (h, bv) = CUDA.blockIdx()
-    v = tv + (bv - 1) * CUDA.blockDim().x
-    return CartesianIndex((i, j, 1, v, h))
-end
-@inline is_valid_index(
-    ::Union{DataLayouts.VIJFH, DataLayouts.VIJHF},
-    I::CI5,
-    us::UniversalSize,
-) = 1 ≤ I[4] ≤ DataLayouts.get_Nv(us)
-
-##### IJFH
-@inline function partition(
-    data::Union{DataLayouts.IJFH, DataLayouts.IJHF},
-    n_max_threads::Integer,
-)
-    (Nij, _, _, _, Nh) = DataLayouts.universal_size(data)
-    Nh_thread = min(
-        Int(fld(n_max_threads, Nij * Nij)),
-        Nh,
-        maximum_allowable_threads()[3],
-    )
-    Nh_blocks = cld(Nh, Nh_thread)
-    @assert prod((Nij, Nij)) ≤ n_max_threads "threads,n_max_threads=($(prod((Nij, Nij))),$n_max_threads)"
-    return (; threads = (Nij, Nij, Nh_thread), blocks = (Nh_blocks,))
-end
-@inline function universal_index(::Union{DataLayouts.IJFH, DataLayouts.IJHF})
-    (i, j, th) = CUDA.threadIdx()
-    (bh,) = CUDA.blockIdx()
-    h = th + (bh - 1) * CUDA.blockDim().z
-    return CartesianIndex((i, j, 1, 1, h))
-end
-@inline is_valid_index(
-    ::Union{DataLayouts.IJFH, DataLayouts.IJHF},
-    I::CI5,
-    us::UniversalSize,
-) = 1 ≤ I[5] ≤ DataLayouts.get_Nh(us)
-
-##### IFH
-@inline function partition(
-    data::Union{DataLayouts.IFH, DataLayouts.IHF},
-    n_max_threads::Integer,
-)
-    (Ni, _, _, _, Nh) = DataLayouts.universal_size(data)
-    Nh_thread = min(Int(fld(n_max_threads, Ni)), Nh)
-    Nh_blocks = cld(Nh, Nh_thread)
-    @assert prod((Ni, Nh_thread)) ≤ n_max_threads "threads,n_max_threads=($(prod((Ni, Nh_thread))),$n_max_threads)"
-    return (; threads = (Ni, Nh_thread), blocks = (Nh_blocks,))
-end
-@inline function universal_index(::Union{DataLayouts.IFH, DataLayouts.IHF})
-    (i, th) = CUDA.threadIdx()
-    (bh,) = CUDA.blockIdx()
-    h = th + (bh - 1) * CUDA.blockDim().y
-    return CartesianIndex((i, 1, 1, 1, h))
-end
-@inline is_valid_index(
-    ::Union{DataLayouts.IFH, DataLayouts.IHF},
-    I::CI5,
-    us::UniversalSize,
-) = 1 ≤ I[5] ≤ DataLayouts.get_Nh(us)
-
-##### IJF
-@inline function partition(data::DataLayouts.IJF, n_max_threads::Integer)
-    (Nij, _, _, _, _) = DataLayouts.universal_size(data)
-    @assert prod((Nij, Nij)) ≤ n_max_threads "threads,n_max_threads=($(prod((Nij, Nij))),$n_max_threads)"
-    return (; threads = (Nij, Nij), blocks = (1,))
-end
-@inline function universal_index(::DataLayouts.IJF)
-    (i, j) = CUDA.threadIdx()
-    return CartesianIndex((i, j, 1, 1, 1))
-end
-@inline is_valid_index(::DataLayouts.IJF, I::CI5, us::UniversalSize) = true
-
-##### IF
-@inline function partition(data::DataLayouts.IF, n_max_threads::Integer)
-    (Ni, _, _, _, _) = DataLayouts.universal_size(data)
-    @assert Ni ≤ n_max_threads "threads,n_max_threads=($(Ni),$n_max_threads)"
-    return (; threads = (Ni,), blocks = (1,))
-end
-@inline function universal_index(::DataLayouts.IF)
-    (i,) = CUDA.threadIdx()
-    return CartesianIndex((i, 1, 1, 1, 1))
-end
-@inline is_valid_index(::DataLayouts.IF, I::CI5, us::UniversalSize) = true
-
-##### VIFH
-@inline function partition(
-    data::Union{DataLayouts.VIFH, DataLayouts.VIHF},
-    n_max_threads::Integer,
-)
-    (Ni, _, _, Nv, Nh) = DataLayouts.universal_size(data)
-    Nv_thread = min(Int(fld(n_max_threads, Ni)), Nv)
-    Nv_blocks = cld(Nv, Nv_thread)
-    @assert prod((Nv_thread, Ni)) ≤ n_max_threads "threads,n_max_threads=($(prod((Nv_thread, Ni))),$n_max_threads)"
-    return (; threads = (Nv_thread, Ni), blocks = (Nh, Nv_blocks))
-end
-@inline function universal_index(::Union{DataLayouts.VIFH, DataLayouts.VIHF})
-    (tv, i) = CUDA.threadIdx()
-    (h, bv) = CUDA.blockIdx()
-    v = tv + (bv - 1) * CUDA.blockDim().x
-    return CartesianIndex((i, 1, 1, v, h))
-end
-@inline is_valid_index(
-    ::Union{DataLayouts.VIFH, DataLayouts.VIHF},
-    I::CI5,
-    us::UniversalSize,
-) = 1 ≤ I[4] ≤ DataLayouts.get_Nv(us)
-
-##### VF
-@inline function partition(data::DataLayouts.VF, n_max_threads::Integer)
-    (_, _, _, Nv, _) = DataLayouts.universal_size(data)
-    Nvt = fld(n_max_threads, Nv)
-    Nv_thread = Nvt == 0 ? n_max_threads : min(Int(Nvt), Nv)
-    Nv_blocks = cld(Nv, Nv_thread)
-    @assert Nv_thread ≤ n_max_threads "threads,n_max_threads=($(Nv_thread),$n_max_threads)"
-    (; threads = (Nv_thread,), blocks = (Nv_blocks,))
-end
-@inline function universal_index(::DataLayouts.VF)
-    (tv,) = CUDA.threadIdx()
-    (bv,) = CUDA.blockIdx()
-    v = tv + (bv - 1) * CUDA.blockDim().x
-    return CartesianIndex((1, 1, 1, v, 1))
-end
-@inline is_valid_index(::DataLayouts.VF, I::CI5, us::UniversalSize) =
-    1 ≤ I[4] ≤ DataLayouts.get_Nv(us)
-
-##### DataF
-@inline partition(data::DataLayouts.DataF, n_max_threads::Integer) =
-    (; threads = 1, blocks = 1)
-@inline universal_index(::DataLayouts.DataF) = CartesianIndex((1, 1, 1, 1, 1))
-@inline is_valid_index(::DataLayouts.DataF, I::CI5, us::UniversalSize) = true
-
 ##### Masked
-@inline masked_partition(
-    us::DataLayouts.UniversalSize,
-    n_max_threads::Integer,
-    mask::IJHMask,
-) = masked_partition(us, n_max_threads, typeof(mask), mask.N[1])
+@inline cartesian_indicies_mask(us::DataLayouts.UniversalSize, mask::IJHMask) =
+    cartesian_indicies_mask(us, typeof(mask), mask.N[1])
 
-@inline function masked_partition(
+@inline function cartesian_indicies_mask(
     us::DataLayouts.UniversalSize,
-    n_max_threads::Integer,
     ::Type{<:IJHMask},
     n_active_columns::Integer,
 )
     (Ni, _, _, Nv, Nh) = DataLayouts.universal_size(us)
-    Nv_thread = min(Int(fld(n_max_threads, Ni)), Nv)
-    Nv_blocks = cld(Nv, Nv_thread)
-    @assert Nv_thread ≤ n_max_threads "threads,n_max_threads=($Nv_thread,$n_max_threads)"
-    return (; threads = (Nv_thread,), blocks = (n_active_columns, Nv_blocks))
+    return FastCartesianIndices((1:Nv, 1:n_active_columns))
 end
-@inline function masked_universal_index(mask::IJHMask)
-    (tv,) = CUDA.threadIdx()
-    (ijh, bv) = CUDA.blockIdx()
-    v = tv + (bv - 1) * CUDA.blockDim().x
+@inline masked_partition(mask::IJHMask, n_max_threads, us) =
+    masked_partition(typeof(mask), mask.N[1], n_max_threads, us)
+
+@inline function masked_partition(
+    ::Type{<:IJHMask},
+    n_active_columns,
+    n_max_threads,
+    us,
+)
+    (_, _, _, Nv, _) = DataLayouts.universal_size(us)
+    nitems = n_active_columns * Nv
+    return linear_partition(nitems, n_max_threads)
+end
+
+@inline function masked_universal_index(mask::IJHMask, cart_inds)
+    tidx = linear_thread_idx()
+    (v, ijh) = unval(cart_inds)[tidx].I
     (; i_map, j_map, h_map) = mask
     @inbounds i = i_map[ijh]
     @inbounds j = j_map[ijh]
@@ -230,50 +63,31 @@ end
     blocks = cld(nitems, threads)
     return (; threads, blocks)
 end
-@inline function linear_universal_index(us::UniversalSize)
+@inline function cartesian_indices(us::UniversalSize)
     inds = DataLayouts.universal_size(us)
-    CI = CartesianIndices(map(x -> Base.OneTo(x), inds))
-    return CI
+    return FastCartesianIndices(map(Base.OneTo, inds))
 end
 @inline linear_is_valid_index(i::Integer, us::UniversalSize) =
     1 ≤ i ≤ DataLayouts.get_N(us)
 
 ##### Column-wise
-@inline function columnwise_partition(
-    us::DataLayouts.UniversalSize,
-    n_max_threads::Integer,
-)
+@inline function cartesian_indices_columnwise(us::DataLayouts.UniversalSize)
     (Ni, Nj, _, _, Nh) = DataLayouts.universal_size(us)
-    Nh_thread = min(
-        Int(fld(n_max_threads, Ni * Nj)),
-        maximum_allowable_threads()[3],
-        Nh,
-    )
-    Nh_blocks = cld(Nh, Nh_thread)
-    @assert prod((Ni, Nj, Nh_thread)) ≤ n_max_threads "threads,n_max_threads=($(prod((Ni, Nj, Nh_thread))),$n_max_threads)"
-    return (; threads = (Ni, Nj, Nh_thread), blocks = (Nh_blocks,))
+    inds = (Ni, Nj, Nh)
+    return FastCartesianIndices(map(Base.OneTo, inds))
 end
-@inline function columnwise_universal_index(us::UniversalSize)
-    (i, j, th) = CUDA.threadIdx()
-    (bh,) = CUDA.blockIdx()
-    h = th + (bh - 1) * CUDA.blockDim().z
-    return CartesianIndex((i, j, 1, 1, h))
-end
-@inline columnwise_is_valid_index(I::CI5, us::UniversalSize) =
-    1 ≤ I[5] ≤ DataLayouts.get_Nh(us)
 
 ##### Element-wise (e.g., limiters)
 # TODO
 
 ##### Multiple-field solve partition
-@inline function multiple_field_solve_partition(
-    us::DataLayouts.UniversalSize,
-    n_max_threads::Integer;
+@inline function cartesian_indices_multiple_field_solve(
+    us::DataLayouts.UniversalSize;
     Nnames,
 )
     (Ni, Nj, _, _, Nh) = DataLayouts.universal_size(us)
-    @assert prod((Ni, Nj, Nnames)) ≤ n_max_threads "threads,n_max_threads=($(prod((Ni, Nj, Nnames))),$n_max_threads)"
-    return (; threads = (Ni, Nj, Nnames), blocks = (Nh,))
+    inds = (Ni, Nj, Nh, Nnames)
+    return FastCartesianIndices(map(Base.OneTo, inds))
 end
 @inline function multiple_field_solve_universal_index(us::UniversalSize)
     (i, j, iname) = CUDA.threadIdx()
@@ -336,7 +150,10 @@ end
         Nvthreads,
     )
 end
-@inline function fd_stencil_universal_index(space::Spaces.AbstractSpace, us)
+@inline function fd_shmem_stencil_universal_index(
+    space::Spaces.AbstractSpace,
+    us,
+)
     (tv,) = CUDA.threadIdx()
     (h, bv, ij) = CUDA.blockIdx()
     v = tv + (bv - 1) * CUDA.blockDim().x
@@ -347,5 +164,5 @@ end
     @inbounds (i, j) = CartesianIndices((Ni, Nj))[ij].I
     return CartesianIndex((i, j, 1, v, h))
 end
-@inline fd_stencil_is_valid_index(I::CI5, us::UniversalSize) =
+@inline fd_shmem_stencil_is_valid_index(I::CI5, us::UniversalSize) =
     1 ≤ I[5] ≤ DataLayouts.get_Nh(us)

--- a/test/DataLayouts/unit_cuda_threadblocks.jl
+++ b/test/DataLayouts/unit_cuda_threadblocks.jl
@@ -20,17 +20,9 @@ function get_inputs()
     return (; S, args)
 end
 
-pt(d) = ext.partition(d, DataLayouts.get_N(DataLayouts.UniversalSize(d)))
 pt_stencil(d) = ext.fd_shmem_stencil_partition(
     DataLayouts.UniversalSize(d),
     DataLayouts.get_Nv(d),
-)
-pt_columnwise(d) =
-    ext.columnwise_partition(DataLayouts.UniversalSize(d), DataLayouts.get_N(d))
-pt_mfs(d; Nnames) = ext.multiple_field_solve_partition(
-    DataLayouts.UniversalSize(d),
-    DataLayouts.get_N(d);
-    Nnames,
 )
 pt_sem(d) =
     ext.spectral_partition(DataLayouts.UniversalSize(d), DataLayouts.get_N(d))
@@ -41,10 +33,10 @@ function pt_masked(d; frac)
     (Ni, Nj, _, Nv, Nh) = DataLayouts.universal_size(us)
     n_active_columns = Int(round(prod((Ni, Nj, Nh)) * frac; digits = 0))
     ext.masked_partition(
-        us,
-        DataLayouts.get_N(us),
         DataLayouts.IJHMask,
         n_active_columns,
+        DataLayouts.get_N(us),
+        us,
     )
 end
 
@@ -54,75 +46,6 @@ end
     # Fully optimized (but can be 2x slower due to integer division in CartesianIndices).
     # If https://github.com/maleadt/StaticCartesian.jl/issues/1 ever works, we should
     # basically always use that instead.
-end
-@testset "DataF partition" begin
-    (; S, args) = get_inputs()
-    @test pt(DataF{S}(args...)) == (; threads = 1, blocks = 1)
-end
-@testset "IJFH/IJHF partition" begin
-    (; S, args) = get_inputs()
-    for DL in (IJFH, IJHF)
-        @test pt(DL{S}(args...; Nij = 1, Nh = 1)) == (; threads = (1, 1, 1), blocks = (1,))
-        @test pt(DL{S}(args...; Nij = 1, Nh = get_Nh(1))) == (; threads = (1, 1, 6), blocks = (1,))
-        @test pt(DL{S}(args...; Nij = 4, Nh = get_Nh(30))) == (; threads = (4, 4, 64), blocks = (85,))
-        @test pt(DL{S}(args...; Nij = 4, Nh = get_Nh(100))) == (; threads = (4, 4, 64), blocks = (938,))
-        @test pt(DL{S}(args...; Nij = 1, Nh = get_Nh(1))) == (; threads = (1, 1, 6), blocks = (1,))
-        @test pt(DL{S}(args...; Nij = 1, Nh = get_Nh(30))) == (; threads = (1, 1, 64), blocks = (85,))
-        @test pt(DL{S}(args...; Nij = 1, Nh = get_Nh(100))) == (; threads = (1, 1, 64), blocks = (938,))
-    end
-end
-@testset "IFH/IHF partition" begin
-    (; S, args) = get_inputs()
-    for DL in (IFH, IHF)
-        @test pt(DL{S}(args...; Ni = 1, Nh = 1)) == (; threads = (1, 1), blocks = (1,))
-        @test pt(DL{S}(args...; Ni = 1, Nh = get_Nh(1))) == (; threads = (1, 6), blocks = (1,))
-        @test pt(DL{S}(args...; Ni = 4, Nh = get_Nh(30))) == (; threads = (4, 5400), blocks = (1,))
-        @test pt(DL{S}(args...; Ni = 4, Nh = get_Nh(100))) == (; threads = (4, 60000), blocks = (1,)) # TODO: needs fixed (too many threads per block)
-        @test pt(DL{S}(args...; Ni = 1, Nh = get_Nh(30))) == (; threads = (1, 5400), blocks = (1,))
-        @test pt(DL{S}(args...; Ni = 1, Nh = get_Nh(100))) == (; threads = (1, 60000), blocks = (1,)) # TODO: needs fixed (too many threads per block)
-    end
-end
-@testset "IJF partition" begin
-    (; S, args) = get_inputs()
-    @test pt(IJF{S}(args...; Nij = 1)) == (; threads = (1, 1), blocks = (1,))
-    @test pt(IJF{S}(args...; Nij = 4)) == (; threads = (4, 4), blocks = (1,))
-end
-@testset "IF partition" begin
-    (; S, args) = get_inputs()
-    @test pt(IF{S}(args...; Ni = 1)) == (; threads = (1,), blocks = (1,))
-    @test pt(IF{S}(args...; Ni = 4)) == (; threads = (4,), blocks = (1,))
-end
-@testset "VF partition" begin
-    (; S, args) = get_inputs()
-    @test pt(VF{S}(args...; Nv = 1)) == (; threads = (1, ), blocks = (1, ))
-    @test pt(VF{S}(args...; Nv = 10)) == (; threads = (1, ), blocks = (10, ))
-    @test pt(VF{S}(args...; Nv = 64)) == (; threads = (1, ), blocks = (64, ))
-    @test pt(VF{S}(args...; Nv = 1000)) == (; threads = (1, ), blocks = (1000, ))
-end
-@testset "VIJFH/VIJHF partition" begin
-    (; S, args) = get_inputs()
-    for DL in (VIJFH, VIJHF)
-        @test pt(DL{S}(args...; Nv = 1, Nij = 1, Nh = 1)) == (; threads = (1, 1, 1), blocks = (1, 1))
-        @test pt(DL{S}(args...; Nv = 1, Nij = 1, Nh = get_Nh(1))) == (; threads = (1, 1, 1), blocks = (6, 1))
-        @test pt(DL{S}(args...; Nv = 64, Nij = 4, Nh = get_Nh(30))) == (; threads = (64, 4, 4), blocks = (5400, 1))
-        @test pt(DL{S}(args...; Nv = 64, Nij = 4, Nh = get_Nh(100))) == (; threads = (64, 4, 4), blocks = (60000, 1))
-        @test pt(DL{S}(args...; Nv = 64, Nij = 1, Nh = get_Nh(100))) == (; threads = (64, 1, 1), blocks = (60000, 1)) # need more threads per block?
-        @test pt(DL{S}(args...; Nv = 10, Nij = 1, Nh = get_Nh(100))) == (; threads = (10, 1, 1), blocks = (60000, 1)) # need more threads per block
-        @test pt(DL{S}(args...; Nv = 10, Nij = 1, Nh = get_Nh(30))) == (; threads = (10, 1, 1), blocks = (5400, 1)) # need more threads per block
-        @test pt(DL{S}(args...; Nv = 1000, Nij = 1, Nh = get_Nh(30))) == (; threads = (1000, 1, 1), blocks = (5400, 1))
-        @test pt(DL{S}(args...; Nv = 2000, Nij = 1, Nh = get_Nh(30))) == (; threads = (2000, 1, 1), blocks = (5400, 1)) # TODO: fix this? maximum_allowable_threads()[1] == 1024
-    end
-end
-@testset "VIFH/VIHF partition" begin
-    (; S, args) = get_inputs()
-    for DL in (VIFH, VIHF)
-        @test pt(DL{S}(args...; Nv = 1, Ni = 1, Nh = 1)) == (; threads = (1, 1), blocks = (1, 1))
-        @test pt(DL{S}(args...; Nv = 1, Ni = 1, Nh = get_Nh(1))) == (; threads = (1, 1), blocks = (6, 1))
-        @test pt(DL{S}(args...; Nv = 64, Ni = 4, Nh = get_Nh(30))) == (; threads = (64, 4), blocks = (5400, 1))
-        @test pt(DL{S}(args...; Nv = 64, Ni = 4, Nh = get_Nh(100))) == (; threads = (64, 4), blocks = (60000, 1))
-        @test pt(DL{S}(args...; Nv = 64, Ni = 1, Nh = get_Nh(100))) == (; threads = (64, 1), blocks = (60000, 1)) # need more threads per block?
-        @test pt(DL{S}(args...; Nv = 10, Ni = 1, Nh = get_Nh(100))) == (; threads = (10, 1), blocks = (60000, 1)) # need more threads per block
-    end
 end
 
 @testset "fd_shmem_stencil_partition" begin
@@ -159,50 +82,25 @@ end
     end
 end
 
-@testset "columnwise_partition" begin
-    (; S, args) = get_inputs()
-    for DL in (IFH, IHF)
-        @test pt_columnwise(DL{S}(args...; Ni = 1, Nh = get_Nh(100))) == (; threads = (1, 1, 64), blocks = (938,))
-        @test pt_columnwise(DL{S}(args...; Ni = 4, Nh = get_Nh(100))) == (; threads = (4, 1, 64), blocks = (938,))
-        @test pt_columnwise(DL{S}(args...; Ni = 4, Nh = get_Nh(100))) == (; threads = (4, 1, 64), blocks = (938,))
-    end
-    for DL in (IJFH, IJHF)
-        @test pt_columnwise(DL{S}(args...; Nij = 1, Nh = get_Nh(100))) == (; threads = (1, 1, 64), blocks = (938,)) # more threads per block?
-        @test pt_columnwise(DL{S}(args...; Nij = 4, Nh = get_Nh(100))) == (; threads = (4, 4, 64), blocks = (938,)) # more threads per block?
-    end
-end
-
-@testset "multiple_field_solve_partition" begin
-    (; S, args) = get_inputs()
-    for DL in (IFH, IHF)
-        @test pt_mfs(DL{S}(args...; Ni = 1, Nh = get_Nh(100)); Nnames = 1) == (; threads = (1, 1, 1), blocks = (60000,))
-        @test pt_mfs(DL{S}(args...; Ni = 4, Nh = get_Nh(100)); Nnames = 2) == (; threads = (4, 1, 2), blocks = (60000,)) # more threads per block?
-    end
-    for DL in (IJFH, IJHF)
-        @test pt_mfs(DL{S}(args...; Nij = 1, Nh = get_Nh(100)); Nnames = 1) == (; threads = (1, 1, 1), blocks = (60000,)) # more threads per block?
-        @test pt_mfs(DL{S}(args...; Nij = 4, Nh = get_Nh(100)); Nnames = 2) == (; threads = (4, 4, 2), blocks = (60000,)) # more threads per block?
-    end
-end
-
 @testset "masked_partition" begin
     (; S, args) = get_inputs()
     for DL in (VIFH, VIHF)
-        @test pt_masked(DL{S}(args...; Nv = 10, Ni = 1, Nh = get_Nh(100)); frac = 0.5) == (; threads = (10,), blocks = (30000, 1)) # need more threads per block
-        @test pt_masked(DL{S}(args...; Nv = 10, Ni = 1, Nh = get_Nh(100)); frac = 0.1) == (; threads = (10,), blocks = (6000, 1)) # need more threads per block
-        @test pt_masked(DL{S}(args...; Nv = 10, Ni = 1, Nh = get_Nh(100)); frac = 0.8) == (; threads = (10,), blocks = (48000, 1)) # need more threads per block
+        @test pt_masked(DL{S}(args...; Nv = 10, Ni = 1, Nh = get_Nh(100)); frac = 0.5) == (; threads = 300000, blocks = 1)
+        @test pt_masked(DL{S}(args...; Nv = 10, Ni = 1, Nh = get_Nh(100)); frac = 0.1) == (; threads = 60000, blocks = 1)
+        @test pt_masked(DL{S}(args...; Nv = 10, Ni = 1, Nh = get_Nh(100)); frac = 0.8) == (; threads = 480000, blocks = 1)
 
-        @test pt_masked(DL{S}(args...; Nv = 100, Ni = 1, Nh = get_Nh(100)); frac = 0.5) == (; threads = (100,), blocks = (30000, 1)) # need more threads per block
-        @test pt_masked(DL{S}(args...; Nv = 100, Ni = 1, Nh = get_Nh(100)); frac = 0.1) == (; threads = (100,), blocks = (6000, 1)) # need more threads per block
-        @test pt_masked(DL{S}(args...; Nv = 100, Ni = 1, Nh = get_Nh(100)); frac = 0.8) == (; threads = (100,), blocks = (48000, 1)) # need more threads per block
+        @test pt_masked(DL{S}(args...; Nv = 100, Ni = 1, Nh = get_Nh(100)); frac = 0.5) == (; threads = 3000000, blocks = 1)
+        @test pt_masked(DL{S}(args...; Nv = 100, Ni = 1, Nh = get_Nh(100)); frac = 0.1) == (; threads = 600000, blocks = 1)
+        @test pt_masked(DL{S}(args...; Nv = 100, Ni = 1, Nh = get_Nh(100)); frac = 0.8) == (; threads = 4800000, blocks = 1)
     end
     for DL in (VIJFH, VIJHF)
-        @test pt_masked(DL{S}(args...; Nv = 10, Nij = 1, Nh = get_Nh(100)); frac = 0.5) == (; threads = (10,), blocks = (30000, 1)) # need more threads per block
-        @test pt_masked(DL{S}(args...; Nv = 10, Nij = 1, Nh = get_Nh(100)); frac = 0.1) == (; threads = (10,), blocks = (6000, 1)) # need more threads per block
-        @test pt_masked(DL{S}(args...; Nv = 10, Nij = 1, Nh = get_Nh(100)); frac = 0.8) == (; threads = (10,), blocks = (48000, 1)) # need more threads per block
+        @test pt_masked(DL{S}(args...; Nv = 10, Nij = 1, Nh = get_Nh(100)); frac = 0.5) == (; threads = 300000, blocks = 1)
+        @test pt_masked(DL{S}(args...; Nv = 10, Nij = 1, Nh = get_Nh(100)); frac = 0.1) == (; threads = 60000, blocks = 1)
+        @test pt_masked(DL{S}(args...; Nv = 10, Nij = 1, Nh = get_Nh(100)); frac = 0.8) == (; threads = 480000, blocks = 1)
 
-        @test pt_masked(DL{S}(args...; Nv = 100, Nij = 1, Nh = get_Nh(100)); frac = 0.5) == (; threads = (100,), blocks = (30000, 1)) # need more threads per block
-        @test pt_masked(DL{S}(args...; Nv = 100, Nij = 1, Nh = get_Nh(100)); frac = 0.1) == (; threads = (100,), blocks = (6000, 1)) # need more threads per block
-        @test pt_masked(DL{S}(args...; Nv = 100, Nij = 1, Nh = get_Nh(100)); frac = 0.8) == (; threads = (100,), blocks = (48000, 1)) # need more threads per block
+        @test pt_masked(DL{S}(args...; Nv = 100, Nij = 1, Nh = get_Nh(100)); frac = 0.5) == (; threads = 3000000, blocks = 1)
+        @test pt_masked(DL{S}(args...; Nv = 100, Nij = 1, Nh = get_Nh(100)); frac = 0.1) == (; threads = 600000, blocks = 1)
+        @test pt_masked(DL{S}(args...; Nv = 100, Nij = 1, Nh = get_Nh(100)); frac = 0.8) == (; threads = 4800000, blocks = 1)
     end
 end
 


### PR DESCRIPTION
After reviewing performance in the land model, I've come to accept that performance characteristics using multi-dimensional launch configurations are quite sharp. For example, we see good performance with high resolution simulations, but excessively poor if the vertical resolution is low.

All three parts of the launch config and index management:

 - Reasoning about the launch configuration
 - Computing the universal index from the thread / block IDs
 - and checking for valid indices

are entangled, and increasing complexity of the launch configuration requires increasing complexity of the other two.

So, I took a second look at the previous design that I had put in place: always use linear launch configurations and use `CartesianIndices`. The issue with that is that `CartesianIndices(...)[::Int]` results in integer division, which is slow and can hurt performance by as much as 2x.

Fortunately, I managed to get something that seems to be working, and I started the registration process for [ClimaCartesianIndices.jl](https://github.com/CliMA/ClimaCartesianIndices.jl), which defines `FastCartesianIndices`, a drop-in replacement for `CartesianIndices`. The difference is that `FastCartesianIndices(...)[::Int]` avoids integer division by using bit tricks.

See the ClimaCartesianIndices.jl [documentation](https://clima.github.io/ClimaCartesianIndices.jl/dev/) for more information. We could reach near linear indexing speeds by passing `FastCartesianIndices` through to kernels via `Val`, but that will allocate because `Nh` is not in the type domain (we removed it because it, for some unknown reason, spiked compilation times). For now, I think it's still a better trade-off to use CartesianIndices and have more robust performance.

As a result, I'm going to revert most of our multi-dimensional launch configurations to linear ones, and start using `FastCartesianIndices`.

For now, I'm going to skip the kernels that use shared memory (SEM and FD shmem), since we never had linear launch configurations for those to begin with, and I'm not yet sure how to make that work. That will likely be next on the ticket.

Overall, these changes should yield good performance improvements for the land model, and recover performance losses for our lower resolution experiments, across the board.