### PR TITLE
Ignore certain functions withing ClimaCore for kernel renaming

### DIFF
--- a/ext/cuda/cuda_utils.jl
+++ b/ext/cuda/cuda_utils.jl
@@ -64,12 +64,16 @@ const IGNORE_MODULES = (
     :ClimaCoreCUDAExt,
 )
 
+# Functions withing ClimaCore to ignore when determining relevant stack frames
+const CLIMACORE_IGNORE_FUNCS =
+    (:materialize, :materialize!, :foreach, :unrolled_foreach, Symbol("macro expansion"))
 # Helper function to check if a stack frame is relevant
 @inline function is_relevant_frame(frame::Base.StackTraces.StackFrame)
     frame_method = frame.linfo isa Core.CodeInstance ? frame.linfo.def : frame.linfo
     frame_method isa Core.MethodInstance || return false
     mod = frame_method.def.module::Module
     mod_name = fullname(mod)[1]
+    mod_name == :ClimaCore && frame.func::Symbol ∈ CLIMACORE_IGNORE_FUNCS && return false
     return mod_name ∉ IGNORE_MODULES
 end
 


### PR DESCRIPTION
<!-- Provide a clear description of the content -->
This should fix the renaming for #2486

@petebachant While working on this, I noticed that quite a few stack frames are skipped by `is_relevant_frame` because they are inlined. This means `frame.linfo isa Nothing`, but we can still get line info from `frame.line` and `frame.file`. Maybe this could improve some of the renaming and reduce NVTX interference. 
- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
