### PR TITLE
Remove GHA tests on Windows

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -28,7 +28,6 @@ jobs:
           - '1.11'
         os:
           - ubuntu-latest
-          - windows-latest
           # There is a concurrency limit for MacOS runners across the
           # entire organization.
           # (see https://docs.github.com/en/actions/reference/limits#job-concurrency-limits-for-github-hosted-runners)


### PR DESCRIPTION
As of now, there isn't much benefit to testing on Windows.