### PR TITLE
Fix warp-shuffles with tensors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@ ClimaCore.jl Release Notes
 main
 -------
 
+v0.15.3
+-------
+
 - ![][badge-💥breaking] Removed the SciML compatibility layer
   (`src/Fields/compat_diffeq.jl`) and the `RecursiveArrayTools` dependency.
   Nothing in ClimaCore, ClimaAtmos, ClimaLand, or ClimaCoupler uses it: all of
@@ -19,6 +22,11 @@ main
   `muladd` over scalars, which does not exist, so it has thrown a
   `MethodError` on every call since it was added.
   [2576](https://github.com/CliMA/ClimaCore.jl/pull/2576)
+
+- Bugfix for indexing of reduced-dimension fields in GPU finite difference kernels
+  [2584](https://github.com/CliMA/ClimaCore.jl/pull/2584)
+
+- Bugfix for mapreduce with `Tensor` valued `Field`(s) on GPUs [2591](https://github.com/CliMA/ClimaCore.jl/pull/2591)
 
 
 v0.15.1

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.15.1"
+version = "0.15.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.15.2"
+version = "0.15.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/ext/cuda/loops.jl
+++ b/ext/cuda/loops.jl
@@ -165,8 +165,11 @@ function shuffle_reduce(scope, op::O, value, num_values) where {O}
     num_offsets = num_reductions(scope)
     num_inactive = THREADS_PER_WARP - num_active_threads(ThisWarp())
     thread_index = DataLayouts.thread_rank(scope)
-    for offset in ntuple(Base.Fix1(>>, DataLayouts.num_threads(scope)), Val(num_offsets))
-        shuffled_value = CUDA.shfl_xor_sync(CUDA.FULL_MASK >> num_inactive, value, offset)
+    for offset in
+        ntuple(Base.Fix1(>>, DataLayouts.num_threads(scope)) ∘ Int32, Val(num_offsets))
+        # shfl_recurse fails if `offset` is not explicitly converted to an Int32
+        shuffled_value =
+            CUDA.shfl_xor_sync(CUDA.FULL_MASK >> num_inactive, value, offset)
         if thread_index <= num_values && xor(thread_index - 1, offset) + 1 <= num_values
             value = op(value, shuffled_value)
         end
@@ -174,7 +177,9 @@ function shuffle_reduce(scope, op::O, value, num_values) where {O}
     return value
 end
 
-# Extend CUDA's warp shuffle intrinsics to support AutoBroadcasters, recursively
+# Extend CUDA's warp shuffle intrinsics to support AutoBroadcasters and Tensors, recursively
 # shuffling each value that appears in a multi-component reduction.
-CUDA.shfl_recurse(op::O, x::Utilities.AutoBroadcaster) where {O} =
-    Utilities.AutoBroadcaster(UnrolledUtilities.unrolled_map(op, Utilities.unwrap(x)))
+CUDA.shfl_recurse(
+    op::O,
+    x::T,
+) where {O, T <: Union{ClimaCore.Geometry.Tensor, Utilities.AutoBroadcaster}} = map(op, x)

--- a/test/Fields/gpu_reduction.jl
+++ b/test/Fields/gpu_reduction.jl
@@ -186,6 +186,31 @@ end
     @test LinearAlgebra.norm(Yf, 2) ≈ LinearAlgebra.norm(Yf_cpu, 2)
     @test LinearAlgebra.norm(Yf, 3) ≈ LinearAlgebra.norm(Yf_cpu, 3)
     @test LinearAlgebra.norm(Yf, Inf) ≈ LinearAlgebra.norm(Yf_cpu, Inf)
+
+    # Tensor-valued fields are reduced one component at a time, which needs a
+    # shfl_recurse method for Tensors so that the warp shuffles in the reduction
+    # kernel can move them between lanes (see ext/cuda/loops.jl).
+    for (space, space_cpu) in (
+        (hv_center_space, hv_center_space_cpu),
+        (hv_face_space, hv_face_space_cpu),
+    )
+        coords = Fields.coordinate_field(space)
+        coords_cpu = Fields.coordinate_field(space_cpu)
+
+        # A zero-valued vector field, whose sum is exactly zero on both devices.
+        Yz = fill(zero(Geometry.WVector{FT}), space)
+        @test sum(Yz) == zero(Geometry.WVector{FT})
+
+        # One-component and three-component vector fields.
+        Yw = Geometry.WVector.(coords.z)
+        Yw_cpu = Geometry.WVector.(coords_cpu.z)
+        @test sum(Yw) ≈ sum(Yw_cpu)
+
+        Yuvw = Geometry.UVWVector.(coords.long, coords.lat, coords.z)
+        Yuvw_cpu =
+            Geometry.UVWVector.(coords_cpu.long, coords_cpu.lat, coords_cpu.z)
+        @test sum(Yuvw) ≈ sum(Yuvw_cpu)
+    end
 end
 
 @testset "test cuda reduction op for single column" begin

--- a/test/MatrixFields/matrix_field_test_utils.jl
+++ b/test/MatrixFields/matrix_field_test_utils.jl
@@ -564,9 +564,9 @@ function perf_getidx(bc; broken = false)
         time_and_units_str(BT.@belapsed call_getidx($space, $bc, $idx_i, $hidx))
     ber =
         time_and_units_str(BT.@belapsed call_getidx($space, $bc, $idx_r, $hidx))
-    JET.@test_opt call_getidx(space, bc, idx_l, hidx)
-    JET.@test_opt call_getidx(space, bc, idx_i, hidx)
-    JET.@test_opt call_getidx(space, bc, idx_r, hidx)
+    @test_opt call_getidx(space, bc, idx_l, hidx)
+    @test_opt call_getidx(space, bc, idx_i, hidx)
+    @test_opt call_getidx(space, bc, idx_r, hidx)
     @info "getidx times max(left,interior,right) = ($bel,$bei,$ber)"
     return nothing
 end


### PR DESCRIPTION
This was causing ClimaAtmos conservation checks to error. There might be a cleaner way of fixing this. I do not know why the offset needs to be wrapped in Int32, but this fix does not work without it.

Also adds a test for gpu reductions with tensors. This bug was not caught in climacore ci, climaatmos ci, or the climacoupler e2e perf test...


This PR will now release ClimaCore as well
<!-- Provide a clear description of the content -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
