### PR TITLE
Fix allocations with pow

### DIFF
--- a/src/Fields/broadcast.jl
+++ b/src/Fields/broadcast.jl
@@ -313,7 +313,7 @@ end
 Base.Broadcast.broadcasted(
     ::typeof(Base.literal_pow),
     ::typeof(^),
-    f::Field,
+    f::Union{Field, Base.Broadcast.Broadcasted{<:AbstractFieldStyle}},
     ::Val{n},
 ) where {n} = Base.Broadcast.broadcasted(x -> Base.literal_pow(^, x, Val(n)), f)
 

--- a/test/Fields/unit_field.jl
+++ b/test/Fields/unit_field.jl
@@ -147,6 +147,10 @@ function pow_n(f)
     @. f.x = f.x^2
     return nothing
 end
+function pow_n_bc(f)
+    @. f.x = (f.x * 2)^2
+    return nothing
+end
 @testset "Broadcasting with ^n" begin
     FT = Float32
     device = ClimaComms.CPUSingleThreaded() # fill is broken on gpu
@@ -155,6 +159,13 @@ end
         f = fill((; x = FT(1)), space)
         pow_n(f) # Compile first
         p_allocated = @allocated pow_n(f)
+        if space isa Spaces.SpectralElementSpace1D
+            @test p_allocated == 0
+        else
+            @test p_allocated == 0 broken = (device isa ClimaComms.CUDADevice)
+        end
+        pow_n_bc(f) # Compile first
+        p_allocated = @allocated pow_n_bc(f)
         if space isa Spaces.SpectralElementSpace1D
             @test p_allocated == 0
         else


### PR DESCRIPTION
Closes #1126.

Using LazyBroadcast here was pretty convenient, because we could quickly get the broadcasted object to experiment.