### PR TITLE
update GHA

### DIFF
--- a/.github/workflows/ClimaCoreMakie.yml
+++ b/.github/workflows/ClimaCoreMakie.yml
@@ -17,11 +17,11 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1.10'
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - run: sudo apt-get update && sudo apt-get install -y xorg-dev mesa-utils xvfb libgl1 freeglut3-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev
       - name: Install Julia dependencies
         run: >

--- a/.github/workflows/ClimaCorePlots.yml
+++ b/.github/workflows/ClimaCorePlots.yml
@@ -17,11 +17,11 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1.10'
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - name: Install Julia dependencies
         run: >
           julia --project=monorepo -e 'using Pkg; Pkg.develop(path="$(pwd())"); Pkg.develop(path="$(pwd())/lib/ClimaCorePlots")'

--- a/.github/workflows/ClimaCoreSpectra.yml
+++ b/.github/workflows/ClimaCoreSpectra.yml
@@ -17,11 +17,11 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1.10'
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - name: Install Julia dependencies
         run: >
           julia --project=monorepo -e 'using Pkg; Pkg.develop(path="$(pwd())"); Pkg.develop(path="$(pwd())/lib/ClimaCoreSpectra")'

--- a/.github/workflows/ClimaCoreTempestRemap.yml
+++ b/.github/workflows/ClimaCoreTempestRemap.yml
@@ -18,11 +18,11 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1.10'
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - name: Install Julia dependencies
         run: >
           julia --project=monorepo -e 'using Pkg; Pkg.develop(path="$(pwd())"); Pkg.develop(path="$(pwd())/lib/ClimaCoreTempestRemap")'

--- a/.github/workflows/ClimaCoreVTK.yml
+++ b/.github/workflows/ClimaCoreVTK.yml
@@ -17,11 +17,11 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1.10'
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - name: Install Paraview
         run: |
           sudo apt-get update && sudo apt-get -y install paraview python3-paraview

--- a/.github/workflows/DocCleanup.yml
+++ b/.github/workflows/DocCleanup.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
 

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -35,13 +35,13 @@ jobs:
           - '1.10'
           - '1.11'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: 'CliMA/${{ matrix.package }}'
           path: ${{ matrix.package }}

--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -19,12 +19,12 @@ jobs:
     - uses: julia-actions/setup-julia@v2
       with:
         version: '1.10'
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: julia-actions/julia-buildpkg@v1
     - uses: julia-actions/julia-invalidations@v1
       id: invs_pr
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ github.event.repository.default_branch }}
     - uses: julia-actions/julia-buildpkg@v1

--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -9,7 +9,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: julia-actions/julia-format@v3
+      - uses: julia-actions/julia-format@v4
         with:
           version: '1' # Set `version` to '1.0.54' if you need to use JuliaFormatter.jl v1.0.54 (default: '1')
           suggestion-label: 'format-suggest' # leave this unset or empty to show suggestions for all PRs

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -33,11 +33,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
   docbuild:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1.10'

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -22,13 +22,14 @@ jobs:
       matrix:
         version: ['1.10', '1.11']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.version }}
-      - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-downgrade-compat@v1
+      - uses: julia-actions/cache@v3
+      - uses: julia-actions/julia-downgrade-compat@v2
         with:
-          skip: Dates, InteractiveUtils, JET, LinearAlgebra, Logging, Random, Test, SparseArrays, Statistics
+          skip: 'Dates, InteractiveUtils, JET, LinearAlgebra, Logging, Random, Test, SparseArrays, Statistics'
+          mode: 'forcedeps'
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest


### PR DESCRIPTION
This PR combines a bunch of GHA version updates to replace the following PRs.

bump julia-actions/julia-downgrade-compat from 1 to 2 - closes https://github.com/CliMA/ClimaCore.jl/pull/2365
bump julia-actions/cache from 2 to 3 - closes https://github.com/CliMA/ClimaCore.jl/pull/2465
bump actions/checkout from 4 to 6 - closes https://github.com/CliMA/ClimaCore.jl/pull/2393
bump julia-actions/julia-format from 3 to 4 - closes https://github.com/CliMA/ClimaCore.jl/pull/2314
