### PR TITLE
Resolve conflicting spectral broadcast styles for instantiated arguments

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -705,6 +705,11 @@ steps:
         retry: *retry_policy
         command: "julia --color=yes --check-bounds=yes --project=.buildkite test/Operators/spectralelement/rectilinear.jl"
 
+      - label: "Unit: lazy composition"
+        key: unit_lazy_composition
+        retry: *retry_policy
+        command: "julia --color=yes --check-bounds=yes --project=.buildkite test/Operators/spectralelement/lazy_composition.jl"
+
       - label: "Unit: diffusion2d"
         key: unit_diffusion2d
         retry: *retry_policy
@@ -921,6 +926,15 @@ steps:
         command:
           - "julia --project=.buildkite -e 'using CUDA; CUDA.versioninfo()'"
           - "julia --color=yes --check-bounds=yes --project=.buildkite test/Operators/spectralelement/rectilinear_cuda.jl CUDA"
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+        agents:
+          slurm_gpus: 1
+
+      - label: "Unit: lazy composition cuda"
+        key: unit_lazy_composition_cuda
+        retry: *retry_policy
+        command: "julia --color=yes --check-bounds=yes --project=.buildkite test/Operators/spectralelement/lazy_composition.jl"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@ ClimaCore.jl Release Notes
 main
 -------
 
+- Fixed the broadcast-style conflict raised when a spectral-element operator is
+  applied to an instantiated spectral broadcast
+  [2551](https://github.com/CliMA/ClimaCore.jl/pull/2551)
+
 v0.14.54
 -------
 

--- a/src/Operators/spectralelement.jl
+++ b/src/Operators/spectralelement.jl
@@ -507,10 +507,8 @@ Base.Broadcast.BroadcastStyle(
     ::Fields.AbstractFieldStyle,
 ) = style
 
-# The device-resolved style assigned by `instantiate` takes precedence over the
-# generic construction-time style, so an instantiated spectral broadcast can be
-# used as an argument to a new operator broadcast. See the finite-difference
-# analogue for `ColumnStencilStyle` in the CUDA extension.
+# The device-resolved style assigned by `instantiate` takes precedence over
+# the generic construction-time style.
 Base.Broadcast.BroadcastStyle(
     ::SpectralStyle,
     style::AbstractSpectralStyle,

--- a/src/Operators/spectralelement.jl
+++ b/src/Operators/spectralelement.jl
@@ -112,7 +112,7 @@ function Base.Broadcast.broadcasted(op::SpectralElementOperator, args...)
 end
 
 function Base.Broadcast.broadcasted(
-    ::SpectralStyle,
+    style::AbstractSpectralStyle,
     op::SpectralElementOperator,
     args...,
 )
@@ -121,7 +121,7 @@ function Base.Broadcast.broadcasted(
             is_auto_broadcastable(eltype(arg)) ?
             Base.Broadcast.broadcasted(add_auto_broadcasters, arg) : arg
         end
-    return SpectralBroadcasted{SpectralStyle}(op, args′)
+    return SpectralBroadcasted{typeof(style)}(op, args′)
 end
 
 Base.eltype(sbc::SpectralBroadcasted) =
@@ -505,6 +505,15 @@ Base.Broadcast.BroadcastStyle(
 Base.Broadcast.BroadcastStyle(
     style::AbstractSpectralStyle,
     ::Fields.AbstractFieldStyle,
+) = style
+
+# The device-resolved style assigned by `instantiate` takes precedence over the
+# generic construction-time style, so an instantiated spectral broadcast can be
+# used as an argument to a new operator broadcast. See the finite-difference
+# analogue for `ColumnStencilStyle` in the CUDA extension.
+Base.Broadcast.BroadcastStyle(
+    ::SpectralStyle,
+    style::AbstractSpectralStyle,
 ) = style
 
 

--- a/test/Operators/spectralelement/lazy_composition.jl
+++ b/test/Operators/spectralelement/lazy_composition.jl
@@ -12,6 +12,7 @@ import ClimaCore:
     Quadratures
 import ClimaCore.Operators as O
 import Base.Broadcast as BB
+import LazyBroadcast: lazy
 using LinearAlgebra, IntervalSets
 
 @testset "spectral broadcast style combination" begin
@@ -48,4 +49,7 @@ end
     )
     out = @. wdiv(K * ∇f)
     @test parent(out) ≈ 2 .* parent(ref)
+    ∇f_lazy = @. lazy(grad(f) + grad(f))
+    out_lazy = @. wdiv(K * ∇f_lazy)
+    @test parent(out_lazy) ≈ 2 .* parent(ref)
 end

--- a/test/Operators/spectralelement/lazy_composition.jl
+++ b/test/Operators/spectralelement/lazy_composition.jl
@@ -1,0 +1,51 @@
+using Test
+using ClimaComms
+ClimaComms.@import_required_backends
+import ClimaCore:
+    Geometry,
+    Fields,
+    Domains,
+    Topologies,
+    Meshes,
+    Spaces,
+    Operators,
+    Quadratures
+import ClimaCore.Operators as O
+import Base.Broadcast as BB
+using LinearAlgebra, IntervalSets
+
+@testset "spectral broadcast style combination" begin
+    Dev = O.AbstractSpectralStyle(ClimaComms.device())
+    @test BB.result_style(O.SpectralStyle(), Dev()) === Dev()
+    @test BB.result_style(Dev(), O.SpectralStyle()) === Dev()
+    @test BB.result_style(O.SpectralStyle(), O.SpectralStyle()) ===
+          O.SpectralStyle()
+    @test BB.result_style(Dev(), Dev()) === Dev()
+end
+
+@testset "operator over a pre-instantiated spectral broadcast" begin
+    FT = Float64
+    domain = Domains.RectangleDomain(
+        Geometry.XPoint{FT}(-pi) .. Geometry.XPoint{FT}(pi),
+        Geometry.YPoint{FT}(-pi) .. Geometry.YPoint{FT}(pi);
+        x1periodic = true,
+        x2periodic = true,
+    )
+    mesh = Meshes.RectilinearMesh(domain, 4, 4)
+    device = ClimaComms.device()
+    topo = Topologies.Topology2D(ClimaComms.SingletonCommsContext(device), mesh)
+    space = Spaces.SpectralElementSpace2D(topo, Quadratures.GLL{4}())
+    coords = Fields.coordinate_field(space)
+    f = @. sin(coords.x) * cos(coords.y)
+    K = @. FT(1) + coords.y^2 / 10
+    grad = Operators.Gradient()
+    wdiv = Operators.WeakDivergence()
+    ref = @. wdiv(K * grad(f))
+    # Instantiation assigns the device-resolved style, as when the broadcast is
+    # captured with `LazyBroadcast.lazy` and materialized.
+    ∇f = BB.instantiate(
+        Base.broadcasted(+, Base.broadcasted(grad, f), Base.broadcasted(grad, f)),
+    )
+    out = @. wdiv(K * ∇f)
+    @test parent(out) ≈ 2 .* parent(ref)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,7 @@ UnitTest("Fields"                                  ,"Fields/unit_field.jl"), # h
 UnitTest("Reinstantiate broadcasted"               ,"Operators/unit_reinstantiate_bc.jl"),
 UnitTest("Placeholder Fields"                      ,"Operators/unit_common.jl"),
 UnitTest("Spectral elem - rectilinear"             ,"Operators/spectralelement/rectilinear.jl"),
+UnitTest("Spectral elem - lazy composition"        ,"Operators/spectralelement/lazy_composition.jl"),
 UnitTest("Spectral elem - opt"                     ,"Operators/spectralelement/opt.jl"),
 UnitTest("Spectral elem - gradient tensor"         ,"Operators/spectralelement/covar_deriv_ops.jl"),
 UnitTest("Spectral elem - Diffusion 2d"            ,"Operators/spectralelement/unit_diffusion2d.jl"),


### PR DESCRIPTION
## Summary

Composing a spectral-element operator over an already-instantiated spectral broadcast throws `conflicting broadcast rules defined` (`SpectralStyle` vs `CUDASpectralStyle` on GPU, `SpectralStyle` vs `SlabBlockSpectralStyle` on CPU). This arises whenever a broadcast containing spectral operators is instantiated first and then used as an argument to a new operator broadcast, for example a tree captured with `LazyBroadcast.lazy`, whose `materialize` is `instantiate`.

## Mechanism

`Base.Broadcast.broadcasted(op::SpectralElementOperator, args...)` tags construction with the generic `SpectralStyle()` and merges it with the argument styles through `result_style`. `instantiate` re-tags spectral trees with the device-resolved style. The only rule ordering spectral styles is the symmetric `BroadcastStyle(style::AbstractSpectralStyle, ::Fields.AbstractFieldStyle) = style`; since every concrete spectral style is a subtype of both argument types, the pair (generic, device-resolved) matches in both argument orders with different winners, which is the ambiguity `result_style` rejects.

## Fix

Two changes in `src/Operators/spectralelement.jl`, mirroring the finite-difference design:

- A rule making the device-resolved style take precedence over the generic construction-time style: `BroadcastStyle(::SpectralStyle, style::AbstractSpectralStyle) = style`. Both call orders then agree: no explicit reverse-order method is needed because the pair (device style, `SpectralStyle`) already resolves through the pre-existing symmetric rule, which returns its first argument; the new rule is strictly more specific than that rule in both arguments, so there is no ambiguity.
- The construction method `broadcasted(::SpectralStyle, op::SpectralElementOperator, args...)` is generalized to `::AbstractSpectralStyle`, returning `SpectralBroadcasted{typeof(style)}`; `instantiate` re-resolves the style parameter from the device as before, so materialization is unchanged.

The finite-difference hierarchy already handles the analogous pairing: the CUDA extension defines `BroadcastStyle(::ColumnStencilStyle, ::CUDAColumnStencilStyle)` and `broadcasted` is generic over `AbstractStencilStyle` (`src/Operators/finitedifference.jl`, `ext/cuda/operators_finite_difference.jl`). The spectral rule lives in the main package rather than the extension because, unlike finite differences, the spectral construction style is distinct from both device styles and the CPU device style `SlabBlockSpectralStyle` is a main-package type, so the CPU half of the conflict can only be resolved in the main package; the single rule covers both device styles and needs no extension change.

## Validation

- New unit test `test/Operators/spectralelement/lazy_composition.jl`: the style-combination lattice, and a weak divergence applied to a pre-instantiated gradient sum, checked against the inline composition. Passes on CPU and GPU.
- All style pairs were enumerated before and after: only the previously erroring (generic, device-resolved) pairs change behavior; `Test.detect_ambiguities` reports no new ambiguities; no other caller dispatches on the `::SpectralStyle` construction method.
- `test/Operators/spectralelement/rectilinear.jl` passes on the patched source.

Pairs of two different device-resolved styles (e.g. `SlabBlockSpectralStyle` vs `CUDASpectralStyle`) continue to error; that pairing indicates a genuine device mismatch. A more descriptive message could be added separately.

This fix resolves the style ambiguity only. Compiling a single large fused spectral kernel remains subject to pre-existing GPU kernel-size limitations, so the fix does not by itself make arbitrarily large lazy spectral compositions viable on GPU.
