### PR TITLE
Add support for FiniteDifferenceSpaces

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,12 @@ ClimaCore.jl Release Notes
 main
 -------
 
+
+v0.14.43
+-------
+
+- Add support for horizontal operators on column spaces [2375](https://github.com/Clima/ClimaCore.jl/pull/2375)
+
 v0.14.42
 -------
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.14.42"
+version = "0.14.43"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/CommonGrids/CommonGrids.jl
+++ b/src/CommonGrids/CommonGrids.jl
@@ -40,7 +40,7 @@ z_domain = Domains.IntervalDomain(
 )
 z_mesh = Meshes.IntervalMesh(z_domain; nelems = z_elem)
 h_grid = Grids.SpectralElementGrid2D(h_topology, quad)
-z_topology = Topologies.IntervalTopology(context, z_mesh)
+z_topology = Topologies.IntervalTopology(ClimaComms.SingletonCommsContext(device), z_mesh)
 z_grid = Grids.FiniteDifferenceGrid(z_topology)
 grid = Grids.ExtrudedFiniteDifferenceGrid(
     h_grid,
@@ -440,6 +440,19 @@ function Box3DGrid(
             y_elem,
             periodic_x,
             periodic_y,
+        ),
+        Topologies.spacefillingcurve(
+            DefaultRectangleXYMesh(
+                FT;
+                x_min,
+                x_max,
+                y_min,
+                y_max,
+                x_elem,
+                y_elem,
+                periodic_x,
+                periodic_y,
+            ),
         ),
     ),
     z_mesh::Meshes.IntervalMesh = DefaultZMesh(

--- a/src/CommonGrids/Helpers.jl
+++ b/src/CommonGrids/Helpers.jl
@@ -27,13 +27,12 @@ function DefaultSliceXMesh(
     x_elem::Integer,
 ) where {FT}
 
-    x1boundary = (:east, :west)
-    z_boundary_names = (:bottom, :top)
+    x1boundary = periodic_x ? nothing : (:east, :west)
     h_domain = Domains.IntervalDomain(
         Geometry.XPoint{FT}(x_min),
         Geometry.XPoint{FT}(x_max);
         periodic = periodic_x,
-        boundary_names = (:east, :west),
+        boundary_names = x1boundary,
     )
     return Meshes.IntervalMesh(h_domain; nelems = x_elem)
 end
@@ -93,8 +92,9 @@ function DefaultRectangleXYMesh(
     periodic_x::Bool,
     periodic_y::Bool,
 ) where {FT <: AbstractFloat}
-    x1boundary = (:east, :west)
-    x2boundary = (:south, :north)
+    x1boundary = periodic_x ? nothing : (:east, :west)
+    x2boundary = periodic_y ? nothing : (:south, :north)
+
     domain = Domains.RectangleDomain(
         Domains.IntervalDomain(
             Geometry.XPoint{FT}(x_min),

--- a/src/Domains/Domains.jl
+++ b/src/Domains/Domains.jl
@@ -56,7 +56,7 @@ function IntervalDomain(
     if !periodic && isnothing(boundary_names)
         throw(
             ArgumentError(
-                "if `periodic=false` then an `boundary_names::Tuple{Symbol,Symbol}` keyword argument is required.",
+                "if `periodic=false` then a `boundary_names::Tuple{Symbol,Symbol}` keyword argument is required.",
             ),
         )
     end

--- a/src/Fields/indices.jl
+++ b/src/Fields/indices.jl
@@ -245,6 +245,32 @@ function byslab(
     end
 end
 
+function byslab(
+    fn,
+    ::ClimaComms.AbstractCPUDevice,
+    space::Spaces.CenterFiniteDifferenceSpace,
+)
+    Nv = Spaces.nlevels(space)
+    @inbounds begin
+        for v in 1:Nv
+            fn(SlabIndex(v, 1))
+        end
+    end
+end
+
+function byslab(
+    fn,
+    ::ClimaComms.AbstractCPUDevice,
+    space::Spaces.FaceFiniteDifferenceSpace,
+)
+    Nv = Spaces.nlevels(space)
+    @inbounds begin
+        for v in 1:Nv
+            fn(SlabIndex(v - half, 1))
+        end
+    end
+end
+
 universal_index(colidx::Fields.ColumnIndex{2}) =
     CartesianIndex(colidx.ij[1], colidx.ij[2], 1, 1, colidx.h)
 

--- a/src/Geometry/axistensors.jl
+++ b/src/Geometry/axistensors.jl
@@ -219,6 +219,8 @@ const AxisVector{T, A1, S} = AxisTensor{T, 1, Tuple{A1}, S}
 AxisVector(ax::A1, v::SVector{N, T}) where {A1 <: AbstractAxis, N, T} =
     AxisVector{T, A1, SVector{N, T}}((ax,), v)
 
+(AxisVector{T, A, SVector{0, T}} where {T})() where {A} =
+    AxisVector(A.instance, SVector{0, T}())
 (AxisVector{T, A, SVector{1, T}} where {T})(arg1::Real) where {A} =
     AxisVector(A.instance, SVector(arg1))
 (AxisVector{T, A, SVector{2, T}} where {T})(arg1::Real, arg2::Real) where {A} =
@@ -306,11 +308,12 @@ const CovariantTensor = Union{CovariantVector, Covariant2Tensor}
 const ContravariantTensor = Union{ContravariantVector, Contravariant2Tensor}
 const CartesianTensor = Union{CartesianVector, Cartesian2Tensor}
 const LocalTensor = Union{LocalVector, Local2Tensor}
+for I in [(), (1,), (2,), (3,), (1, 2), (1, 3), (2, 3), (1, 2, 3)]
 
-for I in [(1,), (2,), (3,), (1, 2), (1, 3), (2, 3), (1, 2, 3)]
-    strI = join(I)
+    strI = isempty(I) ? "Null" : join(I)
     N = length(I)
-    strUVW = join(map(i -> [:U, :V, :W][i], I))
+
+    strUVW = isempty(I) ? "Null" : join(map(i -> [:U, :V, :W][i], I))
     @eval begin
         const $(Symbol(:Covariant, strI, :Axis)) = CovariantAxis{$I}
         const $(Symbol(:Covariant, strI, :Vector)){T} =
@@ -467,7 +470,7 @@ end
         end
         push!(vals, val)
     end
-    return :(@inbounds AxisVector(ato, SVector($(vals...))))
+    return :(@inbounds AxisVector(ato, SVector{$(length(Ito)), $T}($(vals...))))
 end
 
 function _transform(

--- a/src/Geometry/conversions.jl
+++ b/src/Geometry/conversions.jl
@@ -501,13 +501,16 @@ Curl is only defined for `CovariantVector`` field input types.
 |  Covariant12Vector | (1,2) | Contravariant3Vector |
 |  Covariant3Vector | (1,2) | Contravariant12Vector |
 |  Covariant123Vector | (1,2) | Contravariant123Vector |
-|  Covariant1Vector | (1,) | Contravariant1Vector |
+|  Covariant1Vector | (1,) | ContravariantNullVector |
 |  Covariant2Vector | (1,) | Contravariant3Vector |
 |  Covariant3Vector | (1,) | Contravariant2Vector |
+|  Covariant13Vector | (1,) | Contravariant2Vector |
+|  Covariant123Vector | (1,) | Contravariant23Vector |
 |  Covariant12Vector | (3,) | Contravariant12Vector |
 |  Covariant1Vector | (3,) | Contravariant2Vector |
 |  Covariant2Vector | (3,) | Contravariant1Vector |
 |  Covariant3Vector | (3,) | Contravariant3Vector |
+|  Any CovariantVector | () | ContravariantNullVector |
 """
 @inline curl_result_type(::Val{(1, 2)}, ::Type{Covariant3Vector{FT}}) where {FT} =
     Contravariant12Vector{FT}
@@ -516,9 +519,8 @@ Curl is only defined for `CovariantVector`` field input types.
 @inline curl_result_type(::Val{(1, 2)}, ::Type{Covariant123Vector{FT}}) where {FT} =
     Contravariant123Vector{FT}
 
-
 @inline curl_result_type(::Val{(1,)}, ::Type{Covariant1Vector{FT}}) where {FT} =
-    Contravariant1Vector{FT} # not strictly correct: should be a zero Vector
+    ContravariantNullVector{FT}
 @inline curl_result_type(::Val{(1,)}, ::Type{Covariant2Vector{FT}}) where {FT} =
     Contravariant3Vector{FT}
 @inline curl_result_type(::Val{(1,)}, ::Type{Covariant3Vector{FT}}) where {FT} =
@@ -536,6 +538,9 @@ Curl is only defined for `CovariantVector`` field input types.
     Contravariant1Vector{FT}
 @inline curl_result_type(::Val{(3,)}, ::Type{Covariant3Vector{FT}}) where {FT} =
     Contravariant3Vector{FT}
+
+@inline curl_result_type(_, ::Type{<:CovariantVector{FT}}) where {FT} =
+    ContravariantNullVector{FT}
 
 _norm_sqr(x, local_geometry::LocalGeometry) = sum(x -> _norm_sqr(x, local_geometry), x)
 _norm_sqr(x::Number, ::LocalGeometry) = LinearAlgebra.norm_sqr(x)

--- a/src/Spaces/Spaces.jl
+++ b/src/Spaces/Spaces.jl
@@ -212,4 +212,18 @@ set_mask!(fn, space::ExtrudedFiniteDifferenceSpace) =
 set_mask!(space::AbstractSpace, data::DataLayouts.AbstractData) =
     set_mask!(grid(space), data)
 
+"""
+    slab_type(space)
+
+Determines the appropriate slab data layout type for a given space.
+
+For spaces with 2 horizontal dimensions, returns IJF.
+For 1D spaces, returns IF.
+"""
+slab_type(space::SpectralElementSpace2D) = DataLayouts.IJF
+slab_type(space::SpectralElementSpace1D) = DataLayouts.IF
+slab_type(space::FiniteDifferenceSpace) = DataLayouts.IF
+slab_type(space::ExtrudedFiniteDifferenceSpace) =
+    slab_type(horizontal_space(space))
+
 end # module

--- a/src/Spaces/finitedifference.jl
+++ b/src/Spaces/finitedifference.jl
@@ -36,6 +36,8 @@ staggering(space::FiniteDifferenceSpace) = getfield(space, :staggering)
 space(grid::Grids.AbstractFiniteDifferenceGrid, staggering::Staggering) =
     FiniteDifferenceSpace(grid, staggering)
 
+horizontal_space(space::FiniteDifferenceSpace) = level(space, 1)
+
 function Base.show(io::IO, space::FiniteDifferenceSpace)
     indent = get(io, :indent, 0)
     iio = IOContext(io, :indent => indent + 2)

--- a/src/Spaces/pointspace.jl
+++ b/src/Spaces/pointspace.jl
@@ -55,3 +55,7 @@ function PointSpace(
     )
     return PointSpace(context, local_geometry)
 end
+
+all_nodes(::PointSpace) = (1,)
+
+node_horizontal_length_scale(space::PointSpace) = 1

--- a/src/Spaces/spectralelement.jl
+++ b/src/Spaces/spectralelement.jl
@@ -149,6 +149,8 @@ nlevels(space::SpectralElementSpaceSlab2D) = 1
 The approximate length scale of the distance between nodes. This is defined as the
 length scale of the mesh (see [`Meshes.element_horizontal_length_scale`](@ref)), divided by the
 number of unique quadrature points along each dimension.
+
+Returns a default length scale of 1 when no space is provided.
 """
 function node_horizontal_length_scale(space::AbstractSpectralElementSpace)
     quad = quadrature_style(space)
@@ -157,8 +159,7 @@ function node_horizontal_length_scale(space::AbstractSpectralElementSpace)
            Nu
 end
 
-
-
+node_horizontal_length_scale(::Nothing) = 1
 
 
 Base.@propagate_inbounds function slab(

--- a/src/Topologies/Topologies.jl
+++ b/src/Topologies/Topologies.jl
@@ -62,20 +62,10 @@ function print_context(io::IO, context::ClimaComms.SingletonCommsContext)
 end
 
 function print_context(io::IO, context::ClimaComms.MPICommsContext)
-    if ClimaComms.MPI.Initialized()
-        print(
-            io,
-            "MPICommsContext with ",
-            ClimaComms.nprocs(context),
-            " processes",
-        )
-    else
-        print(io, "MPICommsContext (uninitialized)")
-    end
+    print(io, "MPICommsContext with ", ClimaComms.nprocs(context), " processes")
     print(io, " using ")
     print_device(io, context.device)
 end
-
 
 abstract type AbstractDistributedTopology <: AbstractTopology end
 

--- a/src/to_device.jl
+++ b/src/to_device.jl
@@ -18,15 +18,7 @@ If the input is already defined on the target device, returns a copy.
 
 This means that `out === x` will not in general be satisfied.
 """
-function to_device(
-    device::ClimaComms.AbstractDevice,
-    x::Union{
-        DataLayouts.AbstractData,
-        Spaces.AbstractSpace,
-        Fields.Field,
-        Fields.FieldVector,
-    },
-)
+function to_device(device::ClimaComms.AbstractDevice, x)
     return Adapt.adapt(ClimaComms.array_type(device), x)
 end
 

--- a/test/Fields/unit_field.jl
+++ b/test/Fields/unit_field.jl
@@ -947,7 +947,7 @@ end
         staggering = CellCenter(),
     )
     test_adapt(box_space_fn)
-    test_adapt_types(box_space_fn; broken_space_type_match = true)
+    test_adapt_types(box_space_fn)
 
     slice_space_fn(dev) = SliceXZSpace(;
         device = dev,

--- a/test/Operators/hybrid/unit_3d.jl
+++ b/test/Operators/hybrid/unit_3d.jl
@@ -1,4 +1,10 @@
 include("utils_3d.jl")
+
+@isdefined(TU) || include(
+    joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl"),
+);
+import .TestUtilities as TU;
+
 device = ClimaComms.device()
 
 @testset "sphere divergence" begin
@@ -91,4 +97,16 @@ end
         @. ∇z[colidx] = WVector(∇(fz[colidx]))
     end
     @test ∇z == WVector.(∇.(fz))
+end
+
+@testset "Horizontal operators on extracted column spaces" begin
+    @testset "3D Box space -> column" begin
+        hv_center_space, _ =
+            hvspace_3D((-1.0, 1.0), (-1.0, 1.0), (0.0, 1.0), 2, 2, 5, 3)
+
+        # Extract column at position (i, j, h) = (1, 1, 1)
+        column_space = Spaces.column(hv_center_space, 1, 1, 1)
+        @test column_space isa Spaces.FiniteDifferenceSpace
+        TU.test_column_operators(column_space)
+    end
 end

--- a/test/Spaces/unit_spaces.jl
+++ b/test/Spaces/unit_spaces.jl
@@ -179,6 +179,8 @@ end
 
     @test repr(space) === expected_repr
 
+    @test Spaces.slab_type(space) == DataLayouts.IF
+
     coord_data = Spaces.coordinates_data(space)
     @test eltype(coord_data) == Geometry.XPoint{Float64}
 
@@ -302,6 +304,8 @@ end
 
     @test Spaces.local_geometry_type(typeof(c_space)) <: Geometry.LocalGeometry
 
+    @test Spaces.slab_type(c_space) == DataLayouts.IF
+
     x_max = FT(1)
     y_max = FT(1)
     x_elem = 2
@@ -363,6 +367,8 @@ end
       context: SingletonCommsContext using CPUSingleThreaded
       mesh: 1×1-element RectilinearMesh of RectangleDomain: x ∈ [-3.0,5.0] (periodic) × y ∈ [-2.0,8.0] (:south, :north)
       quadrature: 4-point Gauss-Legendre-Lobatto quadrature"""
+
+    @test Spaces.slab_type(space) == DataLayouts.IJF
 
     coord_data = Spaces.coordinates_data(space)
     @test DataLayouts.farray_size(coord_data) == (4, 4, 2, 1)

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -20,7 +20,7 @@ using Aqua
     # then please lower the limit based on the new number of ambiguities.
     # We're trying to drive this number down to zero to reduce latency.
     # Uncomment for debugging:
-    n_existing_ambiguities = 26
+    n_existing_ambiguities = 25
     if !(length(ambs) ≤ n_existing_ambiguities)
         for method_ambiguity in ambs
             @show method_ambiguity


### PR DESCRIPTION
This PR enables horizontal spectral element operators (gradient, divergence, curl) to work correctly on column spaces extracted from hybrid spaces, returning appropriate zero values since columns have no horizontal dimensions.