### PR TITLE
Ensure CommonGrids uses space filling curve

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@ ClimaCore.jl Release Notes
 main
 -------
 
+v0.14.47
+-------
+- Use space-filling curve for CubedSphereGrid and ExtrudedCubedSphereGrid
+  [2429](https://github.com/CliMA/ClimaCore.jl/pull/2429)
+
 v0.14.46
 -------
 - Restrict GPUCompiler to < v1.7.6 to avoid GPU errors [2430](https://github.com/CliMA/ClimaCore.jl/pull/2430)

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.14.46"
+version = "0.14.47"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/CommonGrids/CommonGrids.jl
+++ b/src/CommonGrids/CommonGrids.jl
@@ -171,6 +171,7 @@ function ExtrudedCubedSphereGrid(
     h_topology::Topologies.AbstractDistributedTopology = Topologies.Topology2D(
         context,
         h_mesh,
+        Topologies.spacefillingcurve(h_mesh),
     ),
     horizontal_layout_type = DataLayouts.IJFH,
     z_mesh::Meshes.IntervalMesh = DefaultZMesh(
@@ -261,6 +262,7 @@ function CubedSphereGrid(
     h_topology::Topologies.AbstractDistributedTopology = Topologies.Topology2D(
         context,
         h_mesh,
+        Topologies.spacefillingcurve(h_mesh),
     ),
     horizontal_layout_type = DataLayouts.IJFH,
     enable_mask::Bool = false,

--- a/src/Topologies/topology2d.jl
+++ b/src/Topologies/topology2d.jl
@@ -702,6 +702,26 @@ end
 
 domain(topology::Topology2D) = domain(topology.mesh)
 nelems(topology::Topology2D) = length(topology.elemorder)
+
+"""
+    uses_spacefillingcurve(topology::Topology2D) -> Bool
+
+Return `true` if the topology uses a space-filling curve for element ordering,
+`false` if it uses the default ordering (e.g., `CartesianIndices`).
+
+# Examples
+
+```julia
+topology = Topology2D(context, mesh)
+if uses_spacefillingcurve(topology)
+    println("Using space-filling curve ordering")
+else
+    println("Using default Cartesian ordering")
+end
+```
+"""
+uses_spacefillingcurve(topology::Topology2D) = !(topology.elemorder isa CartesianIndices)
+
 nlocalelems(topology::Topology2D) = length(topology.local_elem_gidx)
 function localelems(topology::Topology2D)
     topology.elemorder[topology.local_elem_gidx]

--- a/test/CommonGrids/CommonGrids.jl
+++ b/test/CommonGrids/CommonGrids.jl
@@ -5,6 +5,7 @@ using Revise; include(joinpath("test", "CommonGrids", "CommonGrids.jl"))
 import ClimaComms
 ClimaComms.@import_required_backends
 using ClimaCore.CommonGrids
+import ClimaCore.CommonGrids: ExtrudedCubedSphereGrid, CubedSphereGrid, Box3DGrid
 using ClimaCore:
     Geometry,
     Hypsography,
@@ -118,4 +119,44 @@ using Test
     )
     @test grid isa Grids.SpectralElementGrid2D
     @test Grids.topology(grid).mesh isa Meshes.RectilinearMesh
+end
+
+@testset "Space-filling curve usage in CommonGrids" begin
+    @testset "ExtrudedCubedSphereGrid uses space-filling curve" begin
+        grid = ExtrudedCubedSphereGrid(;
+            z_elem = 10,
+            z_min = 0,
+            z_max = 1,
+            radius = 10,
+            h_elem = 10,
+            n_quad_points = 4,
+        )
+        topology = Grids.topology(grid.horizontal_grid)
+        @test Topologies.uses_spacefillingcurve(topology) == true
+    end
+
+    @testset "CubedSphereGrid uses space-filling curve" begin
+        grid = CubedSphereGrid(; radius = 10, n_quad_points = 4, h_elem = 10)
+        topology = Grids.topology(grid)
+        @test Topologies.uses_spacefillingcurve(topology) == true
+    end
+
+    @testset "Box3DGrid uses space-filling curve" begin
+        grid = Box3DGrid(;
+            z_elem = 10,
+            x_min = 0,
+            x_max = 1,
+            y_min = 0,
+            y_max = 1,
+            z_min = 0,
+            z_max = 10,
+            periodic_x = false,
+            periodic_y = false,
+            n_quad_points = 4,
+            x_elem = 3,
+            y_elem = 4,
+        )
+        topology = Grids.topology(grid.horizontal_grid)
+        @test Topologies.uses_spacefillingcurve(topology) == true
+    end
 end

--- a/test/Fields/unit_field.jl
+++ b/test/Fields/unit_field.jl
@@ -909,7 +909,7 @@ end
         staggering = Grids.CellCenter(),
     )
     test_adapt(ecs_space_fn)
-    test_adapt_types(ecs_space_fn; broken_space_type_match = true)
+    test_adapt_types(ecs_space_fn)
 
     cs_space_fn(dev) = CubedSphereSpace(;
         device = dev,
@@ -918,7 +918,7 @@ end
         h_elem = 10,
     )
     test_adapt(cs_space_fn)
-    test_adapt_types(cs_space_fn; broken_space_type_match = true)
+    test_adapt_types(cs_space_fn)
 
     column_space_fn(dev) = ColumnSpace(;
         device = dev,

--- a/test/Topologies/cubedsphere_sfc.jl
+++ b/test/Topologies/cubedsphere_sfc.jl
@@ -1,7 +1,7 @@
 using Test
 
 import ClimaCore:
-    Domains, Fields, Geometry, Meshes, Operators, Spaces, Topologies
+    ClimaComms, Domains, Fields, Geometry, Meshes, Operators, Spaces, Topologies
 
 @testset "Space Filling Curve tests for a cubed sphere mesh with (16) elements per edge" begin
     mesh = Meshes.EquiangularCubedSphere(Domains.SphereDomain(1.0), 16)
@@ -36,5 +36,24 @@ import ClimaCore:
         for (order, cartindex) in enumerate(sfc_elemorder)
             @test sfc_orderindex[cartindex] == order
         end
+    end
+end
+
+@testset "uses_spacefillingcurve tests" begin
+    context = ClimaComms.SingletonCommsContext(ClimaComms.CPUSingleThreaded())
+    @testset "cubed sphere with space-filling curve" begin
+        mesh = Meshes.EquiangularCubedSphere(Domains.SphereDomain(1.0), 6)
+        topology_sfc = Topologies.Topology2D(
+            context,
+            mesh,
+            Topologies.spacefillingcurve(mesh),
+        )
+        @test Topologies.uses_spacefillingcurve(topology_sfc) == true
+    end
+
+    @testset "cubed sphere with default ordering" begin
+        mesh = Meshes.EquiangularCubedSphere(Domains.SphereDomain(1.0), 6)
+        topology_default = Topologies.Topology2D(context, mesh)
+        @test Topologies.uses_spacefillingcurve(topology_default) == false
     end
 end

--- a/test/Topologies/rectangle_sfc.jl
+++ b/test/Topologies/rectangle_sfc.jl
@@ -1,5 +1,6 @@
 using IntervalSets
 using Test
+using ClimaComms
 
 import ClimaCore:
     Domains, Fields, Geometry, Meshes, Operators, Spaces, Topologies
@@ -58,5 +59,26 @@ end
         for (order, cartindex) in enumerate(sfc_elemorder)
             @test sfc_orderindex[cartindex] == order
         end
+    end
+end
+
+@testset "uses_spacefillingcurve tests for rectangular mesh" begin
+    device = ClimaComms.CPUSingleThreaded()
+    context = ClimaComms.SingletonCommsContext(device)
+
+    @testset "rectangular mesh with space-filling curve" begin
+        mesh = rectilinear_grid(4, 4, false, false)
+        topology_sfc = Topologies.Topology2D(
+            context,
+            mesh,
+            Topologies.spacefillingcurve(mesh),
+        )
+        @test Topologies.uses_spacefillingcurve(topology_sfc) == true
+    end
+
+    @testset "rectangular mesh with default ordering" begin
+        mesh = rectilinear_grid(4, 4, false, false)
+        topology_default = Topologies.Topology2D(context, mesh)
+        @test Topologies.uses_spacefillingcurve(topology_default) == false
     end
 end


### PR DESCRIPTION
This PR:
- ensures the CommonGrids use the space filling curve where applicable
- Adds a function `Topology.uses_spacefillingcurve(topology)` to test if a space uses a space filling curve
- Add tests to ensure CommonGrids, cubed sphere, and rectangular mesh all use the space filling curve.