### PR TITLE
Release v0.15.0

### DIFF
--- a/.buildkite/Manifest.toml
+++ b/.buildkite/Manifest.toml
@@ -378,7 +378,7 @@ weakdeps = ["CUDA", "MPI"]
 deps = ["Adapt", "BandedMatrices", "BlockArrays", "ClimaComms", "ClimaInterpolations", "CubedSphere", "DataStructures", "ForwardDiff", "GaussQuadrature", "GilbertCurves", "HDF5", "InteractiveUtils", "IntervalSets", "KrylovKit", "LLVM", "LazyBroadcast", "LinearAlgebra", "MultiBroadcastFusion", "NVTX", "PkgVersion", "Random", "RecursiveArrayTools", "RootSolvers", "SparseArrays", "StaticArrays", "Statistics", "UnrolledUtilities"]
 path = ".."
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
-version = "0.14.55"
+version = "0.15.0"
 weakdeps = ["CUDA", "GPUCompiler", "Krylov"]
 
     [deps.ClimaCore.extensions]
@@ -389,19 +389,19 @@ weakdeps = ["CUDA", "GPUCompiler", "Krylov"]
 deps = ["ClimaComms", "ClimaCore", "RecipesBase", "StaticArrays", "TriplotBase"]
 path = "../lib/ClimaCorePlots"
 uuid = "cf7c7e5a-b407-4c48-9047-11a94a308626"
-version = "0.2.11"
+version = "0.2.12"
 
 [[deps.ClimaCoreTempestRemap]]
 deps = ["ClimaComms", "ClimaCore", "CommonDataModel", "Dates", "DiskArrays", "LinearAlgebra", "NCDatasets", "PkgVersion", "TempestRemap_jll"]
 path = "../lib/ClimaCoreTempestRemap"
 uuid = "d934ef94-cdd4-4710-83d6-720549644b70"
-version = "0.3.18"
+version = "0.3.19"
 
 [[deps.ClimaCoreVTK]]
 deps = ["ClimaCore", "WriteVTK"]
 path = "../lib/ClimaCoreVTK"
 uuid = "c8b6d40d-e815-466f-95ae-c48aefa668fa"
-version = "0.7.6"
+version = "0.7.7"
 
 [[deps.ClimaInterpolations]]
 deps = ["DocStringExtensions"]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,12 +24,13 @@ jobs:
           version: '1.10'
       - name: Install dependencies
         run: >
-          julia --project=docs -e 'using Pkg; Pkg.develop(path=".");
+          julia --project=docs -e 'using Pkg;
           Pkg.develop(path="lib/ClimaCoreVTK");
           Pkg.develop(path="lib/ClimaCoreTempestRemap");
           Pkg.develop(path="lib/ClimaCoreMakie");
           Pkg.develop(path="lib/ClimaCorePlots");
           Pkg.develop(path="lib/ClimaCoreSpectra");
+          Pkg.develop(path=".");
           Pkg.instantiate(;verbose=true)'
       - name: Build and deploy
         env:

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,11 +4,15 @@ ClimaCore.jl Release Notes
 main
 -------
 
-- Fixed a GPU compilation failure (`gpu_gc_pool_alloc` and `jl_f__apply_iterate`
-  in `InvalidIRError`) for kernels over wide or complexly typed broadcast
-  expressions, like the fused EDMFX cloud fraction broadcasts in ClimaAtmos
-  AMIP runs. The broadcast argument traversal functions in `DataLayouts` and
-  the CUDA extension no longer filter arguments with reductions that push into
+
+v0.15.0
+-------
+
+- ![][badge-🐛bugfix] Fixed a GPU compilation failure (`gpu_gc_pool_alloc` and
+  `jl_f__apply_iterate` in `InvalidIRError`) for kernels over wide or complexly
+  typed broadcast expressions, like the fused EDMFX cloud fraction broadcasts in
+  ClimaAtmos AMIP runs. The broadcast argument traversal functions in `DataLayouts`
+  and the CUDA extension no longer filter arguments with reductions that push into
   an accumulator, whose recursively growing type could trigger inference's
   widening heuristics; they now collect layouts with `unrolled_flatmap`, whose
   intermediate types all stay concrete, and `f_dim` reduces with a fixed
@@ -29,24 +33,24 @@ main
   job compiles them through real CUDA kernels. GPU kernel launch latency
   improved by roughly 10%, and the latency benchmark baselines were lowered
   accordingly.
-- Added `Fields.fieldvector2array!` and `Fields.array2fieldvector!`,
-  allocation-free, GPU-safe block-wise copies between a `FieldVector` and a
-  flat vector (plus allocating versions without the `!`). Together with
-  `Krylov.ktypeof(::FieldVector)` (defined in
+- ![][badge-🔥behavioralΔ] Added `Fields.fieldvector2array!` and
+  `Fields.array2fieldvector!`, allocation-free, GPU-safe block-wise copies
+  between a `FieldVector` and a flat vector (plus allocating versions without
+  the `!`). Together with `Krylov.ktypeof(::FieldVector)` (defined in
   `KrylovExt`), these let iterative Krylov solvers keep their workspace vectors
   on the GPU while model code continues to operate on `FieldVector`s.
-- Fixed `zero(::FieldVector)` to preserve scalar (`ScalarWrapper`) components
-  instead of turning them into 0-dimensional `Array`s, and fixed
-  `ClimaComms.array_type(::FieldVector)` (and hence
+- ![][badge-🐛bugfix] Fixed `zero(::FieldVector)` to preserve scalar
+  (`ScalarWrapper`) components instead of turning them into 0-dimensional
+  `Array`s, and fixed `ClimaComms.array_type(::FieldVector)` (and hence
   `Krylov.ktypeof(::FieldVector)`) for `FieldVector`s with plain-array or
   scalar components, which previously threw a `MethodError`.
 - ![][badge-💥breaking] Removed the `Operators.columnwise!` operator, along with
   its CUDA kernels (`ext/cuda/operators_columnwise.jl`), its tests, and its CI
   jobs. It was unused by downstream code.
   [2548](https://github.com/CliMA/ClimaCore.jl/pull/2548)
-- Removed the unused shared-memory finite difference operator code path on GPUs
-  (`CUDAWithShmemColumnStencilStyle` and the `operators_fd_shmem*.jl` files in the
-  CUDA extension), along with its tests, benchmarks, CI job, and the
+- ![][badge-💥breaking] Removed the unused shared-memory finite difference operator
+  code path on GPUs (`CUDAWithShmemColumnStencilStyle` and the `operators_fd_shmem*.jl`
+  files in the CUDA extension), along with its tests, benchmarks, CI job, and the
   `shmem_design.md` documentation page. This path was already disabled by default
   (`Operators.use_fd_shmem()` returns `false`), so default behavior and performance are unchanged.
   Downstream code that opted in by defining `Operators.use_fd_shmem() = true` will no longer
@@ -74,7 +78,8 @@ main
   on GPUs, which previously raised an "Unsupported input type" error even though
   both forms already supported them on CPUs.
   [2556](https://github.com/CliMA/ClimaCore.jl/pull/2556)
-- Refactor DataLayouts module [2522](https://github.com/CliMA/ClimaCore.jl/pull/2522)
+- ![][badge-🔥behavioralΔ] Refactor DataLayouts module
+  [2522](https://github.com/CliMA/ClimaCore.jl/pull/2522)
   - All data layout types are unified into a single `DataLayout` type, and all
     loops over data go through two communication primitives (`foreach_slice` and
     `reduce_points`) that work the same way on CPUs, multi-threaded CPUs, and
@@ -104,8 +109,8 @@ main
   launch, and reused a per-task device buffer for the intermediate results of GPU
   reductions instead of allocating one per reduction.
   [2557](https://github.com/CliMA/ClimaCore.jl/pull/2557)
-- [2572](https://github.com/CliMA/ClimaCore.jl/pull/2572) Fixed DSS for MPI
-  after DataLayouts refactor 
+- ![][badge-🐛bugfix] Fixed DSS for MPI after DataLayouts refactor.
+  [2572](https://github.com/CliMA/ClimaCore.jl/pull/2572)
 
 v0.14.55
 -------

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.14.55"
+version = "0.15.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/lib/ClimaCoreMakie/Project.toml
+++ b/lib/ClimaCoreMakie/Project.toml
@@ -1,10 +1,10 @@
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
 name = "ClimaCoreMakie"
 uuid = "908f55d8-4145-4867-9c14-5dad1a479e4d"
-version = "0.4.7"
+version = "0.4.8"
 
 [compat]
-ClimaCore = "0.11, 0.12, 0.13, 0.14"
+ClimaCore = "0.11, 0.12, 0.13, 0.14, 0.15"
 Makie = "0.24"
 julia = "1.7"
 

--- a/lib/ClimaCorePlots/Project.toml
+++ b/lib/ClimaCorePlots/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCorePlots"
 uuid = "cf7c7e5a-b407-4c48-9047-11a94a308626"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.2.11"
+version = "0.2.12"
 
 [deps]
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
@@ -12,7 +12,7 @@ TriplotBase = "981d1d27-644d-49a2-9326-4793e63143c3"
 
 [compat]
 ClimaComms = "0.6"
-ClimaCore = "0.11, 0.12, 0.13, 0.14"
+ClimaCore = "0.11, 0.12, 0.13, 0.14, 0.15"
 RecipesBase = "1"
 StaticArrays = "1"
 TriplotBase = "0.1"

--- a/lib/ClimaCoreSpectra/Project.toml
+++ b/lib/ClimaCoreSpectra/Project.toml
@@ -1,13 +1,13 @@
 name = "ClimaCoreSpectra"
 uuid = "c2caaa1d-32ae-4754-ba0d-80e7561362e9"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 
 [compat]
-ClimaCore = "0.10.12, 0.11, 0.12, 0.13, 0.14"
+ClimaCore = "0.10.12, 0.11, 0.12, 0.13, 0.14, 0.15"
 julia = "1.7"
 FFTW = "1"

--- a/lib/ClimaCoreTempestRemap/Project.toml
+++ b/lib/ClimaCoreTempestRemap/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCoreTempestRemap"
 uuid = "d934ef94-cdd4-4710-83d6-720549644b70"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.3.18"
+version = "0.3.19"
 
 [deps]
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
@@ -16,7 +16,7 @@ TempestRemap_jll = "8573a8c5-1df0-515e-a024-abad257ee284"
 
 [compat]
 ClimaComms = "0.5, 0.6"
-ClimaCore = "0.11, 0.12, 0.13, 0.14"
+ClimaCore = "0.11, 0.12, 0.13, 0.14, 0.15"
 CommonDataModel = "0.2, 0.3"
 Dates = "1"
 DiskArrays = "<0.4.9" # NCDatasets v0.14.6 does not work with DiskArrays v0.4.9

--- a/lib/ClimaCoreVTK/Project.toml
+++ b/lib/ClimaCoreVTK/Project.toml
@@ -1,10 +1,10 @@
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
 name = "ClimaCoreVTK"
 uuid = "c8b6d40d-e815-466f-95ae-c48aefa668fa"
-version = "0.7.6"
+version = "0.7.7"
 
 [compat]
-ClimaCore = "0.11, 0.12, 0.13, 0.14"
+ClimaCore = "0.11, 0.12, 0.13, 0.14, 0.15"
 WriteVTK = "1.11"
 julia = "1.7"
 


### PR DESCRIPTION
Bump ClimaCore to v0.15.0, and bump the patch versions of all `lib` packages after updating their `compat` entries. This release includes the DataLayouts API refactor, which changes all field layouts to `VIJHWithF` and enables pointwise kernel fusion.

<!-- Provide a clear description of the content -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
