### PR TITLE
Fix eager eval of non-Field broadcasts in calc_level_val

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1192,6 +1192,15 @@ steps:
           slurm_gpus: 1
           slurm_mem: 10GB
 
+      - label: "Unit: matrix field broadcasting (GPU)"
+        key: unit_matrix_field_broadcasting_gpu_scalar_17
+        command: "julia --color=yes --check-bounds=yes --project=.buildkite test/MatrixFields/matrix_fields_broadcasting/test_scalar_17.jl"
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+        agents:
+          slurm_gpus: 1
+          slurm_mem: 10GB
+
         # non-scalar
       - label: "Unit: matrix field broadcasting (GPU)"
         key: unit_matrix_field_broadcasting_gpu_non_scalar_1

--- a/ext/cuda/operators_fd_eager.jl
+++ b/ext/cuda/operators_fd_eager.jl
@@ -1,6 +1,6 @@
 import ClimaCore: Spaces, Quadratures, Topologies, Operators
 import Base.Broadcast: Broadcasted
-import ClimaCore.Fields: Field, field_values
+import ClimaCore.Fields: Field, field_values, AbstractFieldStyle
 import ClimaComms
 import ClimaCore.Utilities: half
 import ClimaCore.Operators
@@ -204,7 +204,7 @@ Base.@propagate_inbounds reconstruct_space_and_call_calc_level_val(
     arg::A,
     space::S,
 ) where {
-    A <: Union{Base.Broadcast.Broadcasted, StencilBroadcasted, Field},
+    A <: Union{Base.Broadcast.Broadcasted{<:AbstractFieldStyle}, StencilBroadcasted, Field},
     S,
 } = @inbounds @inline calc_level_val(arg, reconstruct_placeholder_space(axes(arg), space))
 Base.@propagate_inbounds reconstruct_space_and_call_calc_level_val(

--- a/test/MatrixFields/matrix_fields_broadcasting/test_scalar_17.jl
+++ b/test/MatrixFields/matrix_fields_broadcasting/test_scalar_17.jl
@@ -1,0 +1,33 @@
+#=
+julia --project
+using Revise; include(joinpath("test", "MatrixFields", "matrix_fields_broadcasting", "test_scalar_4.jl"))
+=#
+import ClimaCore
+#! format: off
+include(joinpath(pkgdir(ClimaCore),"test","MatrixFields","matrix_fields_broadcasting","test_scalar_utils.jl"))
+#! format: on
+test_opt = get(ENV, "BUILDKITE", "") == "true"
+@testset "tri-diagonal matrix times Diagonal with nested broadcasts" begin
+    bc = @lazy @. ᶠᶠmat * DiagonalMatrixRow(((1.0f0 - 0.5f0 * 2.0f0 + 0.0f0 * ᶠvec)))
+    result = materialize(bc)
+
+    input_fields = (ᶠᶠmat, ᶠvec)
+    ref_set_result! = (_result, _ᶠᶠmat, _ᶠvec) -> _result .= 0.0f0
+
+    unit_test_field_broadcast_vs_array_reference(
+        result,
+        bc;
+        input_fields,
+        ref_set_result!,
+        using_cuda,
+        allowed_max_eps_error = 10,
+    )
+    test_opt && opt_test_field_broadcast_against_array_reference(
+        result,
+        bc;
+        input_fields,
+        ref_set_result!,
+        using_cuda,
+    )
+    test_opt && !using_cuda && perf_getidx(bc)
+end


### PR DESCRIPTION
<!-- Provide a clear description of the content -->

The finite difference evaluation on GPUs incorrectly handles broadcasts that are not `<: AbstractFieldStyle` when they are nested within another Broadcasted.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
