### PR TITLE
Split downstream ClimaAtmos tests up

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -50,12 +50,62 @@ jobs:
       # from the package itself would cause the aqua test to fail. Instead, we install
       # TestEnv into the base environment, activate the test env for the downstream package,
       # and dev ClimaCore before running the test suite from there.
-      - if: (matrix.package != 'ClimaCoupler.jl')
+      - if: (matrix.package != 'ClimaCoupler.jl' && matrix.package != 'ClimaAtmos.jl')
         run: |
           julia --color=yes -e 'using Pkg; Pkg.add("TestEnv")'
           julia --color=yes --project=${{ matrix.package }} -e 'using Pkg; Pkg.instantiate()'
           julia --color=yes --project=${{ matrix.package }} -e 'using TestEnv; TestEnv.activate();\
             using Pkg; Pkg.develop(; path = "."); include("${{ matrix.package }}/test/runtests.jl")'
+
+      # ClimaAtmos.jl's test suite uses too much memory to run in a single process,
+      # so run each test group in its own step, i.e. its own process.
+      - name: Set up ClimaAtmos.jl
+        if: matrix.package == 'ClimaAtmos.jl'
+        run: |
+          julia --color=yes -e 'using Pkg; Pkg.add("TestEnv")'
+          julia --color=yes --project=ClimaAtmos.jl -e 'using Pkg; Pkg.instantiate()'
+
+      - name: Run infrastructure tests
+        if: matrix.package == 'ClimaAtmos.jl'
+        env:
+          TEST_GROUP: infrastructure
+        run: |
+          julia --color=yes --project=ClimaAtmos.jl -e 'using TestEnv; TestEnv.activate(); using Pkg; Pkg.develop(; path = "."); include("ClimaAtmos.jl/test/runtests.jl")'
+
+      - name: Run diagnostics tests
+        if: matrix.package == 'ClimaAtmos.jl'
+        env:
+          TEST_GROUP: diagnostics
+        run: |
+          julia --color=yes --project=ClimaAtmos.jl -e 'using TestEnv; TestEnv.activate(); using Pkg; Pkg.develop(; path = "."); include("ClimaAtmos.jl/test/runtests.jl")'
+
+      - name: Run dynamics tests
+        if: matrix.package == 'ClimaAtmos.jl'
+        env:
+          TEST_GROUP: dynamics
+        run: |
+          julia --color=yes --project=ClimaAtmos.jl -e 'using TestEnv; TestEnv.activate(); using Pkg; Pkg.develop(; path = "."); include("ClimaAtmos.jl/test/runtests.jl")'
+
+      - name: Run parameterizations tests
+        if: matrix.package == 'ClimaAtmos.jl'
+        env:
+          TEST_GROUP: parameterizations
+        run: |
+          julia --color=yes --project=ClimaAtmos.jl -e 'using TestEnv; TestEnv.activate(); using Pkg; Pkg.develop(; path = "."); include("ClimaAtmos.jl/test/runtests.jl")'
+
+      - name: Run restarts tests
+        if: matrix.package == 'ClimaAtmos.jl'
+        env:
+          TEST_GROUP: restarts
+        run: |
+          julia --color=yes --project=ClimaAtmos.jl -e 'using TestEnv; TestEnv.activate(); using Pkg; Pkg.develop(; path = "."); include("ClimaAtmos.jl/test/runtests.jl")'
+
+      - name: Run era5 tests
+        if: matrix.package == 'ClimaAtmos.jl'
+        env:
+          TEST_GROUP: era5
+        run: |
+          julia --color=yes --project=ClimaAtmos.jl -e 'using TestEnv; TestEnv.activate(); using Pkg; Pkg.develop(; path = "."); include("ClimaAtmos.jl/test/runtests.jl")'
 
       - if: matrix.package == 'ClimaCoupler.jl'
         run: |


### PR DESCRIPTION
ClimaAtmos.jl's test suite uses too much memory to run in a single gha process. I believe this is because the compiled acode and inference cache grows to over the max runner memory.

I don't know why, but I could only get it to work if each test group is run in its own step.

This does create more coupling between atmos and core, and is very repetitive, but at least we will be able to run the downstream atmos test.

<!-- Provide a clear description of the content -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
