### PR TITLE
Fix tail effect on GPUs

### DIFF
--- a/ext/cuda/cuda_utils.jl
+++ b/ext/cuda/cuda_utils.jl
@@ -1,30 +1,275 @@
 import CUDA
 import ClimaCore.Fields
 import ClimaCore.DataLayouts
+import ClimaCore.Utilities
+
+function uncached_device_attributes()
+    device = CUDA.device()
+    get_attr(code) = Int(CUDA.attribute(device, code))
+    sm_version = (
+        get_attr(CUDA.DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR),
+        get_attr(CUDA.DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR),
+    )
+    sm_version[1] > 12 && throw(ArgumentError("Missing device attributes for \
+                                               Compute Capability $(sm_version[1])"))
+    return (;
+        threads_per_warp = get_attr(CUDA.DEVICE_ATTRIBUTE_WARP_SIZE),
+
+        # kernel launch configuration limits
+        max_block_dim_x = get_attr(CUDA.DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X),
+        max_block_dim_y = get_attr(CUDA.DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y),
+        max_block_dim_z = get_attr(CUDA.DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z),
+        max_grid_dim_x = get_attr(CUDA.DEVICE_ATTRIBUTE_MAX_GRID_DIM_X),
+        max_grid_dim_y = get_attr(CUDA.DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y),
+        max_grid_dim_z = get_attr(CUDA.DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z),
+
+        # occupancy limits exposed by the CUDA API
+        sm_count = get_attr(CUDA.DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT),
+        max_threads_per_block = get_attr(CUDA.DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK),
+        max_threads_per_sm = get_attr(CUDA.DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR),
+        max_regs_per_block = get_attr(CUDA.DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK),
+        max_regs_per_sm = get_attr(CUDA.DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_MULTIPROCESSOR),
+        max_shmem_per_block = get_attr(CUDA.DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK),
+        max_shmem_per_sm =
+        get_attr(CUDA.DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR),
+        reserved_shmem_per_block =
+        get_attr(CUDA.DEVICE_ATTRIBUTE_RESERVED_SHARED_MEMORY_PER_BLOCK),
+
+        # more hardware properties from version 12.9 of the CUDA Runtime Headers
+        # https://gitlab.com/nvidia/headers/cuda-individual/cudart/-/blob/main/cuda_occupancy.h#L606-779
+        regs_per_allocation = 256,
+        shmem_per_allocation = sm_version[1] < 8 ? 256 : 128,
+        max_regs_per_thread = sm_version[1] < 7 ? 255 : 256,
+        schedulers_per_sm = sm_version == (6, 0) ? 2 : 4,
+        max_blocks_per_sm =
+        sm_version[1] < 5 || sm_version in ((7, 5), (8, 6), (8, 7)) ? 16 :
+        sm_version in ((8, 9), (10, 1)) || sm_version[1] == 12 ? 24 : 32,
+
+        # custom property to represent how the 2 schedulers/SM of CC 6.0 are
+        # bumped to 4 schedulers/SM for compatibility with other CC 6.x versions
+        # https://gitlab.com/nvidia/headers/cuda-individual/cudart/-/blob/main/cuda_occupancy.h#L1669-1692
+        max_schedulers_per_sm = 4,
+    )
+end
+
+const DEVICE_ATTRIBUTE_CACHE =
+    Ref{Utilities.return_type(uncached_device_attributes, Tuple{})}()
+const DEVICE_ATTRIBUTE_CACHE_INITIALIZED = Threads.Atomic{Bool}(false)
+
+"""
+    device_attributes()
+
+Collection of hardware properties from the CUDA API and CUDA Runtime Headers,
+obtained through calls to `CUDA.attribute`.
+
+Attributes are obtained by querying the C driver, which adds measurable latency
+if done more than once, so all attributes are cached after the first call. An
+`Atomic` initialization flag is used to ensure that every thread either sees a
+fully written cache or sets the cache itself. Any thread can set the cache, as
+ClimaComms only targets one device from threads launched by the same process.
+"""
+function device_attributes()
+    DEVICE_ATTRIBUTE_CACHE_INITIALIZED[] && return DEVICE_ATTRIBUTE_CACHE[]
+    DEVICE_ATTRIBUTE_CACHE[] = uncached_device_attributes()
+    DEVICE_ATTRIBUTE_CACHE_INITIALIZED[] = true
+    return DEVICE_ATTRIBUTE_CACHE[]
+end
+
+# cudaOccMaxActiveBlocksPerMultiprocessor times the number of multiprocessors,
+# and its limiting factor (num_blocks/num_threads/registers/shared_memory); the
+# block-barrier limit is ignored as ClimaCore does not use asynchronous barriers
+# https://gitlab.com/nvidia/headers/cuda-individual/cudart/-/blob/main/cuda_occupancy.h#L1282-1777
+function max_active_blocks(threads_per_block, regs_per_thread, shmem_per_block)
+    attrs = device_attributes()
+    round_up(n, divisor) = cld(n, divisor) * divisor # round n up to next multiple of divisor
+
+    (max_blocks_per_sm, limit) = (attrs.max_blocks_per_sm, :num_blocks)
+
+    if !iszero(threads_per_block)
+        threads_per_block > attrs.max_threads_per_block && return (0, :num_threads)
+        warps_per_block = cld(threads_per_block, attrs.threads_per_warp)
+        (max_warps_per_sm, warp_limit) =
+            (fld(attrs.max_threads_per_sm, attrs.threads_per_warp), :num_threads)
+        if !iszero(regs_per_thread)
+            regs_per_thread > attrs.max_regs_per_thread && return (0, :registers)
+            min_regs_per_warp = regs_per_thread * attrs.threads_per_warp
+            allocated_warps_per_block =
+                round_up(warps_per_block, attrs.max_schedulers_per_sm)
+            allocated_regs_per_warp = round_up(min_regs_per_warp, attrs.regs_per_allocation)
+            allocated_regs_per_block = allocated_warps_per_block * allocated_regs_per_warp
+            allocated_regs_per_block > attrs.max_regs_per_block && return (0, :registers)
+            max_regs_per_scheduler = fld(attrs.max_regs_per_sm, attrs.schedulers_per_sm)
+            max_warps_per_scheduler = fld(max_regs_per_scheduler, allocated_regs_per_warp)
+            max_warps_per_sm_by_regs = max_warps_per_scheduler * attrs.schedulers_per_sm
+            if max_warps_per_sm_by_regs < max_warps_per_sm
+                (max_warps_per_sm, warp_limit) = (max_warps_per_sm_by_regs, :registers)
+            end
+        end
+        max_blocks_per_sm_by_warps = fld(max_warps_per_sm, warps_per_block)
+        if max_blocks_per_sm_by_warps < max_blocks_per_sm
+            (max_blocks_per_sm, limit) = (max_blocks_per_sm_by_warps, warp_limit)
+        end
+    end
+
+    if !iszero(shmem_per_block)
+        min_shmem_per_block = shmem_per_block + attrs.reserved_shmem_per_block
+        max_shmem_per_block = attrs.max_shmem_per_block + attrs.reserved_shmem_per_block
+        allocated_shmem_per_block =
+            round_up(min_shmem_per_block, attrs.shmem_per_allocation)
+        allocated_shmem_per_block > max_shmem_per_block && return (0, :shared_memory)
+        max_blocks_per_sm_by_shmem = fld(attrs.max_shmem_per_sm, allocated_shmem_per_block)
+        if max_blocks_per_sm_by_shmem < max_blocks_per_sm
+            (max_blocks_per_sm, limit) = (max_blocks_per_sm_by_shmem, :shared_memory)
+        end
+    end
+
+    return (max_blocks_per_sm * attrs.sm_count, limit)
+end
+
+# cudaOccMaxPotentialOccupancyBlockSize times the maximum number of waves,
+# optimized for single-stream execution of both small and large workloads
+# https://gitlab.com/nvidia/headers/cuda-individual/cudart/-/blob/main/cuda_occupancy.h#L1865-1965
+function uncached_launch_configuration(cu_func, strict, default_max_waves, config_args...)
+    attrs = device_attributes()
+    cu_func_attrs = CUDA.attributes(cu_func)
+    regs_per_thread = Int(cu_func_attrs[CUDA.FUNC_ATTRIBUTE_NUM_REGS])
+    shmem_per_block = Int(cu_func_attrs[CUDA.FUNC_ATTRIBUTE_SHARED_SIZE_BYTES])
+    default_max_threads_per_block = min(
+        Int(cu_func_attrs[CUDA.FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK]),
+        attrs.max_threads_per_block,
+    )
+
+    get_user_max_threads_per_block() = attrs.max_block_dim_x
+    get_user_max_threads_per_block(user_max_threads) = user_max_threads
+    get_user_max_threads_per_block(_, user_max_threads_per_block) =
+        user_max_threads_per_block
+
+    get_user_max_blocks(_) = attrs.max_grid_dim_x
+    get_user_max_blocks(threads_per_block, user_max_threads) =
+        (strict ? fld : cld)(user_max_threads, threads_per_block) # round down when strict
+    get_user_max_blocks(_, _, user_max_blocks) = user_max_blocks
+
+    user_max_threads_per_block = get_user_max_threads_per_block(config_args...)
+    user_constraints_ignorable = user_max_threads_per_block >= default_max_threads_per_block
+    max_threads_per_block = min(user_max_threads_per_block, default_max_threads_per_block)
+
+    # If max_waves has no default value, assume that higher register pressure
+    # leads to uneven load distributions, and launch more waves to compensate.
+    max_waves = something(default_max_waves, fld(regs_per_thread, 48) + 1)
+
+    # Iterating from small to large block sizes, prefer configurations with more
+    # total threads; on ties, prefer larger blocks (fewer blocks means less
+    # block-scheduling latency), but never accept a new configuration with fewer
+    # blocks unless it still has at least one block per multiprocessor. This
+    # spreads small workloads across as many multiprocessors as possible, while
+    # also confining large workloads to as few blocks as possible.
+    (best_threads_per_block, best_num_blocks, best_limit) = (0, 0, :user)
+    for warps_per_block in 1:cld(max_threads_per_block, attrs.threads_per_warp)
+        threads_per_block =
+            min(warps_per_block * attrs.threads_per_warp, max_threads_per_block)
+        (max_blocks_per_wave, active_blocks_limit) =
+            max_active_blocks(threads_per_block, regs_per_thread, shmem_per_block)
+        user_max_blocks = get_user_max_blocks(threads_per_block, config_args...)
+        user_constraints_ignorable &= user_max_blocks >= max_blocks_per_wave * max_waves
+        (num_blocks, limit) =
+            user_max_blocks <= max_blocks_per_wave * max_waves ? (user_max_blocks, :user) :
+            (max_blocks_per_wave * max_waves, active_blocks_limit)
+        if threads_per_block * num_blocks >= best_threads_per_block * best_num_blocks &&
+           (num_blocks >= attrs.sm_count || num_blocks >= best_num_blocks)
+            (best_threads_per_block, best_num_blocks, best_limit) =
+                (threads_per_block, num_blocks, limit)
+        end
+    end
+
+    # Compare searches unaffected by config_args against CUDA's implementation.
+    if user_constraints_ignorable
+        min_blocks_per_wave = cld(best_num_blocks, max_waves)
+        cuda_config = (; blocks = min_blocks_per_wave, threads = best_threads_per_block)
+        @assert CUDA.launch_configuration(cu_func) == cuda_config
+    end
+
+    return (;
+        threads = best_threads_per_block,
+        blocks = best_num_blocks,
+        limit = best_limit,
+    )
+end
+
+const LAUNCH_CONFIGURATION_CACHE =
+    IdDict{Any, @NamedTuple{threads::Int, blocks::Int, limit::Symbol}}()
+const LAUNCH_CONFIGURATION_CACHE_LOCK = ReentrantLock()
+
+"""
+    launch_configuration(f, args; max_waves = nothing)
+    launch_configuration(f, args, max_threads; strict = true, max_waves = nothing)
+    launch_configuration(f, args, max_threads_per_block, max_blocks; max_waves = nothing)
+
+Analogue of `CUDA.launch_configuration` optimized for single-stream execution,
+which maximizes occupancy across the entire device instead of just one
+multiprocessor, and which spreads small workloads across as many multiprocessors
+as possible. While `CUDA.launch_configuration` and its underlying C function
+`cudaOccMaxPotentialOccupancyBlockSize` only accept a single optional argument,
+`max_threads_per_block`, this function has three different variants:
+ - When no positional arguments are specified, only the hardware constraints on
+   occupancy are considered (like CUDA's implementation without any arguments).
+ - When `max_threads` is specified, the total number of threads is also limited.
+   If `strict` is `true`, this acts as a hard upper bound on the thread count.
+   Otherwise, an extra block of threads may be scheduled, allowing loops that
+   can handle surplus threads to assign every loop iteration to a unique thread.
+ - When `max_threads_per_block` and `max_blocks` are both specified, the block
+   and grid dimensions of the launch configuration are individually limited
+   (similar to CUDA's implementation, but with the addition of `max_blocks`).
+
+In each case, `max_waves` can be specified to control how many waves of blocks
+are scheduled. Kernels with uneven load distributions (e.g., due to conditional
+branches or nonuniform memory accesses) may require multiple waves to prevent
+some multiprocessors from idling while others are still active. However, block
+scheduling also adds measurable latency, so the number of waves should not be
+increased unless load redistribution is necessary. Setting `max_waves` to
+`nothing` gives it a dynamic value based on the kernel's register pressure.
+
+Like `CUDA.launch_configuration`, this returns a `NamedTuple` containing the
+optimal number of threads per block and the optimal number of blocks, and it
+also returns a symbol identifying the dominant factor that limits occupancy:
+ - `:user` when limited by the user-specified constraints (e.g., `max_threads`)
+ - `:num_blocks` when limited by the number of blocks per multiprocessor
+ - `:num_threads` when limited by the number of threads per multiprocessor
+ - `:registers` when limited by the register pressure of each thread
+ - `:shared_memory` when limited by the shared memory requirements of each block
+
+Computing a launch configuration requires querying the C driver for the kernel's
+register pressure and shared memory requirements, which adds measurable latency
+if done more than once per kernel, so the result is cached in an `IdDict`. A
+lock is used to prevent multiple threads from updating the cache simultaneously,
+since an `IdDict` should never be read as it is being rehashed.
+"""
+function launch_configuration(
+    f::F,
+    args,
+    config_args...;
+    strict = true,
+    max_waves = nothing,
+) where {F}
+    cu_func = (CUDA.@cuda always_inline = true launch = false f(args...)).fun
+    cache_key = (cu_func, strict, max_waves, config_args...)
+    lock(LAUNCH_CONFIGURATION_CACHE_LOCK)
+    try
+        return get!(LAUNCH_CONFIGURATION_CACHE, cache_key) do
+            uncached_launch_configuration(cache_key...)
+        end
+    finally
+        unlock(LAUNCH_CONFIGURATION_CACHE_LOCK)
+    end
+end
+
+threads_via_occupancy(f::F, args) where {F} = launch_configuration(f, args).threads
+function config_via_occupancy(f::F, nitems, args) where {F}
+    threads_per_block = launch_configuration(f, args, nitems; strict = false).threads
+    return (; threads = threads_per_block, blocks = cld(nitems, threads_per_block))
+end
 
 const reported_stats = Dict()
 const kernel_names = IdDict()
-# CUDA.launch_configuration runs an occupancy calculation, which costs far more than the
-# rest of a launch, and its result only depends on the kernel. The blocks and threads are
-# copied into a concrete type of our own, so that the cache stays type stable no matter what
-# CUDA.launch_configuration returns, and so that a lookup does not dynamically dispatch.
-const LaunchConfiguration = @NamedTuple{blocks::Int, threads::Int}
-const OCCUPANCY_CACHE = IdDict{Any, LaunchConfiguration}()
-const OCCUPANCY_CACHE_LOCK = ReentrantLock()
-
-# The cache is only read and written while the lock is held, since an IdDict cannot be read
-# while it is being rehashed. The occupancy calculation runs under the lock as well: it only
-# happens once per kernel, and holding the lock keeps two threads from both running it.
-cached_launch_configuration(fun) =
-    lock(OCCUPANCY_CACHE_LOCK) do
-        get!(OCCUPANCY_CACHE, fun) do
-            config = CUDA.launch_configuration(fun)
-            LaunchConfiguration((
-                Int(config.blocks),
-                Int(config.threads),
-            ))
-        end
-    end::LaunchConfiguration
 
 collect_kernel_stats() = false
 
@@ -193,7 +438,7 @@ function auto_launch!(
             # Note: `name = nothing` here will revert to default behavior
             kernel = CUDA.@cuda name = kernel_name always_inline = true launch =
                 false f!(args...)
-            config = cached_launch_configuration(kernel.fun)
+            config = launch_configuration(f!, args)
             threads = min(nitems, config.threads)
             blocks = cld(nitems, threads)
             kernel(args...; threads, blocks) # This knows to use always_inline from above.
@@ -210,7 +455,7 @@ function auto_launch!(
         # occursin("single_field_solve_kernel", string(nameof(F!))) || return nothing
         if !haskey(reported_stats, key)
             kernel = CUDA.@cuda always_inline = true launch = false f!(args...)
-            config = cached_launch_configuration(kernel.fun)
+            config = launch_configuration(f!, args)
             threads = isnothing(nitems) ? nothing : min(nitems, config.threads)
             blocks = isnothing(nitems) ? nothing : cld(nitems, threads)
             # For now, let's just collect info, later we can benchmark
@@ -250,110 +495,6 @@ function auto_launch!(
     end
     return nothing
 end
-
-function threads_via_occupancy(f!::F!, args) where {F!}
-    kernel = CUDA.@cuda always_inline = true launch = false f!(args...)
-    config = cached_launch_configuration(kernel.fun)
-    return config.threads
-end
-
-# Each CUDA.attribute call queries the C driver, which costs more than the rest of a launch
-# configuration put together, so the attributes are only queried once. As in
-# check_device_assumptions, this assumes that every launch from this process targets the
-# same device, which is how ClimaComms assigns devices to processes.
-# The attributes are published through an atomic field, so that a launch on another thread
-# either sees nothing and queries the driver itself, or sees every attribute; an ordinary
-# field would let a reader see the attributes before the values written into them. Two
-# readers can both query before either publishes, which is harmless because they read the
-# same values. The field is untyped because only a pointer-sized field can be atomic, and
-# the type assertion on the value read from it keeps the launch configurations that use the
-# attributes free of the dynamic dispatch that an untyped value would otherwise cause.
-const DeviceAttributes = @NamedTuple{
-    max_block_size::Int,
-    max_threads_per_block::Int,
-    threads_per_warp::Int,
-    max_threads_per_SM::Int,
-    SM_count::Int,
-}
-mutable struct DeviceAttributeCache
-    @atomic attributes::Any
-end
-const CACHED_DEVICE_ATTRIBUTES = DeviceAttributeCache(nothing)
-
-function cached_device_attributes()
-    attributes = @atomic CACHED_DEVICE_ATTRIBUTES.attributes
-    isnothing(attributes) || return attributes::DeviceAttributes
-    device = CUDA.device()
-    device_attribute(name) = Int(CUDA.attribute(device, name))
-    # Named rather than positional, so that no attribute can end up in the wrong field, and
-    # annotated so that a field added here without being added to DeviceAttributes is an
-    # error instead of a silently untyped cache.
-    new_attributes::DeviceAttributes = (;
-        max_block_size = device_attribute(CUDA.DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X),
-        max_threads_per_block = device_attribute(
-            CUDA.DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
-        ),
-        threads_per_warp = device_attribute(CUDA.DEVICE_ATTRIBUTE_WARP_SIZE),
-        max_threads_per_SM = device_attribute(
-            CUDA.DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR,
-        ),
-        SM_count = device_attribute(CUDA.DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT),
-    )
-    @atomic CACHED_DEVICE_ATTRIBUTES.attributes = new_attributes
-    return new_attributes
-end
-
-"""
-    config_via_occupancy(f!::F!, nitems, args) where {F!}
-
-Returns a named tuple of `(:threads, :blocks)` that contains an approximate
-optimal launch configuration for the kernel `f!` with arguments `args`, given
-`nitems` total items to process.
-
-If the number of items is greater than the minimal number of threads required for the config
-suggested by `CUDA.launch_configuration` to be valid, that config is returned. Otherwise,
-the threads are spread out across more SMs to improve occupancy.
-"""
-function config_via_occupancy(f!::F!, nitems, args) where {F!}
-    kernel = CUDA.@cuda always_inline = true launch = false f!(args...)
-    config = cached_launch_configuration(kernel.fun)
-    (; max_block_size, SM_count) = cached_device_attributes()
-    if cld(nitems, config.threads) < config.blocks
-        # gpu will not saturate, so spread out threads across more SMs
-        even_distribution_threads = cld(nitems, SM_count)
-        # Ensure we don't exceed max block size (usually limited by register pressure)
-        # If so, attempt to halve the number of threads
-        even_distribution_threads =
-            even_distribution_threads > max_block_size ? div(even_distribution_threads, 2) :
-            even_distribution_threads
-        # it should be safe to assume even_distribution_threads < config.threads here
-        threads = min(even_distribution_threads, config.threads)
-        blocks = cld(nitems, threads)
-    else
-        threads = min(nitems, config.threads)
-        blocks = cld(nitems, threads)
-    end
-    return (; threads, blocks)
-end
-
-"""
-    max_resident_blocks(threads_per_block)
-
-Maximum number of blocks with the specified number of threads that can
-simultaneously be resident on the GPU, based on the warp scheduler's throughput
-limit. Adapted from version 12.9 of the CUDA Runtime Headers
-(https://gitlab.com/nvidia/headers/cuda-individual/cudart/-/blob/main/cuda_occupancy.h#L1282-1330).
-"""
-function max_resident_blocks(threads_per_block)
-    iszero(threads_per_block) && return typemax(Int) # no limit for empty blocks
-    (; max_threads_per_block, threads_per_warp, max_threads_per_SM, SM_count) =
-        cached_device_attributes()
-    threads_per_block > max_threads_per_block && return 0
-    warps_per_block = cld(threads_per_block, threads_per_warp)
-    max_resident_warps_per_SM = fld(max_threads_per_SM, threads_per_warp)
-    return fld(max_resident_warps_per_SM, warps_per_block) * SM_count
-end
-# TODO: Register pressure and shared memory pressure need to be included here.
 
 """
     thread_index()

--- a/ext/cuda/data_layouts_threadblock.jl
+++ b/ext/cuda/data_layouts_threadblock.jl
@@ -1,9 +1,3 @@
-maximum_allowable_threads() = (
-    CUDA.attribute(CUDA.device(), CUDA.DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X),
-    CUDA.attribute(CUDA.device(), CUDA.DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y),
-    CUDA.attribute(CUDA.device(), CUDA.DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z),
-)
-
 # Wrappers for sizes and indices that are passed to kernels as type parameters.
 @inline unval(x) = x
 @inline unval(::Val{x}) where {x} = x
@@ -88,7 +82,7 @@ end
 ##### spectral kernel partition
 @inline function spectral_partition(data, n_max_threads::Integer = 256)
     (Nv, Ni, Nj, Nh) = size(data)
-    Nvthreads = min(fld(n_max_threads, Ni * Nj), maximum_allowable_threads()[3])
+    Nvthreads = min(fld(n_max_threads, Ni * Nj), device_attributes().max_block_dim_z)
     Nvblocks = cld(Nv, Nvthreads)
     @assert prod((Ni, Nj, Nvthreads)) ≤ n_max_threads "threads,n_max_threads=($(prod((Ni, Nj, Nvthreads))),$n_max_threads)"
     @assert Ni * Nj ≤ n_max_threads
@@ -122,7 +116,8 @@ end
 )
     (Nv, Ni, Nj, Nh) = size(data)
     Nvthreads = n_face_levels
-    @assert Nvthreads <= maximum_allowable_threads()[1] "Number of vertical face levels cannot exceed $(maximum_allowable_threads()[1])"
+    Nvlimit = device_attributes().max_block_dim_x
+    @assert Nvthreads <= Nvlimit "Number of vertical face levels cannot exceed $Nvlimit"
     Nvblocks = cld(Nv, Nvthreads) # +1 may be needed to guarantee that shared memory is populated at the last cell face
     return (;
         threads = (Nvthreads,),

--- a/ext/cuda/loops.jl
+++ b/ext/cuda/loops.jl
@@ -1,20 +1,24 @@
 function DataLayouts.foreach_slice(::ThisHost, op::O, f::F, args...; kwargs...) where {O, F}
     check_device_assumptions()
+
     # Capture the kwargs as a NamedTuple, whose names are type parameters. The
     # Pairs structure of kwargs stores its names in a Tuple of Symbols, which
     # cannot be passed to a kernel because Symbols are not bitstypes.
-    nt_kwargs = values(kwargs)
-    kernel(args...) = DataLayouts.foreach_slice(ThisKernel(), op, f, args...; nt_kwargs...)
-    if DataLayouts.slice_subscope(ThisKernel(), op, args...) == ThisBlock()
-        max_slice_points = maximum(Base.Fix1(DataLayouts.num_slice_points, op), args)
-        threads = min(threads_via_occupancy(kernel, args), max_slice_points)
-        blocks = length(DataLayouts.each_slice_index(op, first(args)))
-    else
-        (; threads, blocks) = config_via_occupancy(kernel, maximum(length, args), args)
-    end
-    blocks = min(max_resident_blocks(threads), blocks)
-    auto_launch!(kernel, args; threads_s = threads, blocks_s = blocks)
-    return nothing
+    kernel_kwargs = values(kwargs)
+    kernel_function(args...) =
+        DataLayouts.foreach_slice(ThisKernel(), op, f, args...; kernel_kwargs...)
+
+    (; threads, blocks) =
+        if DataLayouts.slice_subscope(ThisKernel(), op, args...) == ThisBlock()
+            max_slice_points = maximum(Base.Fix1(DataLayouts.num_slice_points, op), args)
+            max_slices = length(DataLayouts.each_slice_index(op, first(args)))
+            launch_configuration(kernel_function, args, max_slice_points, max_slices)
+        else
+            # Extra threads run empty loops, so max_points isn't a strict limit.
+            max_points = maximum(length, args)
+            launch_configuration(kernel_function, args, max_points; strict = false)
+        end
+    auto_launch!(kernel_function, args; threads_s = threads, blocks_s = blocks)
 end
 
 # Only save a reduction result to an array from one thread per reduction scope.
@@ -23,30 +27,24 @@ is_first_thread_in(scope) = isone(DataLayouts.thread_rank(scope))
 # Reduce each block's values, then reduce the results in a single-block kernel.
 function DataLayouts.reduce_points(::ThisHost, op::O, arg; kwargs...) where {O}
     check_device_assumptions()
-    nt_kwargs = values(kwargs)
-    function kernel(results, arg)
-        result = DataLayouts.reduce_points(ThisBlock(), op, arg; nt_kwargs...)
+
+    kernel_kwargs = values(kwargs)
+    function kernel_function(results, arg)
+        result = DataLayouts.reduce_points(ThisBlock(), op, arg; kernel_kwargs...)
         if is_first_thread_in(ThisBlock())
             @inbounds results[DataLayouts.partition_rank(ThisKernel())] = result
         end
         return nothing
     end
+
     T = return_type(op, NTuple{2, eltype(arg)})
-    # Measure occupancy with an empty view of the buffer that the launches below use, since
-    # a kernel is compiled separately for every type of argument it is given.
-    empty_results = DataLayouts.scoped_array(ThisHost(), T, 0; buffer = true)
-    # Launch at most one thread per point, so every thread's strided range of
-    # indices is nonempty. Threads without values would need warp-shuffle
-    # placeholders, which reductions without init values (like min) do not have.
-    max_threads = threads_via_occupancy(kernel, (empty_results, arg))
-    threads = min(length(arg), max_threads)
-    blocks = max(fld(length(arg), threads), 1)
-    num_results = min(max_resident_blocks(threads), blocks)
-    results = DataLayouts.scoped_array(ThisHost(), T, num_results; buffer = true)
-    auto_launch!(kernel, (results, arg); threads_s = threads, blocks_s = num_results)
-    if !isone(num_results)
-        threads = min(threads_via_occupancy(kernel, (results, results)), num_results)
-        auto_launch!(kernel, (results, results); threads_s = threads, blocks_s = 1)
+    results = DataLayouts.scoped_array(ThisHost(), T, 0; buffer = true)
+    (; threads, blocks) = launch_configuration(kernel_function, (results, arg), length(arg))
+    results = DataLayouts.scoped_array(ThisHost(), T, blocks; buffer = true)
+    auto_launch!(kernel_function, (results, arg); threads_s = threads, blocks_s = blocks)
+    if !isone(blocks)
+        (; threads) = launch_configuration(kernel_function, (results, results), blocks, 1)
+        auto_launch!(kernel_function, (results, results); threads_s = threads, blocks_s = 1)
     end
     return CUDA.@allowscalar @inbounds results[1]
 end

--- a/ext/cuda/scopes.jl
+++ b/ext/cuda/scopes.jl
@@ -1,23 +1,14 @@
 const THREADS_PER_WARP = 32
 const MAX_WARPS_PER_BLOCK = 32
 
-# Only check the first launch: device attributes are fixed for a given device,
-# and querying them on every launch would add measurable latency.
-const device_assumptions_checked = Ref(false)
+# To reduce latency, only check device attributes before the first launch.
+const DEVICE_ASSUMPTIONS_CHECKED = Ref(false)
 function check_device_assumptions()
-    device_assumptions_checked[] && return nothing
-    device = CUDA.device()
-    if (
-        THREADS_PER_WARP != CUDA.attribute(device, CUDA.DEVICE_ATTRIBUTE_WARP_SIZE) ||
-        MAX_WARPS_PER_BLOCK * THREADS_PER_WARP !=
-        CUDA.attribute(device, CUDA.DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK)
-    )
-        major = CUDA.attribute(device, CUDA.DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR)
-        minor = CUDA.attribute(device, CUDA.DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR)
-        throw(ArgumentError("Compute Capability $major.$minor is not supported"))
-    end
-    device_assumptions_checked[] = true
-    return nothing
+    DEVICE_ASSUMPTIONS_CHECKED[] && return true
+    (; threads_per_warp, max_threads_per_block) = device_attributes()
+    @assert THREADS_PER_WARP == threads_per_warp
+    @assert MAX_WARPS_PER_BLOCK * THREADS_PER_WARP == max_threads_per_block
+    DEVICE_ASSUMPTIONS_CHECKED[] = true
 end
 
 DataLayouts.DataScope(::Type{<:CUDA.CuArray}) = ThisHost()

--- a/src/DataLayouts/broadcast.jl
+++ b/src/DataLayouts/broadcast.jl
@@ -157,7 +157,7 @@ Replaces each of the [`layout_args`](@ref) in a broadcast expression with
         Base.@_propagate_inbounds_meta
         arg isa MaybeLazyDataLayout ? f(arg, f_args...) : arg
     end
-    return Broadcast.broadcasted(bc.f, modified_args...)
+    return Broadcast.Broadcasted(bc.style, bc.f, modified_args)
 end
 @propagate_inbounds function modify_args(f::F, bc::FusedMultiBroadcast, f_args...) where {F}
     modified_pairs = unrolled_map_with_inbounds(bc.pairs) do (dest, bc)

--- a/test/gpu/latency_benchmarks.jl
+++ b/test/gpu/latency_benchmarks.jl
@@ -30,7 +30,7 @@ import LazyBroadcast: lazy
     CUDA.synchronize()
     latency = median(@benchmark $scalar_field_1 .= $scalar_field_1 .+ $scalar_field_2).time
     # update this value if the kernel launch time changes significantly and it is expected
-    baseline_latency = 18000
+    baseline_latency = 15000
     latency_atol = 2000
     @test latency ≈ baseline_latency atol = latency_atol
     percent_change_latency =
@@ -45,7 +45,7 @@ import LazyBroadcast: lazy
                 $scalar_field_1 .+ $scalar_field_2 .+ $scalar_field_1 .+ $scalar_field_2
         ).time
     # update this value if the kernel launch time changes significantly and it is expected
-    baseline_latency = 24000
+    baseline_latency = 23000
     @test latency ≈ baseline_latency atol = latency_atol
     percent_change_latency =
         round(Int, (latency - baseline_latency) / baseline_latency * 100)
@@ -58,7 +58,7 @@ import LazyBroadcast: lazy
     CUDA.synchronize()
     latency = median(@benchmark $scalar_field_1 .= $lazy_sum_3).time
     # update this value if the kernel launch time changes significantly and it is expected
-    baseline_latency = 42000
+    baseline_latency = 37000
     @test latency ≈ baseline_latency atol = latency_atol
     percent_change_latency =
         round(Int, (latency - baseline_latency) / baseline_latency * 100)


### PR DESCRIPTION
This PR extends `max_resident_blocks` (renamed to `max_active_blocks`) so that it accounts for register pressure and shared memory requirements, fixing the "tail effect" problem that was introduced in #2522 for 64-level pointwise kernels (see [this comment](https://github.com/CliMA/ClimaCore.jl/pull/2522#issuecomment-5063662876) for details). This PR also improves the launch configuration caching, leading to a 5%--20% drop in kernel launch latency, and it exposes all occupancy limits that the CUDA API can identify internally.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
