### PR TITLE
Make mask IO unit tests deterministic

### DIFF
--- a/test/InputOutput/unit_spectralelement2d.jl
+++ b/test/InputOutput/unit_spectralelement2d.jl
@@ -124,7 +124,7 @@ end
     Y = Fields.FieldVector(y0 = y0)
 
     Spaces.set_mask!(space) do coords
-        rand() > 0.5
+        sin(coords.x) > 0.5
     end
 
     # write field vector to hdf5 file


### PR DESCRIPTION
This will also make sure that we don't accidentally have a mask where at least some columns are masked out. Otherwise we can get div by zero errors (seen [here](https://buildkite.com/clima/climacore-ci/builds/5628#0196636d-be18-42bd-b028-a63ebc98d24c)). cc @Sbozzolo