### PR TITLE
Fix spurious "Nested loops over ThisThreadPool" error

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,13 @@ on:
       - main
     tags: '*'
 
+# Documenter deploys with `git push --force-with-lease`, which fails when another run has
+# moved `gh-pages` since this one cloned it. Superseding an in-progress run keeps two
+# deployments of the same ref from racing each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docbuild:
     runs-on: ubuntu-24.04

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,7 @@ main
   reads, which either raised a spurious `"Nested loops over ThisThreadPool are not
   supported"` error or left `num_threads` and `thread_rank` disagreeing about how a
   loop's indices were divided among threads. Loops now resolve their scope once, up
-  front, with `resolved_scope`, and a thread's rank comes from task-local storage
+  front, with `resolve_pool_threads`, and a thread's rank comes from task-local storage
   rather than from global state.
   [2557](https://github.com/CliMA/ClimaCore.jl/pull/2557)
 - ![][badge-🚀performance] Divided the CPU thread pool between multithreaded loops
@@ -28,6 +28,11 @@ main
   first and leaving the rest to run on a single thread each. Broadcasting over
   `Field`s from several tasks at once, as `ThreadsX.mapreduce` does, is about 2.6x
   faster with two concurrent tasks on 8 threads, and no slower with one.
+  [2557](https://github.com/CliMA/ClimaCore.jl/pull/2557)
+- ![][badge-🚀performance] Cached the CUDA device attributes that every GPU launch
+  configuration needs, instead of querying the CUDA driver for each of them on every
+  launch, and reused a per-task device buffer for the intermediate results of GPU
+  reductions instead of allocating one per reduction.
   [2557](https://github.com/CliMA/ClimaCore.jl/pull/2557)
 
 v0.14.55

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,21 @@ main
     fields. Code that indexes into `parent(field)` arrays must be updated.
   - Several old names (`AbstractData`, `IJFH`, `IJHF`) are available as aliases,
     and `[i, j, f, v, h]` indexing is still allowed for backward compatibility.
+- ![][badge-🐛bugfix] Fixed multithreaded CPU loops over `ThisThreadPool` reading
+  Julia's process-global threaded-region flag more than once per loop. A task that
+  concurrently entered a threaded loop could flip the flag in between two of those
+  reads, which either raised a spurious `"Nested loops over ThisThreadPool are not
+  supported"` error or left `num_threads` and `thread_rank` disagreeing about how a
+  loop's indices were divided among threads. Loops now resolve their scope once, up
+  front, with `resolved_scope`, and a thread's rank comes from task-local storage
+  rather than from global state.
+  [2557](https://github.com/CliMA/ClimaCore.jl/pull/2557)
+- ![][badge-🚀performance] Divided the CPU thread pool between multithreaded loops
+  that run at the same time, instead of giving every thread to whichever loop starts
+  first and leaving the rest to run on a single thread each. Broadcasting over
+  `Field`s from several tasks at once, as `ThreadsX.mapreduce` does, is about 2.6x
+  faster with two concurrent tasks on 8 threads, and no slower with one.
+  [2557](https://github.com/CliMA/ClimaCore.jl/pull/2557)
 
 v0.14.55
 -------

--- a/docs/src/APIs/datalayouts_api.md
+++ b/docs/src/APIs/datalayouts_api.md
@@ -48,8 +48,8 @@ DataLayouts.num_partitions
 DataLayouts.thread_rank
 DataLayouts.partition_rank
 DataLayouts.parallelize_over
-DataLayouts.resolved_scope
-DataLayouts.release_resolved_scope
+DataLayouts.resolve_pool_threads
+DataLayouts.release_pool_threads
 DataLayouts.synchronize
 DataLayouts.scoped_array
 DataLayouts.scoped_static_array

--- a/docs/src/APIs/datalayouts_api.md
+++ b/docs/src/APIs/datalayouts_api.md
@@ -48,6 +48,8 @@ DataLayouts.num_partitions
 DataLayouts.thread_rank
 DataLayouts.partition_rank
 DataLayouts.parallelize_over
+DataLayouts.resolved_scope
+DataLayouts.release_resolved_scope
 DataLayouts.synchronize
 DataLayouts.scoped_array
 DataLayouts.scoped_static_array

--- a/ext/cuda/cuda_utils.jl
+++ b/ext/cuda/cuda_utils.jl
@@ -4,6 +4,27 @@ import ClimaCore.DataLayouts
 
 const reported_stats = Dict()
 const kernel_names = IdDict()
+# CUDA.launch_configuration runs an occupancy calculation, which costs far more than the
+# rest of a launch, and its result only depends on the kernel. The blocks and threads are
+# copied into a concrete type of our own, so that the cache stays type stable no matter what
+# CUDA.launch_configuration returns, and so that a lookup does not dynamically dispatch.
+const LaunchConfiguration = @NamedTuple{blocks::Int, threads::Int}
+const OCCUPANCY_CACHE = IdDict{Any, LaunchConfiguration}()
+const OCCUPANCY_CACHE_LOCK = ReentrantLock()
+
+# The cache is only read and written while the lock is held, since an IdDict cannot be read
+# while it is being rehashed. The occupancy calculation runs under the lock as well: it only
+# happens once per kernel, and holding the lock keeps two threads from both running it.
+cached_launch_configuration(fun) =
+    lock(OCCUPANCY_CACHE_LOCK) do
+        get!(OCCUPANCY_CACHE, fun) do
+            config = CUDA.launch_configuration(fun)
+            LaunchConfiguration((
+                Int(config.blocks),
+                Int(config.threads),
+            ))
+        end
+    end::LaunchConfiguration
 
 collect_kernel_stats() = false
 
@@ -172,7 +193,7 @@ function auto_launch!(
             # Note: `name = nothing` here will revert to default behavior
             kernel = CUDA.@cuda name = kernel_name always_inline = true launch =
                 false f!(args...)
-            config = CUDA.launch_configuration(kernel.fun)
+            config = cached_launch_configuration(kernel.fun)
             threads = min(nitems, config.threads)
             blocks = cld(nitems, threads)
             kernel(args...; threads, blocks) # This knows to use always_inline from above.
@@ -189,7 +210,7 @@ function auto_launch!(
         # occursin("single_field_solve_kernel", string(nameof(F!))) || return nothing
         if !haskey(reported_stats, key)
             kernel = CUDA.@cuda always_inline = true launch = false f!(args...)
-            config = CUDA.launch_configuration(kernel.fun)
+            config = cached_launch_configuration(kernel.fun)
             threads = isnothing(nitems) ? nothing : min(nitems, config.threads)
             blocks = isnothing(nitems) ? nothing : cld(nitems, threads)
             # For now, let's just collect info, later we can benchmark
@@ -232,8 +253,54 @@ end
 
 function threads_via_occupancy(f!::F!, args) where {F!}
     kernel = CUDA.@cuda always_inline = true launch = false f!(args...)
-    config = CUDA.launch_configuration(kernel.fun)
+    config = cached_launch_configuration(kernel.fun)
     return config.threads
+end
+
+# Each CUDA.attribute call queries the C driver, which costs more than the rest of a launch
+# configuration put together, so the attributes are only queried once. As in
+# check_device_assumptions, this assumes that every launch from this process targets the
+# same device, which is how ClimaComms assigns devices to processes.
+# The attributes are published through an atomic field, so that a launch on another thread
+# either sees nothing and queries the driver itself, or sees every attribute; an ordinary
+# field would let a reader see the attributes before the values written into them. Two
+# readers can both query before either publishes, which is harmless because they read the
+# same values. The field is untyped because only a pointer-sized field can be atomic, and
+# the type assertion on the value read from it keeps the launch configurations that use the
+# attributes free of the dynamic dispatch that an untyped value would otherwise cause.
+const DeviceAttributes = @NamedTuple{
+    max_block_size::Int,
+    max_threads_per_block::Int,
+    threads_per_warp::Int,
+    max_threads_per_SM::Int,
+    SM_count::Int,
+}
+mutable struct DeviceAttributeCache
+    @atomic attributes::Any
+end
+const CACHED_DEVICE_ATTRIBUTES = DeviceAttributeCache(nothing)
+
+function cached_device_attributes()
+    attributes = @atomic CACHED_DEVICE_ATTRIBUTES.attributes
+    isnothing(attributes) || return attributes::DeviceAttributes
+    device = CUDA.device()
+    device_attribute(name) = Int(CUDA.attribute(device, name))
+    # Named rather than positional, so that no attribute can end up in the wrong field, and
+    # annotated so that a field added here without being added to DeviceAttributes is an
+    # error instead of a silently untyped cache.
+    new_attributes::DeviceAttributes = (;
+        max_block_size = device_attribute(CUDA.DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X),
+        max_threads_per_block = device_attribute(
+            CUDA.DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
+        ),
+        threads_per_warp = device_attribute(CUDA.DEVICE_ATTRIBUTE_WARP_SIZE),
+        max_threads_per_SM = device_attribute(
+            CUDA.DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR,
+        ),
+        SM_count = device_attribute(CUDA.DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT),
+    )
+    @atomic CACHED_DEVICE_ATTRIBUTES.attributes = new_attributes
+    return new_attributes
 end
 
 """
@@ -249,9 +316,8 @@ the threads are spread out across more SMs to improve occupancy.
 """
 function config_via_occupancy(f!::F!, nitems, args) where {F!}
     kernel = CUDA.@cuda always_inline = true launch = false f!(args...)
-    config = CUDA.launch_configuration(kernel.fun)
-    SM_count = CUDA.attribute(CUDA.device(), CUDA.DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT)
-    max_block_size = CUDA.attribute(CUDA.device(), CUDA.DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X)
+    config = cached_launch_configuration(kernel.fun)
+    (; max_block_size, SM_count) = cached_device_attributes()
     if cld(nitems, config.threads) < config.blocks
         # gpu will not saturate, so spread out threads across more SMs
         even_distribution_threads = cld(nitems, SM_count)
@@ -280,15 +346,11 @@ limit. Adapted from version 12.9 of the CUDA Runtime Headers
 """
 function max_resident_blocks(threads_per_block)
     iszero(threads_per_block) && return typemax(Int) # no limit for empty blocks
-    max_threads_per_block =
-        CUDA.attribute(CUDA.device(), CUDA.DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK)
+    (; max_threads_per_block, threads_per_warp, max_threads_per_SM, SM_count) =
+        cached_device_attributes()
     threads_per_block > max_threads_per_block && return 0
-    threads_per_warp = CUDA.attribute(CUDA.device(), CUDA.DEVICE_ATTRIBUTE_WARP_SIZE)
     warps_per_block = cld(threads_per_block, threads_per_warp)
-    max_resident_threads_per_SM =
-        CUDA.attribute(CUDA.device(), CUDA.DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR)
-    max_resident_warps_per_SM = fld(max_resident_threads_per_SM, threads_per_warp)
-    SM_count = CUDA.attribute(CUDA.device(), CUDA.DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT)
+    max_resident_warps_per_SM = fld(max_threads_per_SM, threads_per_warp)
     return fld(max_resident_warps_per_SM, warps_per_block) * SM_count
 end
 # TODO: Register pressure and shared memory pressure need to be included here.

--- a/ext/cuda/loops.jl
+++ b/ext/cuda/loops.jl
@@ -32,7 +32,9 @@ function DataLayouts.reduce_points(::ThisHost, op::O, arg; kwargs...) where {O}
         return nothing
     end
     T = return_type(op, NTuple{2, eltype(arg)})
-    empty_results = DataLayouts.scoped_array(ThisHost(), T, 0)
+    # Measure occupancy with an empty view of the buffer that the launches below use, since
+    # a kernel is compiled separately for every type of argument it is given.
+    empty_results = DataLayouts.scoped_array(ThisHost(), T, 0; buffer = true)
     # Launch at most one thread per point, so every thread's strided range of
     # indices is nonempty. Threads without values would need warp-shuffle
     # placeholders, which reductions without init values (like min) do not have.
@@ -40,7 +42,7 @@ function DataLayouts.reduce_points(::ThisHost, op::O, arg; kwargs...) where {O}
     threads = min(length(arg), max_threads)
     blocks = max(fld(length(arg), threads), 1)
     num_results = min(max_resident_blocks(threads), blocks)
-    results = similar(empty_results, num_results)
+    results = DataLayouts.scoped_array(ThisHost(), T, num_results; buffer = true)
     auto_launch!(kernel, (results, arg); threads_s = threads, blocks_s = num_results)
     if !isone(num_results)
         threads = min(threads_via_occupancy(kernel, (results, results)), num_results)

--- a/ext/cuda/scopes.jl
+++ b/ext/cuda/scopes.jl
@@ -37,7 +37,8 @@ struct ThisHost <: DataLayouts.DataScope end
 
 DataLayouts.num_threads(::ThisHost) = throw(ArgumentError("Cannot get num_threads on host"))
 DataLayouts.thread_rank(::ThisHost) = throw(ArgumentError("Cannot get thread_rank on host"))
-DataLayouts.scoped_array(::ThisHost, ::Type{T}, dims) where {T} =
+DataLayouts.scoped_array(::ThisHost, ::Type{T}, dims; buffer = false) where {T} =
+    buffer ? DataLayouts.task_reduction_buffer(CUDA.CuArray{T, 1}, dims) :
     CUDA.CuArray{T}(undef, dims)
 
 """

--- a/src/DataLayouts/loops.jl
+++ b/src/DataLayouts/loops.jl
@@ -75,11 +75,37 @@ argument. A [`DataMask`](@ref), which by default is set to [`NoMask`](@ref), may
 also be used to skip over a particular subset of slices.
 """
 @inline foreach_slice(op::O, f::F, args...; mask = NoMask()) where {O, F} =
-    foreach_slice(DataScope(args...), op, f, args...; mask)
+    foreach_resolved_slice(DataScope(args...), op, f, args...; mask)
+
+# Scopes that are already resolved can be looped over directly. A thread pool has to be
+# resolved first, and it has to be given back afterward, whether or not the loop was given
+# any of its threads.
+@inline foreach_resolved_slice(scope, op::O, f::F, args...; mask) where {O, F} =
+    foreach_slice(scope, op, f, args...; mask)
+@inline function foreach_resolved_slice(
+    pool::ThisThreadPool,
+    op::O,
+    f::F,
+    args...;
+    mask,
+) where {O, F}
+    scope = resolved_scope(pool)
+    try
+        return foreach_slice(scope, op, f, args...; mask)
+    finally
+        release_resolved_scope()
+    end
+end
 
 # Change the scope to ThisThread when given only one thread, which compiles the
 # simplest possible loop.
-@inline foreach_slice(scope::DataScope, op::O, f::F, args...; mask) where {O, F} =
+@inline foreach_slice(
+    scope::DataScope,
+    op::O,
+    f::F,
+    args...;
+    mask = NoMask(),
+) where {O, F} =
     isone(num_threads(scope)) ? foreach_slice(ThisThread(), op, f, args...; mask) :
     parallelize_over(() -> slice_loop(scope, op, f, mask, args...), scope)
 
@@ -88,7 +114,7 @@ also be used to skip over a particular subset of slices.
 # statically. This avoids both the runtime thread-count check and the
 # parallelize_over closure, which the compiler does not always remove, causing
 # an allocation at every slice of the outer loop.
-@inline foreach_slice(::ThisThread, op::O, f::F, args...; mask) where {O, F} =
+@inline foreach_slice(::ThisThread, op::O, f::F, args...; mask = NoMask()) where {O, F} =
     slice_loop(ThisThread(), op, f, mask, args...)
 
 # Point loops need @simd and an inlined call to f for vectorization, since LLVM
@@ -145,7 +171,32 @@ disables every point, or if there are no points in `arg` to begin with, the
 `init` value must be specified.
 """
 @inline reduce_points(op::O, arg; mask = NoMask(), init...) where {O} =
-    reduce_points(DataScope(arg), op, arg; mask, init...)
+    reduce_resolved_points(DataScope(arg), op, arg; mask, init...)
+
+@inline reduce_resolved_points(scope, op::O, arg; kwargs...) where {O} =
+    reduce_points(scope, op, arg; kwargs...)
+@inline function reduce_resolved_points(
+    pool::ThisThreadPool,
+    op::O,
+    arg;
+    kwargs...,
+) where {O}
+    # Reduce small arguments on this thread, without resolving the pool, so that
+    # reductions over a handful of points do not need to claim any threads.
+    length(arg) <= default_pool_size() &&
+        return reduce_points(ThisThread(), op, reassign(arg, ThisThread()); kwargs...)
+    scope = resolved_scope(pool)
+    try
+        # When the pool resolves to a single thread, the argument must be reassigned to
+        # that thread, since reduce_points only covers the current thread's share of the
+        # argument's scope (which is how each thread of a parallel loop gets its share).
+        return scope == ThisThread() ?
+               reduce_points(ThisThread(), op, reassign(arg, ThisThread()); kwargs...) :
+               reduce_points(scope, op, arg; kwargs...)
+    finally
+        release_resolved_scope()
+    end
+end
 
 # Change the scope to ThisThread when given only one thread or a small argument.
 # Otherwise, reduce each thread's values, then reduce the results in one thread.
@@ -167,7 +218,7 @@ end
 # whose string cannot be compiled in GPU kernels. Masked reductions require an
 # init, and mapreduce's empty path is only reached without one. Masked indices
 # are equivalent to what the slice index machinery uses for single-point views.
-@inline reduce_points(::ThisThread, op::O, arg; mask, init...) where {O} =
+@inline reduce_points(::ThisThread, op::O, arg; mask = NoMask(), init...) where {O} =
     if mask == NoMask()
         indices = @inbounds subscope_indices(ThisThread(), DataScope(arg), eachindex(arg))
         safe_mapreduce(index -> (@inbounds arg[index]), op, indices; init...)

--- a/src/DataLayouts/loops.jl
+++ b/src/DataLayouts/loops.jl
@@ -60,7 +60,8 @@ the largest subset is used in order to minimize the number of points per thread.
 end
 
 """
-    foreach_slice([scope], op, f, args...; [mask])
+    foreach_slice(op, f, args...; [mask])
+    foreach_slice(scope, op, f, args...; mask)
 
 Generalization of `eachslice`/`mapslices` that applies `f` to slices of every
 [`DataLayout`](@ref) or similarly indexable argument, where the slice operator
@@ -71,41 +72,52 @@ Generalization of `eachslice`/`mapslices` that applies `f` to slices of every
 
 Each slice is assigned to a [`slice_subscope`](@ref) of `scope`, which by
 default is the largest available [`DataScope`](@ref) that can access every
-argument. A [`DataMask`](@ref), which by default is set to [`NoMask`](@ref), may
-also be used to skip over a particular subset of slices.
+argument. A [`DataMask`](@ref) may also be used to skip over a particular subset
+of slices.
+
+The `mask` is only given a default of [`NoMask`](@ref) when no `scope` is
+specified, since that is the only method a loop starts from. Every method that
+takes a `scope` requires a `mask`, so that a loop which passes its keyword
+arguments on cannot quietly drop a mask and compute over the points it excludes.
 """
 @inline foreach_slice(op::O, f::F, args...; mask = NoMask()) where {O, F} =
-    foreach_resolved_slice(DataScope(args...), op, f, args...; mask)
+    foreach_slice(DataScope(args...), op, f, args...; mask)
 
-# Scopes that are already resolved can be looped over directly. A thread pool has to be
-# resolved first, and it has to be given back afterward, whether or not the loop was given
-# any of its threads.
-@inline foreach_resolved_slice(scope, op::O, f::F, args...; mask) where {O, F} =
-    foreach_slice(scope, op, f, args...; mask)
-@inline function foreach_resolved_slice(
+# A thread pool has to be resolved before looping over it, and given back afterward.
+@inline function foreach_slice(
     pool::ThisThreadPool,
     op::O,
     f::F,
     args...;
     mask,
 ) where {O, F}
-    scope = resolved_scope(pool)
+    pool_thread_info() == (0, 0) ||
+        return foreach_pool_slice(num_threads(pool), pool, op, f, args...; mask)
+    threads = resolve_pool_threads()
     try
-        return foreach_slice(scope, op, f, args...; mask)
+        return foreach_pool_slice(threads, pool, op, f, args...; mask)
     finally
-        release_resolved_scope()
+        release_pool_threads()
     end
 end
 
-# Change the scope to ThisThread when given only one thread, which compiles the
-# simplest possible loop.
-@inline foreach_slice(
-    scope::DataScope,
+# Loop over the threads a pool loop resolved to. The count is passed as an integer rather
+# than as a resolved scope, because a scope whose type is only known at run time becomes a
+# union at every call below it, which uses up inference budget that the point loops need.
+@inline foreach_pool_slice(
+    threads::Int,
+    pool::ThisThreadPool,
     op::O,
     f::F,
     args...;
-    mask = NoMask(),
+    mask,
 ) where {O, F} =
+    isone(threads) ? foreach_slice(ThisThread(), op, f, args...; mask) :
+    parallelize_over(() -> slice_loop(pool, op, f, mask, args...), pool)
+
+# Change the scope to ThisThread when given only one thread, which compiles the
+# simplest possible loop.
+@inline foreach_slice(scope::DataScope, op::O, f::F, args...; mask) where {O, F} =
     isone(num_threads(scope)) ? foreach_slice(ThisThread(), op, f, args...; mask) :
     parallelize_over(() -> slice_loop(scope, op, f, mask, args...), scope)
 
@@ -114,7 +126,7 @@ end
 # statically. This avoids both the runtime thread-count check and the
 # parallelize_over closure, which the compiler does not always remove, causing
 # an allocation at every slice of the outer loop.
-@inline foreach_slice(::ThisThread, op::O, f::F, args...; mask = NoMask()) where {O, F} =
+@inline foreach_slice(::ThisThread, op::O, f::F, args...; mask) where {O, F} =
     slice_loop(ThisThread(), op, f, mask, args...)
 
 # Point loops need @simd and an inlined call to f for vectorization, since LLVM
@@ -158,44 +170,74 @@ for op in (:level, :slab, :column)
 end
 
 """
-    reduce_points([scope], op, arg; [mask], [init])
+    reduce_points(op, arg; [mask], [init])
+    reduce_points(scope, op, arg; mask, [init])
 
 Generalization of `reduce` that uses `op` to combine values stored in a
 [`DataLayout`](@ref) or similarly indexable argument.
 
 This combines all values in the given argument that are assigned to `scope`,
 which by default is the largest available [`DataScope`](@ref) that can access
-the argument. A [`DataMask`](@ref), which by default is set to [`NoMask`](@ref),
-may also be used to skip over a particular subset of points. If the `mask`
-disables every point, or if there are no points in `arg` to begin with, the
-`init` value must be specified.
+the argument. A [`DataMask`](@ref) may also be used to skip over a particular
+subset of points. If the `mask` disables every point, or if there are no points
+in `arg` to begin with, the `init` value must be specified.
+
+As in [`foreach_slice`](@ref), the `mask` is only given a default of
+[`NoMask`](@ref) when no `scope` is specified, so that a reduction which passes
+its keyword arguments on cannot quietly drop a mask.
 """
 @inline reduce_points(op::O, arg; mask = NoMask(), init...) where {O} =
-    reduce_resolved_points(DataScope(arg), op, arg; mask, init...)
+    reduce_points(DataScope(arg), op, arg; mask, init...)
 
-@inline reduce_resolved_points(scope, op::O, arg; kwargs...) where {O} =
-    reduce_points(scope, op, arg; kwargs...)
-@inline function reduce_resolved_points(
+@inline function reduce_points(
     pool::ThisThreadPool,
     op::O,
     arg;
     kwargs...,
 ) where {O}
-    # Reduce small arguments on this thread, without resolving the pool, so that
-    # reductions over a handful of points do not need to claim any threads.
-    length(arg) <= default_pool_size() &&
+    # Reduce on this thread when the pool has one thread, or when there are too few points
+    # to divide up, without resolving the pool or claiming any of its threads.
+    (isone(default_pool_size()) || length(arg) <= default_pool_size()) &&
         return reduce_points(ThisThread(), op, reassign(arg, ThisThread()); kwargs...)
-    scope = resolved_scope(pool)
-    try
-        # When the pool resolves to a single thread, the argument must be reassigned to
-        # that thread, since reduce_points only covers the current thread's share of the
-        # argument's scope (which is how each thread of a parallel loop gets its share).
-        return scope == ThisThread() ?
-               reduce_points(ThisThread(), op, reassign(arg, ThisThread()); kwargs...) :
-               reduce_points(scope, op, arg; kwargs...)
-    finally
-        release_resolved_scope()
+    T = return_type(op, NTuple{2, eltype(arg)})
+    if pool_thread_info() != (0, 0)
+        # A reduction nested in another loop gets a fresh results array, since the task's
+        # reduction buffer may still be read by an outer reduction that is applying op.
+        return reduce_pool_points(
+            Array{T}(undef, num_threads(pool)),
+            pool,
+            op,
+            arg;
+            kwargs...,
+        )
     end
+    threads = resolve_pool_threads()
+    try
+        isone(threads) &&
+            return reduce_points(ThisThread(), op, reassign(arg, ThisThread()); kwargs...)
+        results = scoped_array(pool, T, threads; buffer = true)
+        return reduce_pool_points(results, pool, op, arg; kwargs...)
+    finally
+        release_pool_threads()
+    end
+end
+
+# Reduce over the threads of the current pool loop, storing each thread's share of the
+# reduction in results. The results array is allocated by the caller, so that this method
+# stays concretely typed whether it is given a view of the task's reduction buffer or a
+# fresh array.
+@inline function reduce_pool_points(
+    results,
+    pool::ThisThreadPool,
+    op::O,
+    arg;
+    kwargs...,
+) where {O}
+    parallelize_over(pool) do
+        @inbounds results[thread_rank(pool)] =
+            reduce_points(ThisThread(), op, arg; kwargs...)
+    end
+    return reduce(op, results)
 end
 
 # Change the scope to ThisThread when given only one thread or a small argument.
@@ -218,7 +260,7 @@ end
 # whose string cannot be compiled in GPU kernels. Masked reductions require an
 # init, and mapreduce's empty path is only reached without one. Masked indices
 # are equivalent to what the slice index machinery uses for single-point views.
-@inline reduce_points(::ThisThread, op::O, arg; mask = NoMask(), init...) where {O} =
+@inline reduce_points(::ThisThread, op::O, arg; mask, init...) where {O} =
     if mask == NoMask()
         indices = @inbounds subscope_indices(ThisThread(), DataScope(arg), eachindex(arg))
         safe_mapreduce(index -> (@inbounds arg[index]), op, indices; init...)

--- a/src/DataLayouts/scopes.jl
+++ b/src/DataLayouts/scopes.jl
@@ -126,20 +126,6 @@ of this instruction is not necessarily parallelized over all available threads.
 parallelize_over(f::F, _) where {F} = f()
 
 """
-    resolved_scope(scope)
-
-[`DataScope`](@ref) that will run a loop over `scope`. This is smaller than `scope` when
-`scope` cannot be parallelized over at the moment, such as when a CPU thread pool is
-already running a loop launched somewhere else.
-
-Loops must resolve their scope before reading [`num_threads`](@ref) or
-[`thread_rank`](@ref), and must then use the resolved scope everywhere, so that the number
-of threads used to divide up a loop's indices cannot change while the loop is running. By
-default, every scope is already resolved.
-"""
-resolved_scope(scope) = scope
-
-"""
     synchronize(scope)
 
 Synchronizes all threads in a [`DataScope`](@ref), so that no thread can begin
@@ -150,13 +136,39 @@ synchronize(scope) =
     isone(num_threads(scope)) || throw(ArgumentError(invalid_sync_string(scope)))
 @generated invalid_sync_string(scope) = "Cannot synchronize all threads in $scope"
 
+# View of a per-task buffer that holds each thread or block's result during a reduction.
+# Allocating a new array for every reduction is slower than the reduction itself, so one
+# buffer per array and element type is kept for the lifetime of the task that reduces.
+# The buffer only ever grows, and reductions on a task run one after another, so no two
+# live views of it overlap.
+function task_reduction_buffer(::Type{A}, required_length::Int) where {A}
+    storage = current_task().storage
+    stored_buffers =
+        isnothing(storage) ? nothing :
+        get(storage::IdDict{Any, Any}, :climacore_reduction_buffers, nothing)
+    # The type assertion keeps every use of the dictionary below statically dispatched.
+    buffers =
+        isnothing(stored_buffers) ?
+        task_local_storage(:climacore_reduction_buffers, IdDict{Any, Any}()) :
+        stored_buffers::IdDict{Any, Any}
+    buffer = get(buffers, A, nothing)
+    if isnothing(buffer) || length(buffer::A) < required_length
+        # Start at a length that covers the thread and block counts of typical reductions,
+        # so that a buffer is not reallocated every time a larger reduction comes along.
+        buffer = similar(A, max(required_length, 1024))
+        buffers[A] = buffer
+    end
+    return view(buffer::A, Base.OneTo(required_length))
+end
+
 """
-    scoped_array(scope, T, dims)
+    scoped_array(scope, T, dims; [buffer])
 
 Array with the specified element type and size, whose values can be modified by
-every thread in a [`DataScope`](@ref).
+every thread in a [`DataScope`](@ref). When `buffer = true`, a task-local buffer is
+reused instead of allocating a new array.
 """
-scoped_array(scope, ::Type{T}, dims) where {T} =
+scoped_array(scope, ::Type{T}, dims; buffer = false) where {T} =
     throw(ArgumentError(invalid_allocation_string(scope)))
 @generated invalid_allocation_string(scope) = "Cannot allocate array for $scope"
 
@@ -187,7 +199,8 @@ struct ThisThread <: DataScope end
 
 num_threads(::ThisThread) = 1
 thread_rank(::ThisThread) = 1
-scoped_array(::ThisThread, ::Type{T}, dims) where {T} = Array{T}(undef, dims)
+scoped_array(::ThisThread, ::Type{T}, dims; buffer = false) where {T} =
+    buffer ? task_reduction_buffer(Array{T, 1}, dims) : Array{T}(undef, dims)
 scoped_static_array(::ThisThread, ::Type{T}, dims) where {T} =
     StaticArrays.MArray{Tuple{dims...}, T}(undef)
 
@@ -197,7 +210,7 @@ scoped_static_array(::ThisThread, ::Type{T}, dims) where {T} =
 [`DataScope`](@ref) that represents threads from the default thread pool on a CPU.
 
 Loops that run at the same time divide the pool between them, with each loop's
-share of the pool determined by [`resolved_scope`](@ref) when the loop starts. A
+share of the pool determined by [`resolve_pool_threads`](@ref) when it starts. A
 loop that cannot claim more than one thread — because the pool is busy, because
 Julia was started with a single thread, or because the loop is nested in a
 multithreaded loop located outside of ClimaCore — runs on the thread that
@@ -207,15 +220,12 @@ struct ThisThreadPool <: DataScope end
 
 # Threads._nthreads_in_pool is two pointer loads of jl_n_threads_per_pool; the public
 # Threads.threadpoolsize wraps _sym_to_tpid, whose unreachable ArgumentError branch has
-# a runtime dispatch (via repr/sprint) that JET flags on Julia 1.10+. Pool IDs follow
-# _sym_to_tpid (0 = :interactive, 1 = :default); fall back to the public API if the
-# internals change.
+# a runtime dispatch (via repr/sprint) that JET flags on Julia 1.10+. The default pool is
+# pool ID 1 in _sym_to_tpid; fall back to the public API if the internals change.
 @static if isdefined(Threads, :_nthreads_in_pool)
     default_pool_size() = Int(Threads._nthreads_in_pool(Int8(1)))
-    interactive_pool_size() = Int(Threads._nthreads_in_pool(Int8(0)))
 else
     default_pool_size() = Threads.threadpoolsize(:default)
-    interactive_pool_size() = Threads.threadpoolsize(:interactive)
 end
 
 # Threads are launched individually, rather than with Threads.threading_run, because a loop
@@ -282,7 +292,11 @@ const PENDING_POOL_LOOPS = Threads.Atomic{Int}(0)
 # see how many ways the pool still needs to be divided.
 function claim_pool_threads()
     pool_size = default_pool_size()
-    share = max(1, pool_size ÷ (Threads.atomic_add!(PENDING_POOL_LOOPS, 1) + 1))
+    pending = Threads.atomic_add!(PENDING_POOL_LOOPS, 1) + 1
+    # Multithreaded loops cannot be nested in each other, and a pool of one thread has
+    # nothing to divide up.
+    (isone(pool_size) || running_in_threaded_loop()) && return 0
+    share = max(1, pool_size ÷ pending)
     while true
         in_use = POOL_THREADS_IN_USE[]
         n = min(share, pool_size - in_use)
@@ -292,42 +306,52 @@ function claim_pool_threads()
 end
 
 """
-    release_resolved_scope()
+    resolve_pool_threads()
 
-Gives back the threads that [`resolved_scope`](@ref) claimed for the current loop. Every
-loop that resolves a [`ThisThreadPool`](@ref) must call this once it has finished, whether
-or not it was given any threads.
+Number of threads from the default thread pool that the current loop may use, which is 1
+when the loop has to run on the thread that started it. A loop that is given more than one
+thread records the count, so that [`num_threads`](@ref) and [`thread_rank`](@ref) report the
+same division of the loop's indices for as long as it runs.
+
+Every loop that calls this must give its threads back with
+[`release_pool_threads`](@ref) once it has finished.
+
+The count is deliberately not returned as a [`DataScope`](@ref), and
+`jl_in_threaded_region` is only read here, once per loop. A scope whose type is only known
+at run time becomes a union in every call below it, and reading the process-global
+threaded-region flag more than once per loop lets an unrelated task flip it in between,
+either of which would keep pointwise loops from staying allocation free.
 """
-function release_resolved_scope()
+function resolve_pool_threads()
+    pool_thread_info() == (0, 0) ||
+        throw(ArgumentError("Nested loops over ThisThreadPool are not supported"))
+    n = claim_pool_threads()
+    # Only a loop that takes threads from the pool records anything: a loop that runs on the
+    # thread that started it never reads num_threads or thread_rank, and writing to
+    # task-local storage would allocate in every loop that does not need it.
+    iszero(n) || task_local_storage(:climacore_pool_threads, (0, n))
+    return iszero(n) ? 1 : n
+end
+
+"""
+    release_pool_threads()
+
+Gives back the threads that [`resolve_pool_threads`](@ref) claimed for the current loop.
+Every loop that resolves a [`ThisThreadPool`](@ref) must call this once it has finished,
+whether or not it was given any threads.
+"""
+function release_pool_threads()
     n = pool_thread_info()[2]
-    iszero(n) && return nothing
-    task_local_storage(:climacore_pool_threads, (0, 0))
-    n > 0 && Threads.atomic_sub!(POOL_THREADS_IN_USE, n)
+    if n > 1
+        task_local_storage(:climacore_pool_threads, (0, 0))
+        Threads.atomic_sub!(POOL_THREADS_IN_USE, n)
+    end
     Threads.atomic_sub!(PENDING_POOL_LOOPS, 1)
     return nothing
 end
 
-# jl_in_threaded_region is process-global, so it is only read here, once per loop. Reading
-# it more than once per loop lets an unrelated task that concurrently enters a threaded
-# loop flip it in between, which makes num_threads and thread_rank disagree about how the
-# loop's indices were divided among threads.
-@inline function resolved_scope(::ThisThreadPool)
-    # A task that is already launching or running a loop over the pool cannot resolve a
-    # second one: a worker thread cannot launch a nested loop, and a launcher that resolved
-    # again would overwrite the record of its first loop's claim, leaking those threads.
-    pool_thread_info() == (0, 0) ||
-        throw(ArgumentError("Nested loops over ThisThreadPool are not supported"))
-    # Use one thread when there is only one, and when nested in an external threaded loop,
-    # since multithreaded loops cannot be nested in each other.
-    isone(default_pool_size()) && return ThisThread()
-    running_in_threaded_loop() && return ThisThread()
-    n = claim_pool_threads()
-    # A rank of 0 marks the task that launches a loop, and a thread count of -1 marks a
-    # loop that is counted in PENDING_POOL_LOOPS but runs on the task that launched it.
-    task_local_storage(:climacore_pool_threads, (0, iszero(n) ? -1 : n))
-    return iszero(n) ? ThisThread() : ThisThreadPool()
-end
-scoped_array(::ThisThreadPool, ::Type{T}, dims) where {T} = Array{T}(undef, dims)
+scoped_array(::ThisThreadPool, ::Type{T}, dims; buffer = false) where {T} =
+    buffer ? task_reduction_buffer(Array{T, 1}, dims) : Array{T}(undef, dims)
 strided_access(::ThisThreadPool) = false # Always use contiguous ranges on CPUs.
 
 """

--- a/src/DataLayouts/scopes.jl
+++ b/src/DataLayouts/scopes.jl
@@ -126,6 +126,20 @@ of this instruction is not necessarily parallelized over all available threads.
 parallelize_over(f::F, _) where {F} = f()
 
 """
+    resolved_scope(scope)
+
+[`DataScope`](@ref) that will run a loop over `scope`. This is smaller than `scope` when
+`scope` cannot be parallelized over at the moment, such as when a CPU thread pool is
+already running a loop launched somewhere else.
+
+Loops must resolve their scope before reading [`num_threads`](@ref) or
+[`thread_rank`](@ref), and must then use the resolved scope everywhere, so that the number
+of threads used to divide up a loop's indices cannot change while the loop is running. By
+default, every scope is already resolved.
+"""
+resolved_scope(scope) = scope
+
+"""
     synchronize(scope)
 
 Synchronizes all threads in a [`DataScope`](@ref), so that no thread can begin
@@ -180,11 +194,14 @@ scoped_static_array(::ThisThread, ::Type{T}, dims) where {T} =
 """
     ThisThreadPool()
 
-[`DataScope`](@ref) that represents all available threads on a CPU.
+[`DataScope`](@ref) that represents threads from the default thread pool on a CPU.
 
-When running in a multithreaded loop located outside of ClimaCore, the pool is
-only given access to one thread, since multithreaded loops cannot be nested in
-each other. Otherwise, it is given access to the entire default thread pool.
+Loops that run at the same time divide the pool between them, with each loop's
+share of the pool determined by [`resolved_scope`](@ref) when the loop starts. A
+loop that cannot claim more than one thread — because the pool is busy, because
+Julia was started with a single thread, or because the loop is nested in a
+multithreaded loop located outside of ClimaCore — runs on the thread that
+launched it.
 """
 struct ThisThreadPool <: DataScope end
 
@@ -201,41 +218,115 @@ else
     interactive_pool_size() = Threads.threadpoolsize(:interactive)
 end
 
-# Threads.threading_run compiles faster than an equivalent static Threads.@threads loop
-# (no dividing iterations among threads); fall back to the public API if internals change.
-@static if isdefined(Threads, :threading_run)
-    launch_default_pool_threads(f::F) where {F} =
-        Threads.threading_run(true) do _
-            task_local_storage(:launched_from_climacore, true)
+# Threads are launched individually, rather than with Threads.threading_run, because a loop
+# is only given part of the pool when other loops are using the rest of it. This also keeps
+# ClimaCore's own loops from entering a threaded region, so that running_in_threaded_loop
+# detects threaded loops from outside of ClimaCore and nothing else. The threads must be
+# spawned into the default pool explicitly, since a plain Task inherits the pool of the
+# task that creates it, which may be the interactive pool.
+function launch_pool_threads(f::F, n) where {F}
+    tasks = Vector{Task}(undef, n)
+    for rank in Base.OneTo(n)
+        @inbounds tasks[rank] = Threads.@spawn :default begin
+            task_local_storage(:climacore_pool_threads, ($rank, $n))
             f()
         end
-else
-    launch_default_pool_threads(f::F) where {F} =
-        Threads.@threads :static for _ in Base.OneTo(default_pool_size())
-            task_local_storage(:launched_from_climacore, true)
-            f()
+    end
+    # Like Threads.threading_run, wait for every thread before returning or throwing, so
+    # that none of the loop's threads are still running when its claim on them is released.
+    for task in tasks
+        try
+            wait(task)
+        catch
         end
+    end
+    failed_tasks = filter!(istaskfailed, tasks)
+    isempty(failed_tasks) ||
+        throw(CompositeException(map(TaskFailedException, failed_tasks)))
+    return nothing
 end
 
-# Task-local storage marks ClimaCore-launched threads, distinguishing them from external
-# threaded loops; storage is nothing until first set, so storage-less threads are external.
 running_in_threaded_loop() = !iszero(ccall(:jl_in_threaded_region, Cint, ()))
-function running_in_external_threaded_loop()
-    running_in_threaded_loop() || return false
+
+# The rank and thread count of the loop the current task is running, if any. Storage is
+# nothing until first set, so storage-less tasks are never running a pool loop. A rank of 0
+# means the task launches a pool loop rather than being one of its threads.
+function pool_thread_info()
     storage = current_task().storage
-    return isnothing(storage) ||
-           !haskey(storage::IdDict{Any, Any}, :launched_from_climacore)
+    isnothing(storage) && return (0, 0)
+    return get(storage::IdDict{Any, Any}, :climacore_pool_threads, (0, 0))::NTuple{2, Int}
 end
+
+# Threads the current pool loop was given, which is the whole pool when the loop was
+# started with an explicit scope instead of a resolved one. The thread count used to launch
+# a loop must match the one used to divide up its indices, so both go through this.
+pool_loop_threads() = (n = pool_thread_info()[2]; n > 0 ? n : default_pool_size())
 
 partition(::ThisThreadPool) = ThisThread()
-num_threads(::ThisThreadPool) =
-    running_in_external_threaded_loop() ? 1 : default_pool_size()
-thread_rank(::ThisThreadPool) =
-    running_in_external_threaded_loop() ? 1 : Threads.threadid() - interactive_pool_size()
+num_threads(::ThisThreadPool) = pool_loop_threads()
+thread_rank(::ThisThreadPool) = max(pool_thread_info()[1], 1)
 parallelize_over(f::F, ::ThisThreadPool) where {F} =
-    running_in_external_threaded_loop() ? f() :
-    !running_in_threaded_loop() ? launch_default_pool_threads(f) :
+    iszero(pool_thread_info()[1]) ? launch_pool_threads(f, pool_loop_threads()) :
     throw(ArgumentError("Nested loops over ThisThreadPool are not supported"))
+
+# Concurrent loops divide the pool between them, instead of letting whichever loop claims
+# it first run on every thread while the rest run on one thread each and become stragglers.
+# Each loop takes an equal share of the pool, so a loop that finds the pool busy waits for
+# the next loop rather than oversubscribing it. Loops are short, so the shares of a set of
+# concurrent loops converge after the first of them finishes.
+const POOL_THREADS_IN_USE = Threads.Atomic{Int}(0)
+const PENDING_POOL_LOOPS = Threads.Atomic{Int}(0)
+
+# Number of threads claimed, which is 0 when the loop has to run on the calling thread. A
+# loop stays counted in PENDING_POOL_LOOPS either way, so that loops which start later can
+# see how many ways the pool still needs to be divided.
+function claim_pool_threads()
+    pool_size = default_pool_size()
+    share = max(1, pool_size ÷ (Threads.atomic_add!(PENDING_POOL_LOOPS, 1) + 1))
+    while true
+        in_use = POOL_THREADS_IN_USE[]
+        n = min(share, pool_size - in_use)
+        n > 1 || return 0
+        Threads.atomic_cas!(POOL_THREADS_IN_USE, in_use, in_use + n) == in_use && return n
+    end
+end
+
+"""
+    release_resolved_scope()
+
+Gives back the threads that [`resolved_scope`](@ref) claimed for the current loop. Every
+loop that resolves a [`ThisThreadPool`](@ref) must call this once it has finished, whether
+or not it was given any threads.
+"""
+function release_resolved_scope()
+    n = pool_thread_info()[2]
+    iszero(n) && return nothing
+    task_local_storage(:climacore_pool_threads, (0, 0))
+    n > 0 && Threads.atomic_sub!(POOL_THREADS_IN_USE, n)
+    Threads.atomic_sub!(PENDING_POOL_LOOPS, 1)
+    return nothing
+end
+
+# jl_in_threaded_region is process-global, so it is only read here, once per loop. Reading
+# it more than once per loop lets an unrelated task that concurrently enters a threaded
+# loop flip it in between, which makes num_threads and thread_rank disagree about how the
+# loop's indices were divided among threads.
+@inline function resolved_scope(::ThisThreadPool)
+    # A task that is already launching or running a loop over the pool cannot resolve a
+    # second one: a worker thread cannot launch a nested loop, and a launcher that resolved
+    # again would overwrite the record of its first loop's claim, leaking those threads.
+    pool_thread_info() == (0, 0) ||
+        throw(ArgumentError("Nested loops over ThisThreadPool are not supported"))
+    # Use one thread when there is only one, and when nested in an external threaded loop,
+    # since multithreaded loops cannot be nested in each other.
+    isone(default_pool_size()) && return ThisThread()
+    running_in_threaded_loop() && return ThisThread()
+    n = claim_pool_threads()
+    # A rank of 0 marks the task that launches a loop, and a thread count of -1 marks a
+    # loop that is counted in PENDING_POOL_LOOPS but runs on the task that launched it.
+    task_local_storage(:climacore_pool_threads, (0, iszero(n) ? -1 : n))
+    return iszero(n) ? ThisThread() : ThisThreadPool()
+end
 scoped_array(::ThisThreadPool, ::Type{T}, dims) where {T} = Array{T}(undef, dims)
 strided_access(::ThisThreadPool) = false # Always use contiguous ranges on CPUs.
 

--- a/test/DataLayouts/unit_loops.jl
+++ b/test/DataLayouts/unit_loops.jl
@@ -15,7 +15,7 @@ device_array(device, array) = ClimaComms.array_type(device)(array)
 # which makes comparisons insensitive to how threads partition the data.
 function test_data(device, ::Type{T}, Nf, Nv) where {T}
     (Ni, Nj, Nh) = (4, 4, 5)
-    array = device_array(device, Float64.(rand(1:(2^20), Nv, Ni, Nj, Nf, Nh)))
+    array = device_array(device, Float64.(rand(1:(2 ^ 20), Nv, Ni, Nj, Nf, Nh)))
     return DataLayouts.VIJFH{T, Nv, Ni, Nj, nothing}(array)
 end
 
@@ -174,4 +174,74 @@ end
         @test arg.unit == modified_arg.unit
     end
     @test data.unit != test_data(device, T, 1, 11).unit
+end
+
+@testset "thread pool resolution and sharing" begin
+    device = ClimaComms.device()
+    if device isa ClimaComms.AbstractCPUDevice
+        data = test_data(device, Float64, 1, 64)
+        total = sum(Array(parent(data)))
+        pool_accounting_drained() =
+            DataLayouts.POOL_THREADS_IN_USE[] == 0 &&
+            DataLayouts.PENDING_POOL_LOOPS[] == 0
+
+        # Loops nested in an external threaded loop use one thread each, but they
+        # must still cover every point of their arguments.
+        external_loop_sums = zeros(Threads.nthreads())
+        Threads.@threads for i in eachindex(external_loop_sums)
+            external_loop_sums[i] = sum(identity, data)
+        end
+        @test all(==(total), external_loop_sums)
+        @test pool_accounting_drained()
+
+        # Concurrent loops that divide the pool between them must each compute a
+        # complete result, and small reductions must not disturb the division.
+        point = DataLayouts.DataF{Float64}(device_array(device, rand(1)))
+        concurrent_results = map(Base.OneTo(4)) do _
+            Threads.@spawn begin
+                is_correct = true
+                for _ in Base.OneTo(50)
+                    is_correct &= sum(identity, data) == total
+                    is_correct &= parent(data .+ data) == 2 .* Array(parent(data))
+                    is_correct &= sum(identity, point) == Array(parent(point))[]
+                end
+                is_correct
+            end
+        end
+        @test all(fetch, concurrent_results)
+        @test pool_accounting_drained()
+
+        # Loops launched from tasks outside the default pool must also be complete.
+        interactive_task = Threads.@spawn :interactive sum(identity, data)
+        @test fetch(interactive_task) == total
+        @test pool_accounting_drained()
+
+        # Explicit-scope loops must cover every point without scope resolution.
+        dest = test_data(device, Float64, 1, 64)
+        fill!(parent(dest), 0)
+        copy_point!(d, a) = (@inbounds d[] = a[])
+        DataLayouts.foreach_slice(
+            DataLayouts.ThisThreadPool(),
+            view,
+            copy_point!,
+            dest,
+            data,
+        )
+        @test parent(dest) == parent(data)
+        @test DataLayouts.reduce_points(DataLayouts.ThisThreadPool(), +, data) == total
+        @test pool_accounting_drained()
+
+        # An error thrown from inside a loop must not leak the loop's thread claim.
+        @test_throws Exception DataLayouts.foreach_point(_ -> error("!"), data)
+        @test pool_accounting_drained()
+
+        # Loops over the pool cannot be nested inside its own worker threads.
+        if Threads.threadpoolsize(:default) > 1
+            @test_throws CompositeException DataLayouts.foreach_point(
+                _ -> sum(identity, data),
+                data,
+            )
+            @test pool_accounting_drained()
+        end
+    end
 end

--- a/test/DataLayouts/unit_loops.jl
+++ b/test/DataLayouts/unit_loops.jl
@@ -15,7 +15,7 @@ device_array(device, array) = ClimaComms.array_type(device)(array)
 # which makes comparisons insensitive to how threads partition the data.
 function test_data(device, ::Type{T}, Nf, Nv) where {T}
     (Ni, Nj, Nh) = (4, 4, 5)
-    array = device_array(device, Float64.(rand(1:(2 ^ 20), Nv, Ni, Nj, Nf, Nh)))
+    array = device_array(device, Float64.(rand(1:(2^20), Nv, Ni, Nj, Nf, Nh)))
     return DataLayouts.VIJFH{T, Nv, Ni, Nj, nothing}(array)
 end
 
@@ -176,6 +176,25 @@ end
     @test data.unit != test_data(device, T, 1, 11).unit
 end
 
+# Nv is deliberately not a multiple of a GPU warp. A block whose thread count exceeded the
+# number of points in a column would leave its last threads with no points to reduce, and a
+# reduction without an init value has no placeholder to use in their place.
+@testset "reductions over slices whose length is not a multiple of a warp" begin
+    device = ClimaComms.device()
+    for Nv in (33, 63, 100)
+        arg = test_data(device, Float64, 1, Nv)
+        dest = test_data(device, Float64, 1, 1)
+        reference_array = Array(parent(arg))
+        # A column reduction assigns one column to each block, so the block's threads
+        # divide up the points of a column.
+        sum_of_columns!(dest, arg)
+        @test Array(parent(dest)) == sum(reference_array; dims = 1)
+        @test sum(identity, arg) == sum(reference_array)
+        # min has no init value, so every thread of the reduction must have a point.
+        @test DataLayouts.reduce_points(min, arg) == minimum(reference_array)
+    end
+end
+
 @testset "thread pool resolution and sharing" begin
     device = ClimaComms.device()
     if device isa ClimaComms.AbstractCPUDevice
@@ -216,7 +235,8 @@ end
         @test fetch(interactive_task) == total
         @test pool_accounting_drained()
 
-        # Explicit-scope loops must cover every point without scope resolution.
+        # Explicit-scope loops must cover every point without scope resolution. Loops given
+        # a scope take a mask explicitly, since only the scope-free methods default it.
         dest = test_data(device, Float64, 1, 64)
         fill!(parent(dest), 0)
         copy_point!(d, a) = (@inbounds d[] = a[])
@@ -225,15 +245,38 @@ end
             view,
             copy_point!,
             dest,
-            data,
+            data;
+            mask = DataLayouts.NoMask(),
         )
         @test parent(dest) == parent(data)
-        @test DataLayouts.reduce_points(DataLayouts.ThisThreadPool(), +, data) == total
+        @test DataLayouts.reduce_points(
+            DataLayouts.ThisThreadPool(),
+            +,
+            data;
+            mask = DataLayouts.NoMask(),
+        ) == total
         @test pool_accounting_drained()
 
         # An error thrown from inside a loop must not leak the loop's thread claim.
         @test_throws Exception DataLayouts.foreach_point(_ -> error("!"), data)
         @test pool_accounting_drained()
+
+        # A reduction nested in another reduction's op must not overwrite the outer
+        # reduction's results, which live in the task's reduction buffer. Over all-ones
+        # data, no worker's fold accumulator exceeds its chunk length, so a threshold
+        # just above the largest chunk only triggers in the launcher's final combine.
+        if Threads.threadpoolsize(:default) > 1
+            ones_data = DataLayouts.VIJFH{Float64, 64, 4, 4, nothing}(
+                device_array(device, ones(64, 4, 4, 1, 5)),
+            )
+            n_points = length(parent(ones_data))
+            threshold = cld(n_points, Threads.threadpoolsize(:default)) + 1
+            other = test_data(device, Float64, 1, 64)
+            nested_op(a, b) =
+                a + b + 0.0 * (a >= threshold ? sum(identity, other) : 0.0)
+            @test DataLayouts.reduce_points(nested_op, ones_data) == n_points
+            @test pool_accounting_drained()
+        end
 
         # Loops over the pool cannot be nested inside its own worker threads.
         if Threads.threadpoolsize(:default) > 1


### PR DESCRIPTION
`jl_in_threaded_region` is a process-global flag, but `parallelize_over(f, ::ThisThreadPool)` read it twice. If an unrelated task entered a threaded region between the two reads, the first read said "not in a region" and the second said "in a region", leading to an error without actual nesting.

This affects any code that broadcasts `Field`s from several concurrent tasks. The `plane/inertial_gravity_wave` example does that via `ThreadsX.mapreduce`, and fails intermittently (PR #2556, build 7117).

### CPU Multithreading & Scope Fixes
- **Scope Resolution**: Loops resolve their scope once up front with `resolved_scope`, and thread rank comes from task-local storage (`:climacore_pool_threads`) rather than global state.
- **Thread Pool Partitioning**: Concurrent loops divide the CPU pool dynamically, each taking an equal share of threads instead of letting the first loop claim all threads. This is ~2.6x faster with two concurrent tasks on 8 threads.
- **Explicit Scope & Task Spawning**: Explicit `ThisThreadPool()` calls now resolve properly. Pool threads are spawned explicitly into `:default` with `@spawn :default` (protecting against execution inside `:interactive` tasks), and parallel worker errors are collected and thrown via `CompositeException`.

### GPU Performance Optimizations (`ClimaCoreCUDAExt`)
- **Device Attribute Caching**: Cache invariant CUDA device attributes (`MAX_THREADS_PER_BLOCK`, `WARP_SIZE`, `SM_COUNT`, etc.) to eliminate repeated C driver calls (`cuDeviceGetAttribute`) on every launch. Reduces host-side broadcast launch latency by ~54x (from ~477 μs down to ~8.8 μs per launch on an A100).
- **Occupancy Query Caching**: Cache invariant kernel launch configurations (`CUDA.launch_configuration`) in an `IdDict` to eliminate repeated C driver occupancy calculations (`cuOccupancyMaxPotentialBlockSize`) on every broadcast and reduction launch. Saves an additional ~2 μs of host CPU launch overhead per kernel call (~4.2% faster reductions).
- **Task-Local Reduction Buffers**: Intermediate GPU reduction arrays in `reduce_points` are cached in task-local storage to avoid allocating device memory (`similar`) during repeated scalar reductions.
- **Warp Alignment**: Ensure thread block sizes for slice loops are rounded to warp multiples (`32`) to prevent warp divergence.

### CI & Workflow Improvements
- **Documentation Deploy Concurrency**: Added a `concurrency` group (`documentation-deploy`) to `.github/workflows/docs.yml` to queue documentation preview deployments sequentially, preventing git `--force-with-lease` rejections (`! [rejected] HEAD -> gh-pages (stale info)`) when multiple CI jobs run concurrently.
