### PR TITLE
Set random seed in split divergence conservation test

### DIFF
--- a/test/Operators/spectralelement/split_divergence.jl
+++ b/test/Operators/spectralelement/split_divergence.jl
@@ -14,6 +14,9 @@ import ClimaCore:
     Quadratures
 using LinearAlgebra, IntervalSets
 
+import Random
+Random.seed!(1234)
+
 include(
     joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl"),
 )


### PR DESCRIPTION
This PR sets a random seed for the split divergence conservation test, because the test was failing in https://github.com/CliMA/ClimaCore.jl/pull/2422.