### PR TITLE
Add a seed for random inputs in UpwindBiasedGradient test

### DIFF
--- a/test/Operators/finitedifference/convergence_column.jl
+++ b/test/Operators/finitedifference/convergence_column.jl
@@ -3,7 +3,7 @@ julia --project
 using Revise; include("test/Operators/finitedifference/convergence_column.jl")
 =#
 using Test
-using StaticArrays, IntervalSets, LinearAlgebra
+using Random, StaticArrays, IntervalSets, LinearAlgebra
 
 using ClimaComms
 ClimaComms.@import_required_backends
@@ -429,6 +429,7 @@ end
         center_space = Spaces.CenterFiniteDifferenceSpace(device, mesh)
         face_space = Spaces.face_space(center_space)
 
+        Random.seed!(1) # ensures reproducibility
         ᶜw = Geometry.WVector.(map(_ -> 2 * rand() - 1, ones(center_space)))
         ᶠw = Geometry.WVector.(map(_ -> 2 * rand() - 1, ones(face_space)))
 


### PR DESCRIPTION
This PR adds a random seed to the convergence test for `UpwindBiasedGradient` from #2345. There have been several random CI failures since I added that test, which can be avoided by using an appropriate seed for the randomized inputs. It is unfortunate that the convergence order error is not negligibly small for all possible inputs, but it makes sense that there will always be certain seeds that lead to arbitrarily high errors.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
