### PR TITLE
Run Unit Tests on pushes to main and pin CI badge to main

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -1,10 +1,13 @@
 name: Unit Tests
 
 on:
-  pull_request:
+  push:
     branches:
       - main
     tags: '*'
+  pull_request:
+    branches:
+      - main
 
 # Needed to allow julia-actions/cache to delete old caches that it has created
 permissions:

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ The dynamical core (_dycore_) of the CliMA Earth System Model: composable, GPU-c
 [license-img]: https://img.shields.io/badge/license-Apache%202.0-blue.svg
 [license-url]: https://github.com/CliMA/ClimaCore.jl/blob/main/LICENSE
 
-[gha-ci-img]: https://github.com/CliMA/ClimaCore.jl/actions/workflows/UnitTests.yml/badge.svg
-[gha-ci-url]: https://github.com/CliMA/ClimaCore.jl/actions/workflows/UnitTests.yml
+[gha-ci-img]: https://github.com/CliMA/ClimaCore.jl/actions/workflows/UnitTests.yml/badge.svg?branch=main
+[gha-ci-url]: https://github.com/CliMA/ClimaCore.jl/actions/workflows/UnitTests.yml?query=branch%3Amain
 
 [bk-ci-img]: https://badge.buildkite.com/2b63d3c49347804f61bd8e99c8b85e05871253b92612cd1af4.svg?branch=main
 [bk-ci-url]: https://buildkite.com/clima/climacore-ci/builds?branch=main


### PR DESCRIPTION
## Summary
- The `Unit Tests` workflow only triggered on `pull_request`, so the README CI badge showed the status of the latest PR run on any branch — currently a failing run from an unrelated PR branch.
- Add a `push` trigger for `main` so the workflow runs on the default branch, and move the `tags: '*'` filter to `push` (tag filters have no effect under `pull_request`).
- Pin the README badge and its link to `?branch=main` so it tracks main only.