### PR TITLE
Simpler horizontal remapping methods for diagnostics 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ ClimaCore.jl Release Notes
 main
 -------
 
+- Add support for bilinear interpolation for diagnostics to the Remapper. [2455](https://github.com/CliMA/ClimaCore.jl/pull/2455)
+
 v0.14.49
 -------
 - Add `PressureInterpolator` [2422](https://github.com/CliMA/ClimaCore.jl/pull/2422)

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
 ClimaCoreMakie = "908f55d8-4145-4867-9c14-5dad1a479e4d"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -66,6 +66,7 @@ withenv("GKSwstype" => "nul") do
         doctest = true,
         modules = [
             ClimaCore,
+            ClimaCore.Remapping,
             ClimaCoreVTK,
             ClimaCoreSpectra,
             ClimaCorePlots,

--- a/docs/src/APIs/remapping_api.md
+++ b/docs/src/APIs/remapping_api.md
@@ -14,4 +14,7 @@ Remapping.pressure_space
 Remapping.update!
 Remapping.interpolate_pressure
 Remapping.interpolate_pressure!
+Remapping.AbstractRemappingMethod
+Remapping.SpectralElementRemapping
+Remapping.BilinearRemapping
 ```

--- a/ext/cuda/remapping_interpolate_array.jl
+++ b/ext/cuda/remapping_interpolate_array.jl
@@ -1,5 +1,5 @@
 import ClimaCore.Remapping: interpolate_slab!
-import ClimaCore: Topologies, Spaces, Fields, Operators
+import ClimaCore: Topologies, Spaces, Fields, Operators, Quadratures
 import CUDA
 using CUDA: @cuda
 function interpolate_slab!(
@@ -124,6 +124,49 @@ function interpolate_slab_level!(
 end
 
 # GPU kernel for 3D configurations
+#
+# SOURCE GRID: GLL nodes in the element (where the field is defined). Indexed by (ii, jj).
+# TARGET: interpolation point (one per thread); we compute value = Σ I1[i]*I2[j]*field[ii,jj].
+#
+# Horizontal indexing (per element):
+#
+#   Spectral (Nq1 = Nq2 = Nq): target uses all source GLL nodes. Weights I1, I2 have length Nq.
+#     Source index = loop index: (ii, jj) = (i, j). Example Nq=4 (· = source node, * = target):
+#
+#         source grid (GLL)          target * gets value from all 16 nodes
+#         j 1   2   3   4
+#       i +---+---+---+---+
+#       1 | · | · | · | · |
+#       2 | · | · | * | · |   →  ij = CartesianIndex((i, j)) for each ·
+#       3 | · | · | · | · |
+#       4 +---+---+---+---+
+#
+#   Bilinear (Nq1 = Nq2 = 2): only when the element has Nq=2 (two GLL points per dim).
+#
+#     Code: ii = is_bilinear ? (1 + (i-1)*(Nq-1)) : i  (and jj likewise).
+#     Bilinear branch (Nq1=Nq2=2): i,j∈{1,2} → ii,jj∈{1,Nq} → four corners only.
+#     Spectral branch (Nq1=Nq2=Nq): ii=i, jj=j → all nodes, or 4 via zeros in I1,I2.
+#
+#     Nq=2 only (2×2 = corners):
+#
+#         (1,1)·-------·(1,2)
+#              |   *   |        * = target; (i,j)=(1,1),(2,1),(1,2),(2,2) → (ii,jj) = corners
+#         (2,1)·-------·(2,2)
+#
+#     Nq>2: target between interior nodes → stencil = 4 nodes of containing sub-cell (spectral branch).
+#
+#         source grid (GLL, Nq=4)    2×2 sub-cell containing target *
+#         j 1   2   3   4
+#       i +---+---+---+---+
+#       1 | · | · | · | · |
+#       2 | · | · | · | · |
+#       3 | · | · | * | · |   * = target; stencil = (2,2),(3,2),(2,3),(3,3) — the 4 · around *
+#       4 +---+---+---+---+
+#
+#         (2,2)·-------·(2,3)
+#              |   *   |        same idea as Nq=2, but sub-cell is interior
+#         (3,2)·-------·(3,3)
+#
 function interpolate_slab_level_kernel!(
     output_array,
     field,
@@ -138,13 +181,19 @@ function interpolate_slab_level_kernel!(
         space = axes(field)
         FT = Spaces.undertype(space)
         Nq1, Nq2 = length(I1), length(I2)
+        quad = Spaces.quadrature_style(space)
+        Nq = Quadratures.degrees_of_freedom(quad)
+        is_bilinear = (Nq1 == 2 && Nq2 == 2)
         v_lo, v_hi, ξ3 = vidx_ref_coordinates[index]
 
         f_lo = zero(FT)
         f_hi = zero(FT)
 
         for j in 1:Nq2, i in 1:Nq1
-            ij = CartesianIndex((i, j))
+            # Bilinear: map stencil index 1,2 → node index 1,Nq; else use index as-is
+            ii = is_bilinear ? (1 + (i - 1) * (Nq - 1)) : i
+            jj = is_bilinear ? (1 + (j - 1) * (Nq - 1)) : j
+            ij = CartesianIndex((ii, jj))
             f_lo +=
                 I1[i] *
                 I2[j] *
@@ -173,15 +222,20 @@ function interpolate_slab_level_kernel!(
     @inbounds begin
         space = axes(field)
         FT = Spaces.undertype(space)
-        Nq = length(I1)
-
+        Nq1 = length(I1)
+        quad = Spaces.quadrature_style(space)
+        Nq = Quadratures.degrees_of_freedom(quad)
+        # When Nq1==2 we have a 2-point (linear) bilinear stencil: map stencil index 1,2 → node 1,Nq
+        is_bilinear = (Nq1 == 2)
         v_lo, v_hi, ξ3 = vidx_ref_coordinates[index]
 
         f_lo = zero(FT)
         f_hi = zero(FT)
 
-        for i in 1:Nq
-            ij = CartesianIndex((i,))
+        for i in 1:Nq1
+            # Bilinear: map stencil index 1,2 → node index 1,Nq; else use index as-is
+            ii = is_bilinear ? (1 + (i - 1) * (Nq - 1)) : i
+            ij = CartesianIndex((ii,))
             f_lo +=
                 I1[i] *
                 Operators.get_node(space, field, ij, Fields.SlabIndex(v_lo, h))

--- a/src/Remapping/Remapping.jl
+++ b/src/Remapping/Remapping.jl
@@ -2,6 +2,8 @@ module Remapping
 
 using LinearAlgebra, StaticArrays
 
+export AbstractRemappingMethod, SpectralElementRemapping, BilinearRemapping
+
 import ClimaComms
 import ..DataLayouts,
     ..Geometry,

--- a/test/Remapping/distributed_remapping.jl
+++ b/test/Remapping/distributed_remapping.jl
@@ -314,6 +314,196 @@ end
     end
 end
 
+@testset "3D box - bilinear horizontal" begin
+    # Same setup as "3D box" but with horizontal_method = BilinearRemapping().
+    vertdomain = Domains.IntervalDomain(
+        Geometry.ZPoint(0.0),
+        Geometry.ZPoint(1000.0);
+        boundary_names = (:bottom, :top),
+    )
+
+    vertmesh = Meshes.IntervalMesh(vertdomain, nelems = 30)
+    verttopo = Topologies.IntervalTopology(
+        ClimaComms.SingletonCommsContext(device),
+        vertmesh,
+    )
+    vert_center_space = Spaces.CenterFiniteDifferenceSpace(verttopo)
+
+    horzdomain = Domains.RectangleDomain(
+        Geometry.XPoint(-500.0) .. Geometry.XPoint(500.0),
+        Geometry.YPoint(-500.0) .. Geometry.YPoint(500.0),
+        x1periodic = true,
+        x2periodic = true,
+    )
+
+    quad = Quadratures.GLL{4}()
+    horzmesh = Meshes.RectilinearMesh(horzdomain, 10, 10)
+    horztopology = Topologies.Topology2D(context, horzmesh)
+    horzspace = Spaces.SpectralElementSpace2D(horztopology, quad)
+
+    hv_center_space =
+        Spaces.ExtrudedFiniteDifferenceSpace(horzspace, vert_center_space)
+
+    coords = Fields.coordinate_field(hv_center_space)
+
+    xpts = range(-500.0, 500.0, length = 21)
+    ypts = range(-500.0, 500.0, length = 21)
+    zpts = range(0.0, 1000.0, length = 21)
+    hcoords = [Geometry.XYPoint(x, y) for x in xpts, y in ypts]
+    zcoords = [Geometry.ZPoint(z) for z in zpts]
+
+    remapper = Remapping.Remapper(
+        hv_center_space,
+        hcoords,
+        zcoords;
+        buffer_length = 2,
+        horizontal_method = Remapping.BilinearRemapping(),
+    )
+
+    interp_x = Remapping.interpolate(remapper, coords.x)
+    if ClimaComms.iamroot(context)
+        @test Array(interp_x) ≈ [x for x in xpts, y in ypts, z in zpts]
+    end
+
+    interp_y = Remapping.interpolate(remapper, coords.y)
+    if ClimaComms.iamroot(context)
+        @test Array(interp_y) ≈ [y for x in xpts, y in ypts, z in zpts]
+    end
+
+    interp_z = Remapping.interpolate(remapper, coords.z)
+    expected_z = [z for x in xpts, y in ypts, z in zpts]
+    if ClimaComms.iamroot(context)
+        @test Array(interp_z[:, :, 2:(end - 1)]) ≈ expected_z[:, :, 2:(end - 1)]
+        @test Array(interp_z[:, :, 1]) ≈
+              [1000.0 * (0 / 30 + 1 / 30) / 2 for x in xpts, y in ypts]
+        @test Array(interp_z[:, :, end]) ≈
+              [1000.0 * (29 / 30 + 30 / 30) / 2 for x in xpts, y in ypts]
+    end
+
+    # Remapping two fields
+    interp_xy = Remapping.interpolate(remapper, [coords.x, coords.y])
+    if ClimaComms.iamroot(context)
+        @test interp_x ≈ interp_xy[:, :, :, 1]
+        @test interp_y ≈ interp_xy[:, :, :, 2]
+    end
+    # Remapping three fields (more than the buffer length)
+    interp_xyx = Remapping.interpolate(remapper, [coords.x, coords.y, coords.x])
+    if ClimaComms.iamroot(context)
+        @test interp_x ≈ interp_xyx[:, :, :, 1]
+        @test interp_y ≈ interp_xyx[:, :, :, 2]
+        @test interp_x ≈ interp_xyx[:, :, :, 3]
+    end
+
+    # Remapping in-place one field
+    dest = ArrayType(zeros(21, 21, 21))
+    Remapping.interpolate!(dest, remapper, coords.x)
+    if ClimaComms.iamroot(context)
+        @test interp_x ≈ dest
+    end
+
+    # Two fields
+    dest = ArrayType(zeros(21, 21, 21, 2))
+    Remapping.interpolate!(dest, remapper, [coords.x, coords.y])
+    if ClimaComms.iamroot(context)
+        @test interp_x ≈ dest[:, :, :, 1]
+        @test interp_y ≈ dest[:, :, :, 2]
+    end
+
+    # Three fields (more than buffer length)
+    dest = ArrayType(zeros(21, 21, 21, 3))
+    Remapping.interpolate!(dest, remapper, [coords.x, coords.y, coords.x])
+    if ClimaComms.iamroot(context)
+        @test interp_x ≈ dest[:, :, :, 1]
+        @test interp_y ≈ dest[:, :, :, 2]
+        @test interp_x ≈ dest[:, :, :, 3]
+    end
+
+    # Horizontal-only with bilinear
+    horiz_space = Spaces.horizontal_space(hv_center_space)
+    horiz_remapper = Remapping.Remapper(
+        horiz_space,
+        hcoords;
+        buffer_length = 2,
+        horizontal_method = Remapping.BilinearRemapping(),
+    )
+
+    coords_h = Fields.coordinate_field(horiz_space)
+
+    interp_x = Remapping.interpolate(horiz_remapper, coords_h.x)
+    if ClimaComms.iamroot(context)
+        @test Array(interp_x) ≈ [x for x in xpts, y in ypts]
+    end
+
+    interp_y = Remapping.interpolate(horiz_remapper, coords_h.y)
+    if ClimaComms.iamroot(context)
+        @test Array(interp_y) ≈ [y for x in xpts, y in ypts]
+    end
+
+    # Two fields
+    interp_xy = Remapping.interpolate(horiz_remapper, [coords_h.x, coords_h.y])
+    if ClimaComms.iamroot(context)
+        @test interp_xy[:, :, 1] ≈ interp_x
+        @test interp_xy[:, :, 2] ≈ interp_y
+    end
+
+    # Three fields
+    interp_xyx =
+        Remapping.interpolate(horiz_remapper, [coords_h.x, coords_h.y, coords_h.x])
+    if ClimaComms.iamroot(context)
+        @test interp_xyx[:, :, 1] ≈ interp_x
+        @test interp_xyx[:, :, 2] ≈ interp_y
+        @test interp_xyx[:, :, 3] ≈ interp_x
+    end
+
+    # Remapping in-place one field
+    dest = ArrayType(zeros(21, 21))
+    Remapping.interpolate!(dest, horiz_remapper, coords_h.x)
+    if ClimaComms.iamroot(context)
+        @test interp_x ≈ dest
+    end
+
+    # Two fields
+    dest = ArrayType(zeros(21, 21, 2))
+    Remapping.interpolate!(dest, horiz_remapper, [coords_h.x, coords_h.y])
+    if ClimaComms.iamroot(context)
+        @test interp_x ≈ dest[:, :, 1]
+        @test interp_y ≈ dest[:, :, 2]
+    end
+
+    # Three fields (more than buffer length)
+    dest = ArrayType(zeros(21, 21, 3))
+    Remapping.interpolate!(dest, horiz_remapper, [coords_h.x, coords_h.y, coords_h.x])
+    if ClimaComms.iamroot(context)
+        @test interp_x ≈ dest[:, :, 1]
+        @test interp_y ≈ dest[:, :, 2]
+        @test interp_x ≈ dest[:, :, 3]
+    end
+
+    # 1D horizontal with BilinearRemapping (linear on 2-point cell)
+    horzdomain_1d = Domains.IntervalDomain(
+        Geometry.XPoint(-500.0) .. Geometry.XPoint(500.0),
+        periodic = true,
+    )
+    horzmesh_1d = Meshes.IntervalMesh(horzdomain_1d, nelems = 10)
+    horztopology_1d = Topologies.IntervalTopology(
+        ClimaComms.SingletonCommsContext(device),
+        horzmesh_1d,
+    )
+    horzspace_1d = Spaces.SpectralElementSpace1D(horztopology_1d, quad)
+    xpts_1d = range(-500.0, 500.0, length = 11)
+    hcoords_1d = [Geometry.XPoint(x) for x in xpts_1d]
+    remapper_1d = Remapping.Remapper(
+        horzspace_1d,
+        hcoords_1d;
+        buffer_length = 1,
+        horizontal_method = Remapping.BilinearRemapping(),
+    )
+    coords_1d = Fields.coordinate_field(horzspace_1d)
+    interp_x_1d = Remapping.interpolate(remapper_1d, coords_1d.x)
+    if ClimaComms.iamroot(context)
+        @test Array(interp_x_1d) ≈ [x for x in xpts_1d]
+    end
+end
 
 @testset "3D box - space filling curve" begin
     vertdomain = Domains.IntervalDomain(

--- a/test/Remapping/interpolate_array.jl
+++ b/test/Remapping/interpolate_array.jl
@@ -124,6 +124,109 @@ end
           [1000.0 * (29 / 30 + 30 / 30) / 2 for x in xpts, y in ypts]
 end
 
+@testset "3D box - bilinear horizontal" begin
+    # Same setup as "3D box" but with horizontal_method = BilinearRemapping()
+    vertdomain = Domains.IntervalDomain(
+        Geometry.ZPoint(0.0),
+        Geometry.ZPoint(1000.0);
+        boundary_names = (:bottom, :top),
+    )
+
+    vertmesh = Meshes.IntervalMesh(vertdomain, nelems = 30)
+    verttopo = Topologies.IntervalTopology(
+        ClimaComms.SingletonCommsContext(device),
+        vertmesh,
+    )
+    vert_center_space = Spaces.CenterFiniteDifferenceSpace(verttopo)
+
+    horzdomain = Domains.RectangleDomain(
+        Geometry.XPoint(-500.0) .. Geometry.XPoint(500.0),
+        Geometry.YPoint(-500.0) .. Geometry.YPoint(500.0),
+        x1periodic = true,
+        x2periodic = true,
+    )
+
+    quad = Quadratures.GLL{4}()
+    horzmesh = Meshes.RectilinearMesh(horzdomain, 10, 10)
+    horztopology = Topologies.Topology2D(
+        ClimaComms.SingletonCommsContext(device),
+        horzmesh,
+    )
+    horzspace = Spaces.SpectralElementSpace2D(horztopology, quad)
+
+    hv_center_space =
+        Spaces.ExtrudedFiniteDifferenceSpace(horzspace, vert_center_space)
+
+    coords = Fields.coordinate_field(hv_center_space)
+
+    xpts = range(Geometry.XPoint(-500.0), Geometry.XPoint(500.0), length = 21)
+    ypts = range(Geometry.YPoint(-500.0), Geometry.YPoint(500.0), length = 21)
+    zpts = range(Geometry.ZPoint(0.0), Geometry.ZPoint(1000.0), length = 21)
+
+    interp_x = Remapping.interpolate_array(
+        coords.x,
+        xpts,
+        ypts,
+        zpts;
+        horizontal_method = Remapping.BilinearRemapping(),
+    )
+    @test interp_x ≈ [x.x for x in xpts, y in ypts, z in zpts]
+
+    interp_y = Remapping.interpolate_array(
+        coords.y,
+        xpts,
+        ypts,
+        zpts;
+        horizontal_method = Remapping.BilinearRemapping(),
+    )
+    @test interp_y ≈ [y.y for x in xpts, y in ypts, z in zpts]
+
+    interp_z = Remapping.interpolate_array(
+        coords.z,
+        xpts,
+        ypts,
+        zpts;
+        horizontal_method = Remapping.BilinearRemapping(),
+    )
+    @test interp_z[:, :, 2:(end - 1)] ≈
+          [z.z for x in xpts, y in ypts, z in zpts[2:(end - 1)]]
+    @test interp_z[:, :, 1] ≈
+          [1000.0 * (0 / 30 + 1 / 30) / 2 for x in xpts, y in ypts]
+    @test interp_z[:, :, end] ≈
+          [1000.0 * (29 / 30 + 30 / 30) / 2 for x in xpts, y in ypts]
+
+    # 1D horizontal + vertical with BilinearRemapping (linear on 2-point cell in horizontal)
+    horzdomain_1d = Domains.IntervalDomain(
+        Geometry.XPoint(-500.0) .. Geometry.XPoint(500.0),
+        periodic = true,
+    )
+    horzmesh_1d = Meshes.IntervalMesh(horzdomain_1d, nelems = 10)
+    horztopology_1d = Topologies.IntervalTopology(
+        ClimaComms.SingletonCommsContext(device),
+        horzmesh_1d,
+    )
+    horzspace_1d = Spaces.SpectralElementSpace1D(horztopology_1d, quad)
+    hv_center_1d =
+        Spaces.ExtrudedFiniteDifferenceSpace(horzspace_1d, vert_center_space)
+    coords_1d = Fields.coordinate_field(hv_center_1d)
+    xpts_1d = range(Geometry.XPoint(-500.0), Geometry.XPoint(500.0), length = 11)
+    zpts_1d = range(Geometry.ZPoint(0.0), Geometry.ZPoint(1000.0), length = 11)
+    interp_x_1d = Remapping.interpolate_array(
+        coords_1d.x,
+        xpts_1d,
+        zpts_1d;
+        horizontal_method = Remapping.BilinearRemapping(),
+    )
+    @test interp_x_1d ≈ [x.x for x in xpts_1d, z in zpts_1d]
+    interp_z_1d = Remapping.interpolate_array(
+        coords_1d.z,
+        xpts_1d,
+        zpts_1d;
+        horizontal_method = Remapping.BilinearRemapping(),
+    )
+    @test interp_z_1d[:, 2:(end - 1)] ≈ [z.z for x in xpts_1d, z in zpts_1d[2:(end - 1)]]
+end
+
 @testset "3D box - space filling curve" begin
     vertdomain = Domains.IntervalDomain(
         Geometry.ZPoint(0.0),


### PR DESCRIPTION
Enables simpler bilinear interpolation option (see ClimaInterpolations.jl) within the Remapping module. 

Example: 
<img width="966" height="645" alt="Screenshot 2026-02-04 at 1 16 01 PM" src="https://github.com/user-attachments/assets/5d024e2c-cc0c-40f8-a864-0645da1663b5" />
