### PR TITLE
Add `DebugOnly.allow_mismatched_spaces_unsafe`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,8 +4,17 @@ ClimaCore.jl Release Notes
 main
 -------
 
-- Latitude and longitudes were flipped in the default target coordiantes
+- Latitude and longitudes were flipped in the default target coordinates
 in the remapper, leading to non-sense values.
+
+### ![][badge-✨feature/enhancement] Add option to disable check on spaces. PR [2322](https://github.com/CliMA/ClimaCore.jl/pull/2322)
+
+`ClimaCore.DebugOnly` now contains a function `allow_mismatched_spaces_unsafe`. When
+this function is overridden to return `true`, `ClimaCore` will skip consistency
+checks on spaces in broadcasted expressions. This is useful when debugging with
+`deepcopy`. See
+[documentation](https://clima.github.io/ClimaCore.jl/dev/debugging/#Faster-explorations-when-the-initialization-is-expensive)
+for more information.
 
 v0.14.33
 -------

--- a/docs/src/debugging.md
+++ b/docs/src/debugging.md
@@ -1,20 +1,23 @@
 # Debugging
 
+`ClimaCore` comes with a set of debugging tools for a variety of situations.
+These tools are collected in the [`ClimaCore.DebugOnly`](@ref) modules and are
+presented in this page.
+
+## Finding where `NaN` arise
+
 One of the most challenging tasks that users have is: debug a large simulation
 that is breaking, e.g., yielding `NaN`s somewhere. This is especially complex
 for large models with many terms and implicit time-stepping with all the bells
 and whistles that the CliMA ecosystem offers.
 
-ClimaCore has a module, [`ClimaCore.DebugOnly`](@ref), which contains tools for
-debugging simulations for these complicated situations.
-
 Because so much data (for example, the solution state, and many cached fields)
-is typically contained in ClimaCore data structures, we offer a hook to inspect
-this data after any operation that ClimaCore performs.
+is typically contained in `ClimaCore` data structures, we offer a hook to
+inspect this data after any operation that `ClimaCore` performs.
 
-## Example
+### Example
 
-### Print `NaNs` when they are found
+#### Print `NaNs` when they are found
 
 In this example, we add a callback that simply prints `NaNs found` every
 instance when they are detected in a `ClimaCore` operation.
@@ -46,10 +49,10 @@ If needed, multiple methods of `post_op_callback` can be defined, but here, we
 define a general method that checks if `NaN`s are in the given object.
 
 Note that we need `post_op_callback` to be called for a wide variety of inputs
-because it is called by many many different functions with many different
-objects. Therefore, we recommend that you define `post_op_callback` with a very
-general method signature, like the one above and perhaps use `Infiltrator` to
-inspect the arguemtns.
+because it is called by many different functions with many different objects.
+Therefore, we recommend that you define `post_op_callback` with a very general
+method signature, like the one above and perhaps use `Infiltrator` to inspect
+the arguments.
 
 Now, let us put everything together and demonstrate a complete example:
 
@@ -72,13 +75,127 @@ ClimaCore.DebugOnly.call_post_op_callback() = false # hide
 ```
 This example should print `NaN` on your standard output.
 
-### Infiltrating
+As you see, this only tells us that a `NaN` was found, but not which function
+triggered the `NaN`. A simple way to find that is to extend this example with
+`Infiltrator`.
+
+#### Infiltrating and Exfiltrating
 
 [Infiltrator.jl](https://github.com/JuliaDebug/Infiltrator.jl) is a simple
 debugging tool for Julia packages.
 
-Here is an example, where we can use Infiltrator.jl to find where NaNs is coming
+Here is an example, where we can use Infiltrator.jl to find where `NaN`s is coming
 from interactively.
+
+##### Infiltrating
+
+Suppose you have a `NaN` in your simulation and what to look at the variables
+right before the expression caused the `NaN`. One of the challenges in this is
+that you probably have a tower of function being called, many of which belong to
+other packages.
+
+Let us simulate this case (note this is a toy example optimized for clarity and
+not for performance: the functions below have unnecessary allocations)
+```julia
+import ClimaCore
+using ClimaCore.CommonSpaces
+space = CubedSphereSpace(; radius = 10, n_quad_points = 4, h_elem = 10)
+myrho = ones(space)
+myP = ones(space)
+myu = ones(space)
+
+kinetic_energy(field) = field .* field ./ 2
+other_energy(field) = field ./ sum(field)
+offset_by_one(field) = field .- 1
+
+function specific_energy(rho, P, u)
+    density_without_restmass = offset_by_one(rho)
+    return (kinetic_energy(u) .+ other_energy(P)) ./ density_without_restmass
+end
+
+function renormalized_energy(rho, P, u)
+    energy = specific_energy(rho, P, u)
+    return energy ./ sum(energy)
+end
+
+any(isnan, renormalized_energy(myrho, myP, myu)) # true
+```
+
+To debug this, we first need to identify where the first `NaN` is produced. We
+use `DebugOnly.call_post_op_callback` and infiltrate.
+```julia
+import Infiltrator # must be in your default environment
+ClimaCore.DebugOnly.call_post_op_callback() = true
+function ClimaCore.DebugOnly.post_op_callback(result, args...; kwargs...)
+    has_nans = result isa Number ? isnan(result) : any(isnan, parent(result))
+    has_inf = result isa Number ? isinf(result) : any(isinf, parent(result))
+    @infiltrate has_nans || has_inf
+end
+```
+
+"Infiltrating" means being dropped into a new REPL where in the scope of the
+`@infiltrate` macro. `@infiltrate condition` means that we want to infiltrate
+only when the `condition` is true (in this case `has_nans || has_inf`).
+
+Now, when we run our example, we will see
+```julia
+julia> renormalized_energy(myrho, myP, myu)
+Infiltrating post_op_callback(::ClimaCore.DataLayouts.IJFH{Float64, 4, Array{Float64, 4}}, ::ClimaCore.DataLayouts.IJFH{Float64, 4, Array{Float64, 4}}, ::Vararg{Any}; kwargs::@Kwargs{})
+  at REPL[40]:4
+infil>
+```
+Here, we are dropped into a new REPL with full access to the variables in the scope where the `NaN` occurred. However, because of how `post_op_callback`, this is at a low level within `ClimaCore`, which is typically not useful. Hence, the next step is to type `@trace`, which prints out
+```julia
+[1] post_op_callback(::ClimaCore.DataLayouts.IJFH{…}, ::ClimaCore.DataLayouts.IJFH{…}, ::Vararg{…}; kwargs::@Kwargs{})
+    at REPL[40]:4
+[2] post_op_callback
+    at REPL[40]:1
+[3] copyto!
+    at ClimaCore.jl/src/DataLayouts/copyto.jl:18
+[4] copyto!
+    at ClimaCore.jl/src/Fields/broadcast.jl:190
+[5] copy
+    at ClimaCore.jl/src/Fields/broadcast.jl:97
+[6] materialize
+    at .julia/juliaup/julia-1.11.4+0.x64.linux.gnu/share/julia/base/broadcast.jl:872
+[7] specific_energy(rho::ClimaCore.Fields.Field{…}, P::ClimaCore.Fields.Field{…}, u::ClimaCore.Fields.Field{…})
+    at REPL[31]:2
+[8] renormalized_energy(rho::ClimaCore.Fields.Field{…}, P::ClimaCore.Fields.Field{…}, u::ClimaCore.Fields.Field{…})
+    at REPL[36]:2
+[9] top-level scope
+```
+
+`@trace` returns a type-limited stacktrace that we can read backwards until we
+see our functions. In this case, we see that the first `NaN` is in
+`specific_energy`, so we will investigate that function. We leave the
+Infiltrator REPL with `@exit`, disable the `call_post_op_callback`, and move our
+`infiltrate` call within the target function:
+```julia
+ClimaCore.DebugOnly.call_post_op_callback() = false
+function specific_energy(rho, P, u)
+    @infiltrate
+    density_without_restmass = offset_by_one(rho)
+    return (kinetic_energy(u) .+ other_energy(P)) ./ density_without_restmass
+end
+```
+Now, when we evaluate our problematic expression (the one at the top level, in this case `renormalized_energy(myrho, myP, myu)`), we will be dropped in a REPL inside `specific_energy`. Here, we have access to `density_without_restmass`, and we notice that it can be zero, leading to the `NaN`.
+
+!!! tip
+
+    The infiltrator REPL is different from the normal Julia repl. Type `?` for
+    some useful commands. You can fetch objects defined in the main REPL by
+    prepending their name with `Main`. Similarly, if you want to infiltrate inside a
+    module, prepend `@infiltrate` with `Main` (`Main.@infiltrate`).
+
+Looking at this code, we could have probably guess that the `NaN` comes from a
+division from 0, and the real question is how do we get that?. In more complex
+cases, the functions are spread across different packages and involve several
+different variables. This approach allows one to systematically identify where
+things go wrong.
+
+##### Exfiltrating and StructuredPrinting
+
+Let's now see a different way to use Infiltrator, where we move the variables in specific scope to the Main scope in the REPL and do some analysis on it.
 
 ```julia
 import ClimaCore
@@ -162,7 +279,7 @@ bc.axes.5::Base.OneTo{Int64}
 bc.axes.5.stop::Int64
 ```
 
-### Caveats
+#### Caveats
 
 !!! warn
 
@@ -183,3 +300,41 @@ bc.axes.5.stop::Int64
     as Test.jl may continue running through code execution, until all of the
     tests in a given `@testset` are complete, and the result will be that you
     will get the _last_ observed instance of `NaN` or `Inf`.
+
+#### Faster explorations when the initialization is expensive
+
+Sometimes, we want to start from a given simulation state and explore different
+ideas. For example, we want to run a simulation for 10 days, and then test how
+different approaches affect its stability. Sometimes, checkpoints offer a way to
+do this, but not everything can be checkpointed. 
+
+A simple way to "checkpoint" a simulation is to `deepcopy` its state. This
+allows one to step the copy instead of the original one, which can be re-used to
+make new copies, allowing for various explorations. `ClimaCore` does not support
+this workflow out-of-the-box. The reason for this is that `ClimaCore` uses
+pointers to perform certain safety checks, and deepcopies return new pointers
+(by definition). To enable this, override the
+`DebugOnly.allow_mismatched_spaces_unsafe` function so that it returns true. When
+`DebugOnly.allow_mismatched_spaces_unsafe` returns true, `ClimaCore` can mix fields
+defined on space that are not identically the same.
+
+Let us look at an example of this.
+```julia
+import ClimaCore
+using ClimaCore.CommonSpaces
+other_space = deepcopy(space)
+
+one = ones(space)
+other_one = ones(other_space)
+
+one .+ other_one  # This throws an error 
+
+ClimaCore.DebugOnly.allow_mismatched_spaces_unsafe() = true
+one .+ other_one # Now it's fine!
+```
+
+!!! warn
+
+    `ClimaCore` checks for consistency of spaces to protect you from non-sense
+    results. If you disable this check, you are responsible to ensure that the
+    results make sense.

--- a/src/Fields/broadcast.jl
+++ b/src/Fields/broadcast.jl
@@ -1,3 +1,5 @@
+import ..DebugOnly: allow_mismatched_spaces_unsafe
+
 """
     AbstractFieldStyle
 
@@ -229,7 +231,7 @@ end
     space1::AbstractSpace,
     space2::AbstractSpace,
 )
-    if space1 !== space2
+    if space1 !== space2 && !allow_mismatched_spaces_unsafe()
         if Spaces.issubspace(space2, space1)
             return space1
         elseif Spaces.issubspace(space1, space2)
@@ -263,7 +265,11 @@ end
     space1::AbstractSpace,
     space2::AbstractSpace,
 )
-    if space1 !== space2
+    # When DebugOnly.allow_mismatched_spaces_unsafe() returns true, we ignore the check
+    # and blindly return `space1`. Responsibility is left up to the user to
+    # handle this correctly. This is useful to work with spaces that are == but
+    # not ===, e.g., deepcopied spaces.
+    if space1 !== space2 && !allow_mismatched_spaces_unsafe()
         if Spaces.issubspace(space2, space1) ||
            Spaces.issubspace(space1, space2)
             nothing

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -1,4 +1,5 @@
 import ..Utilities: PlusHalf, half, unionall_type
+import ..DebugOnly: allow_mismatched_spaces_unsafe
 import UnrolledUtilities: unrolled_map
 
 const AllFiniteDifferenceSpace =
@@ -3889,8 +3890,6 @@ function Base.Broadcast.broadcasted(
     StencilBroadcasted{Style}(promote_bcs(op, FT), args)
 end
 
-allow_mismatched_fd_spaces() = false
-
 # check that inferred output field space is equal to dest field space
 @noinline inferred_stencil_spaces_error(
     dest_space_type::Type,
@@ -3905,7 +3904,7 @@ function Base.Broadcast.materialize!(
     bc::Base.Broadcast.Broadcasted{Style},
 ) where {Style <: AbstractStencilStyle}
     dest_space, result_space = axes(dest), axes(bc)
-    if result_space !== dest_space && !allow_mismatched_fd_spaces()
+    if result_space !== dest_space && !allow_mismatched_spaces_unsafe()
         # TODO: we pass the types here to avoid stack copying data
         # but this could lead to a confusing error message (same space type but different instances)
         inferred_stencil_spaces_error(typeof(dest_space), typeof(result_space))


### PR DESCRIPTION
This commit adds an option to skip the consistency checks when working with `ClimaCore` spaces. As discussed in the documentation page, this is useful to enable an interactive "checkpointing" workflow with `deepcopy`.

This commit also adds a description of another debugging workflow to the documentation.