### PR TITLE
pin GPUCompiler to 1.7.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,6 +31,7 @@ UnrolledUtilities = "0fe1646c-419e-43be-ac14-22321958931b"
 
 [weakdeps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+GPUCompiler = "f5f5e495-2405-526c-b7e8-d49c91cb95a5"
 Krylov = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
 
 [extensions]
@@ -54,6 +55,7 @@ Dates = "1"
 FastBroadcast = "0.3.1"
 ForwardDiff = "0.10.15, 1"
 GaussQuadrature = "0.5.8"
+GPUCompiler = "< 1.7.6"
 GilbertCurves = "0.1"
 HDF5 = "0.16.16, 0.17"
 InteractiveUtils = "1"


### PR DESCRIPTION
We've been getting errors when using GPUCompiler 1.7.6 and 1.8.0 (e.g. [here](https://buildkite.com/clima/climacoupler-ci/builds/7640#019bdc9a-93d2-407a-a3e0-3f46d41732e6)). We aren't sure what exactly is causing this, but for now we'll pin GPUCompiler to <= 1.7.5.

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
