### PR TITLE
Fix typos in docs in Grids and Spaces modules

### DIFF
--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -98,7 +98,7 @@ end
 """
     has_horizontal(::AbstractGrid)
 
-Returns a bool indicating that the grid has a vertical part.
+Returns a bool indicating that the grid has a horizontal part.
 """
 function has_horizontal end
 has_horizontal(::AbstractGrid) = false
@@ -110,7 +110,7 @@ has_horizontal(::SpectralElementGrid1D) = true
 """
     has_vertical(::AbstractGrid)
 
-Returns a bool indicating that the space has a vertical part.
+Returns a bool indicating that the grid has a vertical part.
 """
 function has_vertical end
 has_vertical(::AbstractGrid) = false

--- a/src/Grids/column.jl
+++ b/src/Grids/column.jl
@@ -1,7 +1,3 @@
-
-
-
-
 """
     ColumnIndex(ij,h)
 
@@ -22,11 +18,11 @@ end
 
 """
     ColumnGrid(
-        full_grid :: ExtrudedFiniteDifferenceGrid, 
+        full_grid :: ExtrudedFiniteDifferenceGrid,
         colidx    :: ColumnIndex,
     )
 
-A view into a column of a `ExtrudedFiniteDifferenceGrid`. This can be used as an
+A view into a column of a `ExtrudedFiniteDifferenceGrid`.
 """
 struct ColumnGrid{
     G <: AbstractExtrudedFiniteDifferenceGrid,

--- a/src/Grids/spectralelement.jl
+++ b/src/Grids/spectralelement.jl
@@ -117,9 +117,9 @@ end
 
 
 """
-    SpectralElementSpace2D <: AbstractSpace
+    SpectralElementGrid2D <: AbstractSpectralElementGrid
 
-A two-dimensional space: within each element the space is represented as a polynomial.
+A two-dimensional grid: within each element the space is represented as a polynomial.
 """
 mutable struct SpectralElementGrid2D{
     T,
@@ -150,7 +150,7 @@ local_geometry_type(
 ) where {T, Q, GG, LG, D, IS, BS, M} = eltype(LG) # calls eltype from DataLayouts
 
 """
-    SpectralElementSpace2D(
+    SpectralElementGrid2D(
         topology,
         quadrature_style;
         enable_bubble,
@@ -159,7 +159,7 @@ local_geometry_type(
         enable_mask::Bool,
     )
 
-Construct a `SpectralElementSpace2D` instance given a `topology` and `quadrature`. The
+Construct a `SpectralElementGrid2D` instance given a `topology` and `quadrature`. The
 flag `enable_bubble` enables the `bubble correction` for more accurate element areas.
 The flag `autodiff_metric` enables the use of automatic differentiation instead of the
 SEM for computing metric terms.

--- a/src/Spaces/Spaces.jl
+++ b/src/Spaces/Spaces.jl
@@ -198,7 +198,7 @@ has_vertical(::FiniteDifferenceSpace) = false
 """
     has_horizontal(::AbstractSpace)
 
-Returns a bool indicating that the space has a vertical grid.
+Returns a bool indicating that the space has a horizontal grid.
 """
 function has_horizontal end
 has_horizontal(::AbstractSpace) = false


### PR DESCRIPTION
This PR fixes some typos in the documentation.