### PR TITLE
Fix failing MPI tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -195,8 +195,7 @@ steps:
         agents:
            slum_ntasks: 2
            slurm_gpus: 2
-           modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+           modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
   - group: "Unit: Geometry"
     steps:
@@ -275,8 +274,7 @@ steps:
           CLIMACOMMS_CONTEXT: "MPI"
         agents:
           slurm_ntasks: 4
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
   - group: "Unit: Spaces"
     steps:
@@ -328,8 +326,7 @@ steps:
         agents:
           slurm_gpus: 1
           slurm_ntasks: 2
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
       - label: "Unit: common spaces with MPI"
         key: "common_cuda_mpi_spaces"
@@ -340,8 +337,7 @@ steps:
           CLIMACOMMS_CONTEXT: "MPI"
         agents:
           slurm_ntasks: 2
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
       - label: "Unit: distributed cuda spaces"
         key: "gpu_distributed_extruded_cuda_spaces"
@@ -354,8 +350,7 @@ steps:
         agents:
           slurm_gpus_per_task: 1
           slurm_ntasks: 3
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
       - label: "Unit: ddss1"
         key: unit_ddss1
@@ -402,8 +397,7 @@ steps:
           CLIMACOMMS_CONTEXT: "MPI"
         agents:
           slurm_ntasks: 2
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
       - label: "Unit: distributed dss3"
         key: unit_distributed_dss3
@@ -413,8 +407,7 @@ steps:
           CLIMACOMMS_CONTEXT: "MPI"
         agents:
           slurm_ntasks: 3
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
       - label: "Unit: distributed dss4"
         key: unit_distributed_dss4
@@ -424,8 +417,7 @@ steps:
           CLIMACOMMS_CONTEXT: "MPI"
         agents:
           slurm_ntasks: 4
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
       - label: "Unit: distributed remapping (1 process)"
         key: distributed_remapping_1proc
@@ -443,8 +435,7 @@ steps:
           CLIMACOMMS_DEVICE: "CPU"
         agents:
           slurm_ntasks: 2
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
       - label: "Unit: distributed remapping with CUDA (1 process)"
         key: distributed_remapping_gpu_1proc
@@ -475,8 +466,7 @@ steps:
           CLIMACOMMS_CONTEXT: "MPI"
         agents:
           slurm_ntasks: 4
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
       - label: "Unit: cuda extruded spaces"
         key: "extruded_spaces_cuda"
@@ -513,8 +503,7 @@ steps:
         agents:
           slurm_ntasks: 2
           slurm_gpus: 2
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
       - label: "Unit: cuda dss 3-process test"
         key: "gpu_ddss3_test"
@@ -529,8 +518,7 @@ steps:
         agents:
           slurm_ntasks: 3
           slurm_gpus: 3
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
       - label: "Unit: cuda dss 4-process test"
         key: "gpu_ddss4_test"
@@ -545,8 +533,7 @@ steps:
         agents:
           slurm_ntasks: 4
           slurm_gpus: 4
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
       - label: "Unit: cuda Cubed Sphere dss; ne = 32; 2-process test"
         key: "gpu_ddss_ne32_cs_2processes"
@@ -561,8 +548,7 @@ steps:
         agents:
           slurm_ntasks: 2
           slurm_gpus: 2
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
       - label: "Unit: cuda Cubed Sphere dss; ne = 32; 3-process test"
         key: "gpu_ddss_ne32_cs_3processes"
@@ -577,8 +563,7 @@ steps:
         agents:
           slurm_ntasks: 3
           slurm_gpus: 3
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
       - label: "Unit: cuda Cubed Sphere dss; ne = 32; 4-process test"
         key: "gpu_ddss_ne32_cs_4processes"
@@ -593,8 +578,7 @@ steps:
         agents:
           slurm_ntasks: 4
           slurm_gpus: 4
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
   - group: "Unit: Fields"
     steps:
@@ -648,8 +632,7 @@ steps:
         agents:
           slurm_gpus_per_task: 1
           slurm_ntasks: 2
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
   - group: "Unit: Operators"
     steps:
@@ -828,8 +811,7 @@ steps:
         agents:
           slurm_ntasks: 3
           slurm_mem: 20GB
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
       - label: "Unit: run sphere geometry distributed (4)"
         key: unit_run_sphere_geometry_distributed4
@@ -840,8 +822,7 @@ steps:
         agents:
           slurm_ntasks: 4
           slurm_mem: 20GB
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
       - label: "Unit: rectilinear cuda"
         key: unit_rectilinear_cuda
@@ -1466,8 +1447,7 @@ steps:
         agents:
           slurm_nodes: 3
           slurm_tasks_per_node: 1
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
   - group: "Unit: Remapping"
     steps:
@@ -1504,8 +1484,7 @@ steps:
           CLIMACOMMS_CONTEXT: "MPI"
         agents:
           slurm_ntasks: 3
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
       - label: "Unit: limiter mass borrowing"
         key: unit_limiter_mass_borrowing
@@ -1929,8 +1908,7 @@ steps:
           CLIMACOMMS_CONTEXT: "MPI"
         agents:
           slurm_ntasks: 4
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
       - label: ":computer: Bickley jet DG rusanov"
         key: "cpu_bickleyjet_dg_rusanov"
@@ -2143,8 +2121,7 @@ steps:
           CLIMACOMMS_CONTEXT: "MPI"
         agents:
           slurm_ntasks: 2
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
   - group: "Examples: Sphere"
     steps:
@@ -2259,8 +2236,7 @@ steps:
         agents:
           slurm_nodes: 1
           slurm_tasks_per_node: 2
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
       - label: ":computer: Shallow-water 2D sphere barotropic instability alpha30"
         key: "cpu_shallowwater_2d_cg_sphere_barotropic_alpha30"
@@ -2366,8 +2342,7 @@ steps:
           CLIMACOMMS_CONTEXT: "MPI"
         agents:
           slurm_ntasks: 2
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true # remove this after library issues are fixed
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
 
       - label: ":computer: 3D sphere baroclinic wave (ρθ)"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -193,7 +193,7 @@ steps:
            CLIMACOMMS_DEVICE: "CUDA"
            CLIMACOMMS_CONTEXT: "MPI"
         agents:
-           slum_ntasks: 2
+           slurm_ntasks: 2
            slurm_gpus: 2
            modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
@@ -347,6 +347,7 @@ steps:
           - "srun julia --color=yes --check-bounds=yes --project=.buildkite test/Spaces/distributed_cuda/space_construction.jl CUDA"
         env:
           CLIMACOMMS_CONTEXT: "MPI"
+          CLIMACOMMS_DEVICE: "CUDA"
         agents:
           slurm_gpus_per_task: 1
           slurm_ntasks: 3
@@ -629,6 +630,7 @@ steps:
           - "srun julia --color=yes --check-bounds=yes --project=.buildkite test/Fields/reduction_cuda_distributed.jl"
         env:
           CLIMACOMMS_CONTEXT: "MPI"
+          CLIMACOMMS_DEVICE: "CUDA"
         agents:
           slurm_gpus_per_task: 1
           slurm_ntasks: 2

--- a/NEWS.md
+++ b/NEWS.md
@@ -79,6 +79,8 @@ main
   launch, and reused a per-task device buffer for the intermediate results of GPU
   reductions instead of allocating one per reduction.
   [2557](https://github.com/CliMA/ClimaCore.jl/pull/2557)
+- [2572](https://github.com/CliMA/ClimaCore.jl/pull/2572) Fixed DSS for MPI
+  after DataLayouts refactor 
 
 v0.14.55
 -------

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -231,7 +231,7 @@ if is_distributed # replace sol.u on the root processor with the global sol.u
         end
     end
     if ClimaComms.iamroot(comms_ctx)
-        sol = SciMLBase.sensitivity_solution(sol, global_sol_u, sol.t)
+        sol = CTS.ODESolution(sol.t, global_sol_u, sol.prob, sol.alg)
         output_file =
             joinpath(output_dir, "scaling_data_$(nprocs)_processes.jld2")
         println("writing performance data to $output_file")

--- a/src/DataLayouts/DataLayouts.jl
+++ b/src/DataLayouts/DataLayouts.jl
@@ -242,7 +242,15 @@ Base.reinterpret(::Type{T}, data::DataLayout) where {T} = rebuild(data, parent(d
 
 ClimaComms.gather(::ClimaComms.SingletonCommsContext, data::DataLayout) = data
 ClimaComms.gather(ctx::ClimaComms.AbstractCommsContext, data::DataLayout) =
-    rebuild(data, ClimaComms.gather(ctx, parent(data)))
+    gather_data(ctx, data)
+# Disambiguate from ClimaCommsMPIExt's gather(::MPICommsContext, array)
+ClimaComms.gather(ctx::ClimaComms.MPICommsContext, data::DataLayout) =
+    gather_data(ctx, data)
+function gather_data(ctx, data)
+    gathered_array = ClimaComms.gather(ctx, parent(data))
+    # The array gather only returns data on the root process
+    return ClimaComms.iamroot(ctx) ? rebuild(data, gathered_array) : nothing
+end
 
 @inline add_f_dim(dims, dim, ::Val{F}) where {F} =
     isnothing(F) ? dims : unrolled_insert(dims, dim, Val(F))

--- a/src/Topologies/dss_transform.jl
+++ b/src/Topologies/dss_transform.jl
@@ -184,3 +184,24 @@ function create_ghost_buffer(
     )
     GhostBuffer(graph_context, send_data, recv_data)
 end
+
+"""
+    fill_send_buffer!(topology, data, ghost_buffer::GhostBuffer)
+
+Loads the send buffer of `ghost_buffer` with the data of the elements
+that neighboring processes need for their ghost elements.
+"""
+function fill_send_buffer!(
+    topology::Topology2D,
+    data::DataLayouts.DataLayout,
+    ghost_buffer::GhostBuffer,
+)
+    # The parent array stores H at dim 4 or 5, depending on where F is
+    h_dim = DataLayouts.f_dim(data) == 5 ? 4 : 5
+    send_array = parent(ghost_buffer.send_data)
+    data_array = parent(data)
+    for (sidx, lidx) in enumerate(topology.send_elem_lidx)
+        selectdim(send_array, h_dim, sidx) .= selectdim(data_array, h_dim, lidx)
+    end
+    return nothing
+end

--- a/test/Spaces/distributed/ddss2.jl
+++ b/test/Spaces/distributed/ddss2.jl
@@ -43,7 +43,7 @@ include("ddss_setup.jl")
     nel = Topologies.nlocalelems(Spaces.topology(space))
     yarr = parent(y0)
     yarr .=
-        reshape(1:(Nq * Nq * nel), (Nq, Nq, 1, nel)) .+
+        reshape(1:(Nq * Nq * nel), size(yarr)) .+
         (pid - 1) * Nq * Nq * nel
 
     dss2_buffer = Spaces.create_dss_buffer(y0)

--- a/test/Spaces/distributed/ddss3.jl
+++ b/test/Spaces/distributed/ddss3.jl
@@ -77,7 +77,7 @@ partition numbers
     nel = Topologies.nlocalelems(Spaces.topology(space))
     yarr = parent(y0)
     yarr .=
-        reshape(1:(Nq * Nq * nel), (Nq, Nq, 1, nel)) .+
+        reshape(1:(Nq * Nq * nel), size(yarr)) .+
         (pid - 1) * Nq * Nq * nel
 
     dss2_buffer = Spaces.create_dss_buffer(y0)

--- a/test/Spaces/distributed/ddss4.jl
+++ b/test/Spaces/distributed/ddss4.jl
@@ -14,7 +14,7 @@ include("ddss_setup.jl")
     nel = Topologies.nlocalelems(Spaces.topology(space))
     yarr = parent(y0)
     yarr .=
-        reshape(1:(Nq * Nq * nel), (Nq, Nq, 1, nel)) .+
+        reshape(1:(Nq * Nq * nel), size(yarr)) .+
         (pid - 1) * Nq * Nq * nel
 
     dss2_buffer = Spaces.create_dss_buffer(y0)

--- a/test/Spaces/distributed_cuda/ddss2.jl
+++ b/test/Spaces/distributed_cuda/ddss2.jl
@@ -92,7 +92,7 @@ pid, nprocs = ClimaComms.init(context)
     nel = Topologies.nlocalelems(Spaces.topology(space))
     yarr = parent(y0)
     yarr .=
-        reshape(1:(Nq * Nq * nel), (Nq, Nq, 1, nel)) .+
+        reshape(1:(Nq * Nq * nel), size(yarr)) .+
         (pid - 1) * Nq * Nq * nel
     dss_buffer = Spaces.create_dss_buffer(y0)
     Spaces.weighted_dss!(y0, dss_buffer) # DSS2

--- a/test/Spaces/distributed_cuda/ddss3.jl
+++ b/test/Spaces/distributed_cuda/ddss3.jl
@@ -124,7 +124,7 @@ partition numbers
 
     yarr = parent(y0)
     yarr .=
-        reshape(1:(Nq * Nq * nel), (Nq, Nq, 1, nel)) .+
+        reshape(1:(Nq * Nq * nel), size(yarr)) .+
         (pid - 1) * Nq * Nq * nel
 
     dss_buffer = Spaces.create_dss_buffer(y0)

--- a/test/Spaces/distributed_cuda/ddss4.jl
+++ b/test/Spaces/distributed_cuda/ddss4.jl
@@ -63,7 +63,7 @@ pid, nprocs = ClimaComms.init(context)
     nel = Topologies.nlocalelems(Spaces.topology(space))
     yarr = parent(y0)
     yarr .=
-        reshape(1:(Nq * Nq * nel), (Nq, Nq, 1, nel)) .+
+        reshape(1:(Nq * Nq * nel), size(yarr)) .+
         (pid - 1) * Nq * Nq * nel
     dss_buffer = Spaces.create_dss_buffer(y0)
     Spaces.weighted_dss!(y0, dss_buffer) # DSS2


### PR DESCRIPTION
This PR fixes the library issues in the MPI tests and updates them to work with the recent datalayouts refactor. The newer climacommon uses julia 1.12 which loads its binary libcurl.so.4on startup. The manifest uses 1.10 and pins HDF5_jll, which expects a symbol version tag CURL_4 , but the binary provides CURL_OPENSSL_4 so it errors.