### PR TITLE
Tr/minor fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -78,7 +78,7 @@ Statistics = "1"
 StatsBase = "0.34"
 TerminalLoggers = "0.1"
 Test = "1"
-UnrolledUtilities = "0.1.6"
+UnrolledUtilities = "0.1.9"
 julia = "1.10"
 
 [extras]

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -517,7 +517,7 @@ Base.@propagate_inbounds function level(
     v::PlusHalf,
 )
     hspace = level(axes(field), v)
-    @inbounds data = level(field_values(field), v.i + 1)
+    data = level(field_values(field), v.i + 1)
     Field(data, hspace)
 end
 
@@ -664,7 +664,7 @@ element type of the array is the same as the struct type of `field`.
 """
 function field2array(field::Field)
     if sizeof(eltype(field)) != sizeof(eltype(parent(field)))
-        f_axis_size = sizeof(eltype(parent(field))) ÷ sizeof(eltype(field))
+        f_axis_size = sizeof(eltype(field)) ÷ sizeof(eltype(parent(field)))
         error("unable to use field2array because each Field element is \
                represented by $f_axis_size array elements (must be 1)")
     end

--- a/src/Geometry/Geometry.jl
+++ b/src/Geometry/Geometry.jl
@@ -2,6 +2,7 @@ module Geometry
 
 using ..RecursiveApply
 import LinearAlgebra
+import UnrolledUtilities: unrolled_findfirst
 
 using StaticArrays
 

--- a/src/Geometry/axistensors.jl
+++ b/src/Geometry/axistensors.jl
@@ -61,33 +61,8 @@ coordinate_axis(::Type{<:LatLongPoint}) = (1, 2)
 
 coordinate_axis(coord::AbstractPoint) = coordinate_axis(typeof(coord))
 
-@inline idxin(I::Tuple{Int}, i::Int) = 1
-
-@inline function idxin(I::Tuple{Int, Int}, i::Int)
-    @inbounds begin
-        if I[1] == i
-            return 1
-        elseif I[2] == i
-            return 2
-        else
-            return nothing
-        end
-    end
-end
-
-@inline function idxin(I::Tuple{Int, Int, Int}, i::Int)
-    @inbounds begin
-        if I[1] == i
-            return 1
-        elseif I[2] == i
-            return 2
-        elseif I[3] == i
-            return 3
-        else
-            return nothing
-        end
-    end
-end
+@inline idxin(I::NTuple{N, Int}, i::Int) where {N} =
+    unrolled_findfirst(isequal(i), I)
 
 struct PropertyError <: Exception
     ax::Any


### PR DESCRIPTION
This PR addresses three issues:
1. An incorrect error message is shown when `field2array` is called with incompatible elements. 
2. For face fields, the `level` function does not throw `BoundsError`s
3. The indexing behavior for AxisTensors is inconsistent. With any 1d axis tensor vs 2d and 3d.

For the first issue, the message itself is corrected.
For the second issue, tests are added for `level(::Field)`. 
The fix for the second issue requires removing an `@inbounds`, so there may be a performance penalty.


This PR also bumps the UnrolledUtilities compat to v0.1.8. v0.1.7 adds a lot of useful unrolled_functions, including `unrolled_findfirst`, but the downgrade will throw JET errors unless using v0.1.8

Closes #2337 
Closes #2320 
Closes #2348