### PR TITLE
ft: add (left and right) projection of 2-tensors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@ ClimaCore.jl Release Notes
 main
 -------
 
+v0.14.41
+-------
+- Add `project` for both sides of 2-tensors (previously only left side was supported). 
+  Simplify implementation. [2379](https://github.com/Clima/ClimaCore.jl/pull/2379)
+
 v0.14.40
 -------
 - Store `reverse_mode` in the `IntervalMesh` struct, so that we can access it when writing

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.14.40"
+version = "0.14.41"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/test/Geometry/axistensors.jl
+++ b/test/Geometry/axistensors.jl
@@ -2,7 +2,6 @@ using Test, JET
 using ClimaCore.Geometry, ClimaCore.DataLayouts
 using LinearAlgebra, StaticArrays
 import ClimaCore
-ClimaCore.Geometry.assert_exact_transform() = true
 
 @testset "AxisTensors" begin
     x = Geometry.Covariant12Vector(1.0, 2.0)
@@ -169,6 +168,26 @@ end
         Geometry.Covariant12Axis(),
         Geometry.Covariant13Vector(2.0, 2.0) * Geometry.Cartesian1Vector(1.0)',
     ) == Geometry.Covariant12Vector(2.0, 0.0) * Geometry.Cartesian1Vector(1.0)'
+
+    # Test projection over rightmost axis
+    x_C12 = Geometry.Covariant12Vector(2.0, 2.0)
+    x_Cart123 = Geometry.Cartesian123Vector(1.0, 1.0, 1.0)
+    @test Geometry.project(x_C12 * x_Cart123', Geometry.Cartesian3Axis()) ==
+          x_C12 * Geometry.Cartesian3Vector(1.0)'
+    @test Geometry.project(x_C12 * x_Cart123', Geometry.Cartesian23Axis()) ==
+          x_C12 * Geometry.Cartesian23Vector(1.0, 1.0)'
+
+    # Test projection over both axes
+    @test Geometry.project(
+        Geometry.Covariant12Axis(),
+        x_C12 * x_Cart123',
+        Geometry.Cartesian123Axis(),
+    ) == x_C12 * x_Cart123'
+    @test Geometry.project(
+        Geometry.Covariant2Axis(),
+        x_C12 * x_Cart123',
+        Geometry.Cartesian13Axis(),
+    ) == Geometry.Covariant2Vector(2.0) * Geometry.Cartesian13Vector(1.0, 1.0)'
 end
 
 


### PR DESCRIPTION
This pull request refactors and generalizes the projection logic for axis tensors in the `Geometry` module, making the code more flexible and maintainable. The changes include a major rewrite of the `_project` and `project` functions to support arbitrary axes, improved axis indexing, and expanded test coverage for the new projection behavior.

### Refactoring and Generalization of Projection Logic

* Rewrote the `_project` function to handle projections over arbitrary axes using generic index manipulation and utility functions from `UnrolledUtilities`, replacing the previous generated function with a more flexible approach.
* Refactored the `project` function to support projections over both left and right axes, as well as single-axis projections, with additional assertions for axis compatibility.

### Axis Indexing Improvements

* Added `axis_indices` methods for extracting axis indices from `AbstractAxis` and tuples of axes, enabling more generic and reusable indexing logic.

### Dependency and Utility Updates

* Added `UnrolledUtilities` as an import in both the main module and tests to support the new projection logic. [[1]](diffhunk://#diff-89370ac5569f401117bdc6e1d54261185e19b1ecf9dc31b9c0ddacda9eb9bb5dL1-R1) [[2]](diffhunk://#diff-c860fe64788b4863c5c16648f1ef0e5f55a62b9688ce6242c96c295005c0ffddR5)

### Expanded Test Coverage

* Added tests for projections over rightmost axes and both axes simultaneously, verifying the correctness of the new projection logic.

<!-- Provide a clear description of the content -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR **N/A**.
- [ ] Documentation has been added/updated OR **N/A**.
