### PR TITLE
Increase gha unit test time for macos

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   test:
-    timeout-minutes: 80
+    timeout-minutes: ${{ matrix.os == 'macOS-latest' && 120 || 80 }}
     name: ci ${{ matrix.version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
The macOS unit tests usually time out. This increases their time limit 
