### PR TITLE
Tr/bc docs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ v0.14.51
 -------
 
 - Add support for nonuniform data structures [2464](https://github.com/CliMA/ClimaCore.jl/pull/2464)
-- Add shared memory stencil support in CUDAExt (for spaces with non-periodic topologies and no masks) [2466](https://github.com/CliMA/ClimaCore.jl/pull/2466/commits)
+- Add shared memory stencil support in CUDAExt (for spaces with non-periodic topologies and no masks) [2466](https://github.com/CliMA/ClimaCore.jl/pull/2466)
 
 v0.14.50
 -------

--- a/docs/tutorials/introduction.jl
+++ b/docs/tutorials/introduction.jl
@@ -275,10 +275,13 @@ plot(map(x -> x.w, ClimaCore.Geometry.WVector.(∇cosz)), ylim = (0, 10))
 
 sinz = sin.(column_center_coords.z)
 gradc2f = ClimaCore.Operators.GradientC2F()
-## ∇sinz = gradc2f.(sinz) ## this would throw an error
+# this throws an error when julia is launched with --check-bounds=yes
+# if ran with nomrally (auto bounds checking), behavior at the boundary is undefined
+# (i.e. it will read some random memory outside the array)
+# ∇sinz = gradc2f.(sinz) ## undefined behavior at boundary
 #----------------------------------------------------------------------------
 
-# This throws an error because face values at the boundary are _not_ well-defined:
+# This throws an error when bounds checking is enabled because face values at the boundary are _not_ well-defined:
 #
 # ```
 # ...


### PR DESCRIPTION
Updates docs to clarify issue brought up in #2473 

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
