### PR TITLE
Fix BoundsError with broadcasted expression

### DIFF
--- a/src/DataLayouts/broadcast.jl
+++ b/src/DataLayouts/broadcast.jl
@@ -157,7 +157,7 @@ Replaces each of the [`layout_args`](@ref) in a broadcast expression with
         Base.@_propagate_inbounds_meta
         arg isa MaybeLazyDataLayout ? f(arg, f_args...) : arg
     end
-    return Broadcast.Broadcasted(bc.style, bc.f, modified_args, bc.axes)
+    return Broadcast.broadcasted(bc.f, modified_args...)
 end
 @propagate_inbounds function modify_args(f::F, bc::FusedMultiBroadcast, f_args...) where {F}
     modified_pairs = unrolled_map_with_inbounds(bc.pairs) do (dest, bc)

--- a/test/Spaces/opt_spaces.jl
+++ b/test/Spaces/opt_spaces.jl
@@ -36,21 +36,21 @@ end
     if ClimaComms.device(context) isa ClimaComms.CUDADevice
         test_n_failures(88,   TU.PointSpace, context)
         test_n_failures(731,  TU.SpectralElementSpace1D, context)
-        test_n_failures(361, TU.SpectralElementSpace2D, context)
+        test_n_failures(362, TU.SpectralElementSpace2D, context)
         test_n_failures(4,  TU.ColumnCenterFiniteDifferenceSpace, context)
         test_n_failures(5,  TU.ColumnFaceFiniteDifferenceSpace, context)
-        test_n_failures(367, TU.SphereSpectralElementSpace, context)
-        test_n_failures(377, TU.CenterExtrudedFiniteDifferenceSpace, context)
-        test_n_failures(377, TU.FaceExtrudedFiniteDifferenceSpace, context)
+        test_n_failures(368, TU.SphereSpectralElementSpace, context)
+        test_n_failures(378, TU.CenterExtrudedFiniteDifferenceSpace, context)
+        test_n_failures(378, TU.FaceExtrudedFiniteDifferenceSpace, context)
     else
         test_n_failures(0,    TU.PointSpace, context)
-        test_n_failures(156,  TU.SpectralElementSpace1D, context)
-        test_n_failures(274,  TU.SpectralElementSpace2D, context)
+        test_n_failures(157,  TU.SpectralElementSpace1D, context)
+        test_n_failures(275,  TU.SpectralElementSpace2D, context)
         test_n_failures(4,  TU.ColumnCenterFiniteDifferenceSpace, context)
         test_n_failures(5,  TU.ColumnFaceFiniteDifferenceSpace, context)
-        test_n_failures(280,  TU.SphereSpectralElementSpace, context)
-        test_n_failures(290,  TU.CenterExtrudedFiniteDifferenceSpace, context)
-        test_n_failures(290,  TU.FaceExtrudedFiniteDifferenceSpace, context)
+        test_n_failures(281,  TU.SphereSpectralElementSpace, context)
+        test_n_failures(291,  TU.CenterExtrudedFiniteDifferenceSpace, context)
+        test_n_failures(291,  TU.FaceExtrudedFiniteDifferenceSpace, context)
 
         # The OBJECT_CACHE causes inference failures that inhibit understanding
         # inference failures in _SpectralElementGrid2D, so let's `@test_opt` those


### PR DESCRIPTION
closes https://github.com/CliMA/ClimaCore.jl/issues/2566 - On Julia 1.12, you can get a `BoundsError` with

```julia
import ClimaCore
using ClimaCore.CommonSpaces
space = ColumnSpace(; z_min = 0.0, z_max = 1.0, z_elem = 4, staggering = CellCenter())
f = ClimaCore.Fields.ones(space)
f .= f .+ 1
```

Instead of manually constructing the `Broadcasted` expression, we pass it to `Broadcast.broadcasted` instead which will determine the style and axes for us.