### PR TITLE
Allow Field views to be used in foreach_slice

### DIFF
--- a/.buildkite/Manifest.toml
+++ b/.buildkite/Manifest.toml
@@ -378,7 +378,7 @@ weakdeps = ["CUDA", "MPI"]
 deps = ["Adapt", "BandedMatrices", "BlockArrays", "ClimaComms", "ClimaInterpolations", "CubedSphere", "DataStructures", "ForwardDiff", "GaussQuadrature", "GilbertCurves", "HDF5", "InteractiveUtils", "IntervalSets", "KrylovKit", "LLVM", "LazyBroadcast", "LinearAlgebra", "MultiBroadcastFusion", "NVTX", "PkgVersion", "Random", "RecursiveArrayTools", "RootSolvers", "SparseArrays", "StaticArrays", "Statistics", "UnrolledUtilities"]
 path = ".."
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
-version = "0.15.0"
+version = "0.15.1"
 weakdeps = ["CUDA", "GPUCompiler", "Krylov"]
 
     [deps.ClimaCore.extensions]

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,13 @@ ClimaCore.jl Release Notes
 main
 -------
 
+v0.15.1
+-------
+
+- Extend kernel fusion interface (`foreach_slice`/`reduce_points`) to `Field`
+  arguments. [2571](https://github.com/CliMA/ClimaCore.jl/pull/2571)
+- Add `PointCloudSpace` and `MultiColumnFiniteDifferenceSpace` for running independent
+  points/columns in parallel. [2525](https://github.com/CliMA/ClimaCore.jl/pull/2525)
 
 v0.15.0
 -------

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.15.0"
+version = "0.15.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/ext/ClimaCoreCUDAExt.jl
+++ b/ext/ClimaCoreCUDAExt.jl
@@ -3,7 +3,7 @@ module ClimaCoreCUDAExt
 import NVTX
 import ClimaCore.Limiters
 import ClimaComms
-import ClimaCore: DataLayouts, Geometry, Utilities
+import ClimaCore: DataLayouts, Fields, Geometry, Utilities
 import ClimaCore.Geometry: AbstractTensor
 import CUDA
 using CUDA

--- a/ext/cuda/adapt.jl
+++ b/ext/cuda/adapt.jl
@@ -25,6 +25,15 @@ Adapt.adapt_structure(
 
 Adapt.adapt_structure(
     to::CUDA.KernelAdaptor,
+    grid::Grids.SpectralElementGrid1D,
+) = Grids.DeviceSpectralElementGrid1D(
+    Adapt.adapt(to, grid.quadrature_style),
+    Adapt.adapt(to, grid.global_geometry),
+    Adapt.adapt(to, grid.local_geometry),
+)
+
+Adapt.adapt_structure(
+    to::CUDA.KernelAdaptor,
     grid::Grids.SpectralElementGrid2D,
 ) = Grids.DeviceSpectralElementGrid2D(
     Adapt.adapt(to, grid.quadrature_style),

--- a/ext/cuda/cuda_utils.jl
+++ b/ext/cuda/cuda_utils.jl
@@ -147,7 +147,7 @@ function uncached_launch_configuration(cu_func, strict, default_max_waves, confi
 
     get_user_max_threads_per_block() = attrs.max_block_dim_x
     get_user_max_threads_per_block(user_max_threads) = user_max_threads
-    get_user_max_threads_per_block(_, user_max_threads_per_block) =
+    get_user_max_threads_per_block(user_max_threads_per_block, _) =
         user_max_threads_per_block
 
     get_user_max_blocks(_) = attrs.max_grid_dim_x

--- a/ext/cuda/loops.jl
+++ b/ext/cuda/loops.jl
@@ -1,29 +1,32 @@
-function DataLayouts.foreach_slice(::ThisHost, op::O, f::F, args...; kwargs...) where {O, F}
-    check_device_assumptions()
+# Only run a fused foreach_slice kernel when every slice has an inferrable size.
+has_inferred_slice_size(op::O, arg) where {O} =
+    Val{true} == Utilities.return_type(Tuple{typeof(arg)}) do arg
+        slice = op(arg, Tuple(first(DataLayouts.each_slice_index(op, arg)))...)
+        Val(DataLayouts.has_inferred_size(slice))
+    end
 
-    # Capture the kwargs as a NamedTuple, whose names are type parameters. The
-    # Pairs structure of kwargs stores its names in a Tuple of Symbols, which
-    # cannot be passed to a kernel because Symbols are not bitstypes.
-    kernel_kwargs = values(kwargs)
-    kernel_function(args...) =
-        DataLayouts.foreach_slice(ThisKernel(), op, f, args...; kernel_kwargs...)
-
-    # Masked loops iterate compacted active indices inside the kernel, but the
-    # launch is configured with the unmasked totals: they are upper bounds (the
-    # extra threads run empty loops), and reading the active count from the
-    # mask's device array would synchronize the stream at every launch.
-    (; threads, blocks) =
+DataLayouts.foreach_slice(scope::ThisHost, op::O, f::F, mask, args...) where {O, F} =
+    if !all(Base.Fix1(has_inferred_slice_size, op), args)
+        for index in DataLayouts.subscope_slice_indices(scope, scope, mask, op, args...)
+            f(map(arg -> (@inbounds op(arg, Tuple(index)...)), args)...)
+        end
+    else
+        check_device_assumptions()
+        kernel_function(args...) =
+            DataLayouts.foreach_slice(ThisKernel(), op, f, mask, args...)
         if DataLayouts.slice_subscope(ThisKernel(), op, args...) == ThisBlock()
             max_slice_points = maximum(Base.Fix1(DataLayouts.num_slice_points, op), args)
             max_slices = length(DataLayouts.each_slice_index(op, first(args)))
-            launch_configuration(kernel_function, args, max_slice_points, max_slices)
+            (; threads, blocks) =
+                launch_configuration(kernel_function, args, max_slice_points, max_slices)
         else
             # Extra threads run empty loops, so max_points isn't a strict limit.
             max_points = maximum(length, args)
-            launch_configuration(kernel_function, args, max_points; strict = false)
+            (; threads, blocks) =
+                launch_configuration(kernel_function, args, max_points; strict = false)
         end
-    auto_launch!(kernel_function, args; threads_s = threads, blocks_s = blocks)
-end
+        auto_launch!(kernel_function, args; threads_s = threads, blocks_s = blocks)
+    end
 
 # Only save a reduction result to an array from one thread per reduction scope.
 is_first_thread_in(scope) = isone(DataLayouts.thread_rank(scope))
@@ -51,9 +54,12 @@ end
 # first warp of the last block folds the block results in registers and
 # combines them with warp shuffles, which needs no shared memory and therefore
 # supports arbitrarily wide element types.
-function DataLayouts.reduce_points(::ThisHost, op::O, arg; kwargs...) where {O}
+function DataLayouts.reduce_points(scope::ThisHost, op::O, arg; kwargs...) where {O}
     check_device_assumptions()
 
+    # Capture the kwargs as a NamedTuple, whose names are type parameters. The
+    # Pairs structure of kwargs stores its names in a Tuple of Symbols, which
+    # cannot be passed to a kernel because Symbols are not bitstypes.
     kernel_kwargs = values(kwargs)
     function kernel_function(results, finished_blocks, arg, num_blocks)
         result = DataLayouts.reduce_points(ThisBlock(), op, arg; kernel_kwargs...)
@@ -99,14 +105,14 @@ function DataLayouts.reduce_points(::ThisHost, op::O, arg; kwargs...) where {O}
     end
 
     T = return_type(op, NTuple{2, eltype(arg)})
-    results = DataLayouts.scoped_array(ThisHost(), T, 0; buffer = true)
+    results = DataLayouts.scoped_array(scope, T, 0; buffer = true)
     finished_blocks = reduction_sync_counter()
     (; threads, blocks) = launch_configuration(
         kernel_function,
         (results, finished_blocks, arg, Int32(1)),
         length(arg),
     )
-    results = DataLayouts.scoped_array(ThisHost(), T, blocks; buffer = true)
+    results = DataLayouts.scoped_array(scope, T, blocks; buffer = true)
     CUDA.fill!(finished_blocks, Int32(0))
     auto_launch!(
         kernel_function,

--- a/ext/cuda/scopes.jl
+++ b/ext/cuda/scopes.jl
@@ -215,52 +215,12 @@ end
     return @inbounds indices[view_range]
 end
 
-# Unmasked point loops on device scopes iterate eachindex instead of the
-# Cartesian each_slice_index: when every argument supports linear indexing,
-# this avoids the integer divisions that decompose a thread's linear index into
-# a CartesianIndex at every point. Host scopes keep Cartesian indices; see
-# each_maskable_slice_index in DataLayouts for why.
-# The signature has to stay restricted to device scopes. The return type below
-# is a union of a linear range and a CartesianIndices that only resolves where
-# the extents are statically known, so covering host scopes as well would make
-# merely loading this extension turn every CPU point loop over a layout with a
-# dynamic extent into a dynamically dispatched one.
-# Layouts are collected recursively, so that a singleton layout nested inside a
-# broadcast expression is seen by the size check below; a nested broadcast's own
-# combined size would hide it, and a linear index does not project onto
-# singleton dimensions.
-# The layouts are collected into a tuple with unrolled_flatmap, which keeps
-# every intermediate type concrete. Folding the checks into a reduction over a
-# reference layout would instead accumulate a union over the distinct layout
-# types in the broadcast expression, which exceeds inference's union-splitting
-# limits for heterogeneous expressions and makes the size and linearity checks
-# dynamic during GPU compilation.
-@inline get_all_non_point_layouts(arg::DataLayouts.DataLayout) =
-    DataLayouts.is_non_point_arg(arg) ? (arg,) : ()
-@inline get_all_non_point_layouts(
-    bc::DataLayouts.MaybeFusedDataLayoutBroadcast,
-) = unrolled_flatmap(get_all_non_point_layouts, DataLayouts.layout_args(bc))
-@inline get_all_non_point_layouts(other) = ()
-
-@inline is_device_linear(arg) = Base.IndexStyle(arg) == IndexLinear()
-
-@inline function DataLayouts.each_maskable_slice_index(
+# Unmasked point loops on device scopes iterate over eachindex instead of the
+# Cartesian each_slice_index. When every argument supports linear indexing, this
+# avoids the integer divisions required for linear-to-Cartesian conversion.
+@inline DataLayouts.each_maskable_slice_index(
     ::Union{ThisKernel, ThisCooperativeGroup},
     ::NoMask,
     ::typeof(view),
     args...,
-)
-    # 0-dimensional layouts (e.g. DataF args of fused broadcasts) broadcast to
-    # every point, so they do not participate in the size or linearity checks.
-    layouts = unrolled_flatmap(get_all_non_point_layouts, args)
-    isempty(layouts) && return Base.OneTo(1)
-    if unrolled_allequal(size, layouts) &&
-       unrolled_all(is_device_linear, layouts)
-        return Base.OneTo(length(first(layouts)))
-    else
-        # Singleton and mismatched extents require Cartesian indices, which
-        # Broadcast.newindex projects onto each argument's dimensions; genuine
-        # mismatches were already rejected on the host by check_slice_extents.
-        return DataLayouts.each_slice_index(view, args...)
-    end
-end
+) = eachindex(args...)

--- a/src/DataLayouts/DataLayouts.jl
+++ b/src/DataLayouts/DataLayouts.jl
@@ -330,8 +330,8 @@ end
 
 [`DataLayout`](@ref) representing a single value of type `T`, which can be
 stored across multiple array indices. This is used in place of a `Ref` to wrap
-data that is stored in any array. May be constructed either from the parent
-array type or the parent array itself.
+data that is stored in any one-dimensional array. May be constructed either from
+the parent array type or the parent array itself.
 """
 struct DataF{T, S, A} <: DataLayout{T, 0, 1, S, A}
     array::A
@@ -342,10 +342,8 @@ DataF{T, S}(::Type{A}) where {T, S, A} =
     DataF{T, S}(similar(A, num_basetypes(eltype(A), T)))
 function DataF{T, S}(array) where {T, S}
     check_basetype(eltype(array), T)
-    length(array) == num_basetypes(eltype(array), T) ||
-        throw(ArgumentError("Array length is not consistent with element type"))
-    linearly_indexable_array = IndexStyle(array) == IndexLinear() ? array : vec(array)
-    return DataF{T, S, typeof(linearly_indexable_array)}(linearly_indexable_array)
+    check_parent(array, num_basetypes(eltype(array), T))
+    return DataF{T, S, typeof(array)}(array)
 end
 
 @inline shape_params(::Type{<:DataF}) = (;)

--- a/src/DataLayouts/broadcast.jl
+++ b/src/DataLayouts/broadcast.jl
@@ -153,7 +153,7 @@ const DATA_LAYOUT_PRIMITIVES =
 for f in (:ndims, :length, :size, :axes, DATA_LAYOUT_PRIMITIVES...)
     f_with_module_prefix = f in DATA_LAYOUT_PRIMITIVES ? f : :(Base.$f)
     @eval @inline $f_with_module_prefix(bc::FusedMultiBroadcast) =
-        unrolled_allequal($f, layout_args(bc)) ? $f(first(layout_args(bc))) :
+        unrolled_allequal($f, unrolled_map(first, bc.pairs)) ? $f(first(first(bc.pairs))) :
         throw(DimensionMismatch($("$f is inconsistent among fused broadcasts")))
 end
 

--- a/src/DataLayouts/indexing.jl
+++ b/src/DataLayouts/indexing.jl
@@ -40,9 +40,16 @@ Base.IndexStyle(::Type{D}) where {D <: DataLayout} =
 # layout types among the args, which exceeds inference's union-splitting
 # limits for heterogeneous broadcast expressions and makes the shape checks
 # dynamic.
+# Layouts are collected recursively, so that a singleton layout nested inside
+# a broadcast expression is seen by the shape checks: a nested broadcast's own
+# merged shape_params would hide it, and a linear index does not project onto
+# singleton dimensions, so reading such a layout at a linear index would go
+# out of range.
 @inline get_non_point_arg_tuple(arg) = is_non_point_arg(arg) ? (arg,) : ()
+@inline get_non_point_arg_tuple(bc::MaybeFusedDataLayoutBroadcast) =
+    unrolled_flatmap(get_non_point_arg_tuple, layout_args(bc))
 
-@inline function equal_layout_shapes(args::Tuple)
+@inline function equal_layout_shapes(args)
     non_point_args = unrolled_flatmap(get_non_point_arg_tuple, args)
     return unrolled_allequal(layout_type, non_point_args) &&
            unrolled_allequal(shape_params, non_point_args)
@@ -55,17 +62,12 @@ end
 @inline Base.IndexStyle(bc::MaybeFusedDataLayoutBroadcast) =
     equal_layout_shapes(layout_args(bc)) ? IndexLinear() : IndexCartesian()
 
-@inline index_style_layouts(::Tuple{}) = IndexLinear()
-@inline index_style_layouts(args::Tuple{Any}) = IndexStyle(first(args))
-@inline index_style_layouts(args::Tuple) =
-    equal_layout_shapes(args) ?
-    unrolled_mapreduce(IndexStyle, IndexStyle, args) : IndexCartesian()
-
 # Allow linear indexing if all DataLayouts in an expression have the same shape.
 # Add DataLayout-only methods to avoid ambiguities with AbstractArray methods.
 for T in (:IndexableData, :DataLayout)
     @eval @inline Base.IndexStyle(arg1::$T, arg2::$T, args::$T...) =
-        index_style_layouts((arg1, arg2, args...))
+        equal_layout_shapes((arg1, arg2, args...)) ?
+        unrolled_mapreduce(IndexStyle, IndexStyle, (arg1, arg2, args...)) : IndexCartesian()
 
     @eval @inline Base.eachindex(arg::$T, args::$T...) =
         eachindex(IndexStyle(arg, args...), arg, args...)
@@ -77,31 +79,15 @@ for T in (:IndexableData, :DataLayout)
         throw(DimensionMismatch("Inputs to eachindex must have the same size"))
 end
 
-@inline slice_axes(op, arg) = axes(each_slice_index(op, arg))
-
 """
-    each_slice_index(op, args...)
+    each_slice_index(op, arg)
 
 Generalization of `eachindex` for the slice operators [`level`](@ref),
 [`slab`](@ref), [`column`](@ref), and `view` (for creating single-point slices).
 The result is always an iterator of Cartesian indices, whose scalar offsets are
 simple enough for SIMD optimization (a `view` at a linear index wraps its parent
 in a 1-dimensional `ReshapedArray`, which blocks SIMD in pointwise loops).
-
-The arguments' axes are combined with `stable_combine_axes`, which expands
-singleton and 0-dimensional axes like broadcasting does and never throws, since
-this function is called from GPU kernels, where an error path either fails to
-compile or traps with an unrelated CUDA error. Arguments whose axes are
-genuinely incompatible are rejected on the host by [`foreach_slice`](@ref)
-before any kernel is launched.
 """
-@inline each_slice_index(op::O, args...) where {O} = CartesianIndices(
-    unrolled_reduce(
-        stable_combine_axes,
-        unrolled_map(Base.Fix1(slice_axes, op), args),
-    ),
-)
-
 @inline each_slice_index(::typeof(view), arg) = CartesianIndices(size(arg))
 @inline each_slice_index(::typeof(level), arg) = CartesianIndices((nlevels(arg),))
 @inline each_slice_index(::typeof(slab), arg) =
@@ -124,10 +110,6 @@ before any kernel is launched.
     1 <= index <= length(bc) || Base.throw_boundserror(bc, (index,))
 @inline Base.checkbounds(bc::LazyDataLayout, ::CartesianIndex{0}) = checkbounds(bc, 1)
 
-# Like single-point broadcasts, single-point layouts (e.g. level slices with one
-# level) are identified by their length, since they keep their dimensions.
-@inline is_single_point(data, index) = isone(length(data)) && index == CartesianIndex()
-
 # Avoid unnecessary indexing arithmetic whenever possible. Base's default array
 # access methods use Cartesian-to-linear index conversions, without any constant
 # propagation of array dimensions. Even worse, Base's default SubArray access
@@ -136,40 +118,6 @@ before any kernel is launched.
 # and it uses a linear index to access the parent of a constant-stride SubArray.
 @inline field_offset(array::SubArray, ::Val{F}) where {F} =
     first(parentindices(array)[F]) - 1
-
-@propagate_inbounds function array_and_index_args(data::DataLayout, index::Integer)
-    array = parent(data)
-    is_single_point(data, index) && return (array, ())
-    F = f_dim(data)
-    isnothing(F) && return (array, (CartesianIndices(data)[index], Val(F)))
-    # The strides below are computed from runtime sizes rather than from
-    # inferred_size, so that layouts with dynamic extents (every field has a
-    # dynamic Nh) can use the linear fast paths; LLVM constant-folds the
-    # products whenever the sizes are statically known. Converting the index
-    # with CartesianIndices is only needed when a multi-component layout is
-    # given a linear point index, since its parent cannot be accessed linearly.
-    if is_constant_stride_view_type(typeof(array), Val(F))
-        stride = prod(size(data)[1:(F - 1)])
-        f0 = field_offset(array, Val(F))
-        Nf_parent = size(parent(array), F)
-        h0 = (index - 1) ÷ stride
-        p0 = (index - 1) % stride
-        parent_idx = p0 + f0 * stride + h0 * (stride * Nf_parent) + 1
-        return (parent(array), (parent_idx, stride))
-    elseif IndexStyle(data) == IndexLinear()
-        stride = prod(size(data)[1:(F - 1)])
-        return (array, (index, stride))
-    else
-        return (array, (CartesianIndices(data)[index], Val(F)))
-    end
-end
-
-@propagate_inbounds function array_and_index_args(data::DataLayout, index::CartesianIndex)
-    array = parent(data)
-    is_single_point(data, index) && return (array, ())
-    F = f_dim(data)
-    return (array, (index, Val(F)))
-end
 
 # Constant-folded Cartesian-to-linear index conversion for array of size `dims`.
 # The init value is passed positionally instead of as a keyword argument
@@ -184,42 +132,46 @@ end
     return offset + 1
 end
 
-@propagate_inbounds safe_index(data, index) =
-    IndexStyle(data) == IndexCartesian() && index isa Integer ?
-    CartesianIndices(data)[index] : index
+# Propagate all Cartesian indices that are specified by the user, without any
+# Cartesian-to-linear conversion. Avoid linear-to-Cartesian conversion unless it
+# is necessary, using a single integer division to access any constant-stride
+# parent array. Avoid the need to reshape single-point views, converting empty
+# Cartesian indices into full-rank indices for multidimensional parent arrays.
+@propagate_inbounds function array_and_index_args(data, index)
+    array = parent(data)
+    F = f_dim(data)
+    (index == CartesianIndex() && isone(length(data))) &&
+        return (array, isone(ndims(array)) ? () : (first(CartesianIndices(data)), Val(F)))
+    (index isa CartesianIndex || isnothing(F)) && return (array, (index, Val(F)))
+    IndexStyle(data) == IndexCartesian() &&
+        return (array, (CartesianIndices(data)[index], Val(F)))
+    stride = prod(size(data)[1:(F - 1)])
+    IndexStyle(array) == IndexLinear() && return (array, (index, stride))
+    index_for_dims_after_F, offset_for_dims_before_F = divrem(index - 1, stride)
+    parent_Nf = size(parent(array), F)
+    parent_f = field_offset(array, Val(F))
+    num_strides_in_parent = index_for_dims_after_F * parent_Nf + parent_f
+    parent_index = num_strides_in_parent * stride + offset_for_dims_before_F + 1
+    return (parent(array), (parent_index, stride))
+end
 
 # Always convert to the element type of a DataLayout when modifying its values.
 @propagate_inbounds function Base.setindex!(data::DataLayout, value, index::PointIndex)
-    (array, index_args) = array_and_index_args(data, safe_index(data, index))
+    (array, index_args) = array_and_index_args(data, index)
     return set_struct!(array, convert(eltype(data), value), index_args...)
 end
 
 @propagate_inbounds function Base.getindex(data::DataLayout, index::PointIndex)
-    (array, index_args) = array_and_index_args(data, safe_index(data, index))
+    (array, index_args) = array_and_index_args(data, index)
     return get_struct(array, eltype(data), index_args...)
 end
 
 # Represent every single-point DataLayout view using a zero-dimensional DataF.
-@propagate_inbounds Base.view(data::DataLayout, index::PointIndex) =
-    is_single_point(data, index) ? data :
-    DataF{eltype(data), typeof(DataScope(data))}(
-        view_point_struct(data, safe_index(data, index)),
-    )
-
-@propagate_inbounds view_point_struct(data, index) =
-    view_struct(parent(data), eltype(data), index, Val(f_dim(data)))
-
-# A point view at a linear index is built from the same array and index
-# arguments as getindex and setindex!, so that linearly indexable data gets a
-# strided view of its parent's linear indices (at most one integer division,
-# on constant-stride field views) instead of a linear-to-Cartesian index
-# conversion (one division per dimension); point loops construct a view of
-# every argument at every point, so this conversion would otherwise dominate
-# the index arithmetic of GPU broadcast kernels. Data that requires Cartesian
-# indices is converted by array_and_index_args.
-@propagate_inbounds function view_point_struct(data, index::Integer)
+@propagate_inbounds function Base.view(data::DataLayout, index::PointIndex)
     (array, index_args) = array_and_index_args(data, index)
-    return view_struct(array, eltype(data), index_args...)
+    return DataF{eltype(data), typeof(DataScope(data))}(
+        view_struct(array, eltype(data), index_args...),
+    )
 end
 
 # Use Broadcast.newindex to match the behavior of getindex for LazyDataLayouts.

--- a/src/DataLayouts/loops.jl
+++ b/src/DataLayouts/loops.jl
@@ -21,13 +21,14 @@ end
 
 # The scope is passed so that GPU scopes can override the indices of unmasked
 # point loops with eachindex, whose linear indices avoid the integer divisions
-# that decompose a thread's index into a CartesianIndex at every point. Host
-# scopes keep the Cartesian each_slice_index for point loops: a view at a
-# linear index wraps its parent in a 1-dimensional ReshapedArray that blocks
-# SIMD (see each_slice_index), which would make single-component CPU broadcasts
-# slow, while GPU threads iterate too few points per thread for SIMD to matter.
+# required for linear-to-Cartesian conversion. CPU scopes keep the Cartesian
+# each_slice_index for point loops: a view at a linear index wraps its parent in
+# a 1-dimensional ReshapedArray that blocks SIMD (see each_slice_index), which
+# would make single-component CPU broadcasts slow, while GPU threads iterate too
+# few points per thread for SIMD to matter. Although CPU scopes only need one
+# argument, GPU scopes must check every argument for linear indexing support.
 @inline each_maskable_slice_index(_, _, op::O, args...) where {O} =
-    each_slice_index(op, args...)
+    each_slice_index(op, first(args))
 @inline each_maskable_slice_index(_, mask::IJHMask, ::typeof(column), args...) =
     ActiveColumnIndices(mask)
 @inline each_maskable_slice_index(_, mask::IJHMask, ::typeof(view), args...) =
@@ -55,12 +56,9 @@ end
 # broadcasts, whose 0-dimensional DataF args and dimension-preserving
 # Broadcasted args have inconsistent values of inferred_size.
 @inline num_slice_points(::typeof(view), arg) = 1
-@inline function num_slice_points(op::O, arg) where {O}
-    isempty(each_slice_index(op, arg)) && return 0
-    first_slice = @inbounds op(arg, Tuple(first(each_slice_index(op, arg)))...)
-    has_inferred_size(first_slice) && return prod(inferred_size(first_slice))
-    throw(ArgumentError("Size of slice operator result must be inferrable"))
-end
+@inline num_slice_points(op::O, arg) where {O} =
+    isempty(each_slice_index(op, arg)) ? 0 :
+    length(@inbounds op(arg, Tuple(first(each_slice_index(op, arg)))...))
 
 """
     slice_subscope(scope, op, args...)
@@ -71,9 +69,6 @@ subset of `scope` that does not require any thread to process more than one
 point from the largest slice returned by `op`. When no such subset is available,
 the largest subset is used in order to minimize the number of points per thread.
 """
-@inline slice_subscope(scope, ::typeof(column), args...) = ThisThread()
-@inline slice_subscope(scope, ::typeof(view), args...) = ThisThread()
-@inline slice_subscope(scope, ::typeof(level), args...) = ThisThread()
 @inline function slice_subscope(scope, op::O, args...) where {O}
     subscope = partition(scope)
     subscope == ThisThread() && return subscope
@@ -84,7 +79,6 @@ end
 
 """
     foreach_slice(op, f, args...; [mask])
-    foreach_slice(scope, op, f, args...; mask)
 
 Generalization of `eachslice`/`mapslices` that applies `f` to slices of every
 [`DataLayout`](@ref) or similarly indexable argument, where the slice operator
@@ -97,56 +91,25 @@ Each slice is assigned to a [`slice_subscope`](@ref) of `scope`, which by
 default is the largest available [`DataScope`](@ref) that can access every
 argument. A [`DataMask`](@ref) may also be used to skip over a particular subset
 of slices.
-
-The `mask` is only given a default of [`NoMask`](@ref) when no `scope` is
-specified, since that is the only method a loop starts from. Every method that
-takes a `scope` requires a `mask`, so that a loop which passes its keyword
-arguments on cannot quietly drop a mask and compute over the points it excludes.
 """
-@inline function foreach_slice(op::O, f::F, args...; mask = NoMask()) where {O, F}
-    check_slice_extents(op, args...)
-    return foreach_slice(DataScope(args...), op, f, args...; mask)
-end
-
-# Reject arguments whose slice indices are incompatible before any loop starts.
-# This check must run on the host: each_slice_index is called from GPU kernels,
-# where an error path either fails to compile or traps with an unrelated CUDA
-# error, so it combines incompatible axes instead of throwing. Point slices
-# broadcast like ordinary expressions, so their axes only need to match up to
-# singleton and missing dimensions, which project_slice_index sends to index 1;
-# the other slice operators require exact matches.
-@inline function check_slice_extents(op::O, args...) where {O}
-    combined_axes = axes(each_slice_index(op, args...))
-    valid = unrolled_all(args) do arg
-        compatible_axes(op, axes(each_slice_index(op, arg)), combined_axes)
-    end
-    valid || throw(
-        DimensionMismatch("Inputs to foreach_slice must have compatible dimensions"),
-    )
-    return nothing
-end
-
-@inline compatible_axes(op::O, axes1::Tuple, axes2::Tuple) where {O} = axes1 == axes2
-@inline compatible_axes(::typeof(view), axes1::Tuple, axes2::Tuple) =
-    isempty(axes1) ||
-    (
-        (first(axes1) == first(axes2) || isone(length(first(axes1)))) &&
-        compatible_axes(view, Base.tail(axes1), Base.tail(axes2))
-    )
+@inline foreach_slice(op::O, f::F, args...; mask = NoMask()) where {O, F} =
+    unrolled_allequal(Base.Fix1(each_slice_index, op), args) ?
+    foreach_slice(DataScope(args...), op, f, mask, args...) :
+    throw(DimensionMismatch("Inputs to foreach_slice must have compatible dimensions"))
 
 # A thread pool has to be resolved before looping over it, and given back afterward.
 @inline function foreach_slice(
     pool::ThisThreadPool,
     op::O,
     f::F,
-    args...;
     mask,
+    args...,
 ) where {O, F}
     pool_thread_info() == (0, 0) ||
-        return foreach_pool_slice(num_threads(pool), pool, op, f, args...; mask)
+        return foreach_pool_slice(num_threads(pool), pool, op, f, mask, args...)
     threads = resolve_pool_threads()
     try
-        return foreach_pool_slice(threads, pool, op, f, args...; mask)
+        return foreach_pool_slice(threads, pool, op, f, mask, args...)
     finally
         release_pool_threads()
     end
@@ -160,16 +123,24 @@ end
     pool::ThisThreadPool,
     op::O,
     f::F,
-    args...;
     mask,
+    args...,
 ) where {O, F} =
-    isone(threads) ? foreach_slice(ThisThread(), op, f, args...; mask) :
+    isone(threads) ? foreach_slice(ThisThread(), op, f, mask, args...) :
     parallelize_over(() -> slice_loop(pool, op, f, mask, args...), pool)
 
-@inline foreach_slice(scope::DataScope, op::O, f::F, args...; mask) where {O, F} =
+@inline foreach_slice(scope::DataScope, op::O, f::F, mask, args...) where {O, F} =
     slice_loop(scope, op, f, mask, args...)
-@inline foreach_slice(::ThisThread, op::O, f::F, args...; mask) where {O, F} =
-    slice_loop(ThisThread(), op, f, mask, args...)
+
+# The loop body lives behind a function barrier because the generic
+# slice_subscope method branches on a slice size that is only known at run time
+# when a layout extent is dynamic, which widens the subscope to a small Union of
+# scopes. Dispatch on the barrier splits that Union once; without the barrier,
+# the correlated unions of the argument slices must all be split at the call to
+# f, which exceeds inference's union-splitting limit for three or more
+# arguments and makes every slice operation dynamic.
+@inline slice_loop(scope, op::O, f::F, mask, args...) where {O, F} =
+    scoped_slice_loop(slice_subscope(scope, op, args...), scope, op, f, mask, args...)
 
 # Point loops need @simd and an inlined call to f for vectorization, since LLVM
 # cannot vectorize across a flattened CartesianIndices iterator unless @simd
@@ -180,53 +151,14 @@ end
 # broadcasts. Lazy iterators such as Iterators.filter or Iterators.map do not
 # support @simd, and operations on non-point slices typically do too much work
 # per slice for vectorization to be worthwhile.
-# Project a point index onto one argument, so that arguments which broadcast
-# along a dimension (0-dimensional layouts, or layouts with a singleton extent,
-# like single-level surface data) read their single value instead of an
-# out-of-range one. Only point slices need this: the other slice operators
-# require every argument to have identical slice indices. Each argument's
-# singleton dimensions are recorded in a tuple of Bools before the loop starts,
-# so that the per-point projection only selects on loop-invariant flags, which
-# LLVM folds away, instead of comparing dynamic extents at every point; for
-# equal-shaped arguments, the projection is the identity.
-@inline is_singleton_axis(ax) = isone(length(ax))
-@inline singleton_slice_dims(op::O, arg) where {O} = ()
-@inline singleton_slice_dims(::typeof(view), arg) =
-    unrolled_map(is_singleton_axis, axes(each_slice_index(view, arg)))
-
-@inline project_slice_index(op::O, arg, is_singleton, index) where {O} = index
-@inline project_slice_index(::typeof(view), arg, is_singleton, index::Integer) =
-    Broadcast.newindex(arg, index)
-@inline project_slice_index(::typeof(view), arg, is_singleton, index::CartesianIndex) =
-    iszero(ndims(arg)) ? CartesianIndex() :
-    CartesianIndex(projected_index(is_singleton, Tuple(index)))
-@inline projected_index(is_singleton::Tuple, index::Tuple) = (
-    (first(is_singleton) ? 1 : first(index)),
-    projected_index(Base.tail(is_singleton), Base.tail(index))...,
-)
-@inline projected_index(::Tuple{}, index::Tuple) = index
-@inline projected_index(::Tuple{}, ::Tuple{}) = ()
-
-@inline slice_arg((op, subscope, index)::Tuple, arg) =
-    @inbounds reassign(
-        op(
-            arg,
-            Tuple(project_slice_index(op, arg, singleton_slice_dims(op, arg), index))...,
-        ),
-        subscope,
-    )
-
-@inline slice_args(state, ::Tuple{}) = ()
-@inline slice_args(state, args::Tuple) =
-    (slice_arg(state, first(args)), slice_args(state, Base.tail(args))...)
-
-@inline function slice_loop(scope, op::O, f::F, mask, args...) where {O, F}
-    subscope = slice_subscope(scope, op, args...)
+@inline function scoped_slice_loop(subscope, scope, op::O, f::F, mask, args...) where {O, F}
     indices = subscope_slice_indices(subscope, scope, mask, op, args...)
     N_indices = length(indices)
     @simd_if (op == view && simd_over_indices(indices)) for i in 1:N_indices
         index = @inbounds indices[i]
-        slices = slice_args((op, subscope, index), args)
+        slices = unrolled_map(args) do arg
+            @inbounds reassign(op(arg, Tuple(index)...), subscope)
+        end
         @inline f(slices...)
     end
 end
@@ -253,7 +185,6 @@ end
 
 """
     reduce_points(op, arg; [mask], [init])
-    reduce_points(scope, op, arg; mask, [init])
 
 Generalization of `reduce` that uses `op` to combine values stored in a
 [`DataLayout`](@ref) or similarly indexable argument.
@@ -263,10 +194,6 @@ which by default is the largest available [`DataScope`](@ref) that can access
 the argument. A [`DataMask`](@ref) may also be used to skip over a particular
 subset of points. If the `mask` disables every point, or if there are no points
 in `arg` to begin with, the `init` value must be specified.
-
-As in [`foreach_slice`](@ref), the `mask` is only given a default of
-[`NoMask`](@ref) when no `scope` is specified, so that a reduction which passes
-its keyword arguments on cannot quietly drop a mask.
 """
 @inline reduce_points(op::O, arg; mask = NoMask(), init...) where {O} =
     reduce_points(DataScope(arg), op, arg; mask, init...)
@@ -495,13 +422,15 @@ end
 # Optimize unmasked equality checks for similar layouts with the same packed
 # (un-padded) element types by deferring to their parent arrays. Padded values
 # should not be compared in this way, since equality must not depend on padding.
+# Parent arrays with mismatched dimensions are flattened before being compared.
 @inline Base.:(==)(arg1::DataLayout, arg2::DataLayout; mask = NoMask()) =
     size(arg1) == size(arg2) && (
-        mask == NoMask() &&
-        eltype(arg1) == eltype(arg2) &&
-        (Base.ispacked(eltype(arg1)) && Base.ispacked(eltype(arg2))) &&
-        (layout_type(arg1) == layout_type(arg2) && f_dim(arg1) == f_dim(arg2)) ?
-        parent(arg1) == parent(arg2) : mapreduce(==, &, arg1, arg2; mask, init = true)
+        mask != NoMask() ||
+        !(eltype(arg1) == eltype(arg2) && Base.ispacked(eltype(arg1))) ||
+        !(layout_type(arg1) == layout_type(arg2) && f_dim(arg1) == f_dim(arg2)) ?
+        mapreduce(all ∘ ==, &, arg1, arg2; mask, init = true) :
+        ndims(parent(arg1)) == ndims(parent(arg2)) ? parent(arg1) == parent(arg2) :
+        stable_view(parent(arg1), :) == stable_view(parent(arg2), :)
     )
 @inline Base.:(==)(arg1::MaybeLazyDataLayout, arg2::MaybeLazyDataLayout; mask = NoMask()) =
-    size(arg1) == size(arg2) && mapreduce(==, &, arg1, arg2; mask, init = true)
+    size(arg1) == size(arg2) && mapreduce(all ∘ ==, &, arg1, arg2; mask, init = true)

--- a/src/DataLayouts/struct_storage.jl
+++ b/src/DataLayouts/struct_storage.jl
@@ -114,8 +114,11 @@ dimension, `F` may be replaced with `nothing`.
     return @inbounds stable_view(array, all_indices...)
 end
 
-@inline single_index(index, ::Val{Nf}) where {Nf} =
-    isone(Nf) ? Tuple(index) : throw(ArgumentError("F axis is required unless Nf = 1"))
+# Convert the first index into a range so that point views of layouts without
+# an F axis are one-dimensional, matching point views of layouts with an F axis.
+@inline single_component_struct_indices(index, ::Val{Nf}) where {Nf} =
+    isone(Nf) ? (index[1]:index[1], Base.tail(Tuple(index))...) :
+    throw(ArgumentError("F axis is required unless Nf = 1"))
 
 @inline struct_index(i, array) = i
 @inline struct_indices(array, ::Val{Nf}) where {Nf} = (Base.OneTo(Nf),)
@@ -125,13 +128,13 @@ end
 @inline struct_index(i, array, index::CartesianIndex, ::Val{F}) where {F} =
     isnothing(F) ? index : CartesianIndex(unrolled_insert(Tuple(index), i, Val(F)))
 @inline struct_indices(array, ::Val{Nf}, index::CartesianIndex, ::Val{F}) where {Nf, F} =
-    isnothing(F) ? single_index(index, Val(Nf)) :
+    isnothing(F) ? single_component_struct_indices(index, Val(Nf)) :
     unrolled_insert(Tuple(index), Base.OneTo(Nf), Val(F))
 
 @inline struct_index(i, array, index::Integer, ::Val{F}) where {F} =
     isnothing(F) ? index : struct_index(i, array, index, prod(size(array)[1:(F - 1)]))
 @inline struct_indices(array, ::Val{Nf}, index::Integer, ::Val{F}) where {Nf, F} =
-    isnothing(F) ? single_index(index, Val(Nf)) :
+    isnothing(F) ? single_component_struct_indices(index, Val(Nf)) :
     struct_indices(array, Val(Nf), index, prod(size(array)[1:(F - 1)]))
 
 @inline struct_index(i, array, index::Integer, stride::Integer) = index + (i - 1) * stride

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -4,8 +4,8 @@ import ClimaComms
 import MultiBroadcastFusion as MBF
 import ..slab, ..slab_args, ..column, ..column_args, ..level, ..level_args
 import ..DebugOnly: call_post_op_callback, post_op_callback
-import ..DataLayouts:
-    DataLayouts, DataLayout, DataStyle, FusedMultiBroadcast, @fused_direct
+import ..DataLayouts: DataLayouts, DataLayout, DataStyle, PointIndex
+import ..DataLayouts: FusedMultiBroadcast, @fused_direct
 import ..Domains
 import ..Topologies
 import ..Quadratures
@@ -34,6 +34,11 @@ struct Field{V <: DataLayout, S <: AbstractSpace}
 end
 Field(::Type{T}, space::AbstractSpace) where {T} =
     Field(similar(Spaces.coordinates_data(space), T), space)
+
+# Ensure that every Field on a PointSpace has a zero-dimensional DataLayout.
+Field(values::DataLayout, space::AbstractPointSpace) = Field(view(values), space)
+Field(values::V, space::S) where {V <: DataLayout{<:Any, 0}, S <: AbstractPointSpace} =
+    Field{V, S}(values, space)
 
 local_geometry_type(::Field{V, S}) where {V, S} = local_geometry_type(S)
 
@@ -166,26 +171,51 @@ ClimaComms.array_type(field::Field) =
     Field(getproperty(field_values(field), name), axes(field))
 
 Base.eltype(::Type{<:Field{V}}) where {V} = eltype(V)
-Base.parent(field::Field) = parent(field_values(field))
+Base.IndexStyle(::Type{<:Field{V}}) where {V} = IndexStyle(V)
 
-# to play nice with DifferentialEquations; may want to revisit this
-# https://github.com/SciML/SciMLBase.jl/blob/697bd0c0c7365e77fa311f2d32eade70f43a8d50/src/solutions/ode_solutions.jl#L31
-Base.size(field::Field) = ()
-Base.length(field::Field) = 1
+for f in (:parent, :size, :length, :ndims)
+    @eval Base.$f(field::Field) = $f(field_values(field))
+end
+for f in (:DataScope, :shape_params, :inferred_size, :nelems)
+    @eval DataLayouts.$f(field::Field) = DataLayouts.$f(field_values(field))
+end
+
+DataLayouts.reassign(field::Field, scope) =
+    Field(DataLayouts.reassign(field_values(field), scope), axes(field))
 
 Topologies.nlocalelems(field::Field) = Topologies.nlocalelems(axes(field))
 
-Base.@propagate_inbounds slab(field::Field, inds...) =
-    Field(slab(field_values(field), inds...), slab(axes(field), inds...))
+Base.@propagate_inbounds Base.setindex!(field::Field, val, indices::PointIndex...) =
+    setindex!(field, val, CartesianIndex(indices...))
+Base.@propagate_inbounds Base.getindex(field::Field, indices::PointIndex...) =
+    getindex(field, CartesianIndex(indices...))
+Base.@propagate_inbounds Base.view(field::Field, indices::PointIndex...) =
+    view(field, CartesianIndex(indices...))
 
-Base.@propagate_inbounds function column(field::Field, inds...)
-    column_space = column(axes(field), inds...)
-    column_data = column(field_values(field), inds...)
-    Field(level_data(column_space, column_data), column_space)
-end
-@inline column(field::FiniteDifferenceField, inds...) = field
+Base.@propagate_inbounds Base.setindex!(field::Field, val, index::PointIndex) =
+    setindex!(field_values(field), val, index)
+Base.@propagate_inbounds Base.getindex(field::Field, index::PointIndex) =
+    getindex(field_values(field), index)
+Base.@propagate_inbounds Base.view(field::Field, index::PointIndex) =
+    Field(view(field_values(field), index), view(axes(field), index))
 
+Base.getindex(field::Field, ::Colon) = field
+Base.view(field::Field, ::Colon) = field
 
+Base.@propagate_inbounds level(field::Field, v) = Field(
+    level(field_values(field), Spaces.integer_level_index(axes(field), v)),
+    level(axes(field), v),
+)
+
+Base.@propagate_inbounds slab(field::Field, h) =
+    Field(slab(field_values(field), h), slab(axes(field), h))
+Base.@propagate_inbounds slab(field::Field, v, h) = Field(
+    slab(field_values(field), Spaces.integer_level_index(axes(field), v), h),
+    slab(axes(field), v, h),
+)
+
+Base.@propagate_inbounds column(field::Field, indices...) =
+    Field(column(field_values(field), indices...), column(axes(field), indices...))
 
 # nice printing
 # follow x-array like printing?
@@ -451,44 +481,6 @@ Create a buffer for communicating neighbour information of `field`.
 """
 Spaces.create_dss_buffer(field::Field) =
     Spaces.create_dss_buffer(field_values(field), axes(field))
-
-Base.@propagate_inbounds function level(
-    field::Union{
-        CenterFiniteDifferenceField,
-        CenterExtrudedFiniteDifferenceField,
-        CenterMultiColumnFiniteDifferenceField,
-    },
-    v::Int,
-)
-    hspace = level(axes(field), v)
-    data = level(field_values(field), v)
-    Field(level_data(hspace, data), hspace)
-end
-Base.@propagate_inbounds function level(
-    field::Union{
-        FaceFiniteDifferenceField,
-        FaceExtrudedFiniteDifferenceField,
-        FaceMultiColumnFiniteDifferenceField,
-    },
-    v::PlusHalf,
-)
-    hspace = level(axes(field), v)
-    data = level(field_values(field), v.i + 1)
-    Field(level_data(hspace, data), hspace)
-end
-
-# Levels of fields on column spaces are single points, so their data is
-# converted to a DataF to match the local geometry of a PointSpace.
-Base.@propagate_inbounds level_data(::Spaces.AbstractPointSpace, data) =
-    Spaces.point_data(data)
-@inline level_data(hspace, data) = data
-
-Base.getindex(field::Field, ::Colon) = field
-
-Base.@propagate_inbounds Base.getindex(field::PointField) =
-    getindex(field_values(field))
-Base.@propagate_inbounds Base.setindex!(field::PointField, val) =
-    setindex!(field_values(field), val)
 
 """
     set!(f::Function, field::Field, args = ())

--- a/src/Fields/broadcast.jl
+++ b/src/Fields/broadcast.jl
@@ -73,13 +73,18 @@ Base.Broadcast.combine_styles(
     (arg1, arg2, arg3, args...),
 )
 
-# Define broadcastable/broadcasted/eltype/similar/copy to match DataStyle
-# broadcasting, but with the application of a mask when copying
+# Define broadcastable/broadcasted/newindex/eltype/similar/copy to match
+# DataStyle broadcasting (see broadcast.jl in the DataLayouts module).
 Base.Broadcast.broadcastable(field::Field) =
     Field(Base.Broadcast.broadcastable(field_values(field)), axes(field))
 
 Base.Broadcast.broadcasted(style::AbstractFieldStyle, f::F, args...) where {F} =
     auto_broadcasted(style, f, args)
+
+Base.Broadcast.newindex(
+    bc::Union{Field, Base.Broadcast.Broadcasted{<:AbstractFieldStyle}},
+    index::Integer,
+) = iszero(ndims(bc)) ? CartesianIndex() : index
 
 Base.eltype(bc::Base.Broadcast.Broadcasted{<:AbstractFieldStyle}) =
     unsafe_eltype(bc)
@@ -141,6 +146,14 @@ end
 
 field_values(bc::Base.AbstractBroadcasted) = todata(bc)
 
+# Extend the DataLayout methods of IndexStyle and eachindex to Field broadcasts.
+Base.IndexStyle(bc::Base.Broadcast.Broadcasted{<:AbstractFieldStyle}) =
+    IndexStyle(todata(bc))
+Base.eachindex(
+    arg::Union{Field, Base.Broadcast.Broadcasted{<:AbstractFieldStyle}},
+    args::Union{Field, Base.Broadcast.Broadcasted{<:AbstractFieldStyle}}...,
+) = eachindex(todata(arg), unrolled_map(todata, args)...)
+
 # same logic as Base.Broadcast.Broadcasted (which only defines it for Tuples)
 Base.axes(bc::Base.Broadcast.Broadcasted{<:AbstractFieldStyle}) =
     _axes(bc, bc.axes)
@@ -155,8 +168,7 @@ Base.similar(
 Base.similar(
     bc::Base.Broadcast.Broadcasted{<:FieldStyle},
     ::Type{Eltype},
-) where {Eltype} =
-    Field(level_data(axes(bc), similar(todata(bc), Eltype)), axes(bc))
+) where {Eltype} = Field(similar(todata(bc), Eltype), axes(bc))
 
 @inline function Base.copyto!(
     dest::Field,
@@ -202,9 +214,7 @@ _check_mismatched_spaces(::T, ::T) where {T <: AbstractSpace} = nothing
 _check_mismatched_spaces(space1, space2) =
     error("FusedMultiBroadcast spaces are not the same.")
 
-@noinline function error_mismatched_spaces(space1::Type, space2::Type)
-    error("Broacasted spaces are not the same.")
-end
+error_mismatched_spaces() = error("Broacasted spaces are not the same.")
 
 @inline function Base.Broadcast.broadcast_shape(
     space1::AbstractSpace,
@@ -216,7 +226,7 @@ end
         elseif Spaces.issubspace(space1, space2)
             return space2
         else
-            error_mismatched_spaces(typeof(space1), typeof(space2))
+            error_mismatched_spaces()
         end
     end
     return space1
@@ -253,7 +263,7 @@ end
            Spaces.issubspace(space1, space2)
             nothing
         else
-            error_mismatched_spaces(typeof(space1), typeof(space2))
+            error_mismatched_spaces()
         end
     end
     return nothing
@@ -262,7 +272,7 @@ end
     space::AbstractSpace,
     ax2::Tuple,
 )
-    error_mismatched_spaces(typeof(space), typeof(ax2))
+    error_mismatched_spaces()
 end
 @inline function Base.Broadcast.check_broadcast_shape(
     ::AbstractSpace,

--- a/src/Fields/mapreduce.jl
+++ b/src/Fields/mapreduce.jl
@@ -226,4 +226,5 @@ function Base.isapprox(
 end
 
 Base.:(==)(field1::Field, field2::Field) =
-    axes(field1) === axes(field2) && parent(field1) == parent(field2)
+    axes(field1) === axes(field2) &&
+    Fields.field_values(field1) == Fields.field_values(field2)

--- a/src/Grids/column.jl
+++ b/src/Grids/column.jl
@@ -17,35 +17,27 @@ end
 
 
 """
-    ColumnGrid(
-        full_grid :: ExtrudedFiniteDifferenceGrid,
-        colidx    :: ColumnIndex,
-    )
+    ColumnGrid(full_grid, indices)
 
-A view into a column of a `ExtrudedFiniteDifferenceGrid`.
+View of the column at the given indices in an `ExtrudedFiniteDifferenceGrid`.
 """
 struct ColumnGrid{
     G <: AbstractExtrudedFiniteDifferenceGrid,
-    C <: ColumnIndex,
+    I <: Tuple{Vararg{Integer}},
 } <: AbstractFiniteDifferenceGrid
     full_grid::G
-    colidx::C
+    indices::I
 end
 
 Adapt.@adapt_structure ColumnGrid
 
-local_geometry_type(::Type{ColumnGrid{G, C}}) where {G, C} =
-    local_geometry_type(G)
+local_geometry_type(::Type{<:ColumnGrid{G}}) where {G} = local_geometry_type(G)
 
-column(grid::AbstractExtrudedFiniteDifferenceGrid, colidx::ColumnIndex) =
-    ColumnGrid(grid, colidx)
+column(grid::AbstractExtrudedFiniteDifferenceGrid, indices...) = ColumnGrid(grid, indices)
 
 topology(colgrid::ColumnGrid) = vertical_topology(colgrid.full_grid)
 vertical_topology(colgrid::ColumnGrid) = vertical_topology(colgrid.full_grid)
 
-local_geometry_data(colgrid::ColumnGrid, staggering::Staggering) = column(
-    local_geometry_data(colgrid.full_grid, staggering::Staggering),
-    colgrid.colidx.ij...,
-    colgrid.colidx.h,
-)
+local_geometry_data(colgrid::ColumnGrid, staggering::Staggering) =
+    column(local_geometry_data(colgrid.full_grid, staggering), colgrid.indices...)
 global_geometry(colgrid::ColumnGrid) = global_geometry(colgrid.full_grid)

--- a/src/Grids/spectralelement.jl
+++ b/src/Grids/spectralelement.jl
@@ -572,12 +572,20 @@ quadrature_style(grid::AbstractSpectralElementGrid) = grid.quadrature_style
 dss_weights(grid::AbstractSpectralElementGrid, ::Nothing) = grid.dss_weights
 
 ## GPU compatibility
+struct DeviceSpectralElementGrid1D{Q, GG, LG} <: AbstractSpectralElementGrid
+    quadrature_style::Q
+    global_geometry::GG
+    local_geometry::LG
+end
 struct DeviceSpectralElementGrid2D{Q, GG, LG, M} <: AbstractSpectralElementGrid
     quadrature_style::Q
     global_geometry::GG
     local_geometry::LG
     mask::M
 end
+
+ClimaComms.context(grid::DeviceSpectralElementGrid1D) = DeviceSideContext()
+ClimaComms.device(grid::DeviceSpectralElementGrid1D) = DeviceSideDevice()
 
 ClimaComms.context(grid::DeviceSpectralElementGrid2D) = DeviceSideContext()
 ClimaComms.device(grid::DeviceSpectralElementGrid2D) = DeviceSideDevice()

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -3720,25 +3720,13 @@ Base.Broadcast.BroadcastStyle(
 
 Base.eltype(bc::StencilBroadcasted) = return_eltype(bc.op, bc.args...)
 
-function vidx(space::AllFaceFiniteDifferenceSpace, idx)
-    @assert idx isa PlusHalf
-    v = idx + half
-    if Topologies.isperiodic(space)
-        v = mod1(v, Spaces.nlevels(space))
-    end
-    return v
-end
-function vidx(space::AllCenterFiniteDifferenceSpace, idx)
-    @assert idx isa Integer
-    v = idx
-    if Topologies.isperiodic(space)
-        v = mod1(v, Spaces.nlevels(space))
-    end
-    return v
-end
-function vidx(space::AbstractSpace, idx)
-    return 1
-end
+vidx(space::AllFaceFiniteDifferenceSpace, idx::Union{Nothing, PlusHalf}) =
+    isnothing(idx) ? 1 :
+    Topologies.isperiodic(space) ? mod1(idx + half, Spaces.nlevels(space)) : idx + half
+vidx(space::AllCenterFiniteDifferenceSpace, idx::Union{Nothing, Integer}) =
+    isnothing(idx) ? 1 :
+    Topologies.isperiodic(space) ? mod1(idx, Spaces.nlevels(space)) : idx
+vidx(space::AbstractSpace, idx) = 1
 
 # Fields on a column space only have data at a single horizontal index, so the
 # horizontal indices from the broadcast expression do not apply to them.

--- a/src/Spaces/Spaces.jl
+++ b/src/Spaces/Spaces.jl
@@ -20,8 +20,8 @@ using Adapt
 import ..slab, ..column, ..level
 import ..Utilities: PlusHalf, half
 import ..DebugOnly: call_post_op_callback, post_op_callback
-import ..DataLayouts,
-    ..Geometry, ..Domains, ..Meshes, ..Topologies, ..Grids, ..Quadratures
+import ..DataLayouts, ..Geometry, ..Domains, ..Meshes, ..Topologies, ..Grids, ..Quadratures
+import ..DataLayouts: PointIndex
 
 import ..Domains: z_max, z_min
 import ..Meshes: n_elements_per_panel_direction
@@ -61,7 +61,6 @@ abstract type AbstractSpace end
 function grid end
 function staggering end
 
-
 ClimaComms.context(space::AbstractSpace) = ClimaComms.context(grid(space))
 ClimaComms.device(space::AbstractSpace) = ClimaComms.device(grid(space))
 
@@ -84,7 +83,7 @@ global_geometry(space::AbstractSpace) = global_geometry(grid(space))
 space(refspace::AbstractSpace, staggering::Staggering) =
     space(grid(refspace), staggering)
 
-issubspace(::AbstractSpace, ::AbstractSpace) = false
+issubspace(subspace::AbstractSpace, space::AbstractSpace) = subspace === space
 
 undertype(space::AbstractSpace) =
     Geometry.undertype(eltype(local_geometry_data(space)))
@@ -94,6 +93,35 @@ coordinates_data(grid::Grids.AbstractGrid) =
     local_geometry_data(grid).coordinates
 coordinates_data(staggering, grid::Grids.AbstractGrid) =
     local_geometry_data(staggering, grid).coordinates
+
+horizontal_grid(grid::Grids.AbstractSpectralElementGrid) = grid
+horizontal_grid(grid::Grids.LevelGrid) = grid.full_grid.horizontal_grid
+
+vertical_grid(grid::Grids.AbstractFiniteDifferenceGrid) = grid
+vertical_grid(grid::Grids.ColumnGrid) = vertical_grid(grid.full_grid)
+vertical_grid(grid::Grids.AbstractExtrudedFiniteDifferenceGrid) = grid.vertical_grid
+
+# Device-side extruded grids do not store their vertical grids, so the vertical
+# topology, which Adapt preserves, stands in as the identity token compared by
+# issubspace: column slices share a vertical topology exactly when their host
+# grids share a vertical grid.
+vertical_grid(grid::Grids.DeviceExtrudedFiniteDifferenceGrid) =
+    Grids.vertical_topology(grid)
+
+half_level_error() = throw(ArgumentError("Cannot use PlusHalf as CellCenter space index"))
+
+staggered_level_index(space, v::Integer) = staggering(space) isa CellFace ? v - half : v
+staggered_level_index(space, v::PlusHalf) =
+    staggering(space) isa CellFace ? v : half_level_error()
+
+integer_level_index(_, v::Integer) = v
+integer_level_index(space, v::PlusHalf) =
+    staggering(space) isa CellFace ? v + half : half_level_error()
+
+Base.@propagate_inbounds Base.view(space::AbstractSpace, index::PointIndex) =
+    PointSpace(ClimaComms.context(space), view(local_geometry_data(space), index))
+Base.@propagate_inbounds Base.view(space::AbstractSpace, indices::PointIndex...) =
+    view(space, CartesianIndex(indices...))
 
 include("pointspace.jl")
 include("spectralelement.jl")

--- a/src/Spaces/extruded.jl
+++ b/src/Spaces/extruded.jl
@@ -55,16 +55,6 @@ function center_space(space::ExtrudedFiniteDifferenceSpace)
     return ExtrudedFiniteDifferenceSpace(grid(space), CellCenter())
 end
 
-
-#=
-ExtrudedFiniteDifferenceSpace{S}(
-    grid::Grids.ExtrudedFiniteDifferenceGrid,
-) where {S <: Staggering} = ExtrudedFiniteDifferenceSpace(S(), grid)
-ExtrudedFiniteDifferenceSpace{S}(
-    space::ExtrudedFiniteDifferenceSpace,
-) where {S <: Staggering} = ExtrudedFiniteDifferenceSpace{S}(space.grid)
-=#
-
 function ExtrudedFiniteDifferenceSpace(
     horizontal_space::AbstractSpace,
     vertical_space::FiniteDifferenceSpace,
@@ -99,37 +89,6 @@ FiniteDifferenceSpace(space::ExtrudedFiniteDifferenceSpace) =
         Spaces.grid(space).vertical_grid,
         Spaces.staggering(space),
     )
-
-#=
-
-ExtrudedFiniteDifferenceSpace{S}(
-    horizontal_space::AbstractSpace,
-    vertical_space::FiniteDifferenceSpace,
-    hypsography::HypsographyAdaption = Flat(),
-) where {S <: Staggering} = ExtrudedFiniteDifferenceSpace{S}(
-    Grids.ExtrudedFiniteDifferenceGrid(horizontal_space, vertical_space, hypsography),
-)
-=#
-
-function issubspace(
-    hspace::AbstractSpectralElementSpace,
-    extruded_space::ExtrudedFiniteDifferenceSpace,
-)
-    return grid(hspace) === grid(extruded_space).horizontal_grid
-end
-function issubspace(
-    level_space::SpectralElementSpace2D{<:Grids.LevelGrid},
-    extruded_space::ExtrudedFiniteDifferenceSpace,
-)
-    return grid(level_space).full_grid === grid(extruded_space)
-end
-function issubspace(
-    level_space::SpectralElementSpace1D{<:Grids.LevelGrid},
-    extruded_space::ExtrudedFiniteDifferenceSpace,
-)
-    return grid(level_space).full_grid === grid(extruded_space)
-end
-
 
 Adapt.adapt_structure(to, space::ExtrudedFiniteDifferenceSpace) =
     ExtrudedFiniteDifferenceSpace(
@@ -213,34 +172,26 @@ horizontal_space(full_space::ExtrudedFiniteDifferenceSpace) =
 vertical_topology(space::ExtrudedFiniteDifferenceSpace) =
     vertical_topology(grid(space))
 
-function column(space::ExtrudedFiniteDifferenceSpace, colidx::Grids.ColumnIndex)
-    column_grid = column(grid(space), colidx)
-    FiniteDifferenceSpace(column_grid, space.staggering)
-end
+issubspace(subspace::AbstractSpectralElementSpace, space::ExtrudedFiniteDifferenceSpace) =
+    grid(subspace) === grid(space).horizontal_grid ||
+    (grid(subspace) isa Grids.LevelGrid && grid(subspace).full_grid === grid(space))
+issubspace(subspace::FiniteDifferenceSpace, space::ExtrudedFiniteDifferenceSpace) =
+    grid(subspace) === grid(space).vertical_grid ||
+    (grid(subspace) isa Grids.ColumnGrid && grid(subspace).full_grid === grid(space))
 
-Base.@propagate_inbounds function slab(
-    space::ExtrudedFiniteDifferenceSpace,
-    v,
-    h,
-)
+Base.@propagate_inbounds level(space::ExtrudedFiniteDifferenceSpace2D, v) =
+    SpectralElementSpace1D(level(grid(space), staggered_level_index(space, v)))
+Base.@propagate_inbounds level(space::ExtrudedFiniteDifferenceSpace3D, v) =
+    SpectralElementSpace2D(level(grid(space), staggered_level_index(space, v)))
+
+Base.@propagate_inbounds slab(space::ExtrudedFiniteDifferenceSpace, v, h) =
     SpectralElementSpaceSlab(
-        Spaces.quadrature_style(space),
-        slab(local_geometry_data(space), v, h),
+        quadrature_style(space),
+        slab(local_geometry_data(space), integer_level_index(space, v), h),
     )
-end
 
-
-
-# TODO: deprecate these
-column(space::ExtrudedFiniteDifferenceSpace, i, j, h) =
-    column(space, Grids.ColumnIndex((i, j), h))
-column(space::ExtrudedFiniteDifferenceSpace, i, h) =
-    column(space, Grids.ColumnIndex((i,), h))
-
-level(space::ExtrudedFiniteDifferenceSpace, v) =
-    space isa ExtrudedFiniteDifferenceSpace3D ?
-    SpectralElementSpace2D(level(grid(space), v)) :
-    SpectralElementSpace1D(level(grid(space), v))
+Base.@propagate_inbounds column(space::ExtrudedFiniteDifferenceSpace, indices...) =
+    FiniteDifferenceSpace(column(grid(space), indices...), space.staggering)
 
 nlevels(space::ExtrudedFiniteDifferenceSpace) =
     size(local_geometry_data(space), 1)

--- a/src/Spaces/finitedifference.jl
+++ b/src/Spaces/finitedifference.jl
@@ -83,6 +83,20 @@ CenterFiniteDifferenceSpace(
 Adapt.adapt_structure(to, space::FiniteDifferenceSpace) =
     FiniteDifferenceSpace(Adapt.adapt(to, grid(space)), staggering(space))
 
+issubspace(space1::FiniteDifferenceSpace, space2::FiniteDifferenceSpace) =
+    vertical_grid(grid(space1)) === vertical_grid(grid(space2))
+
+Base.@propagate_inbounds level(space::FiniteDifferenceSpace, v) = PointSpace(
+    ClimaComms.context(space),
+    level(local_geometry_data(space), integer_level_index(space, v)),
+)
+
+Base.@propagate_inbounds slab(space::FiniteDifferenceSpace, v, h) =
+    isone(h) ? level(space, v) : throw(ArgumentError("Space has only one column"))
+
+column(space::FiniteDifferenceSpace, indices...) =
+    all(isone, indices) ? space : throw(ArgumentError("Space has only one column"))
+
 """
     face_space(space::FiniteDifferenceSpace)
 
@@ -128,19 +142,4 @@ end
 function right_boundary_name(space::AbstractSpace)
     boundaries = Topologies.boundaries(Spaces.vertical_topology(space))
     propertynames(boundaries)[2]
-end
-
-Base.@propagate_inbounds function level(
-    space::FaceFiniteDifferenceSpace,
-    v::PlusHalf,
-)
-    @inbounds local_geometry = level(local_geometry_data(space), v.i + 1)
-    PointSpace(ClimaComms.context(space), local_geometry)
-end
-Base.@propagate_inbounds function level(
-    space::CenterFiniteDifferenceSpace,
-    v::Int,
-)
-    local_geometry = level(local_geometry_data(space), v)
-    PointSpace(ClimaComms.context(space), local_geometry)
 end

--- a/src/Spaces/multicolumn.jl
+++ b/src/Spaces/multicolumn.jl
@@ -97,57 +97,34 @@ Adapt.adapt_structure(to, space::MultiColumnFiniteDifferenceSpace) =
         staggering(space),
     )
 
-# ---- column / level extraction ----------------------------------------
+issubspace(space1::PointCloudSpace, space2::PointCloudSpace) =
+    horizontal_grid(grid(space1)) === horizontal_grid(grid(space2))
+issubspace(subspace::PointCloudSpace, space::MultiColumnFiniteDifferenceSpace) =
+    grid(subspace) === grid(space).horizontal_grid ||
+    (grid(subspace) isa Grids.LevelGrid && grid(subspace).full_grid === grid(space))
+issubspace(subspace::FiniteDifferenceSpace, space::MultiColumnFiniteDifferenceSpace) =
+    grid(subspace) === grid(space).vertical_grid ||
+    (grid(subspace) isa Grids.ColumnGrid && grid(subspace).full_grid === grid(space))
 
-"""
-    column(space::MultiColumnFiniteDifferenceSpace, colidx::Grids.ColumnIndex)
+level(space::PointCloudSpace, v) =
+    isone(v) ? space : throw(ArgumentError("Space only has one level"))
+Base.@propagate_inbounds level(space::MultiColumnFiniteDifferenceSpace, v) =
+    PointCloudSpace(level(grid(space), staggered_level_index(space, v)))
 
-Return a single-column [`FiniteDifferenceSpace`](@ref) for column `colidx`.
-"""
-function column(
-    space::MultiColumnFiniteDifferenceSpace,
-    colidx::Grids.ColumnIndex,
-)
-    column_grid = Grids.column(grid(space), colidx)
-    FiniteDifferenceSpace(column_grid, space.staggering)
-end
-column(space::MultiColumnFiniteDifferenceSpace, i, h) =
-    column(space, Grids.ColumnIndex((i,), h))
-column(space::MultiColumnFiniteDifferenceSpace, i, j, h) =
-    column(space, Grids.ColumnIndex((i,), h))
+Base.@propagate_inbounds slab(space::PointCloudSpace, v, h) =
+    isone(v) ? slab(space, h) : throw(ArgumentError("Space only has one level"))
+Base.@propagate_inbounds slab(space::PointCloudSpace, h) =
+    PointSpace(ClimaComms.context(space), slab(local_geometry_data(space), h))
+Base.@propagate_inbounds slab(space::MultiColumnFiniteDifferenceSpace, v, h) =
+    PointSpace(
+        ClimaComms.context(space),
+        slab(local_geometry_data(space), integer_level_index(space, v), h),
+    )
 
-"""
-    column(space::PointCloudSpace, i, h)
-
-Return the single-point [`PointSpace`](@ref) for column `h` of a
-[`PointCloudSpace`](@ref).  This is the analogue of
-`column(::SpectralElementSpace1D, i, h)` and enables `field[colidx]` indexing
-inside [`Fields.bycolumn`](@ref) loops over a
-[`MultiColumnFiniteDifferenceSpace`](@ref).
-"""
-Base.@propagate_inbounds function column(space::PointCloudSpace, i, h)
-    local_geometry = column(local_geometry_data(space), i, h)
-    PointSpace(ClimaComms.context(space), local_geometry)
-end
-Base.@propagate_inbounds column(space::PointCloudSpace, i, j, h) =
-    column(space, i, h)
-
-"""
-    level(space::MultiColumnFiniteDifferenceSpace, v)
-
-Return the [`PointCloudSpace`](@ref) (N-point horizontal slice) at
-vertical level `v`.
-"""
-Base.@propagate_inbounds level(
-    space::CenterMultiColumnFiniteDifferenceSpace,
-    v::Int,
-) = PointCloudSpace(Grids.level(grid(space), v))
-Base.@propagate_inbounds level(
-    space::FaceMultiColumnFiniteDifferenceSpace,
-    v::PlusHalf,
-) = PointCloudSpace(Grids.level(grid(space), v))
-
-# ---- space properties --------------------------------------------------
+Base.@propagate_inbounds column(space::PointCloudSpace, indices...) =
+    PointSpace(ClimaComms.context(space), column(local_geometry_data(space), indices...))
+Base.@propagate_inbounds column(space::MultiColumnFiniteDifferenceSpace, indices...) =
+    FiniteDifferenceSpace(column(grid(space), indices...), space.staggering)
 
 ncolumns(space::PointCloudSpace) =
     DataLayouts.nelems(local_geometry_data(space))
@@ -167,32 +144,6 @@ horizontal_space(space::MultiColumnFiniteDifferenceSpace) =
 get_mask(space::PointCloudSpace) = DataLayouts.NoMask()
 get_mask(space::MultiColumnFiniteDifferenceSpace) = DataLayouts.NoMask()
 set_mask!(::Any, ::MultiColumnFiniteDifferenceSpace) = nothing
-
-# Subspace relations, mirroring the extruded spectral-element methods in
-# extruded.jl and spectralelement.jl:
-#  - a level slice is a subspace of the full multi-column space it was sliced
-#    from (enables broadcasting a level field across a full 3D field);
-#  - the level-agnostic horizontal space is a subspace of the full space;
-#  - the horizontal space is a subspace of every level slice (enables
-#    broadcasting surface fields against level slices, regardless of level).
-function issubspace(
-    level_space::PointCloudSpace{<:Grids.LevelGrid},
-    full_space::MultiColumnFiniteDifferenceSpace,
-)
-    return grid(level_space).full_grid === grid(full_space)
-end
-function issubspace(
-    hspace::PointCloudSpace{<:Grids.PointCloudGrid},
-    full_space::MultiColumnFiniteDifferenceSpace,
-)
-    return grid(hspace) === grid(full_space).horizontal_grid
-end
-function issubspace(
-    hspace::PointCloudSpace{<:Grids.PointCloudGrid},
-    level_space::PointCloudSpace{<:Grids.LevelGrid},
-)
-    return grid(hspace) === grid(level_space).full_grid.horizontal_grid
-end
 
 """
     obtain_surface_space(cs::CenterMultiColumnFiniteDifferenceSpace)

--- a/src/Spaces/pointspace.jl
+++ b/src/Spaces/pointspace.jl
@@ -27,29 +27,8 @@ function PointSpace(device::ClimaComms.AbstractDevice, x)
     return PointSpace(context, x)
 end
 
-"""
-    point_data(data)
-
-Convert a view of a single point in a `DataLayout` into a `DataF`, without
-copying the underlying data.
-"""
-point_data(data::DataLayouts.DataF) = data
-Base.@propagate_inbounds function point_data(data::DataLayouts.DataLayout)
-    @assert isone(length(data))
-    T = eltype(data)
-    array = DataLayouts.view_struct(
-        parent(data),
-        T,
-        first(CartesianIndices(data)),
-        Val(DataLayouts.f_dim(data)),
-    )
-    return DataLayouts.DataF{T, typeof(DataLayouts.DataScope(data))}(array)
-end
-
-PointSpace(
-    context::ClimaComms.AbstractCommsContext,
-    data::DataLayouts.DataLayout,
-) = PointSpace(context, point_data(data))
+PointSpace(context::ClimaComms.AbstractCommsContext, data::DataLayouts.DataLayout) =
+    PointSpace(context, view(data)) # view of a DataLayout is always a DataF
 
 function PointSpace(
     context::ClimaComms.AbstractCommsContext,
@@ -86,3 +65,8 @@ end
 all_nodes(::PointSpace) = (1,)
 
 node_horizontal_length_scale(space::PointSpace) = 1
+
+for f in (:level, :slab, :column)
+    @eval $f(space::PointSpace, indices...) =
+        all(isone, indices) ? space : throw(ArgumentError("Space has only one point"))
+end

--- a/src/Spaces/spectralelement.jl
+++ b/src/Spaces/spectralelement.jl
@@ -69,6 +69,8 @@ grid(space::Spaces.SpectralElementSpace1D) = getfield(space, :grid)
 local_geometry_type(::Type{SpectralElementSpace1D{G}}) where {G} =
     local_geometry_type(G)
 
+Adapt.adapt_structure(to, space::SpectralElementSpace1D) =
+    SpectralElementSpace1D(Adapt.adapt(to, grid(space)))
 
 function SpectralElementSpace1D(
     topology::Topologies.IntervalTopology,
@@ -113,14 +115,6 @@ end
 Adapt.adapt_structure(to, space::SpectralElementSpace2D) =
     SpectralElementSpace2D(Adapt.adapt(to, grid(space)))
 
-
-function issubspace(
-    hspace::SpectralElementSpace2D{<:Grids.SpectralElementGrid2D},
-    level_space::SpectralElementSpace2D{<:Grids.LevelGrid},
-)
-    return grid(hspace) === grid(level_space).full_grid.horizontal_grid
-end
-
 """
     SpectralElementSpaceSlab <: AbstractSpace
 
@@ -133,6 +127,22 @@ end
 
 local_geometry_type(::Type{SpectralElementSpaceSlab{Q, G}}) where {Q, G} =
     eltype(G) # calls eltype from DataLayouts
+
+issubspace(space1::SpectralElementSpaceSlab, space2::SpectralElementSpaceSlab) =
+    space1 == space2
+issubspace(space1::AbstractSpectralElementSpace, space2::AbstractSpectralElementSpace) =
+    horizontal_grid(grid(space1)) === horizontal_grid(grid(space2))
+
+level(space::AbstractSpectralElementSpace, v) =
+    isone(v) ? space : throw(ArgumentError("Space only has one level"))
+
+Base.@propagate_inbounds slab(space::AbstractSpectralElementSpace, v, h) =
+    isone(v) ? slab(space, h) : throw(ArgumentError("Space has only one level"))
+Base.@propagate_inbounds slab(space::AbstractSpectralElementSpace, h) =
+    SpectralElementSpaceSlab(quadrature_style(space), slab(local_geometry_data(space), h))
+
+Base.@propagate_inbounds column(space::AbstractSpectralElementSpace, indices...) =
+    PointSpace(ClimaComms.context(space), column(local_geometry_data(space), indices...))
 
 """
     Spaces.node_horizontal_length_scale(space::AbstractSpectralElementSpace)
@@ -151,32 +161,6 @@ function node_horizontal_length_scale(space::AbstractSpectralElementSpace)
 end
 
 node_horizontal_length_scale(::Nothing) = 1
-
-
-Base.@propagate_inbounds function slab(
-    space::AbstractSpectralElementSpace,
-    v,
-    h,
-)
-    SpectralElementSpaceSlab(
-        quadrature_style(space),
-        slab(local_geometry_data(space), v, h),
-    )
-end
-Base.@propagate_inbounds slab(space::AbstractSpectralElementSpace, h) =
-    @inbounds slab(space, 1, h)
-
-Base.@propagate_inbounds function column(space::SpectralElementSpace1D, i, h)
-    local_geometry = column(local_geometry_data(space), i, 1, h)
-    PointSpace(ClimaComms.context(space), local_geometry)
-end
-Base.@propagate_inbounds column(space::SpectralElementSpace1D, i, j, h) =
-    column(space, i, h)
-
-Base.@propagate_inbounds function column(space::SpectralElementSpace2D, i, j, h)
-    local_geometry = column(local_geometry_data(space), i, j, h)
-    PointSpace(ClimaComms.context(space), local_geometry)
-end
 
 function all_nodes(space::SpectralElementSpace2D)
     Nq = Quadratures.degrees_of_freedom(quadrature_style(space))

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -114,7 +114,7 @@ julia> parent(stable_view(array, 4:6))
 ```
 """
 Base.@propagate_inbounds function stable_view(array::AbstractArray, indices...)
-    if indices isa Tuple{Union{Integer, AbstractRange{<:Integer}}} &&
+    if indices isa Tuple{Union{Integer, AbstractRange{<:Integer}, Colon}} &&
        ndims(array) != 1
         array isa Base.ReshapedArray &&
             return stable_view(parent(array), first(indices))

--- a/test/DataLayouts/unit_fill_and_copyto.jl
+++ b/test/DataLayouts/unit_fill_and_copyto.jl
@@ -114,4 +114,18 @@ end
             @test length(unique(Array(parent(data)))) > 1
         end
     end
+    @testset "component views across multiple elements" begin
+        # Component views read their parents with a constant stride, which must
+        # step over every component stored in the parent. A wrong step blends
+        # entries of different components, but only at points beyond the first
+        # stride block, so single-element layouts cannot detect it. The values
+        # are written through the multi-component layout, whose reads and
+        # writes do not use the constant-stride view accessors.
+        for data in testable_layouts(A, Tuple{Float64, Float64})
+            length(data) > 1 || continue
+            fill!(data, (1.0, 2.0))
+            @test reduce(+, data.:1) == length(data)
+            @test reduce(+, data.:2) == 2 * length(data)
+        end
+    end
 end

--- a/test/DataLayouts/unit_loops.jl
+++ b/test/DataLayouts/unit_loops.jl
@@ -113,47 +113,36 @@ end
     @test parent(point .+ data) == parent(data) .+ Array(parent(point))[]
 end
 
-# Point loops broadcast their arguments like ordinary broadcast expressions:
-# 0-dimensional layouts and statically singleton dimensions (e.g. single-level
-# surface data) are expanded to the combined loop bounds, while genuinely
-# mismatched extents are rejected on the host, since the error path can be
-# neither compiled nor cleanly reported in GPU kernels.
-@testset "point loops over arguments with singleton dimensions" begin
+parent_broadcasted(data::DataLayouts.DataLayout) = parent(data)
+parent_broadcasted(bc::DataLayouts.LazyDataLayout) =
+    Base.broadcasted(bc.f, map(parent_broadcasted, bc.args)...)
+
+# Loops over mixed layouts require Cartesian indices, which are extruded by
+# Broadcast.newindex; loops over layouts with the same shape use linear indices.
+# Point layouts are ignored when deciding between linear and Cartesian indexing.
+@testset "broadcast expression indexing" begin
     device = ClimaComms.device()
     volume = test_data(device, Float64, 1, 10)
-    surface = test_data(device, Float64, 1, 1) # statically singleton Nv
-    point = DataLayouts.DataF{Float64}(device_array(device, rand(1)))
-    dest = test_data(device, Float64, 1, 10)
+    surface = test_data(device, Float64, 1, 1)
+    point = view(volume, 1)
 
-    # Singleton dimensions inside broadcast expressions expand like Base's.
-    dest .= volume .+ surface
-    @test parent(dest) == parent(volume) .+ parent(surface)
-
-    # Singleton and 0-dimensional layouts may also be top-level loop arguments.
-    fill!(parent(dest), 0)
-    DataLayouts.foreach_point(
-        (d, a, s, p) -> (@inbounds d[] = a[] + s[] + p[]),
-        dest,
-        volume,
-        surface,
-        point,
+    for (bc, expected_style) in (
+        (Base.broadcasted(+, volume, volume, volume), IndexLinear()),
+        (Base.broadcasted(+, volume, volume, surface), IndexCartesian()),
+        (Base.broadcasted(+, volume, volume, point), IndexLinear()),
+        (Base.broadcasted(+, volume, surface, point), IndexCartesian()),
+        (Base.broadcasted(abs, Base.broadcasted(+, volume, volume)), IndexLinear()),
+        (Base.broadcasted(abs, Base.broadcasted(+, volume, surface)), IndexCartesian()),
+        (Base.broadcasted(abs, Base.broadcasted(+, volume, point)), IndexLinear()),
     )
-    @test parent(dest) == parent(volume) .+ parent(surface) .+ parent(point)
-
-    # Reductions over expressions with mixed shapes require Cartesian indices,
-    # which Broadcast.newindex projects onto singleton dimensions; expressions
-    # whose layouts all share a shape permit linear indices.
-    mixed_bc = Base.broadcasted(+, volume, surface)
-    @test Base.IndexStyle(mixed_bc) == IndexCartesian()
-    @test parent(Base.materialize(mixed_bc)) == parent(volume) .+ parent(surface)
-    # The sum is checked as well, since reductions iterate lazy expressions
-    # directly, without materializing them first.
-    @test sum(identity, mixed_bc) == sum(parent(volume) .+ parent(surface))
-    @test Base.IndexStyle(Base.broadcasted(+, volume, volume)) == IndexLinear()
+        @test Base.IndexStyle(bc) == expected_style
+        @test parent(Base.materialize(bc)) == Base.materialize(parent_broadcasted(bc))
+        @test sum(bc) == sum(parent_broadcasted(bc))
+    end
 
     # Genuinely mismatched extents throw before any kernel is launched.
-    mismatched = test_data(device, Float64, 1, 7)
-    @test_throws DimensionMismatch dest .= volume .+ mismatched
+    mismatched_volume = test_data(device, Float64, 1, 7)
+    @test_throws DimensionMismatch volume .+ mismatched_volume
 end
 
 # Measure allocations from a top-level function, since the @allocated macro has
@@ -283,21 +272,9 @@ end
         dest = test_data(device, Float64, 1, 64)
         fill!(parent(dest), 0)
         copy_point!(d, a) = (@inbounds d[] = a[])
-        DataLayouts.foreach_slice(
-            DataLayouts.ThisThreadPool(),
-            view,
-            copy_point!,
-            dest,
-            data;
-            mask = DataLayouts.NoMask(),
-        )
+        DataLayouts.foreach_point(copy_point!, dest, data; mask = DataLayouts.NoMask())
         @test parent(dest) == parent(data)
-        @test DataLayouts.reduce_points(
-            DataLayouts.ThisThreadPool(),
-            +,
-            data;
-            mask = DataLayouts.NoMask(),
-        ) == total
+        @test DataLayouts.reduce_points(+, data; mask = DataLayouts.NoMask()) == total
         @test pool_accounting_drained()
 
         # An error thrown from inside a loop must not leak the loop's thread claim.

--- a/test/Fields/unit_field.jl
+++ b/test/Fields/unit_field.jl
@@ -14,6 +14,7 @@ import ClimaCore.InputOutput
 import ClimaCore.Utilities: PlusHalf
 import ClimaCore.DataLayouts
 import ClimaCore.DataLayouts: VIJFH
+import ClimaCore.DataLayouts: foreach_point, foreach_level, foreach_slab, foreach_column
 import ClimaCore:
     Fields,
     slab,
@@ -817,20 +818,13 @@ end
     for space in TU.all_spaces(FT)
         TU.levelable(space) || continue
         field = fill((; x = FT(1)), space)
-        level_space = Spaces.level(space, TU.fc_index(1, space))
-        level_data = Spaces.level(Fields.field_values(field), 1)
         level_of_field = Fields.Field(
-            Fields.level_data(level_space, level_data),
-            level_space,
+            Spaces.level(Fields.field_values(field), 1),
+            Spaces.level(space, TU.fc_index(1, space)),
         )
         @test level_of_field == Spaces.level(field, TU.fc_index(1, space))
-        # Compare data instead of Fields, since two PointSpaces constructed by
-        # separate calls to Spaces.level are not identical
-        @test Fields.field_values(level_of_field) == Fields.field_values(
-            Base.materialize(
-                Spaces.level(lazy.(identity.(field)), TU.fc_index(1, space)),
-            ),
-        )
+        @test level_of_field ==
+              Base.materialize(Spaces.level(lazy.(identity.(field)), TU.fc_index(1, space)))
     end
 end
 
@@ -877,20 +871,13 @@ end
         if space isa Union{TwoColumnIndexSpace, ThreeColumnIndexSpace}
             field = fill((; x = FT(1)), space)
             indices = space isa TwoColumnIndexSpace ? (1, 1) : (1, 1, 1)
-            column_space = Spaces.column(space, indices...)
-            column_data = Spaces.column(Fields.field_values(field), indices...)
             column_of_field = Fields.Field(
-                Fields.level_data(column_space, column_data),
-                column_space,
+                Spaces.column(Fields.field_values(field), indices...),
+                Spaces.column(space, indices...),
             )
             @test column_of_field == Spaces.column(field, indices...)
-            # Compare data instead of Fields, since two PointSpaces constructed
-            # by separate calls to Spaces.column are not identical
-            @test Fields.field_values(column_of_field) == Fields.field_values(
-                Base.materialize(
-                    Spaces.column(lazy.(identity.(field)), indices...),
-                ),
-            )
+            @test column_of_field ==
+                  Base.materialize(Spaces.column(lazy.(identity.(field)), indices...))
         end
     end
 end
@@ -1476,6 +1463,86 @@ end
         flat_field = Fields.array2field(flat_array, space)
         @test Array(Fields.field2array(flat_field)) ==
               reshape(Array(flat_array), array_size)
+    end
+end
+
+# A subspace argument nested inside an inner broadcast must switch the whole
+# expression to Cartesian indexing; the inner broadcast's own merged shape
+# would otherwise hide the subspace, and unprojected linear indices would read
+# it out of range (a BoundsError with bounds checks, wrong values without).
+@testset "broadcasts over nested subspace arguments" begin
+    FT = Float64
+    context = ClimaComms.context(ClimaComms.device())
+    for space in (
+        TU.PointColumnEnsembleSpace(FT; context),
+        TU.CenterExtrudedFiniteDifferenceSpace(FT; context),
+    )
+        for subspace in (Spaces.level(space, 1), Spaces.column(space, 1, 1, 1))
+            src1 = Fields.Field(Tuple{FT, FT}, space)
+            src2 = Fields.Field(Tuple{FT, FT}, subspace)
+            parent(src1) .= rand.(FT)
+            parent(src2) .= FT(1) # constant, so a same-space reference exists
+            @test (@. sum(src1 + src2)) ≈ (@. sum(src1) + 2)
+            @test (@. sum((sin(src1) + cos(src2))^2) / 2) ≈
+                  (@. ((sin(src1.:1) + cos(FT(1)))^2 + (sin(src1.:2) + cos(FT(1)))^2) / 2)
+        end
+    end
+end
+
+function test_fused_loop(foreach_slice, space, subspace)
+    FT = Spaces.undertype(space)
+    dest = Fields.Field(FT, space)
+    src1 = Fields.Field(Tuple{FT, FT}, space)
+    src2 = Fields.Field(Tuple{FT, FT}, subspace)
+    parent(src1) .= rand.(FT)
+    parent(src2) .= rand.(FT)
+
+    function fused_loop!(dest, src1, src2)
+        @. dest = 0
+        temp1 = @. sin(src1.:1) + cos(src2.:1)
+        @. dest += temp1 * temp1
+        temp2 = @. sin(src1.:2) + cos(src2.:2)
+        @. dest += temp2 * temp2
+        @. dest /= 2
+    end
+
+    foreach_slice(fused_loop!, dest, src1, src2)
+    @test dest ≈ @. sum((sin(src1) + cos(src2))^2) / 2
+
+    CUDA_FRAMES = @isdefined(CUDA) ? (AnyFrameModule(CUDA),) : ()
+    @test_opt ignored_modules = CUDA_FRAMES foreach_slice(fused_loop!, dest, src1, src2)
+end
+
+@testset "foreach_slice pointwise broadcast fusion" begin
+    context = ClimaComms.context(ClimaComms.device())
+
+    for space1 in TU.all_spaces(Float64; context)
+        test_fused_loop(foreach_point, space1, space1)
+        test_fused_loop(foreach_level, space1, space1)
+        test_fused_loop(foreach_slab, space1, space1)
+        test_fused_loop(foreach_column, space1, space1)
+
+        space2 = Spaces.level(space1, 1)
+        if space1 !== space2
+            @test_throws DimensionMismatch test_fused_loop(foreach_point, space1, space2)
+            @test_throws DimensionMismatch test_fused_loop(foreach_level, space1, space2)
+            @test_throws DimensionMismatch test_fused_loop(foreach_slab, space1, space2)
+
+            test_fused_loop(foreach_column, space1, space2)
+        end
+
+        space3 = Spaces.column(space1, 1, 1, 1)
+        if space1 !== space3
+            @test_throws DimensionMismatch test_fused_loop(foreach_point, space1, space3)
+            @test_throws DimensionMismatch test_fused_loop(foreach_column, space1, space3)
+
+            test_fused_loop(foreach_level, space1, space3)
+            if DataLayouts.nelems(Spaces.local_geometry_data(space1)) == 1
+                test_fused_loop(foreach_slab, space1, space3)
+            else
+                @test_throws DimensionMismatch test_fused_loop(foreach_slab, space1, space3)
+            end
+        end
     end
 end
 


### PR DESCRIPTION
This PR allows `Field` arguments to participate in pointwise kernel fusion through the `foreach_slice` function that was added in #2522, and it bumps the version to 0.15.1.

Without these changes, pointwise kernel fusion requires every `DataLayout` to be extracted from its `Field`, which has two downsides: the resulting code is unnecessarily verbose (e.g., [this example](https://github.com/CliMA/ClimaAtmos.jl/commit/2d8470488f458263126dffebcb8ba90efd031d4d) in ClimaAtmos), and all `local_geometry` operations need to be handled manually (instead of being handled by the `Field` broadcasting machinery). In addition to adding the relevant methods for pointwise `Field` views, this PR ensures that all types of views (point, level, slab, and column) are consistent across the `DataLayouts`, `Spaces`, and `Fields` modules.

This PR also fixes several miscellaneous bugs from version 0.15.0:
- The `max_threads_per_block` and `max_blocks` arguments were flipped on one line in `launch_configuration` (#2558). The argument order is now correct.
- Loops generated by `foreach_point` permitted arguments with different sizes, extruding singleton axes as in `Broadcasted` expressions (#2568). All `foreach_slice` loops now require consistent slice indices, matching the `eachrow`/`eachcol` functions from `Base`, and singleton axes are only extruded when broadcasting.
- Subscopes for `view`, `level`, and `column` were hardcoded to `ThisThread` in `foreach_slice` (#2568). All subscopes are now determined by a single method for `slice_subscope`.
- Slices without statically inferable sizes were passed into fused kernels from `ThisHost` by `foreach_slice` (#2522). Only slices that support dynamic cache allocation can now participate in kernel fusion.
- Both left-hand-side and right-hand-side layouts were checked for consistency when determining `FusedMultiBroadcast` attributes (#2522). Only left-hand-side layouts are now checked; right-hand-side layouts can be extruded and are allowed to have different size attributes.
- Equality checks of `DataLayout` arguments returned false negatives for parent arrays with different dimensionalities (#2522). Mismatched parent arrays are now flattened with `stable_view` before they are compared.
- Equality checks generated `Tuple`/`NamedTuple` results when using `AutoBroadcaster` wrappers (#2522). Reductions are now performed over `all ∘ ==` instead of just `==`, so that equality checks always return booleans.

These changes were tested in ClimaAtmos CI [build 31222](https://buildkite.com/clima/climaatmos-ci/builds/31222). The only failing jobs were small MSE changes and OOM errors during allocation profiling, which can be avoided by selecting different broadcast expressions for kernel fusion.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
