### PR TITLE
Remove some soft-fails

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -920,12 +920,10 @@ steps:
       - label: "Unit: matrix field broadcasting (CPU)"
         key: unit_matrix_field_broadcasting_cpu_scalar_14
         command: "julia --color=yes --check-bounds=yes --project=.buildkite test/MatrixFields/matrix_fields_broadcasting/test_scalar_14.jl"
-        soft_fail: true
 
       - label: "Unit: matrix field broadcasting (CPU)"
         key: unit_matrix_field_broadcasting_cpu_scalar_15
         command: "julia --color=yes --check-bounds=yes --project=.buildkite test/MatrixFields/matrix_fields_broadcasting/test_scalar_15.jl"
-        soft_fail: true
 
       - label: "Unit: matrix field broadcasting (CPU)"
         key: unit_matrix_field_broadcasting_cpu_scalar_16
@@ -1068,7 +1066,6 @@ steps:
       - label: "Unit: matrix field broadcasting (GPU)"
         key: unit_matrix_field_broadcasting_gpu_scalar_13
         command: "julia --color=yes --check-bounds=yes --project=.buildkite test/MatrixFields/matrix_fields_broadcasting/test_scalar_13.jl"
-        soft_fail: true # due to PTX error
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -1129,7 +1126,6 @@ steps:
         command: "julia --color=yes --check-bounds=yes --project=.buildkite test/MatrixFields/matrix_fields_broadcasting/test_non_scalar_3.jl"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
-        soft_fail: true
         agents:
           slurm_gpus: 1
           slurm_mem: 10GB


### PR DESCRIPTION
I noticed in a recent build that a handful of gpu jobs that were previously failing with `soft_fail: true` are now passing. I looked back, and I think they were fixed by #2284.

There's only 4 left, and I think that 2 of them may just need fixes in the test. The other two are probably compiler heuristics.