### PR TITLE
feat: add CLA workflow caller

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,21 @@
+---
+name: CLA Workflow
+
+permissions:
+  contents: write
+  checks: write
+  actions: write
+  pull-requests: write
+
+on:
+  merge_group:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
+      - master
+
+jobs:
+  cla:
+    uses: clima/.github/.github/workflows/cla_template.yml@main
+    secrets: inherit


### PR DESCRIPTION
<!-- Provide a clear description of the content -->
## CLA enforcement

This PR introduces an automated Contributor License Agreement (CLA) check. External contributors must agree to the CLA once via a lightweight GitHub-authenticated flow before their PRs can be merged. The check runs automatically on pull requests and blocks the merge only if a required CLA is missing.

CLA text: https://ecodesign.clima.caltech.edu/cla/download/

How to sign: authenticate with GitHub, type your name, and click the “I agree” button.

(Caltech, MIT, JPL Employees and automated bots are not affected.)

Closes #2427

**Changes:**
- Added `.github/workflows/cla.yml` using the organization template.

---

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.