### PR TITLE
feat(Fields): add soa_broadcast! fast path for point-wise kernels

### DIFF
--- a/ext/ClimaCoreCUDAExt.jl
+++ b/ext/ClimaCoreCUDAExt.jl
@@ -36,5 +36,6 @@ include(joinpath("cuda", "operators_columnwise.jl"))
 include(joinpath("cuda", "matrix_fields_single_field_solve.jl"))
 include(joinpath("cuda", "matrix_fields_multiple_field_solve.jl"))
 include(joinpath("cuda", "operators_spectral_element.jl"))
+include(joinpath("cuda", "soa_broadcast.jl"))
 
 end

--- a/ext/cuda/soa_broadcast.jl
+++ b/ext/cuda/soa_broadcast.jl
@@ -1,0 +1,34 @@
+function soa_broadcast_kernel!(
+    f::F,
+    outs::NTuple{Nf, Any},
+    ins::NTuple{Nin, Any},
+    n,
+) where {F, Nf, Nin}
+    i = (CUDA.blockIdx().x - Int32(1)) * CUDA.blockDim().x + CUDA.threadIdx().x
+    if i ≤ n
+        # `map` over the input tuple unrolls for any arity and stays type-stable
+        # for heterogeneous array types; `ntuple(_, Val(N))` falls back to a
+        # runtime loop for N > 10, which boxes and triggers gpu_gc_pool_alloc.
+        nt = f(map(a -> @inbounds(a[i]), ins)...)
+        ntuple(k -> (@inbounds(outs[k][i] = nt[k]); Int32(0)), Val(Nf))
+    end
+    return nothing
+end
+
+function ClimaCore.Fields._soa_copyto!(
+    ::ClimaCore.DataLayouts.ToCUDA,
+    f::F,
+    outs::NTuple{Nf, Any},
+    ins::NTuple{Nin, Any},
+    n::Integer,
+) where {F, Nf, Nin}
+    n > 0 || return nothing
+    # A plain launch (no forced `always_inline`): forcing inlining of the per-point
+    # function balloons the IR and the LLVM compile for many-call-site functions.
+    kernel = CUDA.@cuda launch = false soa_broadcast_kernel!(f, outs, ins, n)
+    config = CUDA.launch_configuration(kernel.fun)
+    threads = min(n, config.threads)
+    blocks = cld(n, threads)
+    kernel(f, outs, ins, n; threads, blocks)
+    return nothing
+end

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -380,6 +380,7 @@ include("compat_diffeq.jl")
 include("fieldvector.jl")
 include("field_iterator.jl")
 include("indices.jl")
+include("soa_broadcast.jl")
 
 function interpcoord(elemrange, x::Real)
     n = length(elemrange) - 1

--- a/src/Fields/soa_broadcast.jl
+++ b/src/Fields/soa_broadcast.jl
@@ -1,0 +1,48 @@
+import UnrolledUtilities
+
+"""
+    soa_broadcast!(f, out::Field, args::Field...)
+
+!!! warning "Experimental"
+    Experimental, intentionally-restricted fast path; the interface may change or be
+    removed without notice.
+
+Apply the point-wise function `f` to `args` and write the result into the pre-existing
+field `out` in a single device pass (struct-of-arrays). `f` maps the per-point scalar
+values of `args` to either a scalar (for a scalar `out`) or a `NamedTuple` matching
+`eltype(out)`. `out` and all `args` must share the same space, and `args` must be scalar
+fields.
+
+This is a fast-compiling stand-in for `Base.copyto!` of the equivalent broadcast. It
+indexes the underlying arrays linearly, avoiding the `CartesianIndex` code generation that
+makes many-call-site point-wise kernels (e.g. quadrature integrals) compile slowly on the
+GPU. It is restricted to uniform same-space, unmasked, point-wise use and is not a general
+broadcast.
+"""
+function soa_broadcast!(f::F, out::Field, args::Vararg{Field, N}) where {F, N}
+    pns = propertynames(out)
+    outs =
+        isempty(pns) ? (parent(out),) :
+        UnrolledUtilities.unrolled_map(nm -> parent(getproperty(out, nm)), pns)
+    ins = UnrolledUtilities.unrolled_map(parent, args)
+    n = length(ins[1])
+    _soa_copyto!(DataLayouts.device_dispatch(parent(out)), f, outs, ins, n)
+    return out
+end
+
+# CPU path: a plain serial loop. The GPU method is added in ClimaCoreCUDAExt.
+function _soa_copyto!(
+    ::DataLayouts.ToCPU,
+    f::F,
+    outs::NTuple{Nf, Any},
+    ins::NTuple{Nin, Any},
+    n::Integer,
+) where {F, Nf, Nin}
+    @inbounds for i in 1:n
+        # `map` (not `ntuple(_, Val(N))`) so the input extraction unrolls and
+        # stays type-stable for N > 10 heterogeneous array types.
+        nt = f(map(a -> a[i], ins)...)
+        ntuple(k -> (outs[k][i] = nt[k]; nothing), Val(Nf))
+    end
+    return nothing
+end


### PR DESCRIPTION
## Purpose

Add `Fields.soa_broadcast!(f, out, args...)`, a restricted, fast-compiling stand-in for `Base.copyto!` of a point-wise broadcast.

## What

`soa_broadcast!` applies a point-wise function `f` to the per-point scalar values of `args` and writes the result into the pre-existing field `out` in a single device pass, indexing the underlying arrays linearly rather than through `CartesianIndex`.

- Restricted to uniform same-space, unmasked, scalar-field arguments. `f` returns a scalar (for a scalar `out`) or a `NamedTuple` matching `eltype(out)`.
- CPU method: a serial loop. CUDA method: a plain kernel launch.
- Marked experimental; not exported.

## Why

For many-call-site point-wise functions, for example the quadrature-based 2M+P3 microphysics tendencies in ClimaAtmos, the standard broadcast makes the GPU kernel compile very slowly: minutes for the instantaneous tendency, and more than 30 minutes without completion for the full Rosenbrock 2M+P3 tendency. A compile-time decomposition (see the benchmark comment below) identifies the cause: forcing `always_inline` on the broadcast kernel balloons the IR and the LLVM compile. `soa_broadcast!` recovers the fast compile chiefly by not forcing inlining. Two further choices are secondary for compile time and kept for other reasons: linear indexing (instead of `CartesianIndex`), which does not change compile time but gives a roughly 1.6x faster warm kernel on the heavy tendency and reaches the speed of a hand-written `CuArray` kernel without leaving the Fields interface; and extracting inputs with `map` rather than `ntuple(_, Val(N))`, the safe choice for heterogeneous inputs (the `N > 10` boxing fallback cited earlier did not reproduce on the benchmarked Julia/CUDA).

## Notes

- Draft: opened to unblock the downstream ClimaAtmos 2M+P3 EDMF work that consumes this API. The compile-time decomposition is in the comment below.
- `dr/data_style_broadcast_getindex` targets a related goal (a specialized `Base.getindex` for `Broadcasted{<:DataStyle}`) via the generic broadcast path; this is an orthogonal, restricted fast path and the two do not overlap at the file level.
