### PR TITLE
Disable shmem + update patch version > 0.14.32

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.14.31"
+version = "0.14.32"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -4177,12 +4177,15 @@ end
 """
     use_fd_shmem()
 
-Allows users to, from global scope, disable finite
+Allows users to, from global scope, enable finite
 difference shmem for operators that support it.
+TODO: ~30% slowdown was noticed with CC 0.14.31 
+in Aquaplanet benchmarks. This may need attention in 
+future releases
 
 ## Usage
 ```julia
 Operators.use_fd_shmem() = false
 ```
 """
-use_fd_shmem() = true
+use_fd_shmem() = false


### PR DESCRIPTION
The following [performance regression was noticed](https://gist.github.com/akshaysridhar/fca4d50242a8bcc65faa8289b03cdc8f ) when upgrading to ClimaCore v0.14.31 in ClimaAtmos, with additional information here (https://github.com/CliMA/ClimaCore.jl/pull/2304#issuecomment-2839688639). This PR disables shmem for finite diff ops in an attempt to recover a large chunk of this perf loss. 

```
CC v 0.14.30 
https://github.com/CliMA/ClimaCore.jl/pull/2304#issuecomment-2839688639
1 GPU Aquaplanet: 0.694
2 GPU Aquaplanet: 1.358 

CC v 0.14.31
https://github.com/CliMA/ClimaCore.jl/pull/2304#issuecomment-2839688639
1 GPU Aquaplanet: 0.503
2 GPU Aquaplanet: 1.005

CC v 0.14.31 + Disable shmem 
Operators.use_fd_shmem() = false
1 GPU Aquaplanet: 0.611
2 GPU Aquaplanet: 1.285

```