### PR TITLE
Fix slicing of lazy Field broadcasts

### DIFF
--- a/src/DataLayouts/broadcast.jl
+++ b/src/DataLayouts/broadcast.jl
@@ -21,37 +21,45 @@ struct VFStyle{Nv, A} <: DataColumnStyle end
 DataStyle(::Type{VF{S, Nv, A}}) where {S, Nv, A} =
     VFStyle{Nv, parent_array_type(A)}()
 DataColumnStyle(::Type{VFStyle{Nv, A}}) where {Nv, A} = VFStyle{Nv, A}
+Data0DStyle(::Type{VFStyle{Nv, A}}) where {Nv, A} = DataFStyle{A}
 
 abstract type Data1DStyle{Ni} <: DataStyle end
 struct IFHStyle{Ni, A} <: Data1DStyle{Ni} end
 DataStyle(::Type{IFH{S, Ni, A}}) where {S, Ni, A} =
     IFHStyle{Ni, parent_array_type(A)}()
+Data0DStyle(::Type{IFHStyle{Ni, A}}) where {Ni, A} = DataFStyle{A}
 struct IHFStyle{Ni, A} <: Data1DStyle{Ni} end
 DataStyle(::Type{IHF{S, Ni, A}}) where {S, Ni, A} =
     IHFStyle{Ni, parent_array_type(A)}()
+Data0DStyle(::Type{IHFStyle{Ni, A}}) where {Ni, A} = DataFStyle{A}
 
 abstract type DataSlab1DStyle{Ni} <: DataStyle end
 DataSlab1DStyle(::Type{IFHStyle{Ni, A}}) where {Ni, A} = IFStyle{Ni, A}
+DataSlab1DStyle(::Type{IHFStyle{Ni, A}}) where {Ni, A} = IFStyle{Ni, A}
 
 struct IFStyle{Ni, A} <: DataSlab1DStyle{Ni} end
 DataStyle(::Type{IF{S, Ni, A}}) where {S, Ni, A} =
     IFStyle{Ni, parent_array_type(A)}()
+Data0DStyle(::Type{IFStyle{Ni, A}}) where {Ni, A} = DataFStyle{A}
 
 abstract type DataSlab2DStyle{Nij} <: DataStyle end
 struct IJFStyle{Nij, A} <: DataSlab2DStyle{Nij} end
 DataStyle(::Type{IJF{S, Nij, A}}) where {S, Nij, A} =
     IJFStyle{Nij, parent_array_type(A)}()
+Data0DStyle(::Type{IJFStyle{Nij, A}}) where {Nij, A} = DataFStyle{A}
 
 abstract type Data2DStyle{Nij} <: DataStyle end
 struct IJFHStyle{Nij, A} <: Data2DStyle{Nij} end
 DataStyle(::Type{IJFH{S, Nij, A}}) where {S, Nij, A} =
     IJFHStyle{Nij, parent_array_type(A)}()
 DataSlab2DStyle(::Type{IJFHStyle{Nij, A}}) where {Nij, A} = IJFStyle{Nij, A}
+Data0DStyle(::Type{IJFHStyle{Nij, A}}) where {Nij, A} = DataFStyle{A}
 
 struct IJHFStyle{Nij, A} <: Data2DStyle{Nij} end
 DataStyle(::Type{IJHF{S, Nij, A}}) where {S, Nij, A} =
     IJHFStyle{Nij, parent_array_type(A)}()
 DataSlab2DStyle(::Type{IJHFStyle{Nij, A}}) where {Nij, A} = IJFStyle{Nij, A}
+Data0DStyle(::Type{IJHFStyle{Nij, A}}) where {Nij, A} = DataFStyle{A}
 
 abstract type Data1DXStyle{Nv, Ni} <: DataStyle end
 struct VIFHStyle{Nv, Ni, A} <: Data1DXStyle{Nv, Ni} end
@@ -61,6 +69,7 @@ Data1DXStyle(::Type{VIFHStyle{Nv, Ni, A}}) where {Ni, Nv, A} =
     VIFHStyle{Nv, Ni, A}
 DataColumnStyle(::Type{VIFHStyle{Nv, Ni, A}}) where {Ni, Nv, A} = VFStyle{Nv, A}
 DataSlab1DStyle(::Type{VIFHStyle{Nv, Ni, A}}) where {Ni, Nv, A} = IFStyle{Ni, A}
+Data0DStyle(::Type{VIFHStyle{Nv, Ni, A}}) where {Nv, Ni, A} = DataFStyle{A}
 
 struct VIHFStyle{Nv, Ni, A} <: Data1DXStyle{Nv, Ni} end
 DataStyle(::Type{VIHF{S, Nv, Ni, A}}) where {S, Nv, Ni, A} =
@@ -69,6 +78,7 @@ Data1DXStyle(::Type{VIHFStyle{Nv, Ni, A}}) where {Ni, Nv, A} =
     VIHFStyle{Nv, Ni, A}
 DataColumnStyle(::Type{VIHFStyle{Nv, Ni, A}}) where {Ni, Nv, A} = VFStyle{Nv, A}
 DataSlab1DStyle(::Type{VIHFStyle{Nv, Ni, A}}) where {Ni, Nv, A} = IFStyle{Ni, A}
+Data0DStyle(::Type{VIHFStyle{Nv, Ni, A}}) where {Nv, Ni, A} = DataFStyle{A}
 
 abstract type Data2DXStyle{Nv, Nij} <: DataStyle end
 struct VIJFHStyle{Nv, Nij, A} <: Data2DXStyle{Nv, Nij} end
@@ -80,6 +90,7 @@ DataColumnStyle(::Type{VIJFHStyle{Nv, Nij, A}}) where {Nv, Nij, A} =
     VFStyle{Nv, A}
 DataSlab2DStyle(::Type{VIJFHStyle{Nv, Nij, A}}) where {Nv, Nij, A} =
     IJFStyle{Nij, A}
+Data0DStyle(::Type{VIJFHStyle{Nv, Nij, A}}) where {Nv, Nij, A} = DataFStyle{A}
 
 struct VIJHFStyle{Nv, Nij, A} <: Data2DXStyle{Nv, Nij} end
 DataStyle(::Type{VIJHF{S, Nv, Nij, A}}) where {S, Nv, Nij, A} =
@@ -90,6 +101,22 @@ DataColumnStyle(::Type{VIJHFStyle{Nv, Nij, A}}) where {Nv, Nij, A} =
     VFStyle{Nv, A}
 DataSlab2DStyle(::Type{VIJHFStyle{Nv, Nij, A}}) where {Nv, Nij, A} =
     IJFStyle{Nij, A}
+Data0DStyle(::Type{VIJHFStyle{Nv, Nij, A}}) where {Nv, Nij, A} = DataFStyle{A}
+
+const HorizontalDataStyle = Union{
+    Data1DStyle,
+    Data2DStyle,
+    DataSlab1DStyle,
+    DataSlab2DStyle,
+    Data1DXStyle,
+    Data2DXStyle,
+}
+DataColumnStyle(::Type{Style}) where {Style <: HorizontalDataStyle} =
+    Data0DStyle(Style)
+DataSlabStyle(::Type{Style}) where {Style <: Union{Data1DStyle, Data1DXStyle}} =
+    DataSlab1DStyle(Style)
+DataSlabStyle(::Type{Style}) where {Style <: Union{Data2DStyle, Data2DXStyle}} =
+    DataSlab2DStyle(Style)
 
 #####
 ##### Union styles

--- a/src/Fields/broadcast.jl
+++ b/src/Fields/broadcast.jl
@@ -15,6 +15,11 @@ struct FieldStyle{DS <: DataStyle} <: AbstractFieldStyle end
 FieldStyle(::DS) where {DS <: DataStyle} = FieldStyle{DS}()
 FieldStyle(x::Base.Broadcast.Unknown) = x
 
+FieldColumnStyle(::Type{S}) where {DS, S <: FieldStyle{DS}} =
+    FieldStyle{DataLayouts.DataColumnStyle(DS)}
+FieldSlabStyle(::Type{S}) where {DS, S <: FieldStyle{DS}} =
+    FieldStyle{DataLayouts.DataSlabStyle(DS)}
+
 Base.Broadcast.BroadcastStyle(::Type{Field{V, S}}) where {V, S} =
     FieldStyle(DataStyle(V))
 
@@ -97,44 +102,42 @@ end
 
 Base.@propagate_inbounds function slab(
     bc::Base.Broadcast.Broadcasted{Style},
-    v,
-    h,
+    inds...,
 ) where {Style <: AbstractFieldStyle}
-    _args = slab_args(bc.args, v, h)
-    _axes = slab(axes(bc), v, h)
-    Base.Broadcast.Broadcasted{Style}(bc.f, _args, _axes)
+    _Style = FieldSlabStyle(Style)
+    _args = slab_args(bc.args, inds...)
+    _axes = slab(axes(bc), inds...)
+    Base.Broadcast.Broadcasted{_Style}(bc.f, _args, _axes)
 end
 
 Base.@propagate_inbounds function slab(
     bc::DataLayouts.NonExtrudedBroadcasted{Style},
-    v,
-    h,
+    inds...,
 ) where {Style <: AbstractFieldStyle}
-    _args = slab_args(bc.args, v, h)
-    _axes = slab(axes(bc), v, h)
-    DataLayouts.NonExtrudedBroadcasted{Style}(bc.f, _args, _axes)
+    _Style = FieldSlabStyle(Style)
+    _args = slab_args(bc.args, inds...)
+    _axes = slab(axes(bc), inds...)
+    DataLayouts.NonExtrudedBroadcasted{_Style}(bc.f, _args, _axes)
 end
 
 Base.@propagate_inbounds function column(
     bc::Base.Broadcast.Broadcasted{Style},
-    i,
-    j,
-    h,
+    inds...,
 ) where {Style <: AbstractFieldStyle}
-    _args = column_args(bc.args, i, j, h)
-    _axes = column(axes(bc), i, j, h)
-    Base.Broadcast.Broadcasted{Style}(bc.f, _args, _axes)
+    _Style = FieldColumnStyle(Style)
+    _args = column_args(bc.args, inds...)
+    _axes = column(axes(bc), inds...)
+    Base.Broadcast.Broadcasted{_Style}(bc.f, _args, _axes)
 end
 
 Base.@propagate_inbounds function column(
     bc::DataLayouts.NonExtrudedBroadcasted{Style},
-    i,
-    j,
-    h,
+    inds...,
 ) where {Style <: AbstractFieldStyle}
-    _args = column_args(bc.args, i, j, h)
-    _axes = column(axes(bc), i, j, h)
-    DataLayouts.NonExtrudedBroadcasted{Style}(bc.f, _args, _axes)
+    _Style = FieldColumnStyle(Style)
+    _args = column_args(bc.args, inds...)
+    _axes = column(axes(bc), inds...)
+    DataLayouts.NonExtrudedBroadcasted{_Style}(bc.f, _args, _axes)
 end
 
 # Return underlying DataLayout object, DataStyle of broadcasted


### PR DESCRIPTION
This PR fixes a bug that was discovered while working on CliMA/ClimaAtmos.jl#2730:
- Materializing `Fields.column(lazy.(<extruded_field_broadcast>), indices...)` allocates an extruded field instead of a column field
- Materializing `Fields.column(lazy.(<horizontal_field_broadcast>), indices...)` allocates a horizontal field instead of a point field

This is fixed by extending `DataColumnStyle` to horizontal layouts and defining a new `FieldColumnStyle`, which is used in place of the original `FieldStyle`. The same bug also exists for `Fields.slab`, so I've similarly added a `DataSlabStyle` and `FieldSlabStyle`. There was another bug for `Fields.slab` where lazy broadcasts that were sliced with a single index instead of two indices threw an error, so I've generalized `Fields.column` and `Fields.slab` for lazy broadcasts to handle arbitrary numbers of indices.

The unit tests for `Fields.column` have been extended to check lazy broadcasts and extruded spaces, and similar unit tests have been added for `Fields.slab`. While all of these tests pass on CPUs, some of the tests for `Fields.slab` fail on GPUs. It's not clear why this would be the case, but, since `Fields.slab` is not required for ClimaAtmos development, I'll just mark those tests as broken for now.