### PR TITLE
Move Δz_metric_component to Geometry module

### DIFF
--- a/docs/src/APIs/geometry_api.md
+++ b/docs/src/APIs/geometry_api.md
@@ -11,6 +11,18 @@ Geometry.AbstractGlobalGeometry
 Geometry.CartesianGlobalGeometry
 ```
 
+## LocalGeometry
+
+```@docs
+Geometry.LocalGeometry
+```
+
+## Internals
+
+```@docs
+Geometry.Δz_metric_component
+```
+
 ## Coordinates
 
 ```@docs

--- a/docs/src/APIs/spaces_api.md
+++ b/docs/src/APIs/spaces_api.md
@@ -34,12 +34,6 @@ Spaces.FiniteDifferenceSpace
 Users should construct either the center or face space from the mesh, then construct
 the other space from the original one: this internally reuses the same data structures, and avoids allocating additional memory.
 
-### Internals
-
-```@docs
-Spaces.Δz_metric_component
-```
-
 ## Spectral Element Spaces
 
 ```@docs

--- a/src/Geometry/Geometry.jl
+++ b/src/Geometry/Geometry.jl
@@ -31,4 +31,18 @@ include("conversions.jl")
 include("globalgeometry.jl")
 include("rmul_with_projection.jl")
 
+"""
+    Δz_metric_component(::Type{<:AbstractPoint})
+
+The index of the z-component of an abstract point
+in an `AxisTensor`.
+"""
+Δz_metric_component(::Type{<:LatLongZPoint}) = 9
+Δz_metric_component(::Type{<:Cartesian3Point}) = 1
+Δz_metric_component(::Type{<:Cartesian13Point}) = 4
+Δz_metric_component(::Type{<:Cartesian123Point}) = 9
+Δz_metric_component(::Type{<:XYZPoint}) = 9
+Δz_metric_component(::Type{<:ZPoint}) = 1
+Δz_metric_component(::Type{<:XZPoint}) = 4
+
 end # module

--- a/src/Spaces/finitedifference.jl
+++ b/src/Spaces/finitedifference.jl
@@ -108,30 +108,15 @@ nlevels(space::FiniteDifferenceSpace) = length(space)
 Base.length(space::FiniteDifferenceSpace) = length(coordinates_data(space))
 
 """
-    Δz_metric_component(::Type{<:Goemetry.AbstractPoint})
-
-The index of the z-component of an abstract point
-in an `AxisTensor`.
-"""
-Δz_metric_component(::Type{<:Geometry.LatLongZPoint}) = 9
-Δz_metric_component(::Type{<:Geometry.Cartesian3Point}) = 1
-Δz_metric_component(::Type{<:Geometry.Cartesian13Point}) = 4
-Δz_metric_component(::Type{<:Geometry.Cartesian123Point}) = 9
-Δz_metric_component(::Type{<:Geometry.XYZPoint}) = 9
-Δz_metric_component(::Type{<:Geometry.ZPoint}) = 1
-Δz_metric_component(::Type{<:Geometry.XZPoint}) = 4
-
-"""
     Δz_data(space::AbstractSpace)
 
 A DataLayout containing the `Δz` on a given space `space`.
 """
 function Δz_data(space::AbstractSpace)
     lg = local_geometry_data(space)
-    data_layout_type = eltype(lg.coordinates)
     return getproperty(
         lg.∂x∂ξ.components.data,
-        Δz_metric_component(data_layout_type),
+        Geometry.Δz_metric_component(eltype(lg.coordinates)),
     )
 end
 


### PR DESCRIPTION
I realized in #2332 that moving `Δz_metric_component` to the Geometry module just seems to make sense. It really has nothing to do with spaces, and only needs knowledge of LocalGeometry. So, this PR moves it to the lower-level module.