### PR TITLE
Use MacOS runners only on PR merges

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -28,8 +28,15 @@ jobs:
           - '1.11'
         os:
           - ubuntu-latest
-          - macOS-latest
           - windows-latest
+          # There is a concurrency limit for MacOS runners across the
+          # entire organization.
+          # (see https://docs.github.com/en/actions/reference/limits#job-concurrency-limits-for-github-hosted-runners)
+          # To help with this, MacOS runners are only run when PRs are merged
+          # into the main branch.
+          - ${{ github.event_name == 'push' && 'macos-latest' || '' }}
+        exclude:
+          - os: ''
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR is identical to https://github.com/CliMA/ClimaCoupler.jl/pull/1722, https://github.com/CliMA/ClimaAtmos.jl/pull/4287, and https://github.com/CliMA/ClimaLand.jl/pull/1738. There is a concurrency limit of 5 MacOS runners for the entire organization.