### PR TITLE
Attempt implementing Robin boundary conditions for FD operators

### DIFF
--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -111,6 +111,15 @@ struct SetValue{S} <: AbstractBoundaryCondition
 end
 
 """
+    SetRobin(val)
+
+Set a Robin BC.
+"""
+struct SetRobin{S} <: AbstractBoundaryCondition
+    val::S
+end
+
+"""
     SetGradient(val)
 
 Set the gradient at the boundary to be `val`. In the case of gradient operators
@@ -2848,7 +2857,7 @@ The following boundary conditions are supported:
 struct GradientC2F{BC} <: GradientOperator
     bcs::BC
     function GradientC2F(; kwargs...)
-        assert_valid_bcs("GradientC2F", kwargs, (SetValue, SetGradient))
+        assert_valid_bcs("GradientC2F", kwargs, (SetValue, SetGradient, SetRobin))
         new{typeof(NamedTuple(kwargs))}(NamedTuple(kwargs))
     end
     GradientC2F(bcs) = GradientC2F(; bcs...)
@@ -2899,6 +2908,46 @@ Base.@propagate_inbounds function stencil_right_boundary(
     Geometry.Covariant3Vector(2) ⊗ (
         getidx(space, bc.val, nothing, hidx) -
         getidx(space, arg, idx - half, hidx)
+    )
+end
+
+# left/right SetRobin BC
+Base.@propagate_inbounds function stencil_left_boundary(
+    ::GradientC2F,
+    bc::SetRobin,
+    space,
+    idx,
+    hidx,
+    arg,
+)
+    @assert idx == left_face_boundary_idx(space)
+    u_center = getidx(space, arg, idx + half, hidx)
+    g, a, b = bc.val
+    u_face = (g - a*u_center) / (b-a)
+    robin_value = Geometry.WVector(u_center - u_face)
+    Geometry.project(
+        Geometry.Covariant3Axis(),
+        getidx(space, robin_value, nothing, hidx),
+        Geometry.LocalGeometry(space, idx, hidx),
+    )
+end
+Base.@propagate_inbounds function stencil_right_boundary(
+    ::GradientC2F,
+    bc::SetRobin,
+    space,
+    idx,
+    hidx,
+    arg,
+)
+    @assert idx == right_face_boundary_idx(space)
+    u_center = getidx(space, arg, idx - half, hidx)
+    g, a, b = bc.val
+    u_face = (g + a*u_center) / (b+a)
+    robin_value = Geometry.WVector(u_face - u_center)
+    Geometry.project(
+        Geometry.Covariant3Axis(),
+        getidx(space, robin_value, nothing, hidx),
+        Geometry.LocalGeometry(space, idx, hidx),
     )
 end
 

--- a/test_robin.jl
+++ b/test_robin.jl
@@ -1,0 +1,97 @@
+import ClimaCore as CC
+using ClimaComms
+using ClimaCorePlots
+using Plots
+
+function compare_dirichlet(value, data)
+    p = plot()
+    bottom_bc = CC.Operators.SetValue(value)
+    top_bc = CC.Operators.SetValue(value)
+    gradc2f = CC.Operators.GradientC2F(bottom=bottom_bc, top=top_bc)
+    ∇data = gradc2f.(data)
+    plot!(
+        map(x -> x.w, CC.Geometry.WVector.(∇data)),
+        color=:black,
+        label="Dirichlet",
+    )
+
+    bottom_bc = CC.Operators.SetRobin([value, 0.0, 1.0])
+    top_bc = CC.Operators.SetRobin([value, 0.0, 1.0])
+    gradc2f = CC.Operators.GradientC2F(bottom=bottom_bc, top=top_bc)
+    ∇data = gradc2f.(data)
+    plot!(
+        map(x -> x.w, CC.Geometry.WVector.(∇data)),
+        color=:red,
+        label="Robin",
+        linestyle=:dot,
+    )
+    plot!(
+        title="g=$value",
+        legend=:true,
+    )
+    return p
+end
+
+
+function compare_neumann(value, data)
+    p = plot()
+    bottom_bc = CC.Operators.SetGradient(CC.Geometry.WVector(value))
+    top_bc = CC.Operators.SetGradient(CC.Geometry.WVector(value))
+    gradc2f = CC.Operators.GradientC2F(bottom=bottom_bc, top=top_bc)
+    ∇data = gradc2f.(data)
+    plot!(
+        map(x -> x.w, CC.Geometry.WVector.(∇data)),
+        color=:black,
+        label="Neumann",
+    )
+
+    bottom_bc = CC.Operators.SetRobin([value, 1.0, 0.0])
+    top_bc = CC.Operators.SetRobin([value, 1.0, 0.0])
+    gradc2f = CC.Operators.GradientC2F(bottom=bottom_bc, top=top_bc)
+    ∇data = gradc2f.(data)
+    plot!(
+        map(x -> x.w, CC.Geometry.WVector.(∇data)),
+        color=:red,
+        label="Robin",
+        linestyle=:dot,
+    )
+    plot!(
+        title="g=$value",
+        legend=:true,
+    )
+    return p
+end
+
+function get_coord(lower_boundary::Float64, upper_boundary::Float64, nelems::Int)
+    device = ClimaComms.device()
+    domain = CC.Domains.IntervalDomain(
+        CC.Geometry.ZPoint(lower_boundary),
+        CC.Geometry.ZPoint(upper_boundary);
+        boundary_names=(:bottom, :top),
+    )
+    mesh = CC.Meshes.IntervalMesh(domain, nelems=nelems)
+    cspace = CC.Spaces.CenterFiniteDifferenceSpace(device, mesh)
+    coord = CC.Fields.coordinate_field(cspace)
+    return coord
+end
+
+coord = get_coord(0.0, 10.0, 20)
+data = cos.(coord.z)
+
+l = @layout [a b c; d e f]
+
+pd1 = compare_dirichlet(1.0, data)
+pd2 = compare_dirichlet(0.0, data)
+pd3 = compare_dirichlet(-1.0, data)
+pn1 = compare_neumann(1.0, data)
+pn2 = compare_neumann(0.0, data)
+pn3 = compare_neumann(-1.0, data)
+plot(pd1, pd2, pd3, pn1, pn2, pn3; layout = l)
+plot!(;
+    titlefontsize=12,
+    size=(800,600),
+    link=:all,
+    xlabel="∇cos(z)",
+    ylabel="z",
+    legend_position=:right,
+)


### PR DESCRIPTION
This PR is supposed to address #2485, i.e., provide support for Robin conditions for the finite difference operators.
It adds a `SetRobin` boundary condition for the `GradientF2C` operator.

The implementation is not correct yet: It recovers Neumann (`SetGradient`), but not Dirichlet (`SetValue`) boundary conditions. I have added [a script](https://github.com/valentinaschueller/ClimaCore.jl/blob/robin_bc/test_robin.jl) to test this (which can be turned into unit tests later): 
The first row shows the comparison to three different Dirichlet conditions (`SetValue` vs. `SetRobin` with `a=0, b=1`, following the notation in #2485 ).
The second row shows the comparison to three different Neumann conditions (`SetGradient` vs. `SetRobin` with `a=1, b=0`).

<img width="1833" height="1375" alt="image" src="https://github.com/user-attachments/assets/239a95b6-30ce-4a36-b62f-557fc7c5d0d6" />

It seems that the issue is related to the spaces I work with: `SetValue` works directly in the reference element space (with a `Covariant3Vector`), while `SetGradient` takes a boundary condition in physical space (a `WVector`) and projects it.

I am a bit stuck and would appreciate some help/input on what's a good next step!

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
