### PR TITLE
Add gpu latency regression test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -68,6 +68,15 @@ steps:
         agents:
           slurm_gpus: 1
 
+      - label: "Unit: kernel latency benchmarks"
+        key: latency_benchmarks
+        command:
+          - "julia --color=yes --check-bounds=yes --project=.buildkite test/gpu/latency_benchmarks.jl"
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+        agents:
+          slurm_gpus: 1
+
   - group: "Unit: Utilities"
     steps:
 

--- a/test/gpu/kernel_renaming.jl
+++ b/test/gpu/kernel_renaming.jl
@@ -8,6 +8,7 @@ ClimaComms.@import_required_backends
 @testset "kernel renaming" begin
     ext = Base.get_extension(ClimaCore, :ClimaCoreCUDAExt)
     @assert !isnothing(ext) # cuda must be loaded to test this extension
+    @assert ext.NAME_KERNELS_FROM_STACK_TRACE[]
     space = ExtrudedCubedSphereSpace(Float32;
         z_elem = 10,
         z_min = 0,

--- a/test/gpu/latency_benchmarks.jl
+++ b/test/gpu/latency_benchmarks.jl
@@ -1,0 +1,65 @@
+using ClimaCore
+using ClimaCore.CommonSpaces
+import ClimaComms
+using Test
+using CUDA
+using BenchmarkTools
+import LazyBroadcast: lazy
+
+
+# the timings for these benchmark are taken using the central cluster
+@testset "benchmarks time to kernel launch" begin
+    # test to catch regressions and improvement to kernel launch time from ClimaCoreCUDAExt
+    # after the inital compilation
+    ext = Base.get_extension(ClimaCore, :ClimaCoreCUDAExt)
+    @assert !isnothing(ext) # cuda must be loaded to test this extension
+    space = ExtrudedCubedSphereSpace(Float32;
+        z_elem = 10,
+        z_min = 0,
+        z_max = 1,
+        radius = 10,
+        h_elem = 10,
+        n_quad_points = 4,
+        staggering = CellCenter(),
+    )
+
+    scalar_field_1 = fill(1.0f0, space)
+    scalar_field_2 = fill(1.0f0, space)
+    # basic expression
+    # intentionally benchmark without a sync between each trial
+    # CUDA.synchronize()
+    latency = median(@benchmark $scalar_field_1 .= $scalar_field_1 .+ $scalar_field_2).time
+    # update this value if the kernel launch time changes significantly and it is expected
+    baseline_latency = 20500
+    @test latency ≈ baseline_latency atol = 3000
+    percent_change_latency =
+        round(Int, (latency - baseline_latency) / baseline_latency * 100)
+    @info "Latency: $latency ns, Percent change from baseline: $percent_change_latency%"
+
+    # repeated args expression
+    CUDA.synchronize()
+    latency =
+        median(
+            @benchmark $scalar_field_1 .=
+                $scalar_field_1 .+ $scalar_field_2 .+ $scalar_field_1 .+ $scalar_field_2
+        ).time
+    # update this value if the kernel launch time changes significantly and it is expected
+    baseline_latency = 22500
+    @test latency ≈ baseline_latency atol = 3000
+    percent_change_latency =
+        round(Int, (latency - baseline_latency) / baseline_latency * 100)
+    @info "Latency: $latency ns, Percent change from baseline: $percent_change_latency%"
+
+    # nested lazy broadcast
+    lazy_sum_1 = @. lazy(scalar_field_1 + scalar_field_2)
+    lazy_sum_2 = @. lazy(lazy_sum_1 + lazy_sum_1)
+    lazy_sum_3 = @. lazy(lazy_sum_2 + lazy_sum_2)
+    CUDA.synchronize()
+    latency = median(@benchmark $scalar_field_1 .= $lazy_sum_3).time
+    # update this value if the kernel launch time changes significantly and it is expected
+    baseline_latency = 29000
+    @test latency ≈ baseline_latency atol = 3000
+    percent_change_latency =
+        round(Int, (latency - baseline_latency) / baseline_latency * 100)
+    @info "Latency: $latency ns, Percent change from baseline: $percent_change_latency%"
+end


### PR DESCRIPTION
<!-- Provide a clear description of the content -->

Adds a test for kernel latency from the cuda ext. This does not include the time between the end of the CUDA launch api call end the actual start of the kernel.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
