### PR TITLE
Loosen type restriction in remapping

### DIFF
--- a/src/Remapping/distributed_remapping.jl
+++ b/src/Remapping/distributed_remapping.jl
@@ -910,7 +910,7 @@ function interpolate!(
 
         found_type = nameof(typeof(dest))
 
-        dest isa expected_array_type ||
+        parent(dest) isa expected_array_type ||
             error("dest is a $found_type, expected $expected_array_type")
     end
     index_field_begin, index_field_end =


### PR DESCRIPTION
This type restriction prevents the remapping from being used with `SubArray`s. Checking the parent extends compatibility with `SubArray`s too.
