### PR TITLE
[REPLACED] More efficient solver for TridiagonalMatrixFields

### DIFF
--- a/ext/cuda/matrix_fields_single_field_solve.jl
+++ b/ext/cuda/matrix_fields_single_field_solve.jl
@@ -7,7 +7,7 @@ import ClimaCore.Fields
 import ClimaCore.Spaces
 import ClimaCore.Topologies
 import ClimaCore.MatrixFields
-import ClimaCore.DataLayouts: vindex
+import ClimaCore.DataLayouts: vindex, universal_size
 import ClimaCore.MatrixFields: single_field_solve!
 import ClimaCore.MatrixFields: _single_field_solve!
 import ClimaCore.MatrixFields: band_matrix_solve!, unzip_tuple_field_values
@@ -209,5 +209,118 @@ function band_matrix_solve_local_mem!(
     @inbounds for v in 1:Nv
         x[vindex(v)] = inv(A₀[vindex(v)]) ⊠ b[vindex(v)]
     end
+    return nothing
+end
+
+
+function tridiag_pcr_kernel!(
+    x, a, b, c, d, ::Val{n}, ::Val{n_iter}
+) where {n, n_iter}
+    (idx_i, idx_j, idx_h) = blockIdx()
+    i = threadIdx().x
+    if i > n
+        return nothing
+    end
+
+    T = eltype(a)
+    n_shared = typeof(n)(cld(n, 32) * 32)  # Round n to next multiple to avoid bank conflicts (?)
+    s_a = CUDA.CuStaticSharedArray(T, n_shared)
+    s_b = CUDA.CuStaticSharedArray(T, n_shared)
+    s_c = CUDA.CuStaticSharedArray(T, n_shared)
+    s_d = CUDA.CuStaticSharedArray(T, n_shared)
+
+    idx = CartesianIndex(idx_i, idx_j, 1, i, idx_h)
+
+    # Load into shared memory
+    @inbounds begin
+        local_ai = getindex_field(a, idx)
+        local_bi = getindex_field(b, idx)
+        local_ci = getindex_field(c, idx)
+        local_di = getindex_field(d, idx)
+
+        s_a[i] = local_ai
+        s_b[i] = local_bi
+        s_c[i] = local_ci
+        s_d[i] = local_di
+    end
+    CUDA.sync_threads()
+
+    # PCR iterations
+    stride = 1
+
+    for _ in 1:n_iter
+        i_minus = max(i - stride, 1)
+        i_plus = min(i + stride, n)
+
+        # Compute elimination factors
+        @inbounds begin
+            k1 = (i > stride) ? -local_ai / s_b[i_minus] : zero(T)
+            k2 = (i <= n - stride) ? -local_ci / s_b[i_plus] : zero(T)
+
+            # Update coefficients
+            local_ai = k1 * s_a[i_minus]
+            local_bi = local_bi + k1 * s_c[i_minus] + k2 * s_a[i_plus]
+            local_ci = k2 * s_c[i_plus]
+            local_di = local_di + k1 * s_d[i_minus] + k2 * s_d[i_plus]
+        end
+
+        CUDA.sync_threads()
+
+        # Copy back for next iteration
+        @inbounds begin
+            s_a[i] = local_ai
+            s_b[i] = local_bi
+            s_c[i] = local_ci
+            s_d[i] = local_di
+        end
+
+        CUDA.sync_threads()
+        stride *= 2
+    end
+
+    #  Final solve into x
+    @inbounds setindex_field!(x, local_di / local_bi, idx)
+    return nothing
+end
+
+
+"""
+    single_field_solve_tridiagonal!(cache, x, A, b)
+
+Specialized solver for the tridiagonal MatrixField. Solves each column in
+parallel launching Nv threads per block where Nv is the number of vertical levels.
+Works best if Nv is multiple of 32. Also must be smaller then 256.
+"""
+function single_field_solve_tridiagonal!(cache, x, A, b)
+
+    device = ClimaComms.device(x)
+    device isa ClimaComms.CUDADevice || error("This solver supports only CUDA devices.")
+
+    eltype(A) <: MatrixFields.TridiagonalMatrixRow || error(
+        "This function expects a tridiagonal matrix field, but got a field with element type $(eltype(A))"
+    )
+
+    # Get field dimensions
+    Ni, Nj, _, Nv, Nh = universal_size(Fields.field_values(A))
+
+    # Prepare data
+    Aⱼs = unzip_tuple_field_values(Fields.field_values(A.entries))
+    A₋₁, A₀, A₊₁ = Aⱼs
+    x_data = Fields.field_values(x)
+    b_data = Fields.field_values(b)
+
+    # Solve
+    threads_per_block = min(Nv, 256)
+    n_iter = ceil(Int, log2(Nv))
+    args = (x_data, A₋₁, A₀, A₊₁, b_data, Val(Nv), Val(n_iter))
+
+    auto_launch!(
+        tridiag_pcr_kernel!,
+        args;
+        threads_s = (threads_per_block,),
+        blocks_s = (Ni, Nj, Nh),
+    )
+
+    call_post_op_callback() && post_op_callback(x, device, cache, x, A, b)
     return nothing
 end

--- a/ext/cuda/matrix_fields_single_field_solve.jl
+++ b/ext/cuda/matrix_fields_single_field_solve.jl
@@ -14,6 +14,13 @@ import ClimaCore.MatrixFields: band_matrix_solve!, unzip_tuple_field_values
 import ClimaCore.RecursiveApply: ⊠, ⊞, ⊟, rmap, rzero, rdiv
 
 function single_field_solve!(device::ClimaComms.CUDADevice, cache, x, A, b)
+
+    # Tridiagonal solvers are handled by special implementation
+    if eltype(A) <: MatrixFields.TridiagonalMatrixRow
+        single_field_solve_tridiagonal!(cache, x, A, b)
+        return
+    end
+
     Ni, Nj, _, _, Nh = size(Fields.field_values(A))
     us = UniversalSize(Fields.field_values(A))
     mask = Spaces.get_mask(axes(x))

--- a/src/MatrixFields/field_matrix_solver.jl
+++ b/src/MatrixFields/field_matrix_solver.jl
@@ -279,9 +279,15 @@ function run_field_matrix_solver!(
     case1 = length(names) == 1
     case2 = all(name -> cheap_inv(A[name, name]), names.values)
     case3 = any(name -> cheap_inv(A[name, name]), names.values)
+
+    # Direct all TridiagonalMatrixRow cases to `single_field_solve` path so
+    # they can be redirected to a specialised solver
+    # TODO: Group multiple Tridiagonals to the special 'multiple_field' solver
+    case4 = any(name -> eltype(A[name, name]) <: TridiagonalMatrixRow, names.values)
+
     # TODO: remove case3 and implement _single_field_solve_diag_matrix_row!
     #       in multiple_field_solve!
-    if case1 || case2 || case3
+    if case1 || case2 || case3 || case4
         foreach(names) do name
             single_field_solve!(cache[name], x[name], A[name, name], b[name])
         end


### PR DESCRIPTION
@petebachant @imreddyTeja @sjavis @AdelekeBankole 

In  this PR we will aim to contribute a more efficient implementation of the tridiagonal matrix solver to that effect we:
- split the `multiple_field_solve!` to isolate tridiagonal cases 
- redirect tridiagonal cases to a specialised solver

At the moment the specialised solver is significantly faster (e.g. when tested on L40 single solve reduces from ~200ms to 90ms [compere.tar.gz](https://github.com/user-attachments/files/26542935/compere.tar.gz)). Once we trigger `[perf]` tag we will see how it performs in the complete simulation :crossed_fingers: 

This is still draft since the solver is not good enough from the point of the view of the launch configuration. We launch a block per column and a thread for each vertical level. This works well if the number of levels is close to multiple of `32` (like AMIP), but it is not stable enough.  In this PR we will try to provide and test some alternatives. At the moment I see two options we can try: 

**Stitch Matrixes together on load to shared memory**   
This would basically use the existing (quite fast) shmem solver, but to balance the load, load multiple columns into shmem to solve them as a single matrix (as far as I know some rows with 0 off-diagonals at the matrix 'stiches' should not cause numerical problems...) . Here the problem would be though that since the 1st (or last) element of the off-diagonal would need to be patched to 0 (since it may not be zero, currently having "don't care" status) on load  to shared memory. 

Since the loading of data currently accounts for at least 50% of the solver runtime extra logic on load may not be performant. We shell see.

**Shared Memory Parallel Thomas** 
Since we expect the vertical tridiagonal matrixes to be small we can solve them in batches of 32. Have a single wrap per block and allow each of the threads to solve full matrix with the Parallel Thomas.    


### TODO

When the PR is ready go through the checklist:
- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/).
- [ ] Unit tests are included.
- [ ] Code is exercised in an integration test.
- [ ] Documentation has been added/updated.