### PR TITLE
Run atmos downgrade tests through buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1276,6 +1276,26 @@ steps:
         key: "cpu_invalidations"
         retry: *retry_policy
         command: "julia --color=yes --project=.buildkite perf/invalidations.jl"
+  - group: "Downstream tests"
+    steps:
+      # Downstream test: run ClimaAtmos CI against this ClimaCore commit.
+      # ClimaAtmos's pipeline sees UPSTREAM_PACKAGES and
+      # Pkg.adds each `Package#rev` entry at that rev (see ClimaAtmos.jl's
+      # .buildkite/full_pipeline.yml "Downstream test hook"). ClimaCoreSpectra and
+      # ClimaCoreTempestRemap are used in ClimaAtmos CI. They live in this repo's lib/, so
+      # pin them to the same commit to keep the family mutually consistent.
+      - label: ":rocket: Downstream: trigger ClimaAtmos CI"
+        # Deliberately NOT climaatmos-ci: downstream builds run on atmos `main`,
+        # and building them under the same pipeline would pollute climaatmos-ci's
+        # main-branch status badge and build history. climaatmos-downstream uses the same
+        # comfig (pipeline.yml) that climaatmos-ci, but lives in a separate pipeline.
+        trigger: "climaatmos-downstream"
+        build:
+          branch: "main"
+          message: "Downstream test: ClimaCore ${BUILDKITE_BRANCH} @ ${BUILDKITE_COMMIT:0:8}"
+          env:
+            UPSTREAM_PACKAGES: "ClimaCore#${BUILDKITE_COMMIT} ClimaCoreSpectra#${BUILDKITE_COMMIT} ClimaCoreTempestRemap#${BUILDKITE_COMMIT}"
+        soft_fail: true # downstream test failures don't block a merge
 
   - wait
 

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -22,8 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package:
-          - 'ClimaAtmos.jl'
+        package: # atmos is excluded here because buildkite is used to test it
           - 'ClimaCoupler.jl'
           - 'ClimaDiagnostics.jl'
           - 'ClimaLand.jl'


### PR DESCRIPTION
Use CA's buildkite as a downstream test.

Remove atmos from GHA based downstream tests.

The GitHub action downstream tests for climaatmos are very flaky. They often fail due to what I believe is running out of memory. Additionally, running atmos unit tests through GHA doesn't guarantee there won't be gpu errors.  This replaces the gha based atmos downstream tests with a buildkite pipeline step that runs climaatmos buildkite ci with the relevant climacore commit.  

One downside of this is that a failure is less visible. I made the trigger a soft fail to replicate the current behavior of other downstream tests. It also makes the downstream test fail for reproducibility test failures.