### PR TITLE
Break the method self-recursion in the GPU cooperative-group reduction

### DIFF
--- a/ext/cuda/loops.jl
+++ b/ext/cuda/loops.jl
@@ -126,33 +126,51 @@ end
 # Reduce a warp or sub-warp with warp shuffles, limited to active threads since
 # inactive threads have undefined results. For multi-warp scopes, first reduce
 # each warp, then reduce the results in the first warp.
+#
+# The two cases are separate methods, and the multi-warp one reaches the
+# warp-level reduction through `single_warp_reduce_points` rather than through
+# this generic method, so that neither calls itself. The split keeps each
+# method's job to one scope; it is not a fix for the `InvalidIRError` that
+# `sum` over a weighted level-field broadcast raises in ClimaAtmos, which the
+# split leaves unchanged. That error is a dynamic `shfl_recurse` in
+# `shuffle_reduce` below, so the value reaching the shuffles is abstractly
+# typed; it comes from `reduce_points(ThisThread(), ...)`, whose element type
+# is fixed by `return_type(op, NTuple{2, eltype(arg)})` at the launch site.
 DataLayouts.reduce_points(scope::ThisCooperativeGroup, op::O, arg; kwargs...) where {O} =
     if scope != ThisBlock() && DataLayouts.num_threads(scope) <= THREADS_PER_WARP
-        thread_result =
-            DataLayouts.reduce_points(DataLayouts.ThisThread(), op, arg; kwargs...)
-        shuffle_reduce(scope, op, thread_result, num_active_threads(scope))
+        single_warp_reduce_points(scope, op, arg; kwargs...)
     else
-        num_results = DataLayouts.num_subscopes(ThisWarp(), scope)
-        max_results = scope == ThisBlock() ? MAX_WARPS_PER_BLOCK : num_results
-        warp_index = DataLayouts.subscope_rank(ThisWarp(), scope)
-        warp_result = DataLayouts.reduce_points(ThisWarp(), op, arg; kwargs...)
-        results = DataLayouts.scoped_static_array(scope, typeof(warp_result), max_results)
-        if is_first_thread_in(ThisWarp())
-            @inbounds results[warp_index] = warp_result
+        multi_warp_reduce_points(scope, op, arg; kwargs...)
+    end
+
+@inline function single_warp_reduce_points(scope, op::O, arg; kwargs...) where {O}
+    thread_result =
+        DataLayouts.reduce_points(DataLayouts.ThisThread(), op, arg; kwargs...)
+    return shuffle_reduce(scope, op, thread_result, num_active_threads(scope))
+end
+
+@inline function multi_warp_reduce_points(scope, op::O, arg; kwargs...) where {O}
+    num_results = DataLayouts.num_subscopes(ThisWarp(), scope)
+    max_results = scope == ThisBlock() ? MAX_WARPS_PER_BLOCK : num_results
+    warp_index = DataLayouts.subscope_rank(ThisWarp(), scope)
+    warp_result = single_warp_reduce_points(ThisWarp(), op, arg; kwargs...)
+    results = DataLayouts.scoped_static_array(scope, typeof(warp_result), max_results)
+    if is_first_thread_in(ThisWarp())
+        @inbounds results[warp_index] = warp_result
+    end
+    DataLayouts.synchronize(scope)
+    if !isone(num_results)
+        if isone(warp_index)
+            @inbounds warp_result = results[DataLayouts.thread_rank(ThisWarp())]
+            final_result = shuffle_reduce(ThisWarp(), op, warp_result, num_results)
+            if is_first_thread_in(ThisWarp())
+                @inbounds results[1] = final_result
+            end
         end
         DataLayouts.synchronize(scope)
-        if !isone(num_results)
-            if isone(warp_index)
-                @inbounds warp_result = results[DataLayouts.thread_rank(ThisWarp())]
-                final_result = shuffle_reduce(ThisWarp(), op, warp_result, num_results)
-                if is_first_thread_in(ThisWarp())
-                    @inbounds results[1] = final_result
-                end
-            end
-            DataLayouts.synchronize(scope)
-        end
-        @inbounds results[1]
     end
+    return @inbounds results[1]
+end
 
 # Use the scope type to generate the number of pairwise reductions, log2(N), in
 # the compiler, without needing to rely on constant propagation in GPU kernels.

--- a/test/Fields/gpu_reduction.jl
+++ b/test/Fields/gpu_reduction.jl
@@ -4,6 +4,7 @@ ClimaComms.@import_required_backends
 using Statistics
 using LinearAlgebra
 
+import ClimaCore
 import ClimaCore:
     Domains,
     Fields,
@@ -13,7 +14,9 @@ import ClimaCore:
     Spaces,
     Quadratures,
     Topologies,
-    DataLayouts
+    DataLayouts,
+    CommonGrids,
+    CommonSpaces
 
 include("reduction_cuda_utils.jl")
 
@@ -290,4 +293,35 @@ end
     q_cpu = @. q₀(coords_cpu, 1.2, 1.5)
 
     @test [sum(q)...] ≈ [sum(q_cpu)...]
+end
+
+@testset "weighted reduction over a level of an extruded field" begin
+    # The reduction ClimaAtmos' `horizontal_integral_at_boundary` performs: a
+    # `sum` over a broadcast that divides a level of a face field by the
+    # level's Δz. This covers that shape on the GPU against the CPU value. It
+    # does not reproduce the `InvalidIRError` that the same reduction raises
+    # from ClimaAtmos, so a green run here does not mean that path compiles.
+    FT = Float32
+    make_face_space(dev) = CommonSpaces.ExtrudedCubedSphereSpace(
+        FT;
+        z_elem = 10,
+        z_min = 0,
+        z_max = 30000.0,
+        radius = 6.371f6,
+        h_elem = 4,
+        n_quad_points = 4,
+        staggering = CommonGrids.Grids.CellFace(),
+        device = dev,
+    )
+    horizontal_integral_at_boundary(f) =
+        sum(f ./ Fields.Δz_field(axes(f)) .* 2)
+    results = map((
+        ClimaComms.CUDADevice(),
+        ClimaComms.CPUSingleThreaded(),
+    )) do dev
+        f = ones(make_face_space(dev))
+        flev = Fields.level(f, ClimaCore.Utilities.half)
+        horizontal_integral_at_boundary(flev)
+    end
+    @test results[1] ≈ results[2] rtol = sqrt(eps(FT))
 end


### PR DESCRIPTION
Splits `reduce_points(::ThisCooperativeGroup, ...)` into
`single_warp_reduce_points` and `multi_warp_reduce_points`, so that each method
handles one scope and neither calls itself. The direct call is equivalent: the
inner `reduce_points(ThisWarp(), ...)` always took the warp branch, since
`ThisWarp() != ThisBlock()` and a warp has exactly `THREADS_PER_WARP` threads.

This is a structural change only. It was written on the theory that the
`InvalidIRError` ClimaAtmos threw in `horizontal_integral_at_boundary` came from
inference widening the return type of a self-recursive method; however, a run with this
change alone produced the same error. The actual cause is a missing `CUDA.shfl_recurse` 
method for `Geometry.Tensor`, fixed in #2591.

Also adds a GPU test of the reduction shape ClimaAtmos uses (a `sum` over a
level of a face field divided by Δz), against the CPU value. The test reduces a
scalar field, so it passes with or without #2591's fix — `Float32` is shuffled
natively.