### PR TITLE
Add support for quoted properties in name macro

### DIFF
--- a/test/MatrixFields/field_names.jl
+++ b/test/MatrixFields/field_names.jl
@@ -24,10 +24,14 @@ get_x() =
     @test_all @name(a.c.:(1).d) == MatrixFields.FieldName(:a, :c, 1, :d)
     @test_all @name(a.c.:(3).:(1)) == MatrixFields.FieldName(:a, :c, 3, 1)
 
-    @test_throws "not a valid property name" @macroexpand @name("a")
-    @test_throws "not a valid property name" @macroexpand @name([a])
-    @test_throws "not a valid property name" @macroexpand @name((a.c.:3.0):1)
-    @test_throws "not a valid property name" @macroexpand @name(a.c.:(3).(1))
+    i = 1
+    @test @name(a.c.:($i).d) == @name(a.c.:(1).d)
+    @test @name(a.c.:($(i + 2)).:($i)) == @name(a.c.:(3).:(1))
+
+    @test_throws "invalid syntax" @macroexpand @name("a")
+    @test_throws "invalid syntax" @macroexpand @name([a])
+    @test_throws "invalid syntax" @macroexpand @name((a.c.:3.0):1)
+    @test_throws "invalid syntax" @macroexpand @name(a.c.:(3).(1))
 
     @test string(@name()) == "@name()"
     @test string(@name(a.c.:(1).d)) == "@name(a.c.:(1).d)"


### PR DESCRIPTION
This PR fixes a bug identified by @trontrytel that has prevented us from having `FieldName`s like `@name(c.sgsʲs.:($j))`. Following this change, interpolation of property names with `$$j` in `@.` expressions should work the same way as interpolation with `$j` outside `@.` expressions.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
