### PR TITLE
Make the spectral-element operators dimension generic

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -854,6 +854,17 @@ steps:
         agents:
           slurm_gpus: 1
 
+      - label: "Unit: plane cuda"
+        key: unit_plane_cuda
+        retry: *retry_policy
+        command:
+          - "julia --project=.buildkite -e 'using CUDA; CUDA.versioninfo()'"
+          - "julia --color=yes --check-bounds=yes --project=.buildkite test/Operators/spectralelement/plane_cuda.jl CUDA"
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+        agents:
+          slurm_gpus: 1
+
       - label: "Unit: operators on levels and extruded spaces"
         key: unit_cuda_operators_example
         retry: *retry_policy

--- a/NEWS.md
+++ b/NEWS.md
@@ -65,6 +65,19 @@ main
   and fused-multiply-add selection that follows restructuring the accumulation
   loops; the largest observed difference is 5.3e-15 on values of order 1 to 20.
   [2559](https://github.com/CliMA/ClimaCore.jl/pull/2559)
+- Unified the remaining duplicated spectral-element operator code, finishing the
+  work above: `Interpolate`, `Restrict` and `tensor_product!` each had one
+  implementation per dimension and now have one that contracts a single axis at a
+  time (`rmatmul1`/`rmatmul2` are removed), and `get_node`, `set_node!`,
+  `get_local_geometry`, `slab_node_index` and `node_indices` lose their
+  per-dimension pairs. Callers should note that the two-dimensional `get_node`
+  and `set_node!` now accept a bare `FiniteDifferenceSpace`, and that
+  `get_local_geometry` and `set_node!` now raise `"invalid space"` for a space of
+  unknown staggering instead of reading level `slabidx.v`. Bitwise unchanged on
+  GPUs and for 73 of the 74 checked CPU expressions; `Restrict` on a
+  `SpectralElementSpace1D` moves 3 of 15 nodes by at most 1 ulp, from
+  fused-multiply-add selection after the loop was made generic (summation order
+  unchanged). [2559](https://github.com/CliMA/ClimaCore.jl/pull/2559)
 - ![][badge-🐛bugfix] Fixed spectral-element operators failing to run on the GPU
   over a `SpectralElementSpace1D`. The space could not be passed to a kernel
   (`KernelError: passing non-bitstype argument`) because, unlike

--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,30 @@ main
   on GPUs, which previously raised an "Unsupported input type" error even though
   both forms already supported them on CPUs.
   [2556](https://github.com/CliMA/ClimaCore.jl/pull/2556)
+- Made the spectral-element operators dimension generic, completing the
+  unification begun above: `Divergence`, `SplitDivergence`, `Gradient` and `Curl`
+  had separate one- and two-dimensional implementations of the same
+  tensor-product stencil, on both the CPU (`apply_operator`) and the GPU
+  (`operator_evaluate` and the shared-memory allocation and fill), and each
+  two-dimensional method repeated its one-dimensional counterpart once per axis.
+  Each operator now has a single implementation that loops over the axes it works
+  over, with the axis index carried in the type domain so the loop unrolls, and
+  it composes with the `FormType` parameter above: one method per operator now
+  covers both dimensions and both forms. CPU results are bitwise unchanged. On
+  GPUs, 40 of the 50 checked operator expressions are bitwise unchanged and the
+  other 10 (two-dimensional `Divergence`, `SplitDivergence`, `Gradient` and
+  `Curl`) differ by a few `eps` of the accumulated terms, from the reassociation
+  and fused-multiply-add selection that follows restructuring the accumulation
+  loops; the largest observed difference is 5.3e-15 on values of order 1 to 20.
+  [2559](https://github.com/CliMA/ClimaCore.jl/pull/2559)
+- ![][badge-🐛bugfix] Fixed spectral-element operators failing to run on the GPU
+  over a `SpectralElementSpace1D`. The space could not be passed to a kernel
+  (`KernelError: passing non-bitstype argument`) because, unlike
+  `SpectralElementGrid2D`, `SpectralElementGrid1D` had no device-side counterpart
+  to convert to. Adds `Grids.DeviceSpectralElementGrid1D` and the corresponding
+  `Adapt` rules. This also makes `to_device` work on a `SpectralElementSpace1D`,
+  where it previously returned the space unchanged.
+  [2559](https://github.com/CliMA/ClimaCore.jl/pull/2559)
 - Refactor DataLayouts module [2522](https://github.com/CliMA/ClimaCore.jl/pull/2522)
   - All data layout types are unified into a single `DataLayout` type, and all
     loops over data go through two communication primitives (`foreach_slice` and

--- a/ext/cuda/adapt.jl
+++ b/ext/cuda/adapt.jl
@@ -25,6 +25,15 @@ Adapt.adapt_structure(
 
 Adapt.adapt_structure(
     to::CUDA.KernelAdaptor,
+    grid::Grids.SpectralElementGrid1D,
+) = Grids.DeviceSpectralElementGrid1D(
+    Adapt.adapt(to, grid.quadrature_style),
+    Adapt.adapt(to, grid.global_geometry),
+    Adapt.adapt(to, grid.local_geometry),
+)
+
+Adapt.adapt_structure(
+    to::CUDA.KernelAdaptor,
     grid::Grids.SpectralElementGrid2D,
 ) = Grids.DeviceSpectralElementGrid2D(
     Adapt.adapt(to, grid.quadrature_style),

--- a/ext/cuda/operators_sem_shmem.jl
+++ b/ext/cuda/operators_sem_shmem.jl
@@ -7,6 +7,7 @@ import ClimaCore.Operators: form_jacobian, form_weighted_arg
 import ClimaCore.Operators:
     axis_vals,
     axis_index,
+    foreach_axis,
     contravariant,
     curl_covariant_components,
     curl_uses_component,
@@ -91,7 +92,8 @@ Base.@propagate_inbounds function operator_fill_shmem!(
     local_geometry = get_local_geometry(space, ij, slabidx)
     node = shmem_index(op, ij)
     jacobian = form_jacobian(F(), local_geometry)
-    unrolled_foreach(axis_vals(op)) do vd
+    foreach_axis(op) do vd
+        @inline
         @inbounds Jv[axis_index(vd)][node] =
             jacobian * contravariant(vd, arg, local_geometry)
     end
@@ -124,7 +126,8 @@ Base.@propagate_inbounds function operator_fill_shmem!(
     local_geometry = get_local_geometry(space, ij, slabidx)
     node = shmem_index(op, ij)
     (; J) = local_geometry
-    unrolled_foreach(axis_vals(op)) do vd
+    foreach_axis(op) do vd
+        @inline
         @inbounds work[axis_index(vd)][node] =
             J * contravariant(vd, arg1, local_geometry)
     end

--- a/ext/cuda/operators_sem_shmem.jl
+++ b/ext/cuda/operators_sem_shmem.jl
@@ -1,261 +1,192 @@
-import ClimaCore: DataLayouts, Spaces, Geometry, Operators, Quadratures
+import ClimaCore: Spaces, Operators, Quadratures
 import CUDA
-import ClimaCore.Operators:
-    Divergence,
-    SplitDivergence,
-    Gradient,
-    Curl
+import UnrolledUtilities: unrolled_map, unrolled_foreach
+import ClimaCore.Operators: Divergence, SplitDivergence, Gradient, Curl
 import ClimaCore.Operators: operator_return_eltype, get_local_geometry
 import ClimaCore.Operators: form_jacobian, form_weighted_arg
+import ClimaCore.Operators:
+    axis_vals,
+    axis_index,
+    contravariant,
+    curl_covariant_components,
+    curl_uses_component,
+    slab_dims
 
-# Both forms of the divergence hold one scaled contravariant component per dimension in
-# shared memory, so they share these methods; they differ only in the Jacobian factor that
-# scales the components (see form_jacobian), so the shared arrays named Jv hold J uⁱ for the
+# These methods serve every dimension and both forms of each operator. The
+# shared-memory work arrays are dimension-generic: an operator over axes `I` uses
+# arrays with one `Nq` per axis in `I`, indexed by the node index truncated to
+# those axes (on the GPU `ij` is always two-dimensional, with `j = 1` for
+# one-dimensional spaces) plus this thread's slab index. See the
+# "Dimension-generic building blocks" section of
+# `src/Operators/spectralelement.jl`, and the `FormType` helpers above it for the
+# strong/weak differences.
+
+"""
+    shmem_dims(op, space, Val(Nvt))
+
+Shape of a shared-memory work array for `op`: one `Nq` per axis it works over,
+plus `Nvt` slabs per block.
+"""
+@inline function shmem_dims(
+    op::Operators.SpectralElementOperator,
+    space,
+    ::Val{Nvt},
+) where {Nvt}
+    QS = Spaces.quadrature_style(space)
+    Nq = Quadratures.degrees_of_freedom(QS)
+    return (slab_dims(op, Nq)..., Nvt)
+end
+
+"""
+    sem_shmem(T, op, space, Val(Nvt))
+
+A shared-memory work array with element type `T`, holding one value per node of
+`op`'s slab for each of the `Nvt` slabs in the block.
+"""
+@inline sem_shmem(::Type{T}, op, space, valNvt) where {T} =
+    CUDA.CuStaticSharedArray(T, shmem_dims(op, space, valNvt))
+
+"""
+    sem_shmem_per_axis(T, op, space, Val(Nvt))
+
+One [`sem_shmem`](@ref) array per axis that `op` works over. The tuple is built
+with `unrolled_map`, so each element comes from its own `CuStaticSharedArray`
+call and the allocations are distinct.
+"""
+@inline sem_shmem_per_axis(::Type{T}, op, space, valNvt) where {T} =
+    unrolled_map(_ -> sem_shmem(T, op, space, valNvt), axis_vals(op))
+
+"""
+    shmem_index(op, ij)
+
+Index of node `ij` in a work array allocated by [`sem_shmem`](@ref): the node
+index truncated to the axes `op` works over, plus this thread's slab index.
+"""
+@inline shmem_index(::Operators.SpectralElementOperator{I}, ij) where {I} =
+    CartesianIndex(ntuple(d -> ij[d], Val(length(I)))..., CUDA.threadIdx().z)
+
+# Both forms of the divergence hold one scaled contravariant component per
+# dimension in shared memory; they differ only in the Jacobian factor that scales
+# the components (see form_jacobian), so the arrays named Jv hold J uⁱ for the
 # strong form and WJ uⁱ for the weak form.
 Base.@propagate_inbounds function operator_shmem(
     space,
-    ::Val{Nvt},
-    op::Divergence{(1,)},
+    valNvt::Val{Nvt},
+    op::Divergence{I},
     arg,
-) where {Nvt}
-    QS = Spaces.quadrature_style(space)
-    Nq = Quadratures.degrees_of_freedom(QS)
+) where {Nvt, I}
     # allocate temp output
     RT = operator_return_eltype(op, eltype(arg))
-    Jv¹ = CUDA.CuStaticSharedArray(RT, (Nq, Nvt))
-    return (Jv¹,)
-end
-Base.@propagate_inbounds function operator_shmem(
-    space,
-    ::Val{Nvt},
-    op::Divergence{(1, 2)},
-    arg,
-) where {Nvt}
-    QS = Spaces.quadrature_style(space)
-    Nq = Quadratures.degrees_of_freedom(QS)
-    # allocate temp output
-    RT = operator_return_eltype(op, eltype(arg))
-    Jv¹ = CUDA.CuStaticSharedArray(RT, (Nq, Nq, Nvt))
-    Jv² = CUDA.CuStaticSharedArray(RT, (Nq, Nq, Nvt))
-    return (Jv¹, Jv²)
+    return sem_shmem_per_axis(RT, op, space, valNvt)
 end
 
 Base.@propagate_inbounds function operator_fill_shmem!(
-    op::Divergence{(1,), F},
-    (Jv¹,),
+    op::Divergence{I, F},
+    Jv,
     space,
     ij,
     slabidx,
     arg,
-) where {F}
-    vt = threadIdx().z
+) where {I, F}
     local_geometry = get_local_geometry(space, ij, slabidx)
-    i, _ = ij.I
+    node = shmem_index(op, ij)
     jacobian = form_jacobian(F(), local_geometry)
-    Jv¹[i, vt] = jacobian * Geometry.contravariant1(arg, local_geometry)
-end
-Base.@propagate_inbounds function operator_fill_shmem!(
-    op::Divergence{(1, 2), F},
-    (Jv¹, Jv²),
-    space,
-    ij,
-    slabidx,
-    arg,
-) where {F}
-    vt = threadIdx().z
-    local_geometry = get_local_geometry(space, ij, slabidx)
-    i, j = ij.I
-    jacobian = form_jacobian(F(), local_geometry)
-    Jv¹[i, j, vt] = jacobian * Geometry.contravariant1(arg, local_geometry)
-    Jv²[i, j, vt] = jacobian * Geometry.contravariant2(arg, local_geometry)
+    unrolled_foreach(axis_vals(op)) do vd
+        @inbounds Jv[axis_index(vd)][node] =
+            jacobian * contravariant(vd, arg, local_geometry)
+    end
 end
 
 Base.@propagate_inbounds function operator_shmem(
     space,
-    ::Val{Nvt},
-    op::SplitDivergence{(1,)},
+    valNvt::Val{Nvt},
+    op::SplitDivergence{I},
     arg1,
     arg2,
-) where {Nvt}
+) where {Nvt, I}
     FT = Spaces.undertype(space)
-    QS = Spaces.quadrature_style(space)
-    Nq = Quadratures.degrees_of_freedom(QS)
     JT = operator_return_eltype(op, eltype(arg1), FT)
-    # allocate temp output for Ju1 and psi
-    Ju1 = CUDA.CuStaticSharedArray(JT, (Nq, Nvt))
-    psi = CUDA.CuStaticSharedArray(eltype(arg2), (Nq, Nvt))
-    return (Ju1, psi)
-end
-Base.@propagate_inbounds function operator_shmem(
-    space,
-    ::Val{Nvt},
-    op::SplitDivergence{(1, 2)},
-    arg1,
-    arg2,
-) where {Nvt}
-    FT = Spaces.undertype(space)
-    QS = Spaces.quadrature_style(space)
-    Nq = Quadratures.degrees_of_freedom(QS)
-    JT = operator_return_eltype(op, eltype(arg1), FT)
-    # allocate temp output for Ju1, Ju2, and psi
-    Ju1 = CUDA.CuStaticSharedArray(JT, (Nq, Nq, Nvt))
-    Ju2 = CUDA.CuStaticSharedArray(JT, (Nq, Nq, Nvt))
-    psi = CUDA.CuStaticSharedArray(eltype(arg2), (Nq, Nq, Nvt))
-    return (Ju1, Ju2, psi)
+    # allocate temp output for the mass flux Juᵈ along each axis, and for psi
+    Ju = sem_shmem_per_axis(JT, op, space, valNvt)
+    psi = sem_shmem(eltype(arg2), op, space, valNvt)
+    return (Ju..., psi)
 end
 
 Base.@propagate_inbounds function operator_fill_shmem!(
-    op::SplitDivergence{(1,)},
-    (Ju1, psi),
+    op::SplitDivergence{I},
+    work,
     space,
     ij,
     slabidx,
     arg1,
     arg2,
-)
-    vt = threadIdx().z
+) where {I}
     local_geometry = get_local_geometry(space, ij, slabidx)
-    i, _ = ij.I
+    node = shmem_index(op, ij)
     (; J) = local_geometry
-    Ju1[i, vt] = J * Geometry.contravariant1(arg1, local_geometry)
-    psi[i, vt] = arg2
+    unrolled_foreach(axis_vals(op)) do vd
+        @inbounds work[axis_index(vd)][node] =
+            J * contravariant(vd, arg1, local_geometry)
+    end
+    @inbounds last(work)[node] = arg2
 end
 
-Base.@propagate_inbounds function operator_fill_shmem!(
-    op::SplitDivergence{(1, 2)},
-    (Ju1, Ju2, psi),
-    space,
-    ij,
-    slabidx,
-    arg1,
-    arg2,
-)
-    vt = threadIdx().z
-    local_geometry = get_local_geometry(space, ij, slabidx)
-    i, j = ij.I
-    (; J) = local_geometry
-    Ju1[i, j, vt] = J * Geometry.contravariant1(arg1, local_geometry)
-    Ju2[i, j, vt] = J * Geometry.contravariant2(arg1, local_geometry)
-    psi[i, j, vt] = arg2
-end
-
-# Both forms of the gradient hold the argument in shared memory, so they share these
-# methods; they differ only in the quadrature weighting applied to it (see
-# form_weighted_arg), so the shared array holds f for the strong form and W f for the weak
-# form. It is wrapped in a tuple to match the other operators.
+# Both forms of the gradient hold the argument in shared memory; they differ only
+# in the quadrature weighting applied to it (see form_weighted_arg), so the array
+# holds f for the strong form and W f for the weak form. It is wrapped in a tuple
+# to match the other operators.
 Base.@propagate_inbounds function operator_shmem(
     space,
-    ::Val{Nvt},
-    op::Gradient{(1,)},
+    valNvt::Val{Nvt},
+    op::Gradient{I},
     arg,
-) where {Nvt}
-    QS = Spaces.quadrature_style(space)
-    Nq = Quadratures.degrees_of_freedom(QS)
-    f = CUDA.CuStaticSharedArray(eltype(arg), (Nq, Nvt))
-    return (f,)
-end
-Base.@propagate_inbounds function operator_shmem(
-    space,
-    ::Val{Nvt},
-    op::Gradient{(1, 2)},
-    arg,
-) where {Nvt}
-    QS = Spaces.quadrature_style(space)
-    Nq = Quadratures.degrees_of_freedom(QS)
-    f = CUDA.CuStaticSharedArray(eltype(arg), (Nq, Nq, Nvt))
+) where {Nvt, I}
+    f = sem_shmem(eltype(arg), op, space, valNvt)
     return (f,)
 end
 
 Base.@propagate_inbounds function operator_fill_shmem!(
-    op::Gradient{(1,), F},
+    op::Gradient{I, F},
     (f,),
     space,
     ij,
     slabidx,
     arg,
-) where {F}
-    vt = threadIdx().z
+) where {I, F}
     local_geometry = get_local_geometry(space, ij, slabidx)
-    i, _ = ij.I
-    f[i, vt] = form_weighted_arg(F(), local_geometry, arg)
-end
-Base.@propagate_inbounds function operator_fill_shmem!(
-    op::Gradient{(1, 2), F},
-    (f,),
-    space,
-    ij,
-    slabidx,
-    arg,
-) where {F}
-    vt = threadIdx().z
-    local_geometry = get_local_geometry(space, ij, slabidx)
-    i, j = ij.I
-    f[i, j, vt] = form_weighted_arg(F(), local_geometry, arg)
+    @inbounds f[shmem_index(op, ij)] = form_weighted_arg(F(), local_geometry, arg)
 end
 
-# Both forms of the curl hold the covariant components of the argument in shared memory, so
-# they share these methods; they differ only in the quadrature weighting applied to those
+# Both forms of the curl hold the covariant components of the argument in shared
+# memory; they differ only in the quadrature weighting applied to those
 # components (see form_weighted_arg). `curl_result_type` always returns a
-# Contravariant123Vector, so all three components are allocated in 2D, while the first is
-# unused in 1D.
+# Contravariant123Vector, but a curl over axes `I` only reads the components that
+# `curl_uses_component` selects: the entries of `work` for the others are
+# `nothing`.
 Base.@propagate_inbounds function operator_shmem(
     space,
-    ::Val{Nvt},
-    op::Curl{(1,)},
+    valNvt::Val{Nvt},
+    op::Curl{I},
     arg,
-) where {Nvt}
-    QS = Spaces.quadrature_style(space)
-    Nq = Quadratures.degrees_of_freedom(QS)
+) where {Nvt, I}
     ET = eltype(eltype(arg))
-    v₂ = CUDA.CuStaticSharedArray(ET, (Nq, Nvt))
-    v₃ = CUDA.CuStaticSharedArray(ET, (Nq, Nvt))
-    return (nothing, v₂, v₃)
-end
-Base.@propagate_inbounds function operator_shmem(
-    space,
-    ::Val{Nvt},
-    op::Curl{(1, 2)},
-    arg,
-) where {Nvt}
-    QS = Spaces.quadrature_style(space)
-    Nq = Quadratures.degrees_of_freedom(QS)
-    ET = eltype(eltype(arg))
-    v₁ = CUDA.CuStaticSharedArray(ET, (Nq, Nq, Nvt))
-    v₂ = CUDA.CuStaticSharedArray(ET, (Nq, Nq, Nvt))
-    v₃ = CUDA.CuStaticSharedArray(ET, (Nq, Nq, Nvt))
-    return (v₁, v₂, v₃)
+    return unrolled_map((Val(1), Val(2), Val(3))) do vk
+        curl_uses_component(op, vk) ? sem_shmem(ET, op, space, valNvt) : nothing
+    end
 end
 
 Base.@propagate_inbounds function operator_fill_shmem!(
-    op::Curl{(1,), F},
+    op::Curl{I, F},
     work,
     space,
     ij,
     slabidx,
     arg,
-) where {F}
-    vt = threadIdx().z
-    i, _ = ij.I
+) where {I, F}
     local_geometry = get_local_geometry(space, ij, slabidx)
-    _, v₂, v₃ = work
-    weighted(x) = form_weighted_arg(F(), local_geometry, x)
-    v₂[i, vt] = weighted(Geometry.covariant2(arg, local_geometry))
-    v₃[i, vt] = weighted(Geometry.covariant3(arg, local_geometry))
-end
-Base.@propagate_inbounds function operator_fill_shmem!(
-    op::Curl{(1, 2), F},
-    work,
-    space,
-    ij,
-    slabidx,
-    arg,
-) where {F}
-    vt = threadIdx().z
-    i, j = ij.I
-    local_geometry = get_local_geometry(space, ij, slabidx)
-    v₁, v₂, v₃ = work
-    weighted(x) = form_weighted_arg(F(), local_geometry, x)
-    v₁[i, j, vt] = weighted(Geometry.covariant1(arg, local_geometry))
-    v₂[i, j, vt] = weighted(Geometry.covariant2(arg, local_geometry))
-    v₃[i, j, vt] = weighted(Geometry.covariant3(arg, local_geometry))
+    node = shmem_index(op, ij)
+    u = curl_covariant_components(op, F(), arg, local_geometry)
+    unrolled_foreach(work, u) do w_k, u_k
+        @inbounds isnothing(w_k) || (w_k[node] = u_k)
+    end
 end

--- a/ext/cuda/operators_spectral_element.jl
+++ b/ext/cuda/operators_spectral_element.jl
@@ -11,8 +11,6 @@ import ClimaCore.Operators:
 import ClimaCore.Operators:
     axis_vals,
     axis_index,
-    covariant_components,
-    covariant_vector,
     curl_term,
     replace_index,
     sum_axes
@@ -319,10 +317,10 @@ Base.@propagate_inbounds function operator_evaluate(
         @inbounds apply_stencil(F(), D, input, node, vd, ij[d], Nq)
     end
     result = if eltype(input) <: Number
-        covariant_vector(op, ∂f∂ξ)
+        Geometry.covariant_vector(Val(I), ∂f∂ξ)
     elseif eltype(input) <: Geometry.AbstractTensor{1}
         tensor_axes =
-            (covariant_components(op), Geometry.tensor_axes(eltype(input))[1])
+            (Geometry.covariant_axis(Val(I)), Geometry.tensor_axes(eltype(input))[1])
         tensor_components = hcat(unrolled_map(parent, ∂f∂ξ)...)'
         Geometry.Tensor(tensor_components, tensor_axes)
     else

--- a/ext/cuda/operators_spectral_element.jl
+++ b/ext/cuda/operators_spectral_element.jl
@@ -8,6 +8,14 @@ import ClimaCore.Operators: get_local_geometry
 import ClimaCore.Operators: Divergence, SplitDivergence, Gradient, Curl
 import ClimaCore.Operators:
     form_deriv_entry, form_jacobian_rescale, form_weight_rescale
+import ClimaCore.Operators:
+    axis_vals,
+    axis_index,
+    covariant_components,
+    covariant_vector,
+    curl_term,
+    replace_index
+import UnrolledUtilities: unrolled_map, unrolled_reduce
 import Base.Broadcast: Broadcasted
 
 """
@@ -182,186 +190,141 @@ Base.@propagate_inbounds function resolve_shmem!(obj, ij, slabidx)
     nothing
 end
 
-# The methods below serve both forms of each operator: form_deriv_entry supplies the
-# derivative matrix entries (transposed and sign-flipped for the weak form), and
-# form_jacobian_rescale or form_weight_rescale divides the form's Jacobian or
-# quadrature-weight factor back out of the result. Every operator keeps one accumulator
-# per dimension and combines them once at the end, which keeps the accumulation loops as
-# independent dependency chains.
-Base.@propagate_inbounds function operator_evaluate(
-    op::Divergence{(1,), F},
-    (Jv¹,),
-    space,
-    ij,
-    slabidx,
-) where {F}
-    vt = threadIdx().z
-    i, _ = ij.I
+# The methods below serve every dimension and both forms of each operator:
+# form_deriv_entry supplies the derivative matrix entries (transposed and
+# sign-flipped for the weak form), form_jacobian_rescale or form_weight_rescale
+# divides the form's Jacobian or quadrature-weight factor back out of the result,
+# and the loop over axes is unrolled with one accumulator per dimension, combined
+# once at the end, which keeps the accumulation loops as independent dependency
+# chains.
 
-    FT = Spaces.undertype(space)
-    QS = Spaces.quadrature_style(space)
-    Nq = Quadratures.degrees_of_freedom(QS)
-    D = Quadratures.differentiation_matrix(FT, QS)
+"""
+    apply_stencil(form, D, w, node, ::Val{d}, i, Nq)
 
-    local_geometry = get_local_geometry(space, ij, slabidx)
-
-    D₁Jv¹ = form_deriv_entry(F(), D, i, 1) * Jv¹[1, vt]
+``\\sum_k D[i, k] w_k``, where `w_k` is the value of the shared-memory array `w`
+at `node` with its `d`th index replaced by `k`. This is the one-dimensional
+spectral stencil for output node `i` applied along axis `d`; `form` selects the
+matrix entry, so the weak form transposes `D` and flips its sign.
+"""
+Base.@propagate_inbounds function apply_stencil(form, D, w, node, vd, i, Nq)
+    r = form_deriv_entry(form, D, i, 1) * w[replace_index(node, vd, 1)]
     for k in 2:Nq
-        D₁Jv¹ += form_deriv_entry(F(), D, i, k) * Jv¹[k, vt]
+        r += form_deriv_entry(form, D, i, k) * w[replace_index(node, vd, k)]
     end
-    return form_jacobian_rescale(F(), local_geometry, D₁Jv¹)
+    return r
 end
-Base.@propagate_inbounds function operator_evaluate(
-    op::Divergence{(1, 2), F},
-    (Jv¹, Jv²),
-    space,
-    ij,
-    slabidx,
-) where {F}
-    vt = threadIdx().z
-    i, j = ij.I
 
-    FT = Spaces.undertype(space)
-    QS = Spaces.quadrature_style(space)
-    Nq = Quadratures.degrees_of_freedom(QS)
-    D = Quadratures.differentiation_matrix(FT, QS)
+"""
+    curl_stencil(form, D, work, node, ::Val{d}, i, Nq)
 
-    local_geometry = get_local_geometry(space, ij, slabidx)
-
-    D₁Jv¹ = form_deriv_entry(F(), D, i, 1) * Jv¹[1, j, vt]
-    D₂Jv² = form_deriv_entry(F(), D, j, 1) * Jv²[i, 1, vt]
+``\\sum_k ε^{i d m} D[i, k] u_m``, the axis-`d` contribution of a curl summed over
+the stencil, where `work` holds the covariant components `u_m` in shared memory
+(`nothing` for the components the curl does not use).
+"""
+Base.@propagate_inbounds function curl_stencil(form, D, work, node, vd, i, Nq)
+    r = curl_term(
+        vd,
+        form_deriv_entry(form, D, i, 1),
+        shmem_components(work, replace_index(node, vd, 1)),
+    )
     for k in 2:Nq
-        D₁Jv¹ += form_deriv_entry(F(), D, i, k) * Jv¹[k, j, vt]
-        D₂Jv² += form_deriv_entry(F(), D, j, k) * Jv²[i, k, vt]
+        r += curl_term(
+            vd,
+            form_deriv_entry(form, D, i, k),
+            shmem_components(work, replace_index(node, vd, k)),
+        )
     end
-    return form_jacobian_rescale(F(), local_geometry, D₁Jv¹ + D₂Jv²)
+    return r
 end
 
+# The values of a curl's shared-memory component arrays at `node`, keeping the
+# `nothing`s that mark the components the curl does not use.
+Base.@propagate_inbounds shmem_components(work, node) =
+    unrolled_map(w_k -> isnothing(w_k) ? nothing : (@inbounds w_k[node]), work)
+
+# Sum of the per-axis contributions of an operator, unrolled over its axes.
+@inline sum_over_axes(f, op) = unrolled_reduce(+, unrolled_map(f, axis_vals(op)))
+
 Base.@propagate_inbounds function operator_evaluate(
-    op::SplitDivergence{(1,)},
-    (Ju1, psi),
+    op::Divergence{I, F},
+    Jv,
     space,
     ij,
     slabidx,
-)
-    vt = threadIdx().z
-    i, _ = ij.I
-
+) where {I, F}
     FT = Spaces.undertype(space)
     QS = Spaces.quadrature_style(space)
     Nq = Quadratures.degrees_of_freedom(QS)
     D = Quadratures.differentiation_matrix(FT, QS)
-    RT = Geometry.mul_return_type(eltype(Ju1), eltype(psi))
 
     local_geometry = get_local_geometry(space, ij, slabidx)
+    node = shmem_index(op, ij)
 
-    result = zero(RT)
-    for j in 1:Nq
-        j == i && continue
-        result +=
-            D[i, j] * (Ju1[i, vt] + Ju1[j, vt]) * (psi[i, vt] + psi[j, vt]) / 2
+    DJv = sum_over_axes(op) do vd
+        d = axis_index(vd)
+        @inbounds apply_stencil(F(), D, Jv[d], node, vd, ij[d], Nq)
     end
-    return result * local_geometry.invJ
+    return form_jacobian_rescale(F(), local_geometry, DJv)
 end
+
 Base.@propagate_inbounds function operator_evaluate(
-    op::SplitDivergence{(1, 2)},
-    (Ju1, Ju2, psi),
+    op::SplitDivergence{I},
+    work,
     space,
     ij,
     slabidx,
-)
-    vt = threadIdx().z
-    i, j = ij.I
-
+) where {I}
     FT = Spaces.undertype(space)
     QS = Spaces.quadrature_style(space)
     Nq = Quadratures.degrees_of_freedom(QS)
     D = Quadratures.differentiation_matrix(FT, QS)
-    RT = Geometry.mul_return_type(eltype(Ju1), eltype(psi))
 
     local_geometry = get_local_geometry(space, ij, slabidx)
+    node = shmem_index(op, ij)
+    psi = last(work)
 
-    result = zero(RT)
-    for k in 1:Nq
-        k == i && continue
-        result +=
-            D[i, k] *
-            (Ju1[i, j, vt] + Ju1[k, j, vt]) * (psi[i, j, vt] + psi[k, j, vt]) / 2
-    end
-    for k in 1:Nq
-        k == j && continue
-        result +=
-            D[j, k] *
-            (Ju2[i, j, vt] + Ju2[i, k, vt]) * (psi[i, j, vt] + psi[i, k, vt]) / 2
+    result = sum_over_axes(op) do vd
+        d = axis_index(vd)
+        i = ij[d]
+        Juᵈ = work[d]
+        # the two-point flux Fᵈ[i,k] vanishes for k == i
+        r = zero(Geometry.mul_return_type(eltype(Juᵈ), eltype(psi)))
+        @inbounds for k in 1:Nq
+            k == i && continue
+            node_k = replace_index(node, vd, k)
+            r += D[i, k] * (Juᵈ[node] + Juᵈ[node_k]) * (psi[node] + psi[node_k]) / 2
+        end
+        r
     end
     return result * local_geometry.invJ
 end
 
 Base.@propagate_inbounds function operator_evaluate(
-    op::Gradient{(1,), F},
+    op::Gradient{I, F},
     (input,),
     space,
     ij,
     slabidx,
-) where {F}
-    vt = threadIdx().z
-    i, _ = ij.I
-
+) where {I, F}
     FT = Spaces.undertype(space)
     QS = Spaces.quadrature_style(space)
     Nq = Quadratures.degrees_of_freedom(QS)
     D = Quadratures.differentiation_matrix(FT, QS)
 
     local_geometry = get_local_geometry(space, ij, slabidx)
+    node = shmem_index(op, ij)
 
-    @inbounds begin
-        ∂f∂ξ₁ = form_deriv_entry(F(), D, i, 1) * input[1, vt]
-        for k in 2:Nq
-            ∂f∂ξ₁ += form_deriv_entry(F(), D, i, k) * input[k, vt]
-        end
+    # the covariant components of the gradient are the derivatives along each axis
+    ∂f∂ξ = unrolled_map(axis_vals(op)) do vd
+        d = axis_index(vd)
+        @inbounds apply_stencil(F(), D, input, node, vd, ij[d], Nq)
     end
     result = if eltype(input) <: Number
-        Geometry.Covariant1Vector(∂f∂ξ₁)
+        covariant_vector(op, ∂f∂ξ)
     elseif eltype(input) <: Geometry.AbstractTensor{1}
-        tensor_axes = (Geometry.Covariant1Axis(), Geometry.tensor_axes(eltype(input))[1])
-        tensor_components = hcat(parent(∂f∂ξ₁))'
-        Geometry.Tensor(tensor_components, tensor_axes)
-    else
-        error("Unsupported input type for gradient operator: $(eltype(input))")
-    end
-    return form_weight_rescale(F(), local_geometry, result)
-end
-Base.@propagate_inbounds function operator_evaluate(
-    op::Gradient{(1, 2), F},
-    (input,),
-    space,
-    ij,
-    slabidx,
-) where {F}
-    vt = threadIdx().z
-    i, j = ij.I
-
-    FT = Spaces.undertype(space)
-    QS = Spaces.quadrature_style(space)
-    Nq = Quadratures.degrees_of_freedom(QS)
-    D = Quadratures.differentiation_matrix(FT, QS)
-
-    local_geometry = get_local_geometry(space, ij, slabidx)
-
-    @inbounds begin
-        ∂f∂ξ₁ = form_deriv_entry(F(), D, i, 1) * input[1, j, vt]
-        ∂f∂ξ₂ = form_deriv_entry(F(), D, j, 1) * input[i, 1, vt]
-        for k in 2:Nq
-            ∂f∂ξ₁ += form_deriv_entry(F(), D, i, k) * input[k, j, vt]
-            ∂f∂ξ₂ += form_deriv_entry(F(), D, j, k) * input[i, k, vt]
-        end
-    end
-    result = if eltype(input) <: Number
-        Geometry.Covariant12Vector(∂f∂ξ₁, ∂f∂ξ₂)
-    elseif eltype(input) <: Geometry.AbstractTensor{1}
-        tensor_axes = (Geometry.Covariant12Axis(), Geometry.tensor_axes(eltype(input))[1])
-        tensor_components =
-            hcat(parent(∂f∂ξ₁), parent(∂f∂ξ₂))'
+        tensor_axes =
+            (covariant_components(op), Geometry.tensor_axes(eltype(input))[1])
+        tensor_components = hcat(unrolled_map(parent, ∂f∂ξ)...)'
         Geometry.Tensor(tensor_components, tensor_axes)
     else
         error("Unsupported input type for gradient operator: $(eltype(input))")
@@ -370,58 +333,23 @@ Base.@propagate_inbounds function operator_evaluate(
 end
 
 Base.@propagate_inbounds function operator_evaluate(
-    op::Curl{(1,), F},
+    op::Curl{I, F},
     work,
     space,
     ij,
     slabidx,
-) where {F}
-    vt = threadIdx().z
-    i, _ = ij.I
-
+) where {I, F}
     FT = Spaces.undertype(space)
     QS = Spaces.quadrature_style(space)
     Nq = Quadratures.degrees_of_freedom(QS)
     D = Quadratures.differentiation_matrix(FT, QS)
+
     local_geometry = get_local_geometry(space, ij, slabidx)
+    node = shmem_index(op, ij)
 
-    _, v₂, v₃ = work
-    D₁v₂ = form_deriv_entry(F(), D, i, 1) * v₂[1, vt]
-    D₁v₃ = form_deriv_entry(F(), D, i, 1) * v₃[1, vt]
-    @simd for k in 2:Nq
-        D₁v₂ += form_deriv_entry(F(), D, i, k) * v₂[k, vt]
-        D₁v₃ += form_deriv_entry(F(), D, i, k) * v₃[k, vt]
+    result = sum_over_axes(op) do vd
+        d = axis_index(vd)
+        @inbounds curl_stencil(F(), D, work, node, vd, ij[d], Nq)
     end
-    result = Geometry.Contravariant123Vector(zero(FT), -D₁v₃, D₁v₂)
-    return form_jacobian_rescale(F(), local_geometry, result)
-end
-Base.@propagate_inbounds function operator_evaluate(
-    op::Curl{(1, 2), F},
-    work,
-    space,
-    ij,
-    slabidx,
-) where {F}
-    vt = threadIdx().z
-    i, j = ij.I
-
-    FT = Spaces.undertype(space)
-    QS = Spaces.quadrature_style(space)
-    Nq = Quadratures.degrees_of_freedom(QS)
-    D = Quadratures.differentiation_matrix(FT, QS)
-    local_geometry = get_local_geometry(space, ij, slabidx)
-
-    v₁, v₂, v₃ = work
-    D₁v₂ = form_deriv_entry(F(), D, i, 1) * v₂[1, j, vt]
-    D₂v₁ = form_deriv_entry(F(), D, j, 1) * v₁[i, 1, vt]
-    D₁v₃ = form_deriv_entry(F(), D, i, 1) * v₃[1, j, vt]
-    D₂v₃ = form_deriv_entry(F(), D, j, 1) * v₃[i, 1, vt]
-    @simd for k in 2:Nq
-        D₁v₂ += form_deriv_entry(F(), D, i, k) * v₂[k, j, vt]
-        D₂v₁ += form_deriv_entry(F(), D, j, k) * v₁[i, k, vt]
-        D₁v₃ += form_deriv_entry(F(), D, i, k) * v₃[k, j, vt]
-        D₂v₃ += form_deriv_entry(F(), D, j, k) * v₃[i, k, vt]
-    end
-    result = Geometry.Contravariant123Vector(D₂v₃, -D₁v₃, D₁v₂ - D₂v₁)
     return form_jacobian_rescale(F(), local_geometry, result)
 end

--- a/ext/cuda/operators_spectral_element.jl
+++ b/ext/cuda/operators_spectral_element.jl
@@ -14,8 +14,9 @@ import ClimaCore.Operators:
     covariant_components,
     covariant_vector,
     curl_term,
-    replace_index
-import UnrolledUtilities: unrolled_map, unrolled_reduce
+    replace_index,
+    sum_axes
+import UnrolledUtilities: unrolled_map
 import Base.Broadcast: Broadcasted
 
 """
@@ -194,9 +195,8 @@ end
 # form_deriv_entry supplies the derivative matrix entries (transposed and
 # sign-flipped for the weak form), form_jacobian_rescale or form_weight_rescale
 # divides the form's Jacobian or quadrature-weight factor back out of the result,
-# and the loop over axes is unrolled with one accumulator per dimension, combined
-# once at the end, which keeps the accumulation loops as independent dependency
-# chains.
+# and `sum_axes` unrolls the loop over axes, keeping one accumulator per
+# dimension.
 
 """
     apply_stencil(form, D, w, node, ::Val{d}, i, Nq)
@@ -242,9 +242,6 @@ end
 Base.@propagate_inbounds shmem_components(work, node) =
     unrolled_map(w_k -> isnothing(w_k) ? nothing : (@inbounds w_k[node]), work)
 
-# Sum of the per-axis contributions of an operator, unrolled over its axes.
-@inline sum_over_axes(f, op) = unrolled_reduce(+, unrolled_map(f, axis_vals(op)))
-
 Base.@propagate_inbounds function operator_evaluate(
     op::Divergence{I, F},
     Jv,
@@ -260,7 +257,8 @@ Base.@propagate_inbounds function operator_evaluate(
     local_geometry = get_local_geometry(space, ij, slabidx)
     node = shmem_index(op, ij)
 
-    DJv = sum_over_axes(op) do vd
+    DJv = sum_axes(op) do vd
+        @inline
         d = axis_index(vd)
         @inbounds apply_stencil(F(), D, Jv[d], node, vd, ij[d], Nq)
     end
@@ -283,7 +281,8 @@ Base.@propagate_inbounds function operator_evaluate(
     node = shmem_index(op, ij)
     psi = last(work)
 
-    result = sum_over_axes(op) do vd
+    result = sum_axes(op) do vd
+        @inline
         d = axis_index(vd)
         i = ij[d]
         Juᵈ = work[d]
@@ -347,7 +346,8 @@ Base.@propagate_inbounds function operator_evaluate(
     local_geometry = get_local_geometry(space, ij, slabidx)
     node = shmem_index(op, ij)
 
-    result = sum_over_axes(op) do vd
+    result = sum_axes(op) do vd
+        @inline
         d = axis_index(vd)
         @inbounds curl_stencil(F(), D, work, node, vd, ij[d], Nq)
     end

--- a/src/Geometry/tensors.jl
+++ b/src/Geometry/tensors.jl
@@ -595,6 +595,39 @@ for I in [(), (1,), (2,), (3,), (1, 2), (1, 3), (2, 3), (1, 2, 3)]
     @eval const $(Symbol(:Cartesian, strI, :Axis)) = Components{Orthonormal, $I}
 end
 
+# Generic counterparts of the aliases above, for code that is generic over the
+# dimensions `I` rather than written against a fixed set (e.g. the spectral
+# element operators, which work over the axes of whichever space they are applied
+# to). `I` is passed as a `Val`, matching `gradient_result_type` and
+# `curl_result_type`.
+
+"""
+    covariant_axis(::Val{I})
+
+The covariant components over the dimensions `I`, i.e. the generic form of the
+`CovariantNAxis` aliases: `covariant_axis(Val((1, 2))) === Covariant12Axis()`.
+"""
+@inline covariant_axis(::Val{I}) where {I} = Components{Covariant, I}()
+
+"""
+    covariant_vector(::Val{I}, components)
+
+A covariant vector over the dimensions `I` with the given `components`, i.e. the
+generic form of the `CovariantNVector` constructors:
+`covariant_vector(Val((1, 2)), (1.0, 2.0)) == Covariant12Vector(1.0, 2.0)`.
+"""
+@inline covariant_vector(valI::Val, components::Tuple) =
+    Tensor(SVector(components), (covariant_axis(valI),))
+
+"""
+    covariant_basis_vector(::Val{I}, ::Val{d}, c)
+
+`c` times the `d`th covariant basis vector over the dimensions `I`:
+`covariant_basis_vector(Val((1, 2)), Val(2), c) == Covariant12Vector(zero(c), c)`.
+"""
+@inline covariant_basis_vector(::Val{I}, ::Val{d}, c) where {I, d} =
+    covariant_vector(Val(I), ntuple(n -> I[n] == d ? c : zero(c), Val(length(I))))
+
 # Named property access for vectors (e.g., v.u₁, v.u², v.u)
 _symbols(::Covariant) = (:u₁, :u₂, :u₃)
 _symbols(::Contravariant) = (:u¹, :u², :u³)

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -101,6 +101,7 @@ Returns a bool indicating that the grid has a horizontal part.
 function has_horizontal end
 has_horizontal(::AbstractGrid) = false
 has_horizontal(::ExtrudedFiniteDifferenceGrid) = true
+has_horizontal(::DeviceSpectralElementGrid1D) = true
 has_horizontal(::DeviceSpectralElementGrid2D) = true
 has_horizontal(::SpectralElementGrid2D) = true
 has_horizontal(::SpectralElementGrid1D) = true

--- a/src/Grids/spectralelement.jl
+++ b/src/Grids/spectralelement.jl
@@ -572,6 +572,18 @@ quadrature_style(grid::AbstractSpectralElementGrid) = grid.quadrature_style
 dss_weights(grid::AbstractSpectralElementGrid, ::Nothing) = grid.dss_weights
 
 ## GPU compatibility
+# These drop the fields that a device kernel cannot use (the topology, which is
+# not isbits, and the DSS weights), keeping only what the kernel reads through
+# the `AbstractSpectralElementGrid` accessors above.
+struct DeviceSpectralElementGrid1D{Q, GG, LG} <: AbstractSpectralElementGrid
+    quadrature_style::Q
+    global_geometry::GG
+    local_geometry::LG
+end
+
+ClimaComms.context(grid::DeviceSpectralElementGrid1D) = DeviceSideContext()
+ClimaComms.device(grid::DeviceSpectralElementGrid1D) = DeviceSideDevice()
+
 struct DeviceSpectralElementGrid2D{Q, GG, LG, M} <: AbstractSpectralElementGrid
     quadrature_style::Q
     global_geometry::GG

--- a/src/Operators/spectralelement.jl
+++ b/src/Operators/spectralelement.jl
@@ -540,6 +540,19 @@ end
 @inline slab_node_index(ij::CartesianIndex{2}) =
     CartesianIndex(1, ij[1], ij[2], 1)
 
+"""
+    slab_node_index(data, ij)
+
+Index for node `ij` in a single slab of `data`. The four-index `(1, i, j, 1)`
+form above serves the [`SlabData`](@ref) temporaries, the `MArray` temporaries of
+[`tensor_product!`](@ref) and every `VIJHWithF` layout; the layouts that drop a
+dimension are indexed with one index per dimension they keep.
+"""
+@inline slab_node_index(_, ij) = slab_node_index(ij)
+@inline slab_node_index(::DataLayouts.VIH1, ij::CartesianIndex{1}) =
+    CartesianIndex(1, ij[1])
+@inline slab_node_index(::DataLayouts.IH1JH2, ij::CartesianIndex{2}) = ij
+
 Base.@propagate_inbounds function get_node(space, data::SlabData, ij, slabidx)
     data[slab_node_index(ij)]
 end
@@ -721,21 +734,27 @@ because only a method -- not an anonymous function -- can carry them:
 
 """
     slab_dims(op, Nq)
+    slab_dims(axis_vals, Nq)
 
 The shape of one slab of nodes for `op`: `Nq` repeated once per axis it works
-over.
+over. The second form takes the axes as a tuple of `Val`s, for the slabs that
+belong to no operator (see [`tensor_product!`](@ref)).
 """
-@inline slab_dims(::SpectralElementOperator{I}, Nq) where {I} =
-    ntuple(_ -> Nq, Val(length(I)))
+@inline slab_dims(op::SpectralElementOperator, Nq) = slab_dims(axis_vals(op), Nq)
+@inline slab_dims(::NTuple{N, Val}, Nq) where {N} = ntuple(_ -> Nq, Val(N))
 
 """
     replace_index(index, ::Val{d}, k)
 
-The Cartesian `index` with its `d`th component replaced by `k`. Used to walk
-along one axis of a slab while holding the other axes fixed.
+The Cartesian `index` -- or the tuple of extents `index` -- with its `d`th
+component replaced by `k`. Used to walk along one axis of a slab while holding
+the other axes fixed, and to shrink the extent of an axis that has been
+contracted.
 """
-@inline replace_index(index::CartesianIndex{N}, ::Val{d}, k) where {N, d} =
-    CartesianIndex(ntuple(n -> n == d ? k : index[n], Val(N)))
+@inline replace_index(index::CartesianIndex, vd::Val, k) =
+    CartesianIndex(replace_index(Tuple(index), vd, k))
+@inline replace_index(index::NTuple{N, Any}, ::Val{d}, k) where {N, d} =
+    ntuple(n -> n == d ? k : index[n], Val(N))
 
 """
     contravariant(::Val{d}, u, local_geometry)
@@ -750,8 +769,128 @@ The `d`th contravariant (``u^d``) or covariant (``u_d``) component of `u`.
 @inline covariant(::Val{2}, u, lg) = Geometry.covariant2(u, lg)
 @inline covariant(::Val{3}, u, lg) = Geometry.covariant3(u, lg)
 
+# The differential operators above accumulate an independent contribution per
+# axis, so one pass over a slab covers every axis. The tensor-product operators
+# below -- interpolation, restriction and `tensor_product!` -- instead contract
+# their axes *sequentially*, applying the same matrix along one axis at a time,
+# so they fold over the axes rather than looping over them: each contraction
+# reads what the previous one wrote.
 
+"""
+    SlabReader(data)
 
+Reads node `ij` of one slab of `data`, in the form [`contract_axis!`](@ref)
+expects of its source. A callable struct rather than a closure so that the read
+is a method, and can therefore propagate `@inbounds` from its caller.
+"""
+struct SlabReader{D}
+    data::D
+end
+Base.@propagate_inbounds (reader::SlabReader)(ij) =
+    reader.data[slab_node_index(reader.data, ij)]
+
+"""
+    contract_axis!(dst, M, src, post, ::Val{d}, dims_out)
+
+Contract axis `d` with the matrix `M`, writing
+
+    dst[ij] = post(ij, ∑ₖ M[ij[d], k] * src(replace_index(ij, Val(d), k)))
+
+for every node `ij` in `CartesianIndices(dims_out)`, where the sum runs over the
+`size(M, 2)` nodes along axis `d` of the source. `src` reads one node of the
+source by Cartesian index (see [`SlabReader`](@ref) and [`TensorArg`](@ref)), so
+the source may be a slab of data or the argument of an operator, read through
+`get_node` without materialising a slab of it first. `post` rescales the
+contracted value; it is applied here rather than in a second pass over `dst` so
+that the arithmetic keeps the shape it had in the per-dimension methods this
+replaces. Whether a division sits inside or outside the accumulation loop can
+change which of the `muladd`s LLVM contracts into an `fma`, so moving it is not
+free of floating-point consequences even though it computes the same expression.
+"""
+Base.@propagate_inbounds function contract_axis!(
+    dst,
+    M,
+    src::S,
+    post::P,
+    vd,
+    dims_out,
+) where {S, P}
+    Nq_in = size(M, 2)
+    for ij in CartesianIndices(dims_out)
+        i = ij[axis_index(vd)]
+        r = M[i, 1] * src(replace_index(ij, vd, 1))
+        for k in 2:Nq_in
+            r = muladd(M[i, k], src(replace_index(ij, vd, k)), r)
+        end
+        dst[slab_node_index(dst, ij)] = post(ij, r)
+    end
+    return dst
+end
+
+# the `post` of a contraction whose result needs no rescaling
+@inline no_rescale(ij, r) = r
+
+"""
+    contract_axes!(dsts, axis_vals, M, src, post, dims_in)
+
+Contract every axis in `axis_vals` with the matrix `M`, one axis at a time,
+reading the first contraction's source from `src` and each later one from what the
+previous contraction wrote. `dims_in` is the shape of the source slab; each
+contraction shrinks (or grows) the extent of its own axis from `size(M, 2)` to
+`size(M, 1)`.
+
+`dsts` holds one destination per axis: the last contraction writes into
+`last(dsts)`, and the intermediate results go into the temporaries before it (see
+[`contract_temps`](@ref)), so that a single-axis contraction writes straight into
+the output with no temporary at all. `post` rescales the final result only, so
+only the last contraction applies it.
+"""
+Base.@propagate_inbounds contract_axes!(
+    dsts::Tuple{Any},
+    vds::Tuple{Val},
+    M,
+    src,
+    post,
+    dims_in,
+) = contract_axis!(
+    dsts[1],
+    M,
+    src,
+    post,
+    vds[1],
+    replace_index(dims_in, vds[1], size(M, 1)),
+)
+Base.@propagate_inbounds function contract_axes!(
+    dsts::Tuple,
+    vds::Tuple{Val, Vararg{Val}},
+    M,
+    src,
+    post,
+    dims_in,
+)
+    dims_out = replace_index(dims_in, vds[1], size(M, 1))
+    dst = contract_axis!(dsts[1], M, src, no_rescale, vds[1], dims_out)
+    return contract_axes!(
+        Base.tail(dsts),
+        Base.tail(vds),
+        M,
+        SlabReader(dst),
+        post,
+        dims_out,
+    )
+end
+
+"""
+    contract_temps(f, axis_vals)
+
+The temporaries that [`contract_axes!`](@ref) writes its intermediate results
+into: `f()`, once per axis except the last, since the last contraction writes
+straight into the output. Each temporary must be large enough for any
+intermediate extent, because an axis holds `size(M, 2)` nodes until it is
+contracted and `size(M, 1)` afterwards.
+"""
+@inline contract_temps(f::F, ::NTuple{N, Val}) where {F, N} =
+    ntuple(_ -> f(), Val(N - 1))
 
 
 
@@ -1236,67 +1375,6 @@ end
 Interpolate(space) = Interpolate{operator_axes(space), typeof(space)}(space)
 Interpolate{()}(space) = Interpolate{operator_axes(space), typeof(space)}(space)
 
-function apply_operator(op::Interpolate{(1,)}, space_out, slabidx, arg)
-    FT = Spaces.undertype(space_out)
-    space_in = axes(arg)
-    QS_in = Spaces.quadrature_style(space_in)
-    QS_out = Spaces.quadrature_style(space_out)
-    Nq_in = Quadratures.degrees_of_freedom(QS_in)
-    Nq_out = Quadratures.degrees_of_freedom(QS_out)
-    Imat = Quadratures.interpolation_matrix(FT, QS_out, QS_in)
-    RT = eltype(arg)
-    out = slab_data(RT, FT, Nq_out)
-    @inbounds for i in 1:Nq_out
-        # manually inlined rmatmul with slab_getnode
-        ij = CartesianIndex((1,))
-        r = Imat[i, 1] * get_node(space_in, arg, ij, slabidx)
-        for ii in 2:Nq_in
-            ij = CartesianIndex((ii,))
-            r = muladd(
-                Imat[i, ii],
-                get_node(space_in, arg, ij, slabidx),
-                r,
-            )
-        end
-        out[i] = r
-    end
-    return Field(immutable_slab_data(out), space_out)
-end
-
-function apply_operator(op::Interpolate{(1, 2)}, space_out, slabidx, arg)
-    FT = Spaces.undertype(space_out)
-    space_in = axes(arg)
-    QS_in = Spaces.quadrature_style(space_in)
-    QS_out = Spaces.quadrature_style(space_out)
-    Nq_in = Quadratures.degrees_of_freedom(QS_in)
-    Nq_out = Quadratures.degrees_of_freedom(QS_out)
-    Imat = Quadratures.interpolation_matrix(FT, QS_out, QS_in)
-    RT = eltype(arg)
-    # temporary storage
-    temp = slab_data(RT, FT, max(Nq_in, Nq_out), max(Nq_in, Nq_out))
-    out = slab_data(RT, FT, Nq_out, Nq_out)
-    @inbounds for j in 1:Nq_in, i in 1:Nq_out
-        # manually inlined rmatmul1 with slab get_node
-        # we do this to remove one allocated intermediate array
-        ij = CartesianIndex((1, j))
-        r = Imat[i, 1] * get_node(space_in, arg, ij, slabidx)
-        for ii in 2:Nq_in
-            ij = CartesianIndex((ii, j))
-            r = muladd(
-                Imat[i, ii],
-                get_node(space_in, arg, ij, slabidx),
-                r,
-            )
-        end
-        temp[1, i, j, 1] = r
-    end
-    @inbounds for j in 1:Nq_out, i in 1:Nq_out
-        out[1, i, j, 1] = rmatmul2(Imat, temp, i, j)
-    end
-    return Field(immutable_slab_data(out), space_out)
-end
-
-
 """
     r = Restrict(space)
     r.(f)
@@ -1326,170 +1404,191 @@ end
 Restrict(space) = Restrict{operator_axes(space), typeof(space)}(space)
 Restrict{()}(space) = Restrict{operator_axes(space), typeof(space)}(space)
 
-function apply_operator(op::Restrict{(1,)}, space_out, slabidx, arg)
+# Interpolation and restriction contract the same interpolation matrix along every
+# axis, so one implementation covers both, for any axis tuple `I`. They differ only
+# in three factors, in the same way that the strong and weak forms of the
+# differential operators differ in the `form_*` factors above: the matrix
+# contracted along each axis, whether the argument is weighted by the Jacobian
+# factor `WJ` of the input space, and whether the result is divided by the `WJ` of
+# the output space.
+
+"""
+    tensor_matrix(op, FT, QS_out, QS_in)
+
+The matrix that `op` contracts along each of its axes: the barycentric
+interpolation matrix from `QS_in` to `QS_out` for [`Interpolate`](@ref), and the
+transpose of the interpolation matrix from `QS_out` to `QS_in` for
+[`Restrict`](@ref).
+"""
+@inline tensor_matrix(::Interpolate, ::Type{FT}, QS_out, QS_in) where {FT} =
+    Quadratures.interpolation_matrix(FT, QS_out, QS_in)
+@inline tensor_matrix(::Restrict, ::Type{FT}, QS_out, QS_in) where {FT} =
+    Quadratures.interpolation_matrix(FT, QS_in, QS_out)' # transpose
+
+"""
+    tensor_weighted_arg(op, space_in, arg, ij, slabidx)
+
+The value of `arg` at node `ij`, weighted as `op` requires: unweighted for
+[`Interpolate`](@ref), and multiplied by the Jacobian factor `WJ` of the input
+space for [`Restrict`](@ref), which integrates its argument against the test
+functions of the output space.
+"""
+Base.@propagate_inbounds tensor_weighted_arg(
+    ::Interpolate,
+    space_in,
+    arg,
+    ij,
+    slabidx,
+) = get_node(space_in, arg, ij, slabidx)
+Base.@propagate_inbounds tensor_weighted_arg(
+    ::Restrict,
+    space_in,
+    arg,
+    ij,
+    slabidx,
+) =
+    get_local_geometry(space_in, ij, slabidx).WJ *
+    get_node(space_in, arg, ij, slabidx)
+
+"""
+    tensor_rescale(op, space_out, ij, slabidx, x)
+
+The result value `x` at node `ij`, with the weighting that `op` applied to its
+argument divided back out: `x` itself for [`Interpolate`](@ref), and
+`x / WJ` for [`Restrict`](@ref), whose ``(W^* J^*)^{-1}`` factor uses the
+Jacobian factor of the output space.
+"""
+Base.@propagate_inbounds tensor_rescale(::Interpolate, space_out, ij, slabidx, x) = x
+Base.@propagate_inbounds tensor_rescale(::Restrict, space_out, ij, slabidx, x) =
+    x / get_local_geometry(space_out, ij, slabidx).WJ
+
+"""
+    TensorArg(op, space_in, arg, slabidx)
+
+Reads node `ij` of the argument of a [`TensorOperator`](@ref), weighted as the
+operator requires (see [`tensor_weighted_arg`](@ref)), in the form
+[`contract_axis!`](@ref) expects of its source. Reading the argument this way is
+what lets the first contraction consume it directly, without materialising a slab
+of it first.
+"""
+struct TensorArg{O, S, A, SI}
+    op::O
+    space_in::S
+    arg::A
+    slabidx::SI
+end
+Base.@propagate_inbounds (a::TensorArg)(ij) =
+    tensor_weighted_arg(a.op, a.space_in, a.arg, ij, a.slabidx)
+
+"""
+    TensorRescale(op, space_out, slabidx)
+
+Divides the weighting that a [`TensorOperator`](@ref) applied to its argument back
+out of the value at node `ij` (see [`tensor_rescale`](@ref)), in the form
+[`contract_axis!`](@ref) expects of its `post`.
+"""
+struct TensorRescale{O, S, SI}
+    op::O
+    space_out::S
+    slabidx::SI
+end
+Base.@propagate_inbounds (p::TensorRescale)(ij, x) =
+    tensor_rescale(p.op, p.space_out, ij, p.slabidx, x)
+
+Base.@propagate_inbounds function apply_operator(
+    op::TensorOperator{I},
+    space_out,
+    slabidx,
+    arg,
+) where {I}
     FT = Spaces.undertype(space_out)
     space_in = axes(arg)
     QS_in = Spaces.quadrature_style(space_in)
     QS_out = Spaces.quadrature_style(space_out)
     Nq_in = Quadratures.degrees_of_freedom(QS_in)
     Nq_out = Quadratures.degrees_of_freedom(QS_out)
-    ImatT = Quadratures.interpolation_matrix(FT, QS_in, QS_out)' # transpose
+    M = tensor_matrix(op, FT, QS_out, QS_in)
     RT = eltype(arg)
-    out = slab_data(RT, FT, Nq_out)
-    @inbounds for i in 1:Nq_out
-        # manually inlined rmatmul with slab get_node
-        ij = CartesianIndex((1,))
-        WJ = get_local_geometry(space_in, ij, slabidx).WJ
-        r = ImatT[i, 1] * (WJ * get_node(space_in, arg, ij, slabidx))
-        for ii in 2:Nq_in
-            ij = CartesianIndex((ii,))
-            WJ = get_local_geometry(space_in, ij, slabidx).WJ
-            r = muladd(
-                ImatT[i, ii],
-                WJ * get_node(space_in, arg, ij, slabidx),
-                r,
-            )
-        end
-        ij_out = CartesianIndex((i,))
-        WJ_out = get_local_geometry(space_out, ij_out, slabidx).WJ
-        out[i] = r / WJ_out
+    vds = axis_vals(op)
+    out = slab_data(RT, FT, slab_dims(vds, Nq_out)...)
+    # temporary storage, sized for the largest intermediate extent
+    Nq_max = max(Nq_in, Nq_out)
+    temps = contract_temps(vds) do
+        slab_data(RT, FT, slab_dims(vds, Nq_max)...)
     end
+    @inbounds contract_axes!(
+        (temps..., out),
+        vds,
+        M,
+        TensorArg(op, space_in, arg, slabidx),
+        TensorRescale(op, space_out, slabidx),
+        slab_dims(vds, Nq_in),
+    )
     return Field(immutable_slab_data(out), space_out)
 end
 
-function apply_operator(op::Restrict{(1, 2)}, space_out, slabidx, arg)
-    FT = Spaces.undertype(space_out)
-    space_in = axes(arg)
-    QS_in = Spaces.quadrature_style(space_in)
-    QS_out = Spaces.quadrature_style(space_out)
-    Nq_in = Quadratures.degrees_of_freedom(QS_in)
-    Nq_out = Quadratures.degrees_of_freedom(QS_out)
-    ImatT = Quadratures.interpolation_matrix(FT, QS_in, QS_out)' # transpose
-    RT = eltype(arg)
-    # temporary storage
-    temp = slab_data(RT, FT, max(Nq_in, Nq_out), max(Nq_in, Nq_out))
-    out = slab_data(RT, FT, Nq_out, Nq_out)
-    @inbounds for j in 1:Nq_in, i in 1:Nq_out
-        # manually inlined rmatmul1 with slab get_node
-        ij = CartesianIndex((1, j))
-        WJ = get_local_geometry(space_in, ij, slabidx).WJ
-        r = ImatT[i, 1] * (WJ * get_node(space_in, arg, ij, slabidx))
-        for ii in 2:Nq_in
-            ij = CartesianIndex((ii, j))
-            WJ = get_local_geometry(space_in, ij, slabidx).WJ
-            r = muladd(
-                ImatT[i, ii],
-                WJ * get_node(space_in, arg, ij, slabidx),
-                r,
-            )
-        end
-        temp[1, i, j, 1] = r
-    end
-    @inbounds for j in 1:Nq_out, i in 1:Nq_out
-        ij_out = CartesianIndex((i, j))
-        WJ_out = get_local_geometry(space_out, ij_out, slabidx).WJ
-        out[1, i, j, 1] = rmatmul2(ImatT, temp, i, j) / WJ_out
-    end
-    return Field(immutable_slab_data(out), space_out)
-end
 
+"""
+    slab_axis_vals(data)
+
+The axes of one slab of `data`, as a tuple of `Val`s: just `(Val(1),)` for a
+layout with a single node along the second horizontal direction, and
+`(Val(1), Val(2))` otherwise.
+"""
+@inline slab_axis_vals(::DataLayouts.VIJHWithF{<:Any, <:Any, <:Any, 1}) = (Val(1),)
+@inline slab_axis_vals(::DataLayouts.VIJHWithF) = (Val(1), Val(2))
 
 """
     tensor_product!(out, in, M)
     tensor_product!(inout, M)
 
-Computes the tensor product `out = (M ⊗ M) * in` on each element.
+Computes the tensor product `out = (M ⊗ M) * in` on each element, contracting `M`
+along every axis of a slab of `in` (see [`contract_axes!`](@ref)). Unlike
+[`Interpolate`](@ref) this works on data directly rather than on fields, so it can
+write into the plotting layouts that drop a dimension
+([`DataLayouts.VIH1`](@ref) and [`DataLayouts.IH1JH2`](@ref)).
 """
 function tensor_product! end
 
 function tensor_product!(
     out::Union{
-        DataLayouts.VIJHWithF{S, Nv, Ni_out, 1},
+        DataLayouts.VIJHWithF{S, Nv, Ni_out},
         DataLayouts.VIH1{S, Nv, Ni_out},
+        DataLayouts.IH1JH2{S, Ni_out},
     },
-    indata::DataLayouts.VIJHWithF{S, Nv, Ni_in, 1},
+    indata::DataLayouts.VIJHWithF{S, Nv, Ni_in, Nj_in},
     M::SMatrix{Ni_out, Ni_in},
-) where {S, Nv, Ni_out, Ni_in}
+) where {S, Nv, Ni_in, Nj_in, Ni_out}
     Nh_in = DataLayouts.nelems(indata)
     Nh_out = DataLayouts.nelems(out)
     # TODO: assumes the same number of levels (horizontal only)
     @assert Nh_in == Nh_out
+    # the same M is contracted along every axis, so a slab with a second node axis
+    # has to be square, on the way in and on the way out
+    @assert Nj_in == 1 ||
+            (Nj_in == Ni_in && DataLayouts.shape_params(out).Nj == Ni_out)
+    # IH1JH2 keeps a single horizontal plane, so it can only take a single level
+    @assert Nv == 1 || !(out isa DataLayouts.IH1JH2)
+    vds = slab_axis_vals(indata)
+    dims_in = slab_dims(vds, Ni_in)
+    # temporary storage, sized for the largest intermediate extent
+    Nq_max = max(Ni_in, Ni_out)
+    temps = contract_temps(vds) do
+        MArray{Tuple{1, Nq_max, Nq_max, 1}, S, 4, Nq_max * Nq_max}(undef)
+    end
     @inbounds for h in 1:Nh_out, v in 1:Nv
         in_slab = slab(indata, v, h)
         out_slab = slab(out, v, h)
-        for i in 1:Ni_out
-            r = M[i, 1] * in_slab[1]
-            for ii in 2:Ni_in
-                r = muladd(M[i, ii], in_slab[ii], r)
-            end
-            out_slab[i] = r
-        end
+        contract_axes!(
+            (temps..., out_slab),
+            vds,
+            M,
+            SlabReader(in_slab),
+            no_rescale,
+            dims_in,
+        )
     end
     return out
-end
-
-function tensor_product!(
-    out::DataLayouts.VIJHWithF{S, 1, Nij_out, Nij_out},
-    indata::DataLayouts.VIJHWithF{S, 1, Nij_in, Nij_in},
-    M::SMatrix{Nij_out, Nij_in},
-) where {S, Nij_out, Nij_in}
-    Nh = size(indata, 4)
-    @assert Nh == size(out, 4)
-
-    # temporary storage
-    temp = MArray{Tuple{1, Nij_out, Nij_in, 1}, S, 4, Nij_out * Nij_in}(undef)
-
-    @inbounds for h in 1:Nh
-        in_slab = slab(indata, 1, h)
-        out_slab = slab(out, 1, h)
-        for j in 1:Nij_in, i in 1:Nij_out
-            temp[1, i, j, 1] = rmatmul1(M, in_slab, i, j)
-        end
-        for j in 1:Nij_out, i in 1:Nij_out
-            out_slab[1, i, j, 1] = rmatmul2(M, temp, i, j)
-        end
-    end
-    return out
-end
-
-function tensor_product!(
-    out::DataLayouts.IH1JH2{S, Nij_out, Nij_out},
-    indata::DataLayouts.VIJHWithF{S, 1, Nij_in, Nij_in},
-    M::SMatrix{Nij_out, Nij_in},
-) where {S, Nij_out, Nij_in}
-    Nh = DataLayouts.nelems(indata)
-    @assert Nh == DataLayouts.nelems(out)
-
-    # temporary storage
-    temp = MArray{Tuple{1, Nij_out, Nij_in, 1}, S, 4, Nij_out * Nij_in}(undef)
-
-    @inbounds for h in 1:Nh
-        in_slab = slab(indata, 1, h)
-        out_slab = slab(out, 1, h)
-        for j in 1:Nij_in, i in 1:Nij_out
-            temp[1, i, j, 1] = rmatmul1(M, in_slab, i, j)
-        end
-        for j in 1:Nij_out, i in 1:Nij_out
-            out_slab[i, j] = rmatmul2(M, temp, i, j)
-        end
-    end
-    return out
-end
-
-function tensor_product!(
-    out_slab::DataLayouts.VIJHWithF{S, 1, Nij_out, Nij_out, 1},
-    in_slab::DataLayouts.VIJHWithF{S, 1, Nij_in, Nij_in, 1},
-    M::SMatrix{Nij_out, Nij_in},
-) where {S, Nij_out, Nij_in}
-    # temporary storage
-    temp = MArray{Tuple{1, Nij_out, Nij_in, 1}, S, 4, Nij_out * Nij_in}(undef)
-    @inbounds for j in 1:Nij_in, i in 1:Nij_out
-        temp[1, i, j, 1] = rmatmul1(M, in_slab, i, j)
-    end
-    @inbounds for j in 1:Nij_out, i in 1:Nij_out
-        out_slab[1, i, j, 1] = rmatmul2(M, temp, i, j)
-    end
-    return out_slab
 end
 
 function tensor_product!(
@@ -1549,39 +1648,6 @@ Returns a 2D Matrix for plotting / visualizing 2D Fields.
 """
 matrix_interpolate(field::Field, Nu::Integer) =
     matrix_interpolate(field, Quadratures.Uniform{Nu}())
-
-"""
-    rmatmul1(W, S, i, j)
-
-Recursive matrix product along the 1st dimension of `S`. Equivalent to:
-
-    mapreduce(*, +, W[i,:], S[:,j])
-
-"""
-function rmatmul1(W, S, i, j)
-    Nq = size(W, 2)
-    @inbounds r = W[i, 1] * S[1, 1, j, 1]
-    @inbounds for ii in 2:Nq
-        r = muladd(W[i, ii], S[1, ii, j, 1], r)
-    end
-    return r
-end
-
-"""
-    rmatmul2(W, S, i, j)
-
-Recursive matrix product along the 2nd dimension `S`. Equivalent to:
-
-    mapreduce(*, +, W[j,:], S[i, :])
-"""
-function rmatmul2(W, S, i, j)
-    Nq = size(W, 2)
-    @inbounds r = W[j, 1] * S[1, i, 1, 1]
-    @inbounds for jj in 2:Nq
-        r = muladd(W[j, jj], S[1, i, jj, 1], r)
-    end
-    return r
-end
 
 function apply_operator(
     op::SpectralElementOperator{()},

--- a/src/Operators/spectralelement.jl
+++ b/src/Operators/spectralelement.jl
@@ -750,39 +750,6 @@ The `d`th contravariant (``u^d``) or covariant (``u_d``) component of `u`.
 @inline covariant(::Val{2}, u, lg) = Geometry.covariant2(u, lg)
 @inline covariant(::Val{3}, u, lg) = Geometry.covariant3(u, lg)
 
-"""
-    covariant_components(op)
-
-The covariant components (the axis of a covariant vector) over the axes that `op`
-works over, e.g. `Covariant12Axis()` for axes `(1, 2)`.
-"""
-@inline covariant_components(::SpectralElementOperator{I}) where {I} =
-    Geometry.Components{Geometry.Covariant, I}()
-
-"""
-    covariant_vector(op, components)
-
-A covariant vector over the axes that `op` works over, with the given
-`components`, e.g. `Covariant12Vector(components...)` for axes `(1, 2)`.
-"""
-@inline covariant_vector(op::SpectralElementOperator, components::Tuple) =
-    Geometry.Tensor(SVector(components), (covariant_components(op),))
-
-"""
-    covariant_basis_vector(op, ::Val{d}, c)
-
-`c` times the `d`th covariant basis vector of the axes that `op` works over,
-e.g. `Covariant12Vector(0, c)` for axes `(1, 2)` and `d = 2`.
-"""
-@inline covariant_basis_vector(
-    op::SpectralElementOperator{I},
-    ::Val{d},
-    c,
-) where {I, d} = covariant_vector(
-    op,
-    ntuple(n -> I[n] == d ? c : zero(c), Val(length(I))),
-)
-
 
 
 
@@ -1080,8 +1047,8 @@ Base.@propagate_inbounds function apply_operator(
                 i = ij[axis_index(vd)]
                 for k in 1:Nq
                     ∂f∂ξᵈ =
-                        covariant_basis_vector(
-                            op,
+                        Geometry.covariant_basis_vector(
+                            Val(I),
                             vd,
                             form_deriv_entry(form, D, k, i),
                         ) ⊗ x

--- a/src/Operators/spectralelement.jl
+++ b/src/Operators/spectralelement.jl
@@ -52,19 +52,24 @@ operator_axes(space::Spaces.ExtrudedFiniteDifferenceSpace) =
     operator_axes(Spaces.horizontal_space(space))
 
 
-function node_indices(space::Spaces.SpectralElementSpace1D)
-    QS = Spaces.quadrature_style(space)
-    Nq = Quadratures.degrees_of_freedom(QS)
-    CartesianIndices((Nq,))
-end
-function node_indices(space::Spaces.SpectralElementSpace2D)
-    QS = Spaces.quadrature_style(space)
-    Nq = Quadratures.degrees_of_freedom(QS)
-    CartesianIndices((Nq, Nq))
-end
-node_indices(space::Spaces.ExtrudedFiniteDifferenceSpace) =
-    node_indices(Spaces.horizontal_space(space))
+"""
+    node_indices(space)
 
+The indices of the nodes in one slab of `space`: `Nq` of them along each axis that
+an operator on `space` works over (see [`operator_axes`](@ref)).
+"""
+function node_indices(
+    space::Union{
+        Spaces.AbstractSpectralElementSpace,
+        Spaces.ExtrudedFiniteDifferenceSpace,
+    },
+)
+    QS = Spaces.quadrature_style(space)
+    Nq = Quadratures.degrees_of_freedom(QS)
+    return CartesianIndices(ntuple(_ -> Nq, Val(length(operator_axes(space)))))
+end
+
+# `operator_axes` is empty here, but a slab still holds the one node of a column
 node_indices(space::Spaces.FiniteDifferenceSpace) = CartesianIndices((1,))
 
 
@@ -454,49 +459,55 @@ Base.@propagate_inbounds function get_node(
 )
     scalar[1]
 end
-Base.@propagate_inbounds function get_node(
-    parent_space,
-    field::Fields.Field,
-    ij::CartesianIndex{1},
-    slabidx,
-)
-    space = reconstruct_placeholder_space(axes(field), parent_space)
-    i, = Tuple(ij)
+"""
+    data_index(ij, v, h)
+
+Index of node `ij` at level `v` of element `h` in a four-index data layout. A node
+index has one component per axis that an operator works over (see
+[`operator_axes`](@ref)), so the axes it leaves out are indexed at 1 -- the only
+node those layouts store along them.
+"""
+@inline data_index(ij::CartesianIndex{N}, v, h) where {N} =
+    CartesianIndex(v, ntuple(d -> d <= N ? ij[d] : 1, Val(2))..., h)
+
+"""
+    slab_level_index(space, slabidx)
+
+The level at which the slab `slabidx` reads `space`: `slabidx.v` for center
+spaces, staggered by [`half`](@ref) for face spaces, and level 1 for the
+horizontal spaces whose slab index carries no level at all (`slabidx.v ===
+nothing`).
+
+The staggering of `space` has to be known, so an unrecognised space is an error
+rather than a silent read of level `slabidx.v`. Both the one- and the
+two-dimensional node accessors used to inline this logic, but only the
+one-dimensional ones handled a bare `FiniteDifferenceSpace`; that is deliberate
+here, since a horizontal operator applied to an extracted column space reaches
+these accessors with a one-dimensional node index over such a space.
+"""
+@inline function slab_level_index(space, slabidx)
     if space isa Spaces.FaceExtrudedFiniteDifferenceSpace ||
        space isa Spaces.FaceFiniteDifferenceSpace
         _v = slabidx.v + half
     elseif space isa Spaces.CenterExtrudedFiniteDifferenceSpace ||
-           space isa Spaces.AbstractSpectralElementSpace ||
-           space isa Spaces.CenterFiniteDifferenceSpace
-        _v = slabidx.v
-    else
-        error("invalid space")
-    end
-    h = slabidx.h
-    fv = Fields.field_values(field)
-    v = isnothing(_v) ? 1 : _v
-    return fv[v, i, 1, h]
-end
-Base.@propagate_inbounds function get_node(
-    parent_space,
-    field::Fields.Field,
-    ij::CartesianIndex{2},
-    slabidx,
-)
-    space = reconstruct_placeholder_space(axes(field), parent_space)
-    i, j = Tuple(ij)
-    if space isa Spaces.FaceExtrudedFiniteDifferenceSpace
-        _v = slabidx.v + half
-    elseif space isa Spaces.CenterExtrudedFiniteDifferenceSpace ||
+           space isa Spaces.CenterFiniteDifferenceSpace ||
            space isa Spaces.AbstractSpectralElementSpace
         _v = slabidx.v
     else
         error("invalid space")
     end
-    h = slabidx.h
+    return isnothing(_v) ? 1 : _v
+end
+
+Base.@propagate_inbounds function get_node(
+    parent_space,
+    field::Fields.Field,
+    ij::CartesianIndex,
+    slabidx,
+)
+    space = reconstruct_placeholder_space(axes(field), parent_space)
     fv = Fields.field_values(field)
-    v = isnothing(_v) ? 1 : _v
-    return fv[v, i, j, h]
+    return fv[data_index(ij, slab_level_index(space, slabidx), slabidx.h)]
 end
 
 
@@ -536,9 +547,7 @@ end
     DataLayouts.rebuild(data, SArray(parent(data)))
 
 # Index for one node in a slab of data, with v = h = 1.
-@inline slab_node_index(ij::CartesianIndex{1}) = CartesianIndex(1, ij[1], 1, 1)
-@inline slab_node_index(ij::CartesianIndex{2}) =
-    CartesianIndex(1, ij[1], ij[2], 1)
+@inline slab_node_index(ij::CartesianIndex) = data_index(ij, 1, 1)
 
 """
     slab_node_index(data, ij)
@@ -559,15 +568,7 @@ end
 Base.@propagate_inbounds function get_node(
     space,
     field::Fields.Field{<:SlabData},
-    ij::CartesianIndex{1},
-    slabidx,
-)
-    Fields.field_values(field)[slab_node_index(ij)]
-end
-Base.@propagate_inbounds function get_node(
-    space,
-    field::Fields.Field{<:SlabData},
-    ij::CartesianIndex{2},
+    ij::CartesianIndex,
     slabidx,
 )
     Fields.field_values(field)[slab_node_index(ij)]
@@ -591,76 +592,22 @@ Base.@propagate_inbounds function get_local_geometry(
         Spaces.AbstractSpectralElementSpace,
         Spaces.ExtrudedFiniteDifferenceSpace,
     },
-    ij::CartesianIndex{1},
+    ij::CartesianIndex,
     slabidx,
 )
-    i, = Tuple(ij)
-    h = slabidx.h
-    if space isa Spaces.FaceExtrudedFiniteDifferenceSpace
-        _v = slabidx.v + half
-    else
-        _v = slabidx.v
-    end
     lgd = Spaces.local_geometry_data(space)
-    v = isnothing(_v) ? 1 : _v
-    return lgd[v, i, 1, h]
-end
-Base.@propagate_inbounds function get_local_geometry(
-    space::Union{
-        Spaces.AbstractSpectralElementSpace,
-        Spaces.ExtrudedFiniteDifferenceSpace,
-    },
-    ij::CartesianIndex{2},
-    slabidx,
-)
-    i, j = Tuple(ij)
-    h = slabidx.h
-    if space isa Spaces.FaceExtrudedFiniteDifferenceSpace
-        _v = slabidx.v + half
-    else
-        _v = slabidx.v
-    end
-    v = isnothing(_v) ? 1 : _v
-    lgd = Spaces.local_geometry_data(space)
-    return lgd[v, i, j, h]
+    return lgd[data_index(ij, slab_level_index(space, slabidx), slabidx.h)]
 end
 
 Base.@propagate_inbounds function set_node!(
     space,
     field::Fields.Field,
-    ij::CartesianIndex{1},
+    ij::CartesianIndex,
     slabidx,
     val,
 )
-    i, = Tuple(ij)
-    if space isa Spaces.FaceExtrudedFiniteDifferenceSpace ||
-       space isa Spaces.FaceFiniteDifferenceSpace
-        _v = slabidx.v + half
-    else
-        _v = slabidx.v
-    end
-    h = slabidx.h
     fv = Fields.field_values(field)
-    v = isnothing(_v) ? 1 : _v
-    fv[v, i, 1, h] = val
-end
-Base.@propagate_inbounds function set_node!(
-    space,
-    field::Fields.Field,
-    ij::CartesianIndex{2},
-    slabidx,
-    val,
-)
-    i, j = Tuple(ij)
-    if space isa Spaces.FaceExtrudedFiniteDifferenceSpace
-        _v = slabidx.v + half
-    else
-        _v = slabidx.v
-    end
-    h = slabidx.h
-    fv = Fields.field_values(field)
-    v = isnothing(_v) ? 1 : _v
-    fv[v, i, j, h] = val
+    fv[data_index(ij, slab_level_index(space, slabidx), slabidx.h)] = val
 end
 
 Base.Broadcast.BroadcastStyle(

--- a/src/Operators/spectralelement.jl
+++ b/src/Operators/spectralelement.jl
@@ -1,4 +1,4 @@
-import UnrolledUtilities: unrolled_map
+import UnrolledUtilities: unrolled_map, unrolled_foreach, unrolled_any
 import ..Utilities.Unrolled: unrolled_map_with_inbounds
 
 abstract type AbstractSpectralStyle <: Fields.AbstractFieldStyle end
@@ -659,6 +659,103 @@ Base.Broadcast.BroadcastStyle(
 ) = style
 
 
+##### Dimension-generic building blocks
+#
+# The operators below are tensor-product operators: each applies the same
+# one-dimensional stencil along every axis it works over, accumulating the
+# per-axis contributions. Together with the `FormType` helpers above -- which
+# absorb the differences between an operator's strong and weak variants -- these
+# let one implementation cover any axis tuple `I` (`(1,)` on a
+# `SpectralElementSpace1D`, `(1, 2)` on a `SpectralElementSpace2D`), keeping each
+# axis index in the type domain so that the loop over axes unrolls and the node
+# indices stay statically sized.
+#
+# The per-axis closures below carry two annotations that matter for performance:
+# `@inline`, because the mutable slab temporary they write to would otherwise
+# escape and be heap-allocated once per slab, and `@inbounds`, which a closure
+# body does not inherit from the enclosing `@inbounds` block.
+
+"""
+    axis_vals(op)
+
+Tuple of `Val{d}` for each axis index `d` that `op` works over, e.g.
+`(Val(1), Val(2))`. Iterating over this with `unrolled_foreach`/`unrolled_map`
+unrolls the loop over axes and keeps `d` available as a type parameter.
+"""
+@inline axis_vals(::SpectralElementOperator{I}) where {I} = unrolled_map(Val, I)
+
+"""
+    axis_index(::Val{d})
+
+The axis index `d` itself: `ij[axis_index(vd)]` is the node index along axis `d`.
+"""
+@inline axis_index(::Val{d}) where {d} = d
+
+"""
+    slab_dims(op, Nq)
+
+The shape of one slab of nodes for `op`: `Nq` repeated once per axis it works
+over.
+"""
+@inline slab_dims(::SpectralElementOperator{I}, Nq) where {I} =
+    ntuple(_ -> Nq, Val(length(I)))
+
+"""
+    replace_index(index, ::Val{d}, k)
+
+The Cartesian `index` with its `d`th component replaced by `k`. Used to walk
+along one axis of a slab while holding the other axes fixed.
+"""
+@inline replace_index(index::CartesianIndex{N}, ::Val{d}, k) where {N, d} =
+    CartesianIndex(ntuple(n -> n == d ? k : index[n], Val(N)))
+
+"""
+    contravariant(::Val{d}, u, local_geometry)
+    covariant(::Val{d}, u, local_geometry)
+
+The `d`th contravariant (``u^d``) or covariant (``u_d``) component of `u`.
+"""
+@inline contravariant(::Val{1}, u, lg) = Geometry.contravariant1(u, lg)
+@inline contravariant(::Val{2}, u, lg) = Geometry.contravariant2(u, lg)
+@inline contravariant(::Val{3}, u, lg) = Geometry.contravariant3(u, lg)
+@inline covariant(::Val{1}, u, lg) = Geometry.covariant1(u, lg)
+@inline covariant(::Val{2}, u, lg) = Geometry.covariant2(u, lg)
+@inline covariant(::Val{3}, u, lg) = Geometry.covariant3(u, lg)
+
+"""
+    covariant_components(op)
+
+The covariant components (the axis of a covariant vector) over the axes that `op`
+works over, e.g. `Covariant12Axis()` for axes `(1, 2)`.
+"""
+@inline covariant_components(::SpectralElementOperator{I}) where {I} =
+    Geometry.Components{Geometry.Covariant, I}()
+
+"""
+    covariant_vector(op, components)
+
+A covariant vector over the axes that `op` works over, with the given
+`components`, e.g. `Covariant12Vector(components...)` for axes `(1, 2)`.
+"""
+@inline covariant_vector(op::SpectralElementOperator, components::Tuple) =
+    Geometry.Tensor(SVector(components), (covariant_components(op),))
+
+"""
+    covariant_basis_vector(op, ::Val{d}, c)
+
+`c` times the `d`th covariant basis vector of the axes that `op` works over,
+e.g. `Covariant12Vector(0, c)` for axes `(1, 2)` and `d = 2`.
+"""
+@inline covariant_basis_vector(
+    op::SpectralElementOperator{I},
+    ::Val{d},
+    c,
+) where {I, d} = covariant_vector(
+    op,
+    ntuple(n -> I[n] == d ? c : zero(c), Val(length(I))),
+)
+
+
 
 
 
@@ -704,41 +801,12 @@ operator_return_eltype(op::Divergence{I}, ::Type{S}) where {I, S} =
 # -(WJ)⁻¹ ∑ᵢ Dᵢᵀ (WJ uⁱ); see form_deriv_entry, form_jacobian, and
 # form_jacobian_rescale for the form-dependent factors.
 
-function apply_operator(op::Divergence{(1,), F}, space, slabidx, arg) where {F}
-    form = F()
-    FT = Spaces.undertype(space)
-    QS = Spaces.quadrature_style(space)
-    Nq = Quadratures.degrees_of_freedom(QS)
-    D = Quadratures.differentiation_matrix(FT, QS)
-    # allocate temp output
-    RT = operator_return_eltype(op, eltype(arg))
-    out = slab_data(RT, FT, Nq)
-    fill!(parent(out), zero(FT))
-    @inbounds for i in 1:Nq
-        ij = CartesianIndex((i,))
-        local_geometry = get_local_geometry(space, ij, slabidx)
-        v = get_node(space, arg, ij, slabidx)
-        Jv¹ =
-            form_jacobian(form, local_geometry) *
-            Geometry.contravariant1(v, local_geometry)
-        for ii in 1:Nq
-            out[ii] += form_deriv_entry(form, D, ii, i) * Jv¹
-        end
-    end
-    @inbounds for i in 1:Nq
-        ij = CartesianIndex((i,))
-        local_geometry = get_local_geometry(space, ij, slabidx)
-        out[i] = form_jacobian_rescale(form, local_geometry, out[i])
-    end
-    return Field(immutable_slab_data(out), space)
-end
-
 Base.@propagate_inbounds function apply_operator(
-    op::Divergence{(1, 2), F},
+    op::Divergence{I, F},
     space,
     slabidx,
     arg,
-) where {F}
+) where {I, F}
     form = F()
     FT = Spaces.undertype(space)
     QS = Spaces.quadrature_style(space)
@@ -746,29 +814,29 @@ Base.@propagate_inbounds function apply_operator(
     D = Quadratures.differentiation_matrix(FT, QS)
     # allocate temp output
     RT = operator_return_eltype(op, eltype(arg))
-    out = slab_data(RT, FT, Nq, Nq)
+    out = slab_data(RT, FT, slab_dims(op, Nq)...)
     fill!(parent(out), zero(FT))
-    @inbounds for j in 1:Nq, i in 1:Nq
-        ij = CartesianIndex((i, j))
+    @inbounds for ij in node_indices(space)
         local_geometry = get_local_geometry(space, ij, slabidx)
         v = get_node(space, arg, ij, slabidx)
-        Jv¹ =
-            form_jacobian(form, local_geometry) *
-            Geometry.contravariant1(v, local_geometry)
-        for ii in 1:Nq
-            out[1, ii, j, 1] += form_deriv_entry(form, D, ii, i) * Jv¹
-        end
-        Jv² =
-            form_jacobian(form, local_geometry) *
-            Geometry.contravariant2(v, local_geometry)
-        for jj in 1:Nq
-            out[1, i, jj, 1] += form_deriv_entry(form, D, jj, j) * Jv²
+        unrolled_foreach(axis_vals(op)) do vd
+            @inline # `out` heap-allocates per slab if this closure is not inlined
+            @inbounds begin
+                i = ij[axis_index(vd)]
+                Jvᵈ =
+                    form_jacobian(form, local_geometry) *
+                    contravariant(vd, v, local_geometry)
+                for k in 1:Nq
+                    out[slab_node_index(replace_index(ij, vd, k))] +=
+                        form_deriv_entry(form, D, k, i) * Jvᵈ
+                end
+            end
         end
     end
-    @inbounds for j in 1:Nq, i in 1:Nq
-        ij = CartesianIndex((i, j))
+    @inbounds for ij in node_indices(space)
         local_geometry = get_local_geometry(space, ij, slabidx)
-        out[1, i, j, 1] = form_jacobian_rescale(form, local_geometry, out[1, i, j, 1])
+        node = slab_node_index(ij)
+        out[node] = form_jacobian_rescale(form, local_geometry, out[node])
     end
     return Field(immutable_slab_data(out), space)
 end
@@ -868,91 +936,57 @@ operator_return_eltype(
 ) where {I, S1, S2} =
     Geometry.mul_return_type(Geometry.divergence_result_type(S1), S2)
 
-function apply_operator(op::SplitDivergence{(1,)}, space, slabidx, arg1, arg2)
+Base.@propagate_inbounds function apply_operator(
+    op::SplitDivergence{I},
+    space,
+    slabidx,
+    arg1,
+    arg2,
+) where {I}
     FT = Spaces.undertype(space)
     QS = Spaces.quadrature_style(space)
     Nq = Quadratures.degrees_of_freedom(QS)
     D = Quadratures.differentiation_matrix(FT, QS)
     JT = operator_return_eltype(op, eltype(arg1), FT)
     RT = operator_return_eltype(op, eltype(arg1), eltype(arg2))
+    dims = slab_dims(op, Nq)
 
-    Ju1 = slab_data(JT, FT, Nq)
-    psi = slab_data(eltype(arg2), eltype(arg2), Nq)
-    @inbounds for i in 1:Nq
-        ij = CartesianIndex((i,))
+    # `Ju[d]` is the mass flux along axis `d`; `psi` is the advected scalar
+    Ju = unrolled_map(_ -> slab_data(JT, FT, dims...), axis_vals(op))
+    psi = slab_data(eltype(arg2), eltype(arg2), dims...)
+    @inbounds for ij in node_indices(space)
+        node = slab_node_index(ij)
         local_geometry = get_local_geometry(space, ij, slabidx)
         u = get_node(space, arg1, ij, slabidx)
-        Ju1[i] =
-            local_geometry.J * Geometry.contravariant1(u, local_geometry)
-        psi[i] = get_node(space, arg2, ij, slabidx)
+        unrolled_foreach(axis_vals(op)) do vd
+            @inline # `Ju` heap-allocates per slab if this closure is not inlined
+            @inbounds Ju[axis_index(vd)][node] =
+                local_geometry.J * contravariant(vd, u, local_geometry)
+        end
+        psi[node] = get_node(space, arg2, ij, slabidx)
     end
 
-    out = slab_data(RT, FT, Nq)
+    out = slab_data(RT, FT, dims...)
     fill!(parent(out), zero(FT))
-    @inbounds for i in 1:Nq
-        for j in 1:(i - 1) # loop over half the indices, since F1[i,j] = F1[j,i]
-            F1 = (Ju1[i] + Ju1[j]) * (psi[i] + psi[j]) / 2
-            out[i] += D[i, j] * F1
-            out[j] += D[j, i] * F1
+    @inbounds for ij in node_indices(space)
+        node = slab_node_index(ij)
+        unrolled_foreach(axis_vals(op)) do vd
+            @inline # `out` heap-allocates per slab if this closure is not inlined
+            @inbounds begin
+                i = ij[axis_index(vd)]
+                Juᵈ = Ju[axis_index(vd)]
+                for k in 1:(i - 1) # loop over half the indices, since F[i,k] = F[k,i]
+                    node_k = slab_node_index(replace_index(ij, vd, k))
+                    F = ((Juᵈ[node] + Juᵈ[node_k]) * (psi[node] + psi[node_k])) / 2
+                    out[node] += D[i, k] * F
+                    out[node_k] += D[k, i] * F
+                end
+            end
         end
     end
-    @inbounds for i in 1:Nq
-        ij = CartesianIndex((i,))
+    @inbounds for ij in node_indices(space)
         local_geometry = get_local_geometry(space, ij, slabidx)
-        out[i] *= local_geometry.invJ
-    end
-
-    return Field(immutable_slab_data(out), space)
-end
-
-function apply_operator(op::SplitDivergence{(1, 2)}, space, slabidx, arg1, arg2)
-    FT = Spaces.undertype(space)
-    QS = Spaces.quadrature_style(space)
-    Nq = Quadratures.degrees_of_freedom(QS)
-    D = Quadratures.differentiation_matrix(FT, QS)
-    JT = operator_return_eltype(op, eltype(arg1), FT)
-    RT = operator_return_eltype(op, eltype(arg1), eltype(arg2))
-
-    Ju1 = slab_data(JT, FT, Nq, Nq)
-    Ju2 = slab_data(JT, FT, Nq, Nq)
-    psi = slab_data(eltype(arg2), eltype(arg2), Nq, Nq)
-    @inbounds for j in 1:Nq, i in 1:Nq
-        ij = CartesianIndex((i, j))
-        local_geometry = get_local_geometry(space, ij, slabidx)
-        u = get_node(space, arg1, ij, slabidx)
-        Ju1[1, i, j, 1] =
-            local_geometry.J * Geometry.contravariant1(u, local_geometry)
-        Ju2[1, i, j, 1] =
-            local_geometry.J * Geometry.contravariant2(u, local_geometry)
-        psi[1, i, j, 1] = get_node(space, arg2, ij, slabidx)
-    end
-
-    out = slab_data(RT, FT, Nq, Nq)
-    fill!(parent(out), zero(FT))
-    @inbounds for j in 1:Nq, i in 1:Nq
-        for k in 1:(i - 1) # loop over half the indices, since F1[i,k] = F1[k,i]
-            F1 =
-                (
-                    (Ju1[1, i, j, 1] + Ju1[1, k, j, 1]) *
-                    (psi[1, i, j, 1] + psi[1, k, j, 1])
-                ) / 2
-            out[1, i, j, 1] += D[i, k] * F1
-            out[1, k, j, 1] += D[k, i] * F1
-        end
-        for k in 1:(j - 1) # loop over half the indices, since F2[j,k] = F2[k,j]
-            F2 =
-                (
-                    (Ju2[1, i, j, 1] + Ju2[1, i, k, 1]) *
-                    (psi[1, i, j, 1] + psi[1, i, k, 1])
-                ) / 2
-            out[1, i, j, 1] += D[j, k] * F2
-            out[1, i, k, 1] += D[k, j] * F2
-        end
-    end
-    @inbounds for j in 1:Nq, i in 1:Nq
-        ij = CartesianIndex((i, j))
-        local_geometry = get_local_geometry(space, ij, slabidx)
-        out[1, i, j, 1] *= local_geometry.invJ
+        out[slab_node_index(ij)] *= local_geometry.invJ
     end
 
     return Field(immutable_slab_data(out), space)
@@ -994,43 +1028,12 @@ operator_return_eltype(::Gradient{I}, ::Type{S}) where {I, S} =
 # the weak form needs the final W⁻¹ rescale, which stays inlined in each
 # apply_operator so that the strong form can skip that loop entirely.
 
-function apply_operator(op::Gradient{(1,), F}, space, slabidx, arg) where {F}
-    form = F()
-    FT = Spaces.undertype(space)
-    QS = Spaces.quadrature_style(space)
-    Nq = Quadratures.degrees_of_freedom(QS)
-    D = Quadratures.differentiation_matrix(FT, QS)
-    # allocate temp output
-    RT = operator_return_eltype(op, eltype(arg))
-    out = slab_data(RT, FT, Nq)
-    fill!(parent(out), zero(FT))
-    @inbounds for i in 1:Nq
-        ij = CartesianIndex((i,))
-        local_geometry = get_local_geometry(space, ij, slabidx)
-        x = form_weighted_arg(form, local_geometry, get_node(space, arg, ij, slabidx))
-        for ii in 1:Nq
-            ∂f∂ξ =
-                Geometry.Covariant1Vector(form_deriv_entry(form, D, ii, i)) ⊗ x
-            out[ii] += ∂f∂ξ
-        end
-    end
-    if F === WeakForm
-        @inbounds for i in 1:Nq
-            ij = CartesianIndex((i,))
-            local_geometry = get_local_geometry(space, ij, slabidx)
-            W = local_geometry.WJ * local_geometry.invJ
-            out[i] /= W
-        end
-    end
-    return Field(immutable_slab_data(out), space)
-end
-
 Base.@propagate_inbounds function apply_operator(
-    op::Gradient{(1, 2), F},
+    op::Gradient{I, F},
     space,
     slabidx,
     arg,
-) where {F}
+) where {I, F}
     form = F()
     FT = Spaces.undertype(space)
     QS = Spaces.quadrature_style(space)
@@ -1038,42 +1041,86 @@ Base.@propagate_inbounds function apply_operator(
     D = Quadratures.differentiation_matrix(FT, QS)
     # allocate temp output
     RT = operator_return_eltype(op, eltype(arg))
-    out = slab_data(RT, FT, Nq, Nq)
+    out = slab_data(RT, FT, slab_dims(op, Nq)...)
     fill!(parent(out), zero(FT))
-
-    @inbounds for j in 1:Nq, i in 1:Nq
-        ij = CartesianIndex((i, j))
+    @inbounds for ij in node_indices(space)
         local_geometry = get_local_geometry(space, ij, slabidx)
         x = form_weighted_arg(form, local_geometry, get_node(space, arg, ij, slabidx))
-        for ii in 1:Nq
-            ∂f∂ξ₁ =
-                Geometry.Covariant12Vector(
-                    form_deriv_entry(form, D, ii, i),
-                    zero(eltype(D)),
-                ) ⊗ x
-            out[1, ii, j, 1] += ∂f∂ξ₁
-        end
-        for jj in 1:Nq
-            ∂f∂ξ₂ =
-                Geometry.Covariant12Vector(
-                    zero(eltype(D)),
-                    form_deriv_entry(form, D, jj, j),
-                ) ⊗ x
-            out[1, i, jj, 1] += ∂f∂ξ₂
+        unrolled_foreach(axis_vals(op)) do vd
+            @inline # `out` heap-allocates per slab if this closure is not inlined
+            @inbounds begin
+                i = ij[axis_index(vd)]
+                for k in 1:Nq
+                    ∂f∂ξᵈ =
+                        covariant_basis_vector(
+                            op,
+                            vd,
+                            form_deriv_entry(form, D, k, i),
+                        ) ⊗ x
+                    out[slab_node_index(replace_index(ij, vd, k))] += ∂f∂ξᵈ
+                end
+            end
         end
     end
+    # the weak form weights its argument by W without a Jacobian factor to divide
+    # out, so it alone needs this pass; see form_weight_rescale
     if F === WeakForm
-        @inbounds for j in 1:Nq, i in 1:Nq
-            ij = CartesianIndex((i, j))
+        @inbounds for ij in node_indices(space)
             local_geometry = get_local_geometry(space, ij, slabidx)
             W = local_geometry.WJ * local_geometry.invJ
-            out[1, i, j, 1] /= W
+            out[slab_node_index(ij)] /= W
         end
     end
     return Field(immutable_slab_data(out), space)
 end
 
 abstract type CurlSpectralElementOperator{I} <: SpectralElementOperator{I} end
+
+"""
+    curl_uses_component(op, ::Val{k})
+
+Whether a curl over the operator's axes uses the `k`th covariant component of its
+argument. Since ``ε^{i d k}`` vanishes unless `k ≠ d`, axis `d` never uses the
+`d`th component: a curl over `(1,)` needs only ``u_2`` and ``u_3``, while a curl
+over `(1, 2)` needs all three.
+"""
+@inline curl_uses_component(
+    ::CurlSpectralElementOperator{I},
+    ::Val{k},
+) where {I, k} = unrolled_any(!=(k), I)
+
+"""
+    curl_covariant_components(op, form, u, local_geometry)
+
+The covariant components of `u` as a 3-tuple, weighted as the `form` requires
+(see [`form_weighted_arg`](@ref)), with `nothing` in place of the components that
+a curl over the operator's axes does not use (see [`curl_uses_component`](@ref)).
+"""
+@inline curl_covariant_components(
+    op::CurlSpectralElementOperator,
+    form,
+    u,
+    lg,
+) =
+    unrolled_map((Val(1), Val(2), Val(3))) do vk
+        curl_uses_component(op, vk) ?
+        form_weighted_arg(form, lg, covariant(vk, u, lg)) : nothing
+    end
+
+"""
+    curl_term(::Val{d}, c, u)
+
+The contribution of axis `d` to a curl, ``ε^{i d k} c u_k``, where `u` holds the
+covariant components of the argument (as returned by
+[`curl_covariant_components`](@ref)) and `c` scales the derivative along axis
+`d`. This is `c * (eᵈ × u)`, so only the components `k ≠ d` are read and the
+others may be `nothing`. The weak form needs no separate expression: its sign
+flip comes from `c` (see [`form_deriv_entry`](@ref)).
+"""
+@inline curl_term(::Val{1}, c, u) =
+    Geometry.Contravariant123Vector(zero(c), -(c * u[3]), c * u[2])
+@inline curl_term(::Val{2}, c, u) =
+    Geometry.Contravariant123Vector(c * u[3], zero(c), -(c * u[1]))
 
 """
     curl = Curl()
@@ -1129,7 +1176,12 @@ operator_return_eltype(::Curl{I}, ::Type{S}) where {I, S} =
 # -εⁱʲᵏ (WJ)⁻¹ Dⱼᵀ (W uₖ); see form_deriv_entry, form_weighted_arg, and
 # form_jacobian_rescale for the form-dependent factors.
 
-function apply_operator(op::Curl{(1,), F}, space, slabidx, arg) where {F}
+Base.@propagate_inbounds function apply_operator(
+    op::Curl{I, F},
+    space,
+    slabidx,
+    arg,
+) where {I, F}
     form = F()
     FT = Spaces.undertype(space)
     QS = Spaces.quadrature_style(space)
@@ -1137,83 +1189,27 @@ function apply_operator(op::Curl{(1,), F}, space, slabidx, arg) where {F}
     D = Quadratures.differentiation_matrix(FT, QS)
     # allocate temp output
     RT = operator_return_eltype(op, eltype(arg))
-    out = slab_data(RT, FT, Nq)
+    out = slab_data(RT, FT, slab_dims(op, Nq)...)
     fill!(parent(out), zero(FT))
-    @inbounds for i in 1:Nq
-        ij = CartesianIndex((i,))
+    @inbounds for ij in node_indices(space)
         local_geometry = get_local_geometry(space, ij, slabidx)
         v = get_node(space, arg, ij, slabidx)
-        v₂ = form_weighted_arg(
-            form,
-            local_geometry,
-            Geometry.covariant2(v, local_geometry),
-        )
-        v₃ = form_weighted_arg(
-            form,
-            local_geometry,
-            Geometry.covariant3(v, local_geometry),
-        )
-        for ii in 1:Nq
-            D₁v₂ = form_deriv_entry(form, D, ii, i) * v₂
-            D₁v₃ = form_deriv_entry(form, D, ii, i) * v₃
-            out[ii] +=
-                Geometry.Contravariant123Vector(zero(FT), -D₁v₃, D₁v₂)
+        u = curl_covariant_components(op, form, v, local_geometry)
+        unrolled_foreach(axis_vals(op)) do vd
+            @inline # `out` heap-allocates per slab if this closure is not inlined
+            @inbounds begin
+                i = ij[axis_index(vd)]
+                for k in 1:Nq
+                    out[slab_node_index(replace_index(ij, vd, k))] +=
+                        curl_term(vd, form_deriv_entry(form, D, k, i), u)
+                end
+            end
         end
     end
-    @inbounds for i in 1:Nq
-        ij = CartesianIndex((i,))
+    @inbounds for ij in node_indices(space)
         local_geometry = get_local_geometry(space, ij, slabidx)
-        out[i] = form_jacobian_rescale(form, local_geometry, out[i])
-    end
-    return Field(immutable_slab_data(out), space)
-end
-
-function apply_operator(op::Curl{(1, 2), F}, space, slabidx, arg) where {F}
-    form = F()
-    FT = Spaces.undertype(space)
-    QS = Spaces.quadrature_style(space)
-    Nq = Quadratures.degrees_of_freedom(QS)
-    D = Quadratures.differentiation_matrix(FT, QS)
-    # allocate temp output
-    RT = operator_return_eltype(op, eltype(arg))
-    out = slab_data(RT, FT, Nq, Nq)
-    fill!(parent(out), zero(FT))
-    @inbounds for j in 1:Nq, i in 1:Nq
-        ij = CartesianIndex((i, j))
-        local_geometry = get_local_geometry(space, ij, slabidx)
-        v = get_node(space, arg, ij, slabidx)
-        v₁ = form_weighted_arg(
-            form,
-            local_geometry,
-            Geometry.covariant1(v, local_geometry),
-        )
-        v₂ = form_weighted_arg(
-            form,
-            local_geometry,
-            Geometry.covariant2(v, local_geometry),
-        )
-        v₃ = form_weighted_arg(
-            form,
-            local_geometry,
-            Geometry.covariant3(v, local_geometry),
-        )
-        for ii in 1:Nq
-            D₁v₃ = form_deriv_entry(form, D, ii, i) * v₃
-            D₁v₂ = form_deriv_entry(form, D, ii, i) * v₂
-            out[1, ii, j, 1] +=
-                Geometry.Contravariant123Vector(zero(FT), -D₁v₃, D₁v₂)
-        end
-        for jj in 1:Nq
-            D₂v₃ = form_deriv_entry(form, D, jj, j) * v₃
-            D₂v₁ = form_deriv_entry(form, D, jj, j) * v₁
-            out[1, i, jj, 1] +=
-                Geometry.Contravariant123Vector(D₂v₃, zero(FT), -D₂v₁)
-        end
-    end
-    @inbounds for j in 1:Nq, i in 1:Nq
-        ij = CartesianIndex((i, j))
-        local_geometry = get_local_geometry(space, ij, slabidx)
-        out[1, i, j, 1] = form_jacobian_rescale(form, local_geometry, out[1, i, j, 1])
+        node = slab_node_index(ij)
+        out[node] = form_jacobian_rescale(form, local_geometry, out[node])
     end
     return Field(immutable_slab_data(out), space)
 end

--- a/src/Operators/spectralelement.jl
+++ b/src/Operators/spectralelement.jl
@@ -1,4 +1,5 @@
-import UnrolledUtilities: unrolled_map, unrolled_foreach, unrolled_any
+import UnrolledUtilities:
+    unrolled_map, unrolled_foreach, unrolled_reduce, unrolled_any
 import ..Utilities.Unrolled: unrolled_map_with_inbounds
 
 abstract type AbstractSpectralStyle <: Fields.AbstractFieldStyle end
@@ -670,10 +671,11 @@ Base.Broadcast.BroadcastStyle(
 # axis index in the type domain so that the loop over axes unrolls and the node
 # indices stay statically sized.
 #
-# The per-axis closures below carry two annotations that matter for performance:
-# `@inline`, because the mutable slab temporary they write to would otherwise
-# escape and be heap-allocated once per slab, and `@inbounds`, which a closure
-# body does not inherit from the enclosing `@inbounds` block.
+# Loops over axes go through `foreach_axis` and `sum_axes`, which own the
+# inlining discipline the per-axis closures depend on. Their bodies still need
+# their own `@inbounds`: a closure body does not inherit it from the enclosing
+# `@inbounds` block, and only a method (not an anonymous function) can opt into
+# propagating it.
 
 """
     axis_vals(op)
@@ -690,6 +692,32 @@ unrolls the loop over axes and keeps `d` available as a type parameter.
 The axis index `d` itself: `ij[axis_index(vd)]` is the node index along axis `d`.
 """
 @inline axis_index(::Val{d}) where {d} = d
+
+"""
+    foreach_axis(f, op)
+    sum_axes(f, op)
+
+Call `f(Val(d))` for each axis index `d` that `op` works over, unrolled;
+`sum_axes` sums the results, keeping one accumulator per axis and combining them
+once at the end so that the per-axis accumulation loops stay independent
+dependency chains.
+
+Two annotations belong in the body of `f`, and neither can be supplied from here,
+because only a method -- not an anonymous function -- can carry them:
+
+  - `@inline`, as the first statement. Without it the closure is not inlined, so
+    the mutable slab temporary it writes to escapes and is heap-allocated once per
+    slab; that measured 1.1-3.8x slower across the operator kernels. (Forcing the
+    inline from inside these helpers does not work: wrapping `f` in another
+    closure to annotate its call site reintroduces the allocation.)
+  - `@inbounds`, since a closure body does not inherit it from an enclosing
+    `@inbounds` block.
+"""
+@inline foreach_axis(f::F, op::SpectralElementOperator) where {F} =
+    unrolled_foreach(f, axis_vals(op))
+
+@inline sum_axes(f::F, op::SpectralElementOperator) where {F} =
+    unrolled_reduce(+, unrolled_map(f, axis_vals(op)))
 
 """
     slab_dims(op, Nq)
@@ -819,8 +847,8 @@ Base.@propagate_inbounds function apply_operator(
     @inbounds for ij in node_indices(space)
         local_geometry = get_local_geometry(space, ij, slabidx)
         v = get_node(space, arg, ij, slabidx)
-        unrolled_foreach(axis_vals(op)) do vd
-            @inline # `out` heap-allocates per slab if this closure is not inlined
+        foreach_axis(op) do vd
+            @inline
             @inbounds begin
                 i = ij[axis_index(vd)]
                 Jvᵈ =
@@ -958,8 +986,8 @@ Base.@propagate_inbounds function apply_operator(
         node = slab_node_index(ij)
         local_geometry = get_local_geometry(space, ij, slabidx)
         u = get_node(space, arg1, ij, slabidx)
-        unrolled_foreach(axis_vals(op)) do vd
-            @inline # `Ju` heap-allocates per slab if this closure is not inlined
+        foreach_axis(op) do vd
+            @inline
             @inbounds Ju[axis_index(vd)][node] =
                 local_geometry.J * contravariant(vd, u, local_geometry)
         end
@@ -970,8 +998,8 @@ Base.@propagate_inbounds function apply_operator(
     fill!(parent(out), zero(FT))
     @inbounds for ij in node_indices(space)
         node = slab_node_index(ij)
-        unrolled_foreach(axis_vals(op)) do vd
-            @inline # `out` heap-allocates per slab if this closure is not inlined
+        foreach_axis(op) do vd
+            @inline
             @inbounds begin
                 i = ij[axis_index(vd)]
                 Juᵈ = Ju[axis_index(vd)]
@@ -1046,8 +1074,8 @@ Base.@propagate_inbounds function apply_operator(
     @inbounds for ij in node_indices(space)
         local_geometry = get_local_geometry(space, ij, slabidx)
         x = form_weighted_arg(form, local_geometry, get_node(space, arg, ij, slabidx))
-        unrolled_foreach(axis_vals(op)) do vd
-            @inline # `out` heap-allocates per slab if this closure is not inlined
+        foreach_axis(op) do vd
+            @inline
             @inbounds begin
                 i = ij[axis_index(vd)]
                 for k in 1:Nq
@@ -1195,8 +1223,8 @@ Base.@propagate_inbounds function apply_operator(
         local_geometry = get_local_geometry(space, ij, slabidx)
         v = get_node(space, arg, ij, slabidx)
         u = curl_covariant_components(op, form, v, local_geometry)
-        unrolled_foreach(axis_vals(op)) do vd
-            @inline # `out` heap-allocates per slab if this closure is not inlined
+        foreach_axis(op) do vd
+            @inline
             @inbounds begin
                 i = ij[axis_index(vd)]
                 for k in 1:Nq

--- a/src/Spaces/spectralelement.jl
+++ b/src/Spaces/spectralelement.jl
@@ -79,6 +79,9 @@ function SpectralElementSpace1D(
     SpectralElementSpace1D(grid)
 end
 
+Adapt.adapt_structure(to, space::SpectralElementSpace1D) =
+    SpectralElementSpace1D(Adapt.adapt(to, grid(space)))
+
 # 2D
 """
     SpectralElementSpace2D(grid::SpectralElementGrid1D)

--- a/test/Geometry/tensors.jl
+++ b/test/Geometry/tensors.jl
@@ -266,3 +266,31 @@ end
         local_geom,
     ) == Contravariant123Vector(0.25, 1.0, 1.0) ⊗ Covariant12Vector(2.0, 8.0)
 end
+
+@testset "dimension-generic covariant constructors" begin
+    # generic forms of the CovariantNAxis / CovariantNVector aliases, used by code
+    # that is generic over the dimensions it works on (e.g. spectral operators)
+    @test Geometry.covariant_axis(Val((1,))) === Geometry.Covariant1Axis()
+    @test Geometry.covariant_axis(Val((1, 2))) === Geometry.Covariant12Axis()
+    @test Geometry.covariant_axis(Val((1, 2, 3))) === Geometry.Covariant123Axis()
+
+    @test Geometry.covariant_vector(Val((1,)), (1.0,)) == Covariant1Vector(1.0)
+    @test Geometry.covariant_vector(Val((1, 2)), (1.0, 2.0)) ==
+          Covariant12Vector(1.0, 2.0)
+    @test Geometry.covariant_vector(Val((1, 2)), (1.0, 2.0)) isa
+          Covariant12Vector{Float64}
+
+    @test Geometry.covariant_basis_vector(Val((1,)), Val(1), 3.0) ==
+          Covariant1Vector(3.0)
+    @test Geometry.covariant_basis_vector(Val((1, 2)), Val(1), 3.0) ==
+          Covariant12Vector(3.0, 0.0)
+    @test Geometry.covariant_basis_vector(Val((1, 2)), Val(2), 3.0) ==
+          Covariant12Vector(0.0, 3.0)
+    # the axis index is a dimension label, not a position: for I = (2, 3),
+    # Val(2) selects the first component
+    @test Geometry.covariant_basis_vector(Val((2, 3)), Val(3), 3.0) ==
+          Geometry.Covariant23Vector(0.0, 3.0)
+
+    @test (@inferred Geometry.covariant_basis_vector(Val((1, 2)), Val(2), 3.0)) isa
+          Covariant12Vector{Float64}
+end

--- a/test/Operators/spectralelement/plane_cuda.jl
+++ b/test/Operators/spectralelement/plane_cuda.jl
@@ -1,0 +1,137 @@
+#=
+Spectral-element operators over a one-dimensional horizontal space (operator
+axes `(1,)`), checked against the CPU. Covers both a bare
+`SpectralElementSpace1D` and an extruded space built on one, since the two reach
+the GPU kernels through different space types.
+=#
+using Test
+using ClimaComms, ClimaCore
+ClimaComms.@import_required_backends
+import ClimaCore:
+    Geometry,
+    Fields,
+    Domains,
+    Topologies,
+    Meshes,
+    Spaces,
+    Operators,
+    Quadratures
+using LinearAlgebra, IntervalSets
+
+FT = Float64
+Nq = 4
+quad = Quadratures.GLL{Nq}()
+
+hdomain = Domains.IntervalDomain(
+    Geometry.XPoint{FT}(-pi) .. Geometry.XPoint{FT}(pi),
+    periodic = true,
+)
+hmesh = Meshes.IntervalMesh(hdomain, nelems = 16)
+
+vdomain = Domains.IntervalDomain(
+    Geometry.ZPoint{FT}(0) .. Geometry.ZPoint{FT}(10);
+    boundary_names = (:bottom, :top),
+)
+vmesh = Meshes.IntervalMesh(vdomain, nelems = 4)
+
+function hspace(device)
+    context = ClimaComms.SingletonCommsContext(device)
+    topology = Topologies.IntervalTopology(context, hmesh)
+    return Spaces.SpectralElementSpace1D(topology, quad)
+end
+
+function cspace(device)
+    context = ClimaComms.SingletonCommsContext(device)
+    vtopology = Topologies.IntervalTopology(context, vmesh)
+    vspace = Spaces.CenterFiniteDifferenceSpace(vtopology)
+    return Spaces.ExtrudedFiniteDifferenceSpace(hspace(device), vspace)
+end
+
+# Compare an operator expression applied on the GPU against the CPU. `fields` is
+# called with a space and returns the arguments for `op_expr`.
+function test_gpu_matches_cpu(name, space_fn, fields, op_expr)
+    cpu_args = fields(space_fn(ClimaComms.CPUSingleThreaded()))
+    gpu_args = fields(space_fn(ClimaComms.device()))
+    @testset "$name" begin
+        @test Array(parent(op_expr(gpu_args...))) ≈ parent(op_expr(cpu_args...))
+    end
+end
+
+grad = Operators.Gradient()
+wgrad = Operators.WeakGradient()
+div = Operators.Divergence()
+wdiv = Operators.WeakDivergence()
+curl = Operators.Curl()
+wcurl = Operators.WeakCurl()
+split_div = Operators.SplitDivergence()
+
+@testset "1D spectral element operators on the GPU" begin
+    for (space_name, space_fn) in
+        (("SpectralElementSpace1D", hspace), ("extruded 1D", cspace))
+        # a scalar, a vector to take divergences of, and covariant vectors whose
+        # curls exercise each nonzero Levi-Civita term of a one-axis curl
+        scalar(space) = (sin.(Fields.coordinate_field(space).x),)
+        function vector(space)
+            x = Fields.coordinate_field(space).x
+            return (Geometry.UVector.(sin.(x)),)
+        end
+        covariant2(space) =
+            (Geometry.Covariant2Vector.(cos.(Fields.coordinate_field(space).x)),)
+        covariant3(space) =
+            (Geometry.Covariant3Vector.(sin.(Fields.coordinate_field(space).x)),)
+        both(space) = (vector(space)..., scalar(space)...)
+
+        @testset "$space_name" begin
+            test_gpu_matches_cpu("Gradient", space_fn, scalar, f -> grad.(f))
+            test_gpu_matches_cpu("WeakGradient", space_fn, scalar, f -> wgrad.(f))
+            test_gpu_matches_cpu("Divergence", space_fn, vector, u -> div.(u))
+            test_gpu_matches_cpu("WeakDivergence", space_fn, vector, u -> wdiv.(u))
+            test_gpu_matches_cpu("Curl (Covariant2)", space_fn, covariant2, u -> curl.(u))
+            test_gpu_matches_cpu("Curl (Covariant3)", space_fn, covariant3, u -> curl.(u))
+            test_gpu_matches_cpu(
+                "WeakCurl (Covariant2)",
+                space_fn,
+                covariant2,
+                u -> wcurl.(u),
+            )
+            test_gpu_matches_cpu(
+                "WeakCurl (Covariant3)",
+                space_fn,
+                covariant3,
+                u -> wcurl.(u),
+            )
+            test_gpu_matches_cpu(
+                "SplitDivergence",
+                space_fn,
+                both,
+                (u, f) -> split_div.(u, f),
+            )
+            # composed operators share shared memory between the two operators
+            test_gpu_matches_cpu(
+                "Divergence ∘ Gradient",
+                space_fn,
+                scalar,
+                f -> div.(grad.(f)),
+            )
+            test_gpu_matches_cpu(
+                "Curl ∘ Curl",
+                space_fn,
+                covariant2,
+                u -> curl.(Geometry.CovariantVector.(curl.(u))),
+            )
+        end
+    end
+end
+
+@testset "1D spectral element operator values on the GPU" begin
+    # d/dx sin(x) == cos(x), as a Covariant1Vector on a Cartesian 1D space
+    space = hspace(ClimaComms.device())
+    x = Fields.coordinate_field(space).x
+    @test Geometry.UVector.(grad.(sin.(x))) ≈ Geometry.UVector.(cos.(x)) rtol = 1e-2
+
+    # curl of a Covariant3Vector field is -∂/∂x of its component, in the
+    # Contravariant2 direction
+    w = Geometry.Covariant3Vector.(sin.(x))
+    @test Geometry.Contravariant2Vector.(curl.(w)) ≈
+          Geometry.Contravariant2Vector.(.-cos.(x)) rtol = 1e-2
+end

--- a/test/Operators/spectralelement/unit_tensor_product.jl
+++ b/test/Operators/spectralelement/unit_tensor_product.jl
@@ -1,0 +1,61 @@
+#=
+julia --project
+using Revise; include(joinpath("test", "Operators", "spectralelement", "unit_tensor_product.jl"))
+=#
+using Test
+using LinearAlgebra
+import ClimaCore: DataLayouts, Operators, Quadratures
+
+# `tensor_product!` writes into three different output layouts and is also used in
+# place, but only its `IH1JH2` and `VIH1` outputs are reached from
+# `matrix_interpolate`; the `VIJFH` output (ClimaCorePlots) and the two-argument
+# in-place form (examples/bickleyjet) have no other coverage. Every case is
+# checked against an explicit `M * x * M'`.
+@testset "tensor_product!" begin
+    FT = Float64
+    Nij, Nu, Nh, Nv = 4, 5, 3, 2
+    M = Quadratures.interpolation_matrix(
+        FT,
+        Quadratures.Uniform{Nu}(),
+        Quadratures.GLL{Nij}(),
+    )
+
+    # two node axes: the same M is contracted along both
+    indata = DataLayouts.VIJFH{FT, 1, Nij, Nij, Nh}(rand(FT, 1, Nij, Nij, 1, Nh))
+    ref = map(1:Nh) do h
+        M * reshape(parent(indata)[1, :, :, 1, h], Nij, Nij) * M'
+    end
+
+    out = DataLayouts.VIJFH{FT, 1, Nu, Nu, Nh}(zeros(FT, 1, Nu, Nu, 1, Nh))
+    Operators.tensor_product!(out, indata, M)
+    @test all(h -> parent(out)[1, :, :, 1, h] ≈ ref[h], 1:Nh)
+
+    out = DataLayouts.IH1JH2{FT, Nu, Nu, nothing}(zeros(FT, Nu * Nh, Nu))
+    Operators.tensor_product!(out, indata, M)
+    @test all(h -> parent(out)[(Nu * (h - 1) + 1):(Nu * h), :] ≈ ref[h], 1:Nh)
+
+    # one node axis, several levels
+    in1d = DataLayouts.VIJFH{FT, Nv, Nij, 1, Nh}(rand(FT, Nv, Nij, 1, 1, Nh))
+    ref1d = [M * parent(in1d)[v, :, 1, 1, h] for v in 1:Nv, h in 1:Nh]
+    vhs = ((v, h) for v in 1:Nv, h in 1:Nh)
+
+    out = DataLayouts.VIH1{FT, Nv, Nu, nothing}(zeros(FT, Nv, Nu * Nh))
+    Operators.tensor_product!(out, in1d, M)
+    @test all(
+        ((v, h),) -> parent(out)[v, (Nu * (h - 1) + 1):(Nu * h)] ≈ ref1d[v, h],
+        vhs,
+    )
+
+    out = DataLayouts.VIJFH{FT, Nv, Nu, 1, Nh}(zeros(FT, Nv, Nu, 1, 1, Nh))
+    Operators.tensor_product!(out, in1d, M)
+    @test all(((v, h),) -> parent(out)[v, :, 1, 1, h] ≈ ref1d[v, h], vhs)
+
+    # in place, which needs a square M
+    Msq = Quadratures.cutoff_filter_matrix(FT, Quadratures.GLL{Nij}(), 3)
+    inout = DataLayouts.VIJFH{FT, 1, Nij, Nij, Nh}(copy(parent(indata)))
+    refsq = map(1:Nh) do h
+        Msq * reshape(parent(indata)[1, :, :, 1, h], Nij, Nij) * Msq'
+    end
+    Operators.tensor_product!(inout, Msq)
+    @test all(h -> parent(inout)[1, :, :, 1, h] ≈ refsq[h], 1:Nh)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,6 +38,7 @@ UnitTest("Fields"                                  ,"Fields/unit_field.jl"), # h
 UnitTest("Reinstantiate broadcasted"               ,"Operators/unit_reinstantiate_bc.jl"),
 UnitTest("Placeholder Fields"                      ,"Operators/unit_common.jl"),
 UnitTest("Spectral elem - form types"              ,"Operators/spectralelement/unit_form_types.jl"),
+UnitTest("Spectral elem - tensor product"          ,"Operators/spectralelement/unit_tensor_product.jl"),
 UnitTest("Spectral elem - rectilinear"             ,"Operators/spectralelement/rectilinear.jl"),
 UnitTest("Spectral elem - opt"                     ,"Operators/spectralelement/opt.jl"),
 UnitTest("Spectral elem - gradient tensor"         ,"Operators/spectralelement/covar_deriv_ops.jl"),


### PR DESCRIPTION
> **Authorship:** this PR was written primarily by Claude Code (see the
> `Co-Authored-By` trailer on the commits). The refactors, the GPU bug fix, the new
> tests and this description are the agent's work; I set the task and its scope.
> Every measurement quoted below was produced by the agent rather than
> independently reproduced, so please review with that in mind.

> **Rebased onto #2556**, which has since merged. That PR unified the strong/weak
> variants behind a `FormType` parameter while this one was open; the two refactors
> are orthogonal (form vs. dimension) and compose, so this branch was rebuilt on top
> of its `form_*` helpers rather than merged textually. One method per operator now
> covers **both** dimensions and **both** forms. This branch sits directly on the
> merge commit for #2556 with nothing to rebase, and every number below is measured
> against that `main` — so they are smaller than in the original description, since
> #2556 already removed the strong/weak half of the duplication.

## What

The spectral-element operators had separate 1D (`{(1,)}`) and 2D (`{(1, 2)}`) implementations of the same tensor-product stencil, with each 2D method repeating its 1D counterpart once per axis. This was true on both sides:

- CPU: `apply_operator` in `src/Operators/spectralelement.jl`
- GPU: `operator_evaluate` in `ext/cuda/operators_spectral_element.jl`, plus `operator_shmem`/`operator_fill_shmem!` in `ext/cuda/operators_sem_shmem.jl`

Each of `Divergence`, `SplitDivergence`, `WeakDivergence`, `Gradient`, `WeakGradient`, `Curl` and `WeakCurl` now has a single implementation that loops over the axes it works over, with the axis index carried in the type domain so the loop unrolls and the node indices stay statically sized.

The last two commits then remove the rest of the per-dimension duplication in the same file — `Interpolate`/`Restrict`, `tensor_product!`, and the node accessors — described in its own section below.

This removes **78 lines from `src` + `ext`** (850 added, 928 removed). Counting only code -- excluding blank lines, `#` comments and docstrings -- it is **389 lines, a 14% reduction** (2752 -> 2363); the refactors account for -412 code lines and the GPU bug fix plus the `Geometry` move add 23 back. The operator methods themselves go from **37 to 18**:

| | methods before | after | code lines before | after | net |
|---|---|---|---|---|---|
| `ext/cuda/operators_sem_shmem.jl` (`operator_shmem`, `operator_fill_shmem!`) | 16 | 8 | 235 | 133 | **-102** |
| `ext/cuda/operators_spectral_element.jl` (`operator_evaluate`) | 8 | 4 | 342 | 259 | **-83** |
| `src/Operators/spectralelement.jl` (`apply_operator`) | 13 | 6 | 1038 | 811 | **-227** |
| 5 files touched by the 1D fix and the `Geometry` move | -- | -- | 1137 | 1160 | +23 |
| **total** | **37** | **18** | **2752** | **2363** | **-389** |

The six remaining `apply_operator` methods are the four unified differential operators, one for `Interpolate` **and** `Restrict` together, and the zero-axes fallback.

Shared helpers (documented in a "Dimension-generic building blocks" section):

| | |
|---|---|
| `axis_vals(op)` | `(Val(1), Val(2))` for the axes `op` works over |
| `slab_dims(op, Nq)` | slab shape, one `Nq` per axis |
| `replace_index(index, Val(d), k)` | walk along axis `d`, or shrink a contracted axis' extent |
| `contravariant`/`covariant(Val(d), u, lg)` | component accessors by axis |
| `covariant_vector`/`covariant_basis_vector` | build a covariant vector over the operator's axes |
| `curl_uses_component`, `curl_covariant_components`, `curl_term` | Levi-Civita pieces; one helper serves `Curl` and `WeakCurl`, which just negates the coefficient |
| `foreach_axis`/`sum_axes` | the per-axis loop, shared by both devices |
| `contract_axis!`/`contract_axes!`/`contract_temps` | the sequential contraction fold (see below) |
| `data_index`, `slab_level_index` | node index padding and face/center level staggering |
| `shmem_dims`, `sem_shmem`, `sem_shmem_per_axis`, `shmem_index` | GPU shared memory |
| `apply_stencil`, `curl_stencil` | the two GPU stencil kernels (weak operators pass `D'`) |

Two annotations in the per-axis closures matter for performance and are commented in the code: `@inline`, without which the mutable slab temporary escapes and is heap-allocated once per slab (measured 1.1–3.8× slower), and `@inbounds`, which a closure body does not inherit from the enclosing block.

## The rest of the duplication: contractions and node accessors

The differential operators above *accumulate* an independent contribution per axis, so one pass over a slab covers every axis. `Interpolate`, `Restrict` and `tensor_product!` instead contract their axes **sequentially** — contract axis 1 into a temporary, then contract axis 2 out of it — which is why they were left per-dimension in the first three commits. They fold over the axes rather than looping over them:

- `contract_axis!(dst, M, src, post, Val(d), dims_out)` contracts one axis against a matrix,
- `contract_axes!` folds it over a tuple of axes, each contraction reading what the previous one wrote and the last writing into the output,
- `contract_temps` allocates the `length(I) - 1` intermediates, so a single-axis contraction gets no temporary at all — which is what the old 1D methods did by hand.

On top of that, `Interpolate` and `Restrict` differ *only* in three factors, in exactly the shape #2556 used for strong vs. weak: `tensor_matrix` (the matrix, transposed for `Restrict`), `tensor_weighted_arg` (`WJ`-weighted for `Restrict`) and `tensor_rescale` (divided by the output `WJ` for `Restrict`). So **four methods become one**. `tensor_product!` folds with the same primitives, which lets `rmatmul1`/`rmatmul2` go (they had no other callers), and covers all three of its output layouts in one method instead of four.

The node accessors had the same 1D/2D split, differing only in padding the unused node axis with 1 and in repeating the face/center level staggering. Those are now `data_index` and `slab_level_index`:

| | methods before | after |
|---|---|---|
| `apply_operator` for `Interpolate`/`Restrict` | 4 | 1 |
| `tensor_product!` | 5 | 2 |
| `get_node` | 9 | 7 |
| `set_node!`, `get_local_geometry` | 2 each | 1 each |
| `node_indices` | 4 | 2 |

**Two deliberate behaviour changes** for downstream code, both in `NEWS.md`:

- The two-dimensional `get_node` and `set_node!` now accept a bare `Center`/`FaceFiniteDifferenceSpace`, which only their one-dimensional counterparts did. The asymmetry looks incidental (a 2D node index never arises over such a space) but the 1D case is load-bearing: a horizontal operator over an extracted column space reaches these accessors that way.
- Conversely, `get_local_geometry` and `set_node!` now raise `"invalid space"` for a space whose staggering is not recognised, instead of silently reading level `slabidx.v`. `get_node` always did. The full CPU and GPU suites pass with the strict version, which is the evidence that nothing relied on the permissive one.

`tensor_product!`'s invariants also move from dispatch into assertions (square node axes in and out; an `IH1JH2` output takes a single level), since one method cannot express "square only if the input has a second node axis". A mismatched call now fails an assertion rather than raising `MethodError`.

## Bug fix: `SpectralElementSpace1D` on the GPU

Spectral-element operators could not run on the GPU over a bare `SpectralElementSpace1D` at all — the space could not be passed to a kernel (`KernelError: passing non-bitstype argument`, since `.grid` holds an `IntervalTopology` with a mesh and domain). Unlike `SpectralElementGrid2D`, `SpectralElementGrid1D` had no device-side counterpart to convert to. This adds `Grids.DeviceSpectralElementGrid1D` and the corresponding `Adapt` rules.

Side effect: `to_device` now works on a `SpectralElementSpace1D`. It previously hit `Adapt`'s identity fallback and returned the space unchanged.

## Testing

New `test/Operators/spectralelement/plane_cuda.jl` (with a `Unit: plane cuda` pipeline entry) covers the 1D GPU path, which had no test before: all seven operators plus `div∘grad` and `curl∘curl` (which force two operators to share shared memory) over a bare `SpectralElementSpace1D` and an extruded 1D space, compared against the CPU, plus two absolute value checks. With only the fix reverted it fails 11/11 on the bare 1D space and passes 11/11 on the extruded one, isolating the bug.

New `test/Operators/spectralelement/unit_tensor_product.jl` covers `tensor_product!` against an explicit `M * x * M'` for all three of its output layouts and for the in-place two-argument form. The `VIJFH` output (used by ClimaCorePlots) and the in-place form had no coverage at all before, and both are rewritten here; only the `IH1JH2` and `VIH1` outputs were reached indirectly, through `matrix_interpolate`.

Verification beyond the test suites, comparing every operator over 7 spaces (1D/2D, bare/extruded, rectilinear/cubed sphere; 74 expressions) against results captured before the refactors:

- **CPU: 73/74 bit-for-bit identical** to post-#2556 `main`, zero allocations across all 14 kernel/space combinations, kernel timings 0.985–1.018×. The one exception is `Restrict` on a `SpectralElementSpace1D`, where 3 of its 15 nodes move by at most 1 ulp (2.2e-16 on values of order 1). The order of summation is unchanged; LLVM simply contracts a different subset of the contraction's `muladd`s into `fma`s once the loop over output nodes is written generically. Verified by reproducing every value with an explicit chain whose *k*th `muladd` is contracted iff `mask[k]`: one consistent mask reproduces all 15 values, which is what distinguishes "LLVM chose differently" from a reassociated sum. Two candidate fixes (applying the rescale in a second pass over the output; fusing it back into the last contraction) changed nothing, so the fused form was kept because it matches the structure of the code it replaces.
- **GPU: 0 mismatches** — of the 50 expressions that run on both `main` and this branch, 40 are bitwise identical and 10 (2D `Divergence`, `SplitDivergence`, `Gradient`, `Curl`) differ by at most 5.3e-15 on values of order 1–20, from reassociation and FMA selection after restructuring the accumulation loops; the GPU is deterministic run to run. The 20 bare-1D expressions that previously could not compile all agree with the CPU. All 70 supported expressions are bitwise unchanged across the last two commits, which touch the accessors the GPU kernels share.
- GPU kernel timings are within the ±7% session-to-session spread that the *baseline* shows against itself. A single before/after pair suggested `wgrad_div` was 9–11% slower and looked reproducible across two after-runs; sampling the baseline a second time showed the same kernel 1.07× slower than itself and `div_grad` 0.93×. `minimum(trial).time` suppresses within-trial noise but not between-session variation.

Test files run green on both devices: `opt.jl` (JET), `rectilinear.jl`, `plane.jl`, `split_divergence.jl`, `unit_form_types.jl` (added by #2556), `unit_tensor_product.jl`, `covar_deriv_ops.jl`, `unit_diffusion2d.jl`, `sphere_{gradient,divergence,curl,diffusion,diffusion_vec,geometry,sphericalharmonics}.jl`, `unit_sphere_hyperdiffusion{,_vec}.jl`, `hybrid/unit_2d.jl`, `Fields/unit_field.jl`, `Geometry/tensors.jl`; and on GPU `plane_cuda.jl`, `rectilinear_cuda.jl`, `covar_deriv_ops.jl`, `hybrid/{unit_cuda,extruded_3dbox_cuda,extruded_sphere_cuda}.jl`. `detect_ambiguities` is unchanged (40, all pre-existing, none naming anything added here).

Note: `test/Spaces/unit_spaces.jl` "2D spaces with mask" errors on GPU (a `DivergenceF2C` kernel throws `DomainError` from `sqrt(-1)` where the test expects NaNs). Reproduced identically with this branch's changes stashed, so it is pre-existing and unrelated.

## Commits

The five commits are separately verified, in the order they were written:

1. `8804cf06` make the differential operators dimension generic (CPU and GPU)
2. `4ccf31f8` share one `foreach_axis`/`sum_axes` pair between the CPU and GPU operators
3. `caeb50da` move the generic covariant constructors into `Geometry`
4. `7d8a835a` fold the tensor-product operators (`Interpolate`/`Restrict`, `tensor_product!`) over their axes
5. `ef1be22e` collapse the per-dimension node accessors and `node_indices`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148rCSSVswyipJTZjqpEUMd

