### PR TITLE
Add the 1D wave.jl documentation into example.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ docs/src/tutorials/
 *.gz
 *.mp4
 *.png
+.DS_Store


### PR DESCRIPTION
Adds a new subsection to [examples.md](https://github.com/CliMA/ClimaCore.jl/blob/main/docs/src/examples.md) containing documentation for the [wave.jl](https://github.com/CliMA/ClimaCore.jl/blob/main/examples/column/wave.jl) 1D wave equation example implemented with ClimaCore.
This documentation is intended to provide a simple, self-contained example for new users of ClimaCore.

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [X] Documentation has been added/updated OR N/A.
