### PR TITLE
Fix `any(::FieldVector)` referencing an undefined variable

### DIFF
--- a/src/Fields/fieldvector.jl
+++ b/src/Fields/fieldvector.jl
@@ -390,7 +390,7 @@ Base.mapreduce(f, op, fv::FieldVector) =
 Base.any(f, fv::FieldVector) = any(x -> any(f, backing_array(x)), _values(fv))
 Base.any(f::Function, fv::FieldVector) = # avoid ambiguities
     any(x -> any(f, backing_array(x)), _values(fv))
-Base.any(fv::FieldVector) = any(identity, A)
+Base.any(fv::FieldVector) = any(identity, fv)
 
 Base.all(f, fv::FieldVector) = all(x -> all(f, backing_array(x)), _values(fv))
 Base.all(f::Function, fv::FieldVector) =

--- a/test/Fields/unit_field.jl
+++ b/test/Fields/unit_field.jl
@@ -396,6 +396,28 @@ end
     @test occursin("==================== Difference found:", s)
 end
 
+@testset "FieldVector any/all" begin
+    space = spectral_space_2D()
+    u = Geometry.Covariant12Vector.(ones(space), ones(space))
+    Y = Fields.FieldVector(u = u, k = (y = [1.0, 2.0, 3.0], z = 1.0))
+
+    @test !any(isnan, Y)
+    @test all(isfinite, Y)
+    parent(Y.u)[1] = NaN
+    @test any(isnan, Y)
+    @test !all(isfinite, Y)
+
+    # the zero-argument methods, which forward to `identity`
+    Yb = Fields.FieldVector(b = fill(false, space))
+    @test !any(Yb)
+    @test !all(Yb)
+    parent(Yb.b)[1] = true
+    @test any(Yb)
+    @test !all(Yb)
+    parent(Yb.b) .= true
+    @test all(Yb)
+end
+
 # Allocation measurements run in top-level functions, since the @allocated
 # macro has a small constant overhead when it is used in a local scope.
 fv_length_allocations(Y) = @allocated length(Y)


### PR DESCRIPTION
## Purpose

Closes #1432.

`Base.any(fv::FieldVector)` was defined as `any(identity, A)` in `src/Fields/fieldvector.jl`, where `A` does not exist in that scope. Calling it threw:

```
julia> Yb = Fields.FieldVector(b = fill(false, space));

julia> any(Yb)
ERROR: UndefVarError: `A` not defined

julia> all(Yb)   # the parallel method, which correctly uses `fv`
false
```

This has been broken since the method was introduced in cf826d31 (2021-11-10), which is why nothing downstream depends on it.

While confirming this, I also verified that the feature #1432 actually asks for — `any(isnan, Y)` on a `FieldVector` — already works via the predicate methods on the two lines above:

```
any(isnan, Y)     -> false
parent(Y.u)[1] = NaN
any(isnan, Y)     -> true
all(isfinite, Y)  -> false
```

So #1432 is closed by this PR: the requested behaviour is present, and the one adjacent method that was genuinely broken is now fixed.

## Content

- `src/Fields/fieldvector.jl`: `A` → `fv`.
- `test/Fields/unit_field.jl`: new `FieldVector any/all` testset covering both the zero-argument `any`/`all` methods (the regression) and the predicate forms including `any(isnan, Y)`.

Verified locally on Julia 1.10.11 against the `.buildkite` project: the new testset passes 9/9, and the rest of `test/Fields/unit_field.jl` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RK7mxypihyEYPvWmTRy8BT