### PR TITLE
chore: improve error message of check_basetype

### DIFF
--- a/docs/src/APIs/datalayouts_api.md
+++ b/docs/src/APIs/datalayouts_api.md
@@ -19,3 +19,14 @@ DataLayouts.IJHF
 DataLayouts.VIHF
 DataLayouts.VIJHF
 ```
+
+## Internals
+
+```@docs
+DataLayouts.check_basetype
+DataLayouts.is_valid_basetype
+DataLayouts.invalid_basetype_trace
+DataLayouts.replace_basetype
+DataLayouts.parent_array_type
+DataLayouts.promote_parent_array_type
+```

--- a/src/DataLayouts/struct.jl
+++ b/src/DataLayouts/struct.jl
@@ -25,6 +25,26 @@ end
 is_valid_basetype(::Type{T}, ::Type{<:T}) where {T} = true
 
 """
+    invalid_basetype_trace(::Type{T}, ::Type{S})
+
+Returns a `Vector` of types tracing the path from `S` down to the first
+primitive subtype that cannot be represented using base type `T`. Returns an
+empty vector if `T` is a valid base type for `S`.
+"""
+function invalid_basetype_trace(::Type{T}, ::Type{S}) where {T, S}
+    is_valid_basetype(T, S) && return Type[]
+    Base.isprimitivetype(S) && return Type[S]
+    for FT in fieldtypes(S)
+        trace = invalid_basetype_trace(T, FT)
+        if !isempty(trace)
+            pushfirst!(trace, S)
+            return trace
+        end
+    end
+    return Type[]
+end
+
+"""
     check_basetype(::Type{T}, ::Type{S})
 
 Check whether the types `T` and `S` have well-defined sizes, and whether an
@@ -39,7 +59,16 @@ function check_basetype(::Type{T}, ::Type{S}) where {T, S}
             estr = "Struct type $S has indeterminate size"
             :(error($estr))
         elseif !is_valid_basetype(T, S)
-            estr = "Struct type $S cannot be represented using base type $T"
+            trace = invalid_basetype_trace(T, S)
+            _r = Base.text_colors[:red]
+            _c = Base.text_colors[:cyan]
+            _n = Base.text_colors[:normal]
+            trace_str = join(string.(trace), "\n $(_c)↳$(_n) ")
+            estr = string(
+                "$(_r)The struct type contains a subtype which cannot be represented using base type$(_n) ",
+                T, "\n",
+                "$(_c)Trace:$(_n) ", trace_str,
+            )
             :(error($estr))
         else
             :(return nothing)
@@ -47,8 +76,19 @@ function check_basetype(::Type{T}, ::Type{S}) where {T, S}
     else
         isbitstype(T) || error("Base type $T has indeterminate size")
         isbitstype(S) || error("Struct type $S has indeterminate size")
-        is_valid_basetype(T, S) ||
-            error("Struct type $S cannot be represented using base type $T")
+        if !is_valid_basetype(T, S)
+            trace = invalid_basetype_trace(T, S)
+            _r = Base.text_colors[:red]
+            _c = Base.text_colors[:cyan]
+            _n = Base.text_colors[:normal]
+            trace_str = join(string.(trace), "\n $(_c)↳$(_n) ")
+            estr = string(
+                "$(_r)The struct type contains a subtype which cannot be represented using base type$(_n) ",
+                T, "\n",
+                "$(_c)Trace:$(_n) ", trace_str,
+            )
+            error(estr)
+        end
         return nothing
     end
 end


### PR DESCRIPTION
This pull request introduces improvements to the error reporting and documentation for base type validation in the `DataLayouts` module. The main focus is on providing more informative error messages when a struct type cannot be represented using a specified base type, and documenting internal validation functions.

### Error reporting and validation improvements

* Added the `invalid_basetype_trace` function to trace and return the path to the first subtype that cannot be represented using a base type, enhancing debugging for type validation issues.
* Updated the `check_basetype` function to use `invalid_basetype_trace` and provide a detailed, color-coded error message with a trace of problematic subtypes when a struct type cannot be represented using a base type.

### Documentation enhancements

* Documented internal validation functions (`check_basetype`, `is_valid_basetype`, `invalid_basetype_trace`, `replace_basetype`, `parent_array_type`, `promote_parent_array_type`) in the `datalayouts_api.md` file under a new "Internals" section.

### Demonstration

Prior to this PR, an error triggered by incompatible base types might look something like this:
<img width="1909" height="602" alt="image" src="https://github.com/user-attachments/assets/d8a4cb40-00f5-4ec4-bfbd-8bec5acbfede" />


With this PR, the full trace is displayed
<img width="1911" height="1043" alt="image" src="https://github.com/user-attachments/assets/36b05869-de8e-47f7-b638-731ec73698d2" />
