### PR TITLE
add dispatch back in to_device

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,11 @@ main
 -------
 
 
+v0.14.44
+-------
+
+- Revert `to_device` dispatch change from #2375 [2403](https://github.com/CliMA/ClimaCore.jl/pull/2403)
+
 v0.14.43
 -------
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.14.43"
+version = "0.14.44"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/to_device.jl
+++ b/src/to_device.jl
@@ -18,7 +18,15 @@ If the input is already defined on the target device, returns a copy.
 
 This means that `out === x` will not in general be satisfied.
 """
-function to_device(device::ClimaComms.AbstractDevice, x)
+function to_device(
+    device::ClimaComms.AbstractDevice,
+    x::Union{
+        DataLayouts.AbstractData,
+        Spaces.AbstractSpace,
+        Fields.Field,
+        Fields.FieldVector,
+    },
+)
     return Adapt.adapt(ClimaComms.array_type(device), x)
 end
 


### PR DESCRIPTION
Revert the dispatch removal from #2375 to avoid errors from calling `Adapt.adapt` on types it isn't defined for - e.g. https://buildkite.com/clima/climacoupler-longruns/builds/991#019b0f73-6073-4684-a0f7-b1ba9eb91e0f

Also tags a patch release of 0.14.44
