### PR TITLE
Bump to 0.14.33

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,18 @@ ClimaCore.jl Release Notes
 main
 -------
 
+v0.14.33
+-------
+
+- Expanded compat for Krylov to `0.10`. [2318](https://github.com/CliMA/ClimaCore.jl/pull/2318).
+
+v0.14.32
+-------
+
+- Disabled shared memory on finite difference operators. It was found that it
+  has a severe performance penalty for more complex cases.
+  [2317](https://github.com/CliMA/ClimaCore.jl/pull/2317)
+
 - Fixed missing method for `Topologies.mesh(Topology2D)`
    [2288](https://github.com/CliMA/ClimaCore.jl/pull/2288).
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.14.32"
+version = "0.14.33"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
This release is needed to extend the compat for Kyrlov in ClimaTimeSteppers, which is needed to add support for recent versions of Oceananigans in ClimaCoupler.
