### PR TITLE
Fix 2329

### DIFF
--- a/src/Fields/fieldvector.jl
+++ b/src/Fields/fieldvector.jl
@@ -155,16 +155,32 @@ Base.Broadcast.BroadcastStyle(
     as::Base.Broadcast.DefaultArrayStyle{0},
 ) = fs
 Base.Broadcast.BroadcastStyle(
+    as::Base.Broadcast.DefaultArrayStyle{0},
+    fs::FieldVectorStyle,
+) = fs
+Base.Broadcast.BroadcastStyle(
     fs::FieldVectorStyle,
     as::Base.Broadcast.AbstractArrayStyle{0},
+) = fs
+Base.Broadcast.BroadcastStyle(
+    as::Base.Broadcast.AbstractArrayStyle{0},
+    fs::FieldVectorStyle,
 ) = fs
 Base.Broadcast.BroadcastStyle(
     fs::FieldVectorStyle,
     as::Base.Broadcast.DefaultArrayStyle,
 ) = as
 Base.Broadcast.BroadcastStyle(
+    as::Base.Broadcast.DefaultArrayStyle,
+    fs::FieldVectorStyle,
+) = as
+Base.Broadcast.BroadcastStyle(
     fs::FieldVectorStyle,
     as::Base.Broadcast.AbstractArrayStyle,
+) = as
+Base.Broadcast.BroadcastStyle(
+    as::Base.Broadcast.AbstractArrayStyle,
+    fs::FieldVectorStyle,
 ) = as
 
 function Base.similar(


### PR DESCRIPTION
It seems that whatever https://github.com/JuliaLang/julia/pull/35948 is changing results in `Base.Broadcast.BroadcastStyle` getting called with a different order of arguments. I thought that Julia was supposed to swap and try both, but I don't recall where in the docs.