### PR TITLE
Add missing methods for column spaces and FieldVectors

### DIFF
--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -30,7 +30,7 @@ import ..Utilities: PlusHalf, half
 using ..RecursiveApply
 using ClimaComms
 import Adapt
-import UnrolledUtilities: unrolled_map
+import UnrolledUtilities: unrolled_map, unrolled_findfirst
 
 import StaticArrays, LinearAlgebra, Statistics, InteractiveUtils
 

--- a/src/Grids/column.jl
+++ b/src/Grids/column.jl
@@ -36,6 +36,8 @@ struct ColumnGrid{
     colidx::C
 end
 
+Adapt.@adapt_structure ColumnGrid
+
 local_geometry_type(::Type{ColumnGrid{G, C}}) where {G, C} =
     local_geometry_type(G)
 

--- a/src/Spaces/finitedifference.jl
+++ b/src/Spaces/finitedifference.jl
@@ -103,6 +103,7 @@ function center_space(space::FiniteDifferenceSpace)
     return FiniteDifferenceSpace(grid(space), CellCenter())
 end
 
+ncolumns(::FiniteDifferenceSpace) = 1
 nlevels(space::FiniteDifferenceSpace) = length(space)
 # TODO: deprecate?
 Base.length(space::FiniteDifferenceSpace) = length(coordinates_data(space))


### PR DESCRIPTION
<!-- Provide a clear description of the content -->

This PR adds several missing method definitions, which were discovered while working on CliMA/ClimaAtmos.jl#2730:
- `adapt_structure` was not defined for `ColumnGrid`, making vertical slices of 3D spaces incompatible with GPUs
- `ncolumns` was not defined for `FiniteDifferenceSpace`, making it hard to count columns of arbitrary spaces
- `ClimaComms.device` and `ClimaComms.context` were not defined for `FieldVector`, so that we had to extract specific `Field`s to get the device
