### PR TITLE
Fix spelling of indicies

### DIFF
--- a/ext/cuda/data_layouts_copyto.jl
+++ b/ext/cuda/data_layouts_copyto.jl
@@ -50,7 +50,7 @@ if VERSION ≥ v"1.11.0-beta"
             cart_inds = if mask isa NoMask
                 cartesian_indices(us)
             else
-                cartesian_indicies_mask(us, mask)
+                cartesian_indices_mask(us, mask)
             end
             args = (dest, bc, us, mask, cart_inds)
             threads = threads_via_occupancy(knl_copyto!, args)
@@ -95,7 +95,7 @@ else
                 cart_inds = if mask isa NoMask
                     cartesian_indices(us)
                 else
-                    cartesian_indicies_mask(us, mask)
+                    cartesian_indices_mask(us, mask)
                 end
                 args = (dest, bc, us, mask, cart_inds)
                 threads = threads_via_occupancy(knl_copyto!, args)

--- a/ext/cuda/data_layouts_fill.jl
+++ b/ext/cuda/data_layouts_fill.jl
@@ -40,7 +40,7 @@ function Base.fill!(dest::AbstractData, bc, to::ToCUDA, mask = NoMask())
             cart_inds = if mask isa NoMask
                 cartesian_indices(us)
             else
-                cartesian_indicies_mask(us, mask)
+                cartesian_indices_mask(us, mask)
             end
             args = (dest, bc, us, mask, cart_inds)
             threads = threads_via_occupancy(knl_fill!, args)

--- a/ext/cuda/data_layouts_threadblock.jl
+++ b/ext/cuda/data_layouts_threadblock.jl
@@ -18,10 +18,10 @@ computed from CUDA's `threadIdx`,
 function universal_index end
 
 ##### Masked
-@inline cartesian_indicies_mask(us::DataLayouts.UniversalSize, mask::IJHMask) =
-    cartesian_indicies_mask(us, typeof(mask), mask.N[1])
+@inline cartesian_indices_mask(us::DataLayouts.UniversalSize, mask::IJHMask) =
+    cartesian_indices_mask(us, typeof(mask), mask.N[1])
 
-@inline function cartesian_indicies_mask(
+@inline function cartesian_indices_mask(
     us::DataLayouts.UniversalSize,
     ::Type{<:IJHMask},
     n_active_columns::Integer,

--- a/ext/cuda/operators_finite_difference.jl
+++ b/ext/cuda/operators_finite_difference.jl
@@ -108,7 +108,7 @@ function Base.copyto!(
         cart_inds = if mask isa NoMask
             cartesian_indices(us)
         else
-            cartesian_indicies_mask(us, mask)
+            cartesian_indices_mask(us, mask)
         end
 
         args = (

--- a/src/Operators/spectralelement.jl
+++ b/src/Operators/spectralelement.jl
@@ -40,7 +40,7 @@ abstract type SpectralElementOperator{I} <: AbstractOperator end
 """
     operator_axes(space)
 
-Return a tuple of the axis indicies a given field operator works over.
+Return a tuple of the axis indices a given field operator works over.
 """
 function operator_axes end
 


### PR DESCRIPTION
<!-- Provide a clear description of the content -->
 indicies -> indices
- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
