### PR TITLE
Clean up imports flagged by ExplicitImports

### DIFF
--- a/src/DataLayouts/DataLayouts.jl
+++ b/src/DataLayouts/DataLayouts.jl
@@ -1,7 +1,7 @@
 module DataLayouts
 
-import Base: @propagate_inbounds
-import LLVM: unsafe_load
+import Base: @propagate_inbounds, unsafe_load
+import LLVM # for the `unsafe_load` methods on `Core.LLVMPtr`
 import StaticArrays
 import BlockArrays
 import Adapt

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -5,6 +5,7 @@ import MultiBroadcastFusion as MBF
 import ..slab, ..slab_args, ..column, ..column_args, ..level, ..level_args
 import ..DebugOnly: call_post_op_callback, post_op_callback
 import ..DataLayouts: DataLayouts, DataLayout, DataStyle, PointIndex
+# `@fused_direct` is unused here, but re-exposed as `Fields.@fused_direct` for users
 import ..DataLayouts: FusedMultiBroadcast, @fused_direct
 import ..Domains
 import ..Topologies
@@ -13,7 +14,7 @@ import ..Grids: ColumnIndex, local_geometry_type
 import ..Spaces: Spaces, AbstractSpace, AbstractPointSpace, cuda_synchronize
 import ..Spaces: nlevels, ncolumns
 import ..Spaces: get_mask, set_mask!
-import ..Geometry: Geometry, Cartesian12Vector
+import ..Geometry: Geometry
 import ..Utilities: PlusHalf, half, safe_eltype, unsafe_eltype
 import ..Utilities: recursive_bottom_eltype
 import ..Utilities: drop_auto_broadcasters, auto_broadcasted
@@ -361,8 +362,8 @@ local_geometry_field(space::AbstractSpace) =
     Field(Spaces.local_geometry_data(space), space)
 local_geometry_field(field::Field) = local_geometry_field(axes(field))
 
-Fields.local_geometry_field(bc::Base.Broadcast.Broadcasted) =
-    Fields.local_geometry_field(axes(bc))
+local_geometry_field(bc::Base.Broadcast.Broadcasted) =
+    local_geometry_field(axes(bc))
 
 """
     Δz_field(field::Field)

--- a/src/Fields/broadcast.jl
+++ b/src/Fields/broadcast.jl
@@ -134,7 +134,7 @@ _todata_args(args::Tuple) =
     end
 
 todata(obj) = obj
-todata(field::Field) = Fields.field_values(field)
+todata(field::Field) = field_values(field)
 function todata(bc::Base.Broadcast.Broadcasted{FieldStyle{DS}}) where {DS}
     _args = _todata_args(bc.args)
     Base.Broadcast.Broadcasted{DS}(bc.f, _args)
@@ -319,7 +319,7 @@ function Base.Broadcast.broadcasted(
     ::typeof(LinearAlgebra.norm),
     arg,
 )
-    space = Fields.axes(arg)
+    space = axes(arg)
     # wrap in a Field so that the axes line up correctly (it just get's unwraped so effectively a no-op)
     Base.Broadcast.broadcasted(
         fs,
@@ -333,7 +333,7 @@ function Base.Broadcast.broadcasted(
     ::typeof(LinearAlgebra.norm_sqr),
     arg,
 )
-    space = Fields.axes(arg)
+    space = axes(arg)
     # wrap in a Field so that the axes line up correctly (it just get's unwraped so effectively a no-op)
     Base.Broadcast.broadcasted(
         fs,
@@ -349,7 +349,7 @@ function Base.Broadcast.broadcasted(
     arg1,
     arg2,
 )
-    space = Fields.axes(arg1)
+    space = axes(arg1)
     # wrap in a Field so that the axes line up correctly (it just get's unwraped so effectively a no-op)
     Base.Broadcast.broadcasted(
         fs,
@@ -365,7 +365,7 @@ function Base.Broadcast.broadcasted(
     arg1,
     arg2,
 )
-    space = Fields.axes(arg2)
+    space = axes(arg2)
     # wrap in a Field so that the axes line up correctly (it just get's unwraped so effectively a no-op)
     Base.Broadcast.broadcasted(
         fs,
@@ -381,7 +381,7 @@ function Base.Broadcast.broadcasted(
     arg1,
     arg2,
 )
-    space = Fields.axes(arg2)
+    space = axes(arg2)
     # wrap in a Field so that the axes line up correctly (it just get's unwraped so effectively a no-op)
     Base.Broadcast.broadcasted(
         fs,
@@ -397,7 +397,7 @@ function Base.Broadcast.broadcasted(
     ::Type{V},
     arg,
 ) where {V <: Geometry.AbstractTensor{1}}
-    space = Fields.axes(arg)
+    space = axes(arg)
     # wrap in a Field so that the axes line up correctly (it just get's unwraped so effectively a no-op)
     Base.Broadcast.broadcasted(fs, V, arg, local_geometry_field(space))
 end
@@ -407,7 +407,7 @@ function Base.copyto!(
     bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}},
 )
     mask = get_mask(axes(field))
-    copyto!(Fields.field_values(field), todata(bc); mask)
+    copyto!(field_values(field), todata(bc); mask)
     return field
 end
 function Base.copyto!(
@@ -415,7 +415,7 @@ function Base.copyto!(
     bc::Base.Broadcast.Broadcasted{Base.Broadcast.Style{Tuple}},
 )
     mask = get_mask(axes(field))
-    copyto!(Fields.field_values(field), todata(bc); mask)
+    copyto!(field_values(field), todata(bc); mask)
     return field
 end
 

--- a/src/Fields/indices.jl
+++ b/src/Fields/indices.jl
@@ -293,8 +293,8 @@ function byslab(
     end
 end
 
-universal_index(colidx::Fields.ColumnIndex{2}) =
+universal_index(colidx::ColumnIndex{2}) =
     CartesianIndex(1, colidx.ij[1], colidx.ij[2], colidx.h)
 
-universal_index(colidx::Fields.ColumnIndex{1}) =
+universal_index(colidx::ColumnIndex{1}) =
     CartesianIndex(1, colidx.ij[1], 1, colidx.h)

--- a/src/Fields/mapreduce.jl
+++ b/src/Fields/mapreduce.jl
@@ -227,4 +227,4 @@ end
 
 Base.:(==)(field1::Field, field2::Field) =
     axes(field1) === axes(field2) &&
-    Fields.field_values(field1) == Fields.field_values(field2)
+    field_values(field1) == field_values(field2)

--- a/src/Geometry/Geometry.jl
+++ b/src/Geometry/Geometry.jl
@@ -1,7 +1,7 @@
 module Geometry
 
 using ..Utilities: AutoBroadcaster, nested_broadcast, nested_broadcast_result_type
-import LinearAlgebra: det, dot, norm, norm_sqr, cross, UniformScaling, Adjoint
+import LinearAlgebra: dot, norm, norm_sqr, cross, UniformScaling, Adjoint
 import Random
 using StaticArrays, UnrolledUtilities
 

--- a/src/Geometry/globalgeometry.jl
+++ b/src/Geometry/globalgeometry.jl
@@ -222,12 +222,12 @@ function CartesianVector(
 end
 
 function product_geometry(
-    horizontal_local_geometry::Geometry.LocalGeometry,
-    vertical_local_geometry::Geometry.LocalGeometry,
+    horizontal_local_geometry::LocalGeometry,
+    vertical_local_geometry::LocalGeometry,
     global_geometry::AbstractGlobalGeometry,
     ∇z = nothing,
 )
-    coordinates = Geometry.product_coordinates(
+    coordinates = product_coordinates(
         horizontal_local_geometry.coordinates,
         vertical_local_geometry.coordinates,
     )
@@ -244,7 +244,7 @@ function product_geometry(
         vertical_local_geometry, vertical_local_geometry.∂x∂ξ,
     )
     ∂x∂ξ = isnothing(∇z) ? ∂x∂ξ_h + ∂x∂ξ_v : ∂x∂ξ_h + ∂x∂ξ_v + ∇z
-    return Geometry.LocalGeometry(coordinates, J, WJ, ∂x∂ξ)
+    return LocalGeometry(coordinates, J, WJ, ∂x∂ξ)
 end
 
 # Reshape an identity-padded 3×3 metric tensor back to its native I-sized
@@ -254,8 +254,8 @@ end
     reshape(∂x∂ξ, (Components{Orthonormal, I}(), Components{Covariant, I}()))
 
 function product_geometry(
-    horizontal_local_geometry::Geometry.LocalGeometry,
-    vertical_local_geometry::Geometry.LocalGeometry,
+    horizontal_local_geometry::LocalGeometry,
+    vertical_local_geometry::LocalGeometry,
     global_geometry::DeepSphericalGlobalGeometry,
     ∇z = nothing,
 )
@@ -263,7 +263,7 @@ function product_geometry(
     z = vertical_local_geometry.coordinates.z
     scale = ((r + z) / r)
 
-    coordinates = Geometry.product_coordinates(
+    coordinates = product_coordinates(
         horizontal_local_geometry.coordinates,
         vertical_local_geometry.coordinates,
     )
@@ -280,18 +280,18 @@ function product_geometry(
         vertical_local_geometry, vertical_local_geometry.∂x∂ξ,
     )
     ∂x∂ξ = isnothing(∇z) ? ∂x∂ξ_h + ∂x∂ξ_v : ∂x∂ξ_h + ∂x∂ξ_v + ∇z
-    return Geometry.LocalGeometry(coordinates, J, WJ, ∂x∂ξ)
+    return LocalGeometry(coordinates, J, WJ, ∂x∂ξ)
 end
 
 function product_geometry(
-    horizontal_local_geometry::Geometry.LocalGeometry,
-    vertical_local_geometry::Geometry.CoordinateOnlyGeometry,
+    horizontal_local_geometry::LocalGeometry,
+    vertical_local_geometry::CoordinateOnlyGeometry,
     global_geometry::AbstractGlobalGeometry,
     ∇z = nothing,
 )
-    coordinates = Geometry.product_coordinates(
+    coordinates = product_coordinates(
         horizontal_local_geometry.coordinates,
         vertical_local_geometry.coordinates,
     )
-    return Geometry.CoordinateOnlyGeometry(coordinates)
+    return CoordinateOnlyGeometry(coordinates)
 end

--- a/src/Geometry/localgeometry.jl
+++ b/src/Geometry/localgeometry.jl
@@ -1,5 +1,3 @@
-import LinearAlgebra: issymmetric
-
 isapproxsymmetric(A::AbstractMatrix{T}; rtol = 10 * eps(T)) where {T <: AbstractFloat} =
     Base.isapprox(A, A'; rtol)
 

--- a/src/Geometry/mul_with_projection.jl
+++ b/src/Geometry/mul_with_projection.jl
@@ -39,7 +39,7 @@ basis2(::Type{<:AbstractTensor{2, <:Any, <:Tuple{Any, B}}}) where {B} = B
 
 recursively_find_dual_axes_for_projection(
     ::Type{X},
-) where {X <: Tensor{2}} = dual(Geometry.tensor_axes(X)[2])
+) where {X <: Tensor{2}} = dual(tensor_axes(X)[2])
 @inline function recursively_find_dual_axes_for_projection(::Type{X}) where {X}
     Y = eltype(X)
     Y === X && return nothing

--- a/src/Geometry/tensors.jl
+++ b/src/Geometry/tensors.jl
@@ -328,7 +328,7 @@ Base.one(::Type{Tensor{N, T, B, C}}) where {N, T, B, C} =
     Tensor(one(C), B.instance)
 Base.convert(::Type{Tensor{N, T, B, C}}, x::AbstractTensor) where {N, T, B, C} =
     Tensor(convert(C, parent(reshape(x, B.instance))), B.instance)
-Random.rand(rng::Random.AbstractRNG, ::Type{Tensor{N, T, B, C}}) where {N, T, B, C} =
+Base.rand(rng::Random.AbstractRNG, ::Type{Tensor{N, T, B, C}}) where {N, T, B, C} =
     Tensor(rand(rng, C), B.instance)
 
 Base.show(io::IO, x::Tensor) =

--- a/src/Hypsography/Hypsography.jl
+++ b/src/Hypsography/Hypsography.jl
@@ -11,9 +11,6 @@ import ..Geometry,
     ..Spaces,
     ..Fields,
     ..Operators
-import ..Spaces: ExtrudedFiniteDifferenceSpace
-import ClimaCore.Utilities: half
-
 import ..Grids:
     _ExtrudedFiniteDifferenceGrid,
     ExtrudedFiniteDifferenceGrid,

--- a/src/InputOutput/readers.jl
+++ b/src/InputOutput/readers.jl
@@ -383,7 +383,7 @@ function read_topology_new(reader::HDF5Reader, name::AbstractString)
     elseif type == "Topology2D"
         mesh = read_mesh(reader, attrs(group)["mesh"])
         if haskey(group, "elemorder")
-            elemorder_matrix = HDF5.read(group, "elemorder")
+            elemorder_matrix = read(group, "elemorder")
             if reader.file_version < v"0.10.9"
                 elemorder = collect(
                     reinterpret(
@@ -435,7 +435,7 @@ This should cooperate with datasets written by `write!` for datalayouts.
 function read_data_layout(dataset, topology)
     ArrayType = ClimaComms.array_type(topology)
     data_layout = HDF5.read_attribute(dataset, "type")
-    array = HDF5.read(dataset)
+    array = read(dataset)
     if topology isa Topologies.Topology2D
         h_dim = _scan_h_dim(data_layout)
         nd = ndims(array)

--- a/src/MatrixFields/MatrixFields.jl
+++ b/src/MatrixFields/MatrixFields.jl
@@ -41,7 +41,8 @@ multiples of `LinearAlgebra.I`. This comes with the following functionality:
 module MatrixFields
 
 import LinearAlgebra: I, UniformScaling, Adjoint
-import LinearAlgebra: inv, norm, ldiv!, mul!
+import Base: inv
+import LinearAlgebra: norm, ldiv!, mul!
 import StaticArrays: SMatrix, SVector
 import BandedMatrices: BandedMatrix, band, _BandedMatrix
 import KrylovKit
@@ -59,7 +60,6 @@ import ..DataLayouts: DataLayout
 import ..Geometry
 import ..Topologies
 import ..Spaces
-import ..Spaces: local_geometry_type
 import ..Fields
 import ..Operators
 using ..Geometry:

--- a/src/MatrixFields/single_field_solver.jl
+++ b/src/MatrixFields/single_field_solver.jl
@@ -41,7 +41,7 @@ end
 single_field_solve!(_, x, A::ScalingFieldMatrixEntry, b) =
     x .= (inv(scaling_value(A)),) .* b
 single_field_solve!(cache, x, A::ColumnwiseBandMatrixField, b) =
-    if eltype(A) <: MatrixFields.DiagonalMatrixRow
+    if eltype(A) <: DiagonalMatrixRow
         A₀ = A.entries.:1
         @. x = inv(A₀) * b
     else

--- a/src/Meshes/common.jl
+++ b/src/Meshes/common.jl
@@ -119,7 +119,7 @@ function face_connectivity_matrix(
             if is_boundary_face(mesh, elem, face)
                 continue
             end
-            opelem, opface, reversed = Meshes.opposing_face(mesh, elem, face)
+            opelem, opface, reversed = opposing_face(mesh, elem, face)
             j = orderindex[opelem]
             push!(I, i)
             push!(J, j)

--- a/src/Meshes/interval.jl
+++ b/src/Meshes/interval.jl
@@ -34,7 +34,7 @@ end
 Base.:(==)(mesh1::IntervalMesh, mesh2::IntervalMesh) =
     mesh1.domain == mesh2.domain && mesh1.faces == mesh2.faces
 function Base.hash(mesh::IntervalMesh, h::UInt)
-    h = hash(Meshes.IntervalMesh, h)
+    h = hash(IntervalMesh, h)
     h = hash(mesh.domain, h)
     h = hash(mesh.faces, h)
     return h

--- a/src/Meshes/rectangle.jl
+++ b/src/Meshes/rectangle.jl
@@ -25,7 +25,7 @@ Base.:(==)(mesh1::RectilinearMesh, mesh2::RectilinearMesh) =
     mesh1.intervalmesh1 == mesh2.intervalmesh1 &&
     mesh1.intervalmesh2 == mesh2.intervalmesh2
 function Base.hash(mesh::RectilinearMesh, h::UInt)
-    h = hash(Meshes.RectilinearMesh, h)
+    h = hash(RectilinearMesh, h)
     h = hash(mesh.intervalmesh1, h)
     h = hash(mesh.intervalmesh2, h)
     return h

--- a/src/Operators/Operators.jl
+++ b/src/Operators/Operators.jl
@@ -12,7 +12,7 @@ import ..Utilities:
     new, is_auto_broadcastable, add_auto_broadcasters, drop_auto_broadcasters
 import ..DebugOnly: call_post_op_callback, post_op_callback
 import ..DataLayouts
-import ..Geometry: Geometry, Covariant12Vector, Contravariant12Vector, ⊗
+import ..Geometry: Geometry, ⊗
 import ..Spaces: Spaces, Quadratures, AbstractSpace
 import ..Topologies
 import ..Meshes

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -3623,10 +3623,10 @@ end
 @inline function should_call_left_boundary(idx, space, op, args...)
     Topologies.isperiodic(space) && return false
     loc = left_boundary_window(space)
-    return idx < Operators.left_interior_idx(
+    return idx < left_interior_idx(
         space,
         op,
-        Operators.get_boundary(op, loc),
+        get_boundary(op, loc),
         args...,
     )
 end
@@ -3634,10 +3634,10 @@ end
 @inline function should_call_right_boundary(idx, space, op, args...)
     Topologies.isperiodic(space) && return false
     loc = right_boundary_window(space)
-    return idx > Operators.right_interior_idx(
+    return idx > right_interior_idx(
         space,
         op,
-        Operators.get_boundary(op, loc),
+        get_boundary(op, loc),
         args...,
     )
 end

--- a/src/Operators/integrals.jl
+++ b/src/Operators/integrals.jl
@@ -85,9 +85,9 @@ end
 
 const PointwiseOrColumnwiseBroadcasted = Union{
     Base.Broadcast.Broadcasted{
-        <:Union{Fields.FieldStyle, Operators.AbstractStencilStyle},
+        <:Union{Fields.FieldStyle, AbstractStencilStyle},
     },
-    Operators.StencilBroadcasted,
+    StencilBroadcasted,
 }
 
 # TODO: inline / delete this helper

--- a/src/Operators/remapping.jl
+++ b/src/Operators/remapping.jl
@@ -1,7 +1,6 @@
 using ..Meshes
 using ..Spaces:
     AbstractSpace, SpectralElementSpace1D, SpectralElementSpace2D, Quadratures
-using ..Topologies: Topology2D, IntervalTopology
 using ..Fields: Field
 using ..DataLayouts
 using SparseArrays, LinearAlgebra

--- a/src/Operators/spectralelement.jl
+++ b/src/Operators/spectralelement.jl
@@ -1530,7 +1530,7 @@ function matrix_interpolate(
     interp_data =
         DataLayouts.IH1JH2{S, Nu, Nu, nothing}(Matrix{S}(undef, (Nu * n1, Nu * n2)))
     M = Quadratures.interpolation_matrix(Float64, Q_interp, quadrature_style)
-    Operators.tensor_product!(interp_data, Fields.field_values(field), M)
+    tensor_product!(interp_data, Fields.field_values(field), M)
     return parent(interp_data)
 end
 
@@ -1546,7 +1546,7 @@ function matrix_interpolate(
     interp_data =
         DataLayouts.VIH1{S, nl, Nu, nothing}(Matrix{S}(undef, (nl, Nu * n1)))
     M = Quadratures.interpolation_matrix(Float64, Q_interp, quadrature_style)
-    Operators.tensor_product!(interp_data, Fields.field_values(field), M)
+    tensor_product!(interp_data, Fields.field_values(field), M)
     return parent(interp_data)
 end
 

--- a/src/Remapping/interpolate_pressure.jl
+++ b/src/Remapping/interpolate_pressure.jl
@@ -289,7 +289,7 @@ function interpolate_pressure(
 )
     (; pfull_field) = pfull_intp
     dest = fill(one(eltype(pfull_field)), pfull_intp.pressure_space)
-    Remapping.interpolate_pressure!(dest, field, pfull_intp)
+    interpolate_pressure!(dest, field, pfull_intp)
     return dest
 end
 

--- a/src/Spaces/Spaces.jl
+++ b/src/Spaces/Spaces.jl
@@ -73,7 +73,7 @@ local_geometry_data(space::AbstractSpace) =
 dss_weights(space::AbstractSpace) = dss_weights(grid(space), staggering(space))
 
 function n_elements_per_panel_direction(space::AbstractSpace)
-    hspace = Spaces.horizontal_space(space)
+    hspace = horizontal_space(space)
     hmesh = topology(hspace).mesh
     return Meshes.n_elements_per_panel_direction(hmesh)
 end
@@ -140,7 +140,7 @@ function face_space(space::AbstractSpace)
     error("`center_space` can only be called with vertical/extruded spaces")
 end
 
-weighted_jacobian(space::Spaces.AbstractSpace) = local_geometry_data(space).WJ
+weighted_jacobian(space::AbstractSpace) = local_geometry_data(space).WJ
 
 """
     Spaces.local_area(space::Spaces.AbstractSpace)
@@ -148,7 +148,7 @@ weighted_jacobian(space::Spaces.AbstractSpace) = local_geometry_data(space).WJ
 The length/area/volume of `space` local to the current context. See
 [`Spaces.area`](@ref)
 """
-local_area(space::Spaces.AbstractSpace) = Base.sum(weighted_jacobian(space))
+local_area(space::AbstractSpace) = Base.sum(weighted_jacobian(space))
 
 """
     Spaces.area(space::Spaces.AbstractSpace)
@@ -161,7 +161,7 @@ weights ``W_i`` multiplied by the Jacobian determinants ``J_i``:
 
 If `space` is distributed, this uses a `ClimaComms.allreduce` operation.
 """
-area(space::Spaces.AbstractSpace) =
+area(space::AbstractSpace) =
     ClimaComms.allreduce(ClimaComms.context(space), local_area(space), +)
 
 ClimaComms.array_type(space::AbstractSpace) =

--- a/src/Spaces/dss.jl
+++ b/src/Spaces/dss.jl
@@ -1,7 +1,5 @@
 import ..Topologies:
-    DSSBuffer,
     create_dss_buffer,
-    dss!,
     dss_1d!,
     dss_transform!,
     dss_untransform!,
@@ -18,7 +16,7 @@ perimeter(space::AbstractSpectralElementSpace) = Topologies.Perimeter2D(
 """
     create_dss_buffer(data, space)
 
-Creates a [`DSSBuffer`](@ref) for the field data corresponding to `data`
+Creates a [`Topologies.DSSBuffer`](@ref) for the field data corresponding to `data`
 """
 create_dss_buffer(data::DataLayouts.VIJHWithF, space) =
     isone(size(data, 3)) ? nothing :

--- a/src/Spaces/extruded.jl
+++ b/src/Spaces/extruded.jl
@@ -86,8 +86,8 @@ space(space::ExtrudedFiniteDifferenceSpace, staggering::Staggering) =
 
 FiniteDifferenceSpace(space::ExtrudedFiniteDifferenceSpace) =
     FiniteDifferenceSpace(
-        Spaces.grid(space).vertical_grid,
-        Spaces.staggering(space),
+        grid(space).vertical_grid,
+        staggering(space),
     )
 
 Adapt.adapt_structure(to, space::ExtrudedFiniteDifferenceSpace) =
@@ -135,9 +135,9 @@ function Base.show(io::IO, space::ExtrudedFiniteDifferenceSpace)
     print(iio, " "^(indent + 2), "context: ")
     Topologies.print_context(iio, ClimaComms.context(space))
     if has_horizontal(space)
-        hspace = Spaces.horizontal_space(space)
-        hmesh = Spaces.topology(hspace).mesh
-        Topologies.print_context(iio, Spaces.topology(hspace).context)
+        hspace = horizontal_space(space)
+        hmesh = topology(hspace).mesh
+        Topologies.print_context(iio, topology(hspace).context)
         println(iio)
         println(iio, " "^(indent + 2), "horizontal:")
         println(iio, " "^(indent + 4), "mesh: ", hmesh)
@@ -145,7 +145,7 @@ function Base.show(io::IO, space::ExtrudedFiniteDifferenceSpace)
             iio,
             " "^(indent + 4),
             "node_horizontal_length_scale: ",
-            Spaces.node_horizontal_length_scale(hspace),
+            node_horizontal_length_scale(hspace),
         )
         println(
             iio,
@@ -213,23 +213,23 @@ nlevels(space::ExtrudedFiniteDifferenceSpace) =
     size(local_geometry_data(space), 1)
 
 function left_boundary_name(space::ExtrudedFiniteDifferenceSpace)
-    boundaries = Topologies.boundaries(Spaces.vertical_topology(space))
+    boundaries = Topologies.boundaries(vertical_topology(space))
     propertynames(boundaries)[1]
 end
 function right_boundary_name(space::ExtrudedFiniteDifferenceSpace)
-    boundaries = Topologies.boundaries(Spaces.vertical_topology(space))
+    boundaries = Topologies.boundaries(vertical_topology(space))
     propertynames(boundaries)[2]
 end
 
 function eachslabindex(cspace::CenterExtrudedFiniteDifferenceSpace)
-    h_iter = eachslabindex(Spaces.horizontal_space(cspace))
+    h_iter = eachslabindex(horizontal_space(cspace))
     center_local_geometry =
         local_geometry_data(grid(cspace), Grids.CellCenter())
     Nv = size(center_local_geometry, 1)
     return Iterators.product(1:Nv, h_iter)
 end
 function eachslabindex(fspace::FaceExtrudedFiniteDifferenceSpace)
-    h_iter = eachslabindex(Spaces.horizontal_space(fspace))
+    h_iter = eachslabindex(horizontal_space(fspace))
     face_local_geometry = local_geometry_data(grid(fspace), Grids.CellFace())
     Nv = size(face_local_geometry, 1)
     return Iterators.product(1:Nv, h_iter)

--- a/src/Spaces/finitedifference.jl
+++ b/src/Spaces/finitedifference.jl
@@ -135,11 +135,11 @@ function Δz_data(space::AbstractSpace)
 end
 
 function left_boundary_name(space::AbstractSpace)
-    boundaries = Topologies.boundaries(Spaces.vertical_topology(space))
+    boundaries = Topologies.boundaries(vertical_topology(space))
     propertynames(boundaries)[1]
 end
 
 function right_boundary_name(space::AbstractSpace)
-    boundaries = Topologies.boundaries(Spaces.vertical_topology(space))
+    boundaries = Topologies.boundaries(vertical_topology(space))
     propertynames(boundaries)[2]
 end

--- a/src/Spaces/spectralelement.jl
+++ b/src/Spaces/spectralelement.jl
@@ -1,7 +1,7 @@
 abstract type AbstractSpectralElementSpace <: AbstractSpace end
 
 Topologies.nlocalelems(space::AbstractSpectralElementSpace) =
-    Topologies.nlocalelems(Spaces.topology(space))
+    Topologies.nlocalelems(topology(space))
 
 
 
@@ -12,7 +12,7 @@ horizontal_space(space::AbstractSpectralElementSpace) = space
 nlevels(space::AbstractSpectralElementSpace) = 1
 
 eachslabindex(space::AbstractSpectralElementSpace) =
-    1:Topologies.nlocalelems(Spaces.topology(space))
+    1:Topologies.nlocalelems(topology(space))
 
 staggering(space::AbstractSpectralElementSpace) = nothing
 
@@ -28,20 +28,20 @@ function Base.show(io::IO, space::AbstractSpectralElementSpace)
     if hasfield(typeof(grid(space)), :topology)
         # some reduced spaces (like slab space) do not have topology
         print(iio, " "^(indent + 2), "context: ")
-        Topologies.print_context(iio, Spaces.topology(grid(space)).context)
+        Topologies.print_context(iio, topology(grid(space)).context)
         println(iio)
         println(
             iio,
             " "^(indent + 2),
             "mesh: ",
-            Spaces.topology(grid(space)).mesh,
+            topology(grid(space)).mesh,
         )
     end
     print(
         iio,
         " "^(indent + 2),
         "quadrature: ",
-        Spaces.quadrature_style(grid(space)),
+        quadrature_style(grid(space)),
     )
 end
 
@@ -64,7 +64,7 @@ space(grid::Grids.SpectralElementGrid1D, ::Nothing) =
     SpectralElementSpace1D(grid)
 space(grid::Grids.LevelGrid{<:Grids.ExtrudedSpectralElementGrid2D}, ::Nothing) =
     SpectralElementSpace1D(grid)
-grid(space::Spaces.SpectralElementSpace1D) = getfield(space, :grid)
+grid(space::SpectralElementSpace1D) = getfield(space, :grid)
 
 local_geometry_type(::Type{SpectralElementSpace1D{G}}) where {G} =
     local_geometry_type(G)
@@ -101,7 +101,7 @@ space(grid::Grids.LevelGrid{<:Grids.ExtrudedSpectralElementGrid3D}, ::Nothing) =
 local_geometry_type(::Type{SpectralElementSpace2D{G}}) where {G} =
     local_geometry_type(G)
 
-grid(space::Spaces.SpectralElementSpace2D) = getfield(space, :grid)
+grid(space::SpectralElementSpace2D) = getfield(space, :grid)
 
 function SpectralElementSpace2D(
     topology::Topologies.Topology2D,
@@ -156,7 +156,7 @@ Returns a default length scale of 1 when no space is provided.
 function node_horizontal_length_scale(space::AbstractSpectralElementSpace)
     quad = quadrature_style(space)
     Nu = Quadratures.unique_degrees_of_freedom(quad)
-    return Meshes.element_horizontal_length_scale(Spaces.topology(space).mesh) /
+    return Meshes.element_horizontal_length_scale(topology(space).mesh) /
            Nu
 end
 
@@ -192,17 +192,17 @@ Base.eltype(iter::UniqueNodeIterator{<:SpectralElementSpace2D}) =
 
 function Base.length(iter::UniqueNodeIterator{<:SpectralElementSpace2D})
     space = iter.space
-    topology = Spaces.topology(space)
+    space_topology = topology(space)
     Nq = Quadratures.degrees_of_freedom(quadrature_style(space))
 
-    nelem = Topologies.nlocalelems(topology)
-    nvert = length(Topologies.local_vertices(topology))
-    nface_interior = length(Topologies.interior_faces(topology))
-    if isempty(Topologies.boundary_tags(topology))
+    nelem = Topologies.nlocalelems(space_topology)
+    nvert = length(Topologies.local_vertices(space_topology))
+    nface_interior = length(Topologies.interior_faces(space_topology))
+    if isempty(Topologies.boundary_tags(space_topology))
         nface_boundary = 0
     else
-        nface_boundary = sum(Topologies.boundary_tags(topology)) do tag
-            length(Topologies.boundary_faces(topology, tag))
+        nface_boundary = sum(Topologies.boundary_tags(space_topology)) do tag
+            length(Topologies.boundary_faces(space_topology, tag))
         end
     end
     return nelem * (Nq - 2)^2 +
@@ -242,28 +242,28 @@ function Base.iterate(
         # this also doesn't deal with the case where eo == e
         if j == 1
             # face 1
-            eo, _, _ = Topologies.opposing_face(Spaces.topology(space), e, 1)
+            eo, _, _ = Topologies.opposing_face(topology(space), e, 1)
             if 0 < eo < e
                 continue
             end
         end
         if i == Nq
             # face 2
-            eo, _, _ = Topologies.opposing_face(Spaces.topology(space), e, 2)
+            eo, _, _ = Topologies.opposing_face(topology(space), e, 2)
             if 0 < eo < e
                 continue
             end
         end
         if j == Nq
             # face 3
-            eo, _, _ = Topologies.opposing_face(Spaces.topology(space), e, 3)
+            eo, _, _ = Topologies.opposing_face(topology(space), e, 3)
             if 0 < eo < e
                 continue
             end
         end
         if i == 1
             # face 4
-            eo, _, _ = Topologies.opposing_face(Spaces.topology(space), e, 4)
+            eo, _, _ = Topologies.opposing_face(topology(space), e, 4)
             if 0 < eo < e
                 continue
             end

--- a/src/Topologies/interval.jl
+++ b/src/Topologies/interval.jl
@@ -73,23 +73,22 @@ function boundaries(topology::AbstractIntervalTopology)
 end
 
 function domain(topology::AbstractIntervalTopology)
-    mesh = Topologies.mesh(topology)
-    Meshes.domain(mesh)
+    Meshes.domain(mesh(topology))
 end
 
 function nlocalelems(topology::AbstractIntervalTopology)
-    mesh = Topologies.mesh(topology)
-    length(mesh.faces) - 1
+    topology_mesh = mesh(topology)
+    length(topology_mesh.faces) - 1
 end
 
 function vertex_coordinates(topology::AbstractIntervalTopology, elem)
-    mesh = Topologies.mesh(topology)
-    (mesh.faces[elem], mesh.faces[elem + 1])
+    topology_mesh = mesh(topology)
+    (topology_mesh.faces[elem], topology_mesh.faces[elem + 1])
 end
 
 function opposing_face(topology::AbstractIntervalTopology, elem, face)
-    mesh = Topologies.mesh(topology)
-    n = length(mesh.faces) - 1
+    topology_mesh = mesh(topology)
+    n = length(topology_mesh.faces) - 1
     if face == 1
         if elem == 1
             if isperiodic(topology)
@@ -116,12 +115,12 @@ end
 
 function Base.length(fiter::InteriorFaceIterator{<:AbstractIntervalTopology})
     topology = fiter.topology
-    mesh = Topologies.mesh(topology)
+    topology_mesh = mesh(topology)
     periodic = isempty(topology.boundaries)
     if periodic
-        length(mesh.faces) - 1
+        length(topology_mesh.faces) - 1
     else
-        length(mesh.faces) - 2
+        length(topology_mesh.faces) - 2
     end
 end
 
@@ -130,9 +129,9 @@ function Base.iterate(
     i = 1,
 )
     topology = fiter.topology
-    mesh = Topologies.mesh(topology)
-    periodic = isempty(Topologies.boundaries(topology))
-    n = length(mesh.faces) - 1
+    topology_mesh = mesh(topology)
+    periodic = isempty(boundaries(topology))
+    n = length(topology_mesh.faces) - 1
     if i < n
         return (i + 1, 1, i, 2, false), i + 1
     elseif i == n && periodic


### PR DESCRIPTION
Address every finding from `print_explicit_imports(ClimaCore; warn_implicit_imports = false)` that can be fixed from this repo:

- Remove stale explicit imports (imported but unused).
- Drop self-qualification, so names a module owns are referenced directly rather than through the module itself. Where a local variable shadowed the function being called (`mesh` in Topologies, `topology` in Spaces), rename the local instead.
- Access names through their owner module: `Base.rand`, `Base.inv`, `Base.unsafe_load`, `Base.read`, `DiffRules.diffrules`, and `StaticArraysCore.StaticArrayStyle`. DiffRules and StaticArraysCore become direct dependencies, since they were previously reached through ForwardDiff and StaticArrays.

`DataLayouts` still imports LLVM, which defines the `unsafe_load` methods for `Core.LLVMPtr`; only the name now comes from Base, which owns it.

Two sets of stale imports are kept because their uses are invisible to static analysis, and both are commented as such:

- `InputOutput` imports type names so that `read_type`'s `eval` can resolve unqualified type strings, which is what an HDF5 file records when its writer had those names in scope.
- `Fields` imports `@fused_direct` to re-expose it as `Fields.@fused_direct`, which tests and downstream code use.

The remaining findings are accesses to names that dependencies do not declare public (`Base.Broadcast` internals, `ClimaComms.device`, `Adapt.@adapt_structure`, ...), which this package cannot fix.


This was done by claude
<!-- Provide a clear description of the content -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
