### PR TITLE
Adds `Fields.fieldvector2array!` and `Fields.array2fieldvector!`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,8 @@ main
 
 - Added `Fields.fieldvector2array!` and `Fields.array2fieldvector!`,
   allocation-free, GPU-safe block-wise copies between a `FieldVector` and a
-  flat vector. Together with `Krylov.ktypeof(::FieldVector)` (defined in
+  flat vector (plus allocating versions without the `!`). Together with
+  `Krylov.ktypeof(::FieldVector)` (defined in
   `KrylovExt`), these let iterative Krylov solvers keep their workspace vectors
   on the GPU while model code continues to operate on `FieldVector`s.
 - Fixed `zero(::FieldVector)` to preserve scalar (`ScalarWrapper`) components

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,16 @@ ClimaCore.jl Release Notes
 main
 -------
 
+- Added `Fields.fieldvector2array!` and `Fields.array2fieldvector!`,
+  allocation-free, GPU-safe block-wise copies between a `FieldVector` and a
+  flat vector. Together with `Krylov.ktypeof(::FieldVector)` (defined in
+  `KrylovExt`), these let iterative Krylov solvers keep their workspace vectors
+  on the GPU while model code continues to operate on `FieldVector`s.
+- Fixed `zero(::FieldVector)` to preserve scalar (`ScalarWrapper`) components
+  instead of turning them into 0-dimensional `Array`s, and fixed
+  `ClimaComms.array_type(::FieldVector)` (and hence
+  `Krylov.ktypeof(::FieldVector)`) for `FieldVector`s with plain-array or
+  scalar components, which previously threw a `MethodError`.
 - ![][badge-💥breaking] Removed the `Operators.columnwise!` operator, along with
   its CUDA kernels (`ext/cuda/operators_columnwise.jl`), its tests, and its CI
   jobs. It was unused by downstream code.

--- a/src/Fields/fieldvector.jl
+++ b/src/Fields/fieldvector.jl
@@ -415,25 +415,22 @@ end
 
 """
     fieldvector2array!(array, fv)
-    array2fieldvector!(fv, array)
 
-Copy between a `FieldVector` `fv` and a flat `AbstractVector` `array` of the
-same length, without allocating or scalar indexing: each component block is
-copied with a single array-level `copyto!`, so `FieldVector`s backed by GPU
-arrays are supported (including mixed cases, where the flat array and some
-components live on different devices). Entries are ordered as in the
-`FieldVector`'s own linear indexing: component blocks in order, each in the
-linear order of its backing array.
+Copy the entries of the `FieldVector` `fv` into the flat `AbstractVector`
+`array` of the same length, without allocating or scalar indexing: each
+component block is copied with a single array-level `copyto!`, so
+`FieldVector`s backed by GPU arrays are supported (including mixed cases,
+where `array` and some components live on different devices). Entries are
+ordered as in the `FieldVector`'s own linear indexing: component blocks in
+order, each in the linear order of its backing array.
 
 Scalar (`ScalarWrapper`) components are written to `array` with a `fill!` on a
-one-element view, which is GPU-safe; copying them back out of `array` requires
-a scalar read, so `array2fieldvector!` only supports scalar components when
-`array` is a CPU array (a GPU-backed `array` throws a scalar-indexing error
-rather than performing a hidden synchronizing transfer).
+one-element view, which is GPU-safe.
 
 Intended for interfacing with libraries that operate on flat vectors, such as
 the Krylov.jl workspace vectors given by `Krylov.ktypeof(::FieldVector)` (see
-`KrylovExt`).
+`KrylovExt`). See [`array2fieldvector!`](@ref) for the inverse copy and
+[`fieldvector2array`](@ref) for an allocating version.
 """
 function fieldvector2array!(array::AbstractVector, fv::FieldVector)
     length(array) == length(fv) || throw(
@@ -446,6 +443,20 @@ function fieldvector2array!(array::AbstractVector, fv::FieldVector)
     return array
 end
 
+"""
+    array2fieldvector!(fv, array)
+
+Copy the entries of the flat `AbstractVector` `array` into the `FieldVector`
+`fv` of the same length — the inverse of [`fieldvector2array!`](@ref), with
+the same entry ordering, allocation-free block-wise copies, and GPU support.
+
+Copying a scalar (`ScalarWrapper`) component out of `array` requires a scalar
+read, so scalar components are only supported when `array` is a CPU array (a
+GPU-backed `array` throws a scalar-indexing error rather than performing a
+hidden synchronizing transfer).
+
+See [`array2fieldvector`](@ref) for an allocating version.
+"""
 function array2fieldvector!(fv::FieldVector, array::AbstractVector)
     length(array) == length(fv) || throw(
         DimensionMismatch(
@@ -456,6 +467,28 @@ function array2fieldvector!(fv::FieldVector, array::AbstractVector)
     _array2blocks!(Tuple(_values(fv)), array, 0)
     return fv
 end
+
+"""
+    fieldvector2array(fv)
+
+Allocating version of [`fieldvector2array!`](@ref): copy `fv` into a freshly
+allocated flat vector of `fv`'s device array type,
+`ClimaComms.array_type(fv){eltype(fv), 1}`.
+"""
+fieldvector2array(fv::FieldVector) = fieldvector2array!(
+    ClimaComms.array_type(fv){eltype(fv), 1}(undef, length(fv)),
+    fv,
+)
+
+"""
+    array2fieldvector(array, fv_prototype)
+
+Allocating version of [`array2fieldvector!`](@ref): copy `array` into a
+freshly allocated `FieldVector` with the same structure as `fv_prototype`
+(created with `similar`, which preserves component types).
+"""
+array2fieldvector(array::AbstractVector, fv_prototype::FieldVector) =
+    array2fieldvector!(similar(fv_prototype), array)
 
 _blocks2array!(array, offset, ::Tuple{}) = offset
 _blocks2array!(array, offset, vals::Tuple) = _blocks2array!(
@@ -501,14 +534,18 @@ end
 import ClimaComms
 
 function ClimaComms.array_type(x::FieldVector)
-    # ScalarWrapper components hold CPU scalars regardless of where the other
-    # components live, so they do not participate in the promotion.
-    arrays = unrolled_filter(!Base.Fix2(isa, ScalarWrapper), Tuple(_values(x)))
-    isempty(arrays) && return Array
-    return promote_type(unrolled_map(_array_type, arrays)...)
+    T = _array_type(x)
+    # Union{} means x contains nothing but scalars, which live on the CPU.
+    return T === Union{} ? Array : T
 end
-_array_type(x) = ClimaComms.array_type(x) # Fields and nested FieldVectors
-_array_type(x::FieldVector) = ClimaComms.array_type(x) # resolve ambiguity
+# ScalarWrapper components hold CPU scalars regardless of where the other
+# components live, so they must not participate in the promotion, at any
+# nesting depth: their contribution is Union{}, the identity of promote_type
+# (which a nested FieldVector of nothing but scalars also promotes to).
+_array_type(x) = ClimaComms.array_type(x) # Fields
+_array_type(x::FieldVector) =
+    promote_type(unrolled_map(_array_type, Tuple(_values(x)))...)
+_array_type(::ScalarWrapper) = Union{}
 _array_type(::A) where {A <: AbstractArray} = Base.typename(A).wrapper
 
 ClimaComms.device(x::FieldVector) = ClimaComms.device(ClimaComms.context(x))

--- a/src/Fields/fieldvector.jl
+++ b/src/Fields/fieldvector.jl
@@ -43,6 +43,10 @@ Base.size(::ScalarWrapper) = ()
 Base.getindex(s::ScalarWrapper) = s.val
 Base.setindex!(s::ScalarWrapper, value) = s.val = value
 Base.similar(s::ScalarWrapper) = ScalarWrapper(s.val)
+# Without this method, zero(::ScalarWrapper) would return a 0-dimensional
+# Array, so zero(::FieldVector) would not preserve the component types of
+# FieldVectors with scalar components (breaking strict equality with them).
+Base.zero(s::ScalarWrapper) = ScalarWrapper(zero(s.val))
 
 """
     Fields.wrap(x)
@@ -409,10 +413,103 @@ function LinearAlgebra.norm(x::FieldVector)
     sqrt(LinearAlgebra.norm_sqr(x))
 end
 
+"""
+    fieldvector2array!(array, fv)
+    array2fieldvector!(fv, array)
+
+Copy between a `FieldVector` `fv` and a flat `AbstractVector` `array` of the
+same length, without allocating or scalar indexing: each component block is
+copied with a single array-level `copyto!`, so `FieldVector`s backed by GPU
+arrays are supported (including mixed cases, where the flat array and some
+components live on different devices). Entries are ordered as in the
+`FieldVector`'s own linear indexing: component blocks in order, each in the
+linear order of its backing array.
+
+Scalar (`ScalarWrapper`) components are written to `array` with a `fill!` on a
+one-element view, which is GPU-safe; copying them back out of `array` requires
+a scalar read, so `array2fieldvector!` only supports scalar components when
+`array` is a CPU array (a GPU-backed `array` throws a scalar-indexing error
+rather than performing a hidden synchronizing transfer).
+
+Intended for interfacing with libraries that operate on flat vectors, such as
+the Krylov.jl workspace vectors given by `Krylov.ktypeof(::FieldVector)` (see
+`KrylovExt`).
+"""
+function fieldvector2array!(array::AbstractVector, fv::FieldVector)
+    length(array) == length(fv) || throw(
+        DimensionMismatch(
+            "cannot copy FieldVector of length $(length(fv)) to array of \
+             length $(length(array))",
+        ),
+    )
+    _blocks2array!(array, 0, Tuple(_values(fv)))
+    return array
+end
+
+function array2fieldvector!(fv::FieldVector, array::AbstractVector)
+    length(array) == length(fv) || throw(
+        DimensionMismatch(
+            "cannot copy array of length $(length(array)) to FieldVector of \
+             length $(length(fv))",
+        ),
+    )
+    _array2blocks!(Tuple(_values(fv)), array, 0)
+    return fv
+end
+
+_blocks2array!(array, offset, ::Tuple{}) = offset
+_blocks2array!(array, offset, vals::Tuple) = _blocks2array!(
+    array,
+    _block2array!(array, offset, backing_array(first(vals))),
+    Base.tail(vals),
+)
+_block2array!(array, offset, block::FieldVector) =
+    _blocks2array!(array, offset, Tuple(_values(block)))
+function _block2array!(array, offset, block::AbstractArray)
+    n = length(block)
+    copyto!(array, offset + 1, block, 1, n)
+    return offset + n
+end
+# A 0-dimensional block (a ScalarWrapper) holds a CPU scalar; fill! on a
+# one-element view writes it to `array` without allocating or scalar indexing.
+function _block2array!(array, offset, block::AbstractArray{T, 0}) where {T}
+    fill!(view(array, (offset + 1):(offset + 1)), block[])
+    return offset + 1
+end
+
+_array2blocks!(::Tuple{}, array, offset) = offset
+_array2blocks!(vals::Tuple, array, offset) = _array2blocks!(
+    Base.tail(vals),
+    array,
+    _array2block!(backing_array(first(vals)), array, offset),
+)
+_array2block!(block::FieldVector, array, offset) =
+    _array2blocks!(Tuple(_values(block)), array, offset)
+function _array2block!(block::AbstractArray, array, offset)
+    n = length(block)
+    copyto!(block, 1, array, offset + 1, n)
+    return offset + n
+end
+# Reading a scalar block back requires a scalar getindex on `array`; this is
+# allocation-free on CPU arrays and throws a scalar-indexing error for
+# GPU-backed arrays (see the docstring above).
+function _array2block!(block::AbstractArray{T, 0}, array, offset) where {T}
+    block[] = array[offset + 1]
+    return offset + 1
+end
+
 import ClimaComms
 
-ClimaComms.array_type(x::FieldVector) =
-    promote_type(unrolled_map(ClimaComms.array_type, _values(x))...)
+function ClimaComms.array_type(x::FieldVector)
+    # ScalarWrapper components hold CPU scalars regardless of where the other
+    # components live, so they do not participate in the promotion.
+    arrays = unrolled_filter(!Base.Fix2(isa, ScalarWrapper), Tuple(_values(x)))
+    isempty(arrays) && return Array
+    return promote_type(unrolled_map(_array_type, arrays)...)
+end
+_array_type(x) = ClimaComms.array_type(x) # Fields and nested FieldVectors
+_array_type(x::FieldVector) = ClimaComms.array_type(x) # resolve ambiguity
+_array_type(::A) where {A <: AbstractArray} = Base.typename(A).wrapper
 
 ClimaComms.device(x::FieldVector) = ClimaComms.device(ClimaComms.context(x))
 function ClimaComms.context(x::FieldVector)

--- a/test/Fields/unit_field.jl
+++ b/test/Fields/unit_field.jl
@@ -435,6 +435,15 @@ end
     Fields.fieldvector2array!(array, Y2)
     @test array == array2
 
+    # Allocating versions. Note that `array2fieldvector` builds its result
+    # with `similar`, which materializes view-backed components (like `Y.k.x`)
+    # into owned arrays, so values are compared instead of structures.
+    array3 = Fields.fieldvector2array(Y2)
+    @test array3 isa Vector{FT}
+    @test array3 == array2
+    Y3 = Fields.array2fieldvector(array2, Y)
+    @test Fields.fieldvector2array!(zeros(FT, length(Y)), Y3) == array2
+
     @test_throws DimensionMismatch Fields.fieldvector2array!(
         zeros(FT, length(Y) + 1),
         Y,
@@ -577,6 +586,15 @@ end
     @test ClimaComms.array_type(y) == ClimaComms.array_type(device)
     y = Fields.FieldVector(x = xcenters, y = xcenters)
     @test ClimaComms.array_type(y) == ClimaComms.array_type(device)
+    # Scalar components — including nested FieldVectors of nothing but
+    # scalars, as created by wrap(::NamedTuple) — hold CPU scalars and must
+    # not affect the promoted array type.
+    y = Fields.FieldVector(x = xcenters, z = 1.0f0)
+    @test ClimaComms.array_type(y) == ClimaComms.array_type(device)
+    y = Fields.FieldVector(x = xcenters, c = (a = 1.0f0, b = 2.0f0))
+    @test ClimaComms.array_type(y) == ClimaComms.array_type(device)
+    # A FieldVector of nothing but scalars falls back to Array.
+    @test ClimaComms.array_type(Fields.FieldVector(z = 1.0f0)) == Array
 end
 
 @testset "FieldVector basetype replacement and deepcopy" begin

--- a/test/Fields/unit_field.jl
+++ b/test/Fields/unit_field.jl
@@ -396,6 +396,55 @@ end
     @test occursin("==================== Difference found:", s)
 end
 
+@testset "FieldVector flat-array conversions" begin
+    space = spectral_space_2D()
+    FT = Spaces.undertype(space)
+    u = Geometry.Covariant12Vector.(ones(space), 2 .* ones(space))
+    x = Fields.coordinate_field(space).x
+    y = FT[1, 2, 3]
+    z = FT(4)
+    Y = Fields.FieldVector(u = u, k = (x = x, y = y, z = z))
+
+    # array_type supports plain-array and scalar components.
+    @test ClimaComms.array_type(Y) == Array
+
+    array = zeros(FT, length(Y))
+    @test Fields.fieldvector2array!(array, Y) === array
+    # Entries follow the FieldVector's own linear indexing.
+    @test array == [Y[i] for i in eachindex(Y)]
+
+    # `deepcopy` (not `zero`) is used for the round-trip target because `Y.k.x`
+    # is a property view: `zero` materializes its SubArray parent into an owned
+    # Array, which strict `==` treats as a difference.
+    Y2 = deepcopy(Y)
+    fill!(Y2, 0)
+    @test Fields.array2fieldvector!(Y2, array) === Y2
+    @test Y2 == Y
+    @test Y2.k.z === z
+
+    # zero preserves ScalarWrapper components; without a
+    # `zero(::ScalarWrapper)` method they would become 0-dimensional Arrays,
+    # changing the FieldVector's type and breaking strict equality.
+    Ys = Fields.FieldVector(u = u, z = z)
+    @test typeof(zero(Ys)) == typeof(Ys)
+    @test zero(Ys).z === zero(FT)
+
+    # Round-tripping arbitrary data is exact.
+    array2 = rand(FT, length(Y))
+    Fields.array2fieldvector!(Y2, array2)
+    Fields.fieldvector2array!(array, Y2)
+    @test array == array2
+
+    @test_throws DimensionMismatch Fields.fieldvector2array!(
+        zeros(FT, length(Y) + 1),
+        Y,
+    )
+    @test_throws DimensionMismatch Fields.array2fieldvector!(
+        Y2,
+        zeros(FT, length(Y) + 1),
+    )
+end
+
 @testset "Nested FieldVector broadcasting with permuted order" begin
     FT = Float32
     context = ClimaComms.context()


### PR DESCRIPTION
## Purpose

Enable `fieldvectors` in Krylov workspaces

## Changes 

-  Added `Fields.fieldvector2array!` and `Fields.array2fieldvector!`,
  allocation-free, GPU-safe block-wise copies between a `FieldVector` and a
  flat vector. Together with `Krylov.ktypeof(::FieldVector)` (defined in
  `KrylovExt`), these let iterative Krylov solvers keep their workspace vectors on the
  GPU while model code continues to operate on `FieldVector`s.
- Fixed `zero(::FieldVector)` to preserve scalar (`ScalarWrapper`) components
  instead of turning them into 0-dimensional `Array`s, and fixed
  `ClimaComms.array_type(::FieldVector)` (and hence
  `Krylov.ktypeof(::FieldVector)`) for `FieldVector`s with plain-array or
  scalar components, which previously threw a `MethodError`.