### PR TITLE
Skip JET in downgrade action

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -29,6 +29,6 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-downgrade-compat@v1
         with:
-          skip: Dates, InteractiveUtils, LinearAlgebra, Logging, Random, Test, SparseArrays, Statistics
+          skip: Dates, InteractiveUtils, JET, LinearAlgebra, Logging, Random, Test, SparseArrays, Statistics
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest


### PR DESCRIPTION
<!-- Provide a clear description of the content -->

Downgrade was failing because JET compat issues with Julia 1.11.8