### PR TITLE
run CI on julia 1.12 instead of 1.11

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -33,7 +33,7 @@ jobs:
           - 'ClimaUtilities.jl'
         version:
           - '1.10'
-          - '1.11'
+          - '1.12'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         version:
           - '1.10'
-          - '1.11'
+          - '1.12'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['1.10', '1.11']
+        version: ['1.10', '1.12']
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest


### PR DESCRIPTION
Run github actions on julia 1.10 and 1.12 instead of 1.10 and 1.11. Buildkite still runs on 1.10 only
