### PR TITLE
Use a single Pkg.develop for CI

### DIFF
--- a/.buildkite/perf/pipeline.yml
+++ b/.buildkite/perf/pipeline.yml
@@ -25,8 +25,11 @@ steps:
       - echo "--- Instantiate AMIP env"
       # Instantiate and dev install ClimaCore
       - julia --project=$COUPLER_PATH/experiments/AMIP/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'
-      - julia --project=$COUPLER_PATH/experiments/AMIP/ -e 'using Pkg; Pkg.develop(path=".")'
-      - julia --project=$COUPLER_PATH/experiments/AMIP/ -e 'using Pkg; Pkg.develop(path="lib/ClimaCoreMakie")'
+      - julia --project=$COUPLER_PATH/experiments/AMIP/ -e 'using Pkg;
+        Pkg.develop([
+          PackageSpec(path="."),
+          PackageSpec(path="lib/ClimaCoreMakie"),
+        ])'
       - julia --project=$COUPLER_PATH/experiments/AMIP/ -e 'using Pkg; Pkg.add("MPI")'
       - julia --project=$COUPLER_PATH/experiments/AMIP/ -e 'using Pkg; Pkg.precompile()'
       - julia --project=$COUPLER_PATH/experiments/AMIP/ -e 'using Pkg; Pkg.status()'

--- a/.github/workflows/ClimaCoreMakie.yml
+++ b/.github/workflows/ClimaCoreMakie.yml
@@ -25,7 +25,11 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y xorg-dev mesa-utils xvfb libgl1 freeglut3-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev
       - name: Install Julia dependencies
         run: >
-          julia --project=monorepo -e 'using Pkg; Pkg.develop(path="$(pwd())"); Pkg.develop(path="$(pwd())/lib/ClimaCoreMakie")'
+          julia --project=monorepo -e 'using Pkg;
+          Pkg.develop([
+            PackageSpec(path="$(pwd())"),
+            PackageSpec(path="$(pwd())/lib/ClimaCoreMakie"),
+          ])'
       - name: Run the tests
         continue-on-error: true
         env:

--- a/.github/workflows/ClimaCorePlots.yml
+++ b/.github/workflows/ClimaCorePlots.yml
@@ -24,7 +24,11 @@ jobs:
       - uses: julia-actions/cache@v3
       - name: Install Julia dependencies
         run: >
-          julia --project=monorepo -e 'using Pkg; Pkg.develop(path="$(pwd())"); Pkg.develop(path="$(pwd())/lib/ClimaCorePlots")'
+          julia --project=monorepo -e 'using Pkg;
+          Pkg.develop([
+            PackageSpec(path="$(pwd())"),
+            PackageSpec(path="$(pwd())/lib/ClimaCorePlots"),
+          ])'
       - name: Run the tests
         continue-on-error: true
         env:

--- a/.github/workflows/ClimaCoreSpectra.yml
+++ b/.github/workflows/ClimaCoreSpectra.yml
@@ -24,7 +24,11 @@ jobs:
       - uses: julia-actions/cache@v3
       - name: Install Julia dependencies
         run: >
-          julia --project=monorepo -e 'using Pkg; Pkg.develop(path="$(pwd())"); Pkg.develop(path="$(pwd())/lib/ClimaCoreSpectra")'
+          julia --project=monorepo -e 'using Pkg;
+          Pkg.develop([
+            PackageSpec(path="$(pwd())"),
+            PackageSpec(path="$(pwd())/lib/ClimaCoreSpectra"),
+          ])'
       - name: Run the tests
         continue-on-error: true
         env:

--- a/.github/workflows/ClimaCoreTempestRemap.yml
+++ b/.github/workflows/ClimaCoreTempestRemap.yml
@@ -25,7 +25,11 @@ jobs:
       - uses: julia-actions/cache@v3
       - name: Install Julia dependencies
         run: >
-          julia --project=monorepo -e 'using Pkg; Pkg.develop(path="$(pwd())"); Pkg.develop(path="$(pwd())/lib/ClimaCoreTempestRemap")'
+          julia --project=monorepo -e 'using Pkg;
+          Pkg.develop([
+            PackageSpec(path="$(pwd())"),
+            PackageSpec(path="$(pwd())/lib/ClimaCoreTempestRemap"),
+          ])'
       - name: Run the tests
         continue-on-error: true
         env:

--- a/.github/workflows/ClimaCoreVTK.yml
+++ b/.github/workflows/ClimaCoreVTK.yml
@@ -26,9 +26,12 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get -y install paraview python3-paraview
       - name: Install Julia dependencies
-        run: |
-          julia --project=monorepo -e 'using Pkg; Pkg.develop(path="lib/ClimaCoreVTK")'
-          julia --project=monorepo -e 'using Pkg; Pkg.develop(path=".")'
+        run: >
+          julia --project=monorepo -e 'using Pkg;
+          Pkg.develop([
+            PackageSpec(path="lib/ClimaCoreVTK"),
+            PackageSpec(path="."),
+          ])'
       - name: Run the tests
         env:
           CI_OUTPUT_DIR: output

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,12 +25,14 @@ jobs:
       - name: Install dependencies
         run: >
           julia --project=docs -e 'using Pkg;
-          Pkg.develop(path="lib/ClimaCoreVTK");
-          Pkg.develop(path="lib/ClimaCoreTempestRemap");
-          Pkg.develop(path="lib/ClimaCoreMakie");
-          Pkg.develop(path="lib/ClimaCorePlots");
-          Pkg.develop(path="lib/ClimaCoreSpectra");
-          Pkg.develop(path=".");
+          Pkg.develop([
+            PackageSpec(path="lib/ClimaCoreVTK"),
+            PackageSpec(path="lib/ClimaCoreTempestRemap"),
+            PackageSpec(path="lib/ClimaCoreMakie"),
+            PackageSpec(path="lib/ClimaCorePlots"),
+            PackageSpec(path="lib/ClimaCoreSpectra"),
+            PackageSpec(path="."),
+          ]);
           Pkg.instantiate(;verbose=true)'
       - name: Build and deploy
         env:


### PR DESCRIPTION
This PR updates the CI to use a single `Pkg.develop` instead of multiple `Pkg.develop`. Each `Pkg.develop` results in resolving and updating the manifest so minimizing the number of times that `Pkg.develop` is called would speed up this up. It also makes the order of that packages are developed in not matter anymore since all of the developed packages are considered all at once.