### PR TITLE
Add remapping for multiple column space

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -333,6 +333,8 @@ main
     `CommonSpaces.MultiColumnSpace`.
   - The old names are available, but deprecated.
     [2611](https://github.com/CliMA/ClimaCore.jl/pull/2611)
+  - Support remapping for `MultiColumnFiniteDifferenceSpace`
+  [2596](https://github.com/CliMA/ClimaCore.jl/pull/2596)
 
 v0.15.3
 -------

--- a/NEWS.md
+++ b/NEWS.md
@@ -333,7 +333,9 @@ main
     `CommonSpaces.MultiColumnSpace`.
   - The old names are available, but deprecated.
     [2611](https://github.com/CliMA/ClimaCore.jl/pull/2611)
-  - Support remapping for `MultiColumnFiniteDifferenceSpace`
+
+- Support remapping and HDF5 reading/writing for
+  `MultiColumnFiniteDifferenceSpace`
   [2596](https://github.com/CliMA/ClimaCore.jl/pull/2596)
 
 v0.15.3

--- a/ext/cuda/remapping_distributed.jl
+++ b/ext/cuda/remapping_distributed.jl
@@ -2,6 +2,7 @@ import ClimaCore: Topologies, Spaces, Fields, Quadratures
 import ClimaComms
 import CUDA
 using CUDA: @cuda
+import UnrolledUtilities
 import ClimaCore.Remapping: _set_interpolated_values_device!, bilinear, linear
 
 function ClimaCore.Remapping._set_interpolated_values_bilinear!(
@@ -393,15 +394,16 @@ function set_interpolated_values_kernel!(
         v_lo, v_hi = vert_bounding_indices[j]
         A, B = vert_interpolation_weights[j]
 
-        val = zero(eltype(out))
-        for t in 1:Nq
-            val +=
-                I[i, t] * (
-                    A * field_values[k][v_lo, t, 1, h] +
-                    B * field_values[k][v_hi, t, 1, h]
-                )
-        end
-        out[i, j, k] = val
+        out[i, j, k] =
+            UnrolledUtilities.unrolled_applyat(k, field_values) do fvals
+                val = zero(eltype(out))
+                for t in 1:Nq
+                    val +=
+                        I[i, t] *
+                        (A * fvals[v_lo, t, 1, h] + B * fvals[v_hi, t, 1, h])
+                end
+                val
+            end
     end
     return nothing
 end

--- a/src/Grids/multipoint.jl
+++ b/src/Grids/multipoint.jl
@@ -122,6 +122,8 @@ function _MultiPointGrid(
     )
 end
 
+Meshes.domain(grid::MultiPointGrid) = Domains.SphereDomain(grid.global_geometry.radius)
+
 function print_multipoint_horizontal(io::IO, grid::MultiPointGrid, indent)
     println(io, " "^(indent + 2), "horizontal:")
     print(io, " "^(indent + 4), "context: ")

--- a/src/InputOutput/readers.jl
+++ b/src/InputOutput/readers.jl
@@ -501,6 +501,15 @@ function read_grid_new(reader, name)
     elseif type == "FiniteDifferenceGrid"
         topology = read_topology(reader, attrs(group)["topology"])
         return Grids.FiniteDifferenceGrid(topology)
+    elseif type == "MultiPointGrid"
+        radius = attrs(group)["radius"]
+        coords = read(group, "points")
+        points = [
+            Geometry.LatLongPoint(coords[1, i], coords[2, i]) for
+            i in 1:size(coords, 2)
+        ]
+        device = ClimaComms.device(reader.context)
+        return Grids.MultiPointGrid(points; radius, device)
     elseif type == "ExtrudedFiniteDifferenceGrid"
         vertical_grid = read_grid(reader, attrs(group)["vertical_grid"])
         horizontal_grid = read_grid(reader, attrs(group)["horizontal_grid"])
@@ -631,7 +640,13 @@ function read_field(reader::HDF5Reader, name::AbstractString)
             space = Spaces.PointSpace(local_geometry_data)
             topology = nothing
         end
-        if !(space isa Spaces.AbstractPointSpace)
+        if space isa Union{
+            Spaces.MultiPointSpace,
+            Spaces.MultiColumnFiniteDifferenceSpace,
+        }
+            topology = nothing
+            ArrayType = ClimaComms.array_type(ClimaComms.device(reader.context))
+        elseif !(space isa Spaces.AbstractPointSpace)
             topology = Spaces.topology(space)
             ArrayType = ClimaComms.array_type(topology)
         end

--- a/src/InputOutput/writers.jl
+++ b/src/InputOutput/writers.jl
@@ -361,6 +361,7 @@ defaultname(::Grids.SpectralElementGrid1D) = "horizontal_grid"
 defaultname(::Grids.SpectralElementGrid2D) = "horizontal_grid"
 defaultname(::Grids.ExtrudedFiniteDifferenceGrid) = "extruded_finite_difference_grid"
 defaultname(grid::Grids.FiniteDifferenceGrid) = defaultname(grid.topology)
+defaultname(::Grids.MultiPointGrid) = "multi_point_grid"
 defaultname(grid::Grids.LevelGrid) = "$(defaultname(grid.full_grid)): level $(grid.level)"
 
 """
@@ -436,6 +437,20 @@ function write_new!(
     group = create_group(writer.file, "grids/$name")
     write_attribute(group, "type", "FiniteDifferenceGrid")
     write_attribute(group, "topology", write!(writer, Spaces.topology(grid)))
+    return name
+end
+
+function write_new!(
+    writer::HDF5Writer,
+    grid::Grids.MultiPointGrid,
+    name::AbstractString = defaultname(grid),
+)
+    group = create_group(writer.file, "grids/$name")
+    write_attribute(group, "type", "MultiPointGrid")
+    write_attribute(group, "radius", grid.global_geometry.radius)
+    # 2×N matrix of (lat, long) coordinates, one column per point
+    coords = Array(parent(grid.local_geometry.coordinates))
+    write_dataset(group, "points", coords[1, 1, 1, :, :])
     return name
 end
 
@@ -698,12 +713,14 @@ function write!(
     nd = ndims(array)
 
     staggering = Spaces.staggering(space)
-    topology = Spaces.topology(space)
     grid = Spaces.grid(space)
     grid_name = write!(writer, grid)
 
-    if topology isa Topologies.Topology2D &&
-       !(writer.context isa ClimaComms.SingletonCommsContext)
+    # topology is only queried on the distributed path: point-cloud spaces
+    # have no topology and are single-process only
+    if !(writer.context isa ClimaComms.SingletonCommsContext) &&
+       Spaces.topology(space) isa Topologies.Topology2D
+        topology = Spaces.topology(space)
         nelems = Topologies.nelems(topology)
         f_dim = DataLayouts.f_dim(values)
         h_dim = isnothing(f_dim) || f_dim == 5 ? 4 : 5

--- a/src/Remapping/distributed_remapping.jl
+++ b/src/Remapping/distributed_remapping.jl
@@ -137,6 +137,7 @@ struct Remapper{
     T9, # <: AbstractArray,
     T10 <: AbstractArray,
     T11 <: Union{Tuple{Colon}, Tuple{Colon, Colon}, Tuple{Colon, Colon, Colon}},
+    HM <: Union{Nothing, AbstractRemappingMethod},
 }
     # The ClimaComms context
     comms_ctx::CC
@@ -212,7 +213,8 @@ struct Remapper{
     colons::T11
 
     # Horizontal remapping method. BilinearRemapping holds precomputed (s, t) and (i, j).
-    horiz_method::AbstractRemappingMethod
+    # This is `nothing` when there is no horizontal interpolation for the space.
+    horiz_method::HM
 end
 
 """
@@ -285,6 +287,22 @@ Remapper(
 # Purely vertical, positional
 Remapper(
     space::Spaces.FiniteDifferenceSpace,
+    target_zcoords::AbstractArray;
+    buffer_length::Int = 1,
+    horizontal_method::AbstractRemappingMethod = SpectralElementRemapping(),
+) = _Remapper(space; target_zcoords, target_hcoords = nothing, buffer_length)
+
+# Multiple independent columns: vertical-only interpolation
+Remapper(
+    space::Spaces.MultiColumnFiniteDifferenceSpace;
+    target_zcoords::AbstractArray = default_target_zcoords(space),
+    buffer_length::Int = 1,
+    horizontal_method::AbstractRemappingMethod = SpectralElementRemapping(),
+) = _Remapper(space; target_zcoords, target_hcoords = nothing, buffer_length)
+
+# Multiple independent columns, positional
+Remapper(
+    space::Spaces.MultiColumnFiniteDifferenceSpace,
     target_zcoords::AbstractArray;
     buffer_length::Int = 1,
     horizontal_method::AbstractRemappingMethod = SpectralElementRemapping(),
@@ -569,9 +587,82 @@ function _Remapper(
         interpolated_values,
         buffer_length,
         colons,
-        SpectralElementRemapping(), # no horizontal interpolation
+        nothing, # horiz_method: no horizontal interpolation
     )
 end
+
+# Constructor for the case with multiple column space (horizontal_method
+# accepted, ignored)
+function _Remapper(
+    space::Spaces.MultiColumnFiniteDifferenceSpace;
+    target_zcoords::AbstractArray,
+    target_hcoords::Nothing,
+    buffer_length::Int = 1,
+    horizontal_method::AbstractRemappingMethod = SpectralElementRemapping(),
+)
+    comms_ctx = ClimaComms.context(space)
+    FT = Spaces.undertype(space)
+    ArrayType = ClimaComms.array_type(space)
+
+    # Columns share the vertical mesh only when there is no terrain adaption
+    Spaces.grid(space).hypsography isa Grids.Flat ||
+        error("Remapping does not support non-Flat hypsography for multi-column spaces")
+
+    num_columns = Spaces.ncolumns(space)
+
+    vert_interpolation_weights =
+        ArrayType(vertical_interpolation_weights(space, target_zcoords))
+    vert_bounding_indices =
+        ArrayType(vertical_bounding_indices(space, target_zcoords))
+
+    # Use all columns
+    local_horiz_indices = ArrayType(collect(1:num_columns))
+    local_horiz_interpolation_weights = (ArrayType(ones(FT, num_columns, 1)),)
+    field_values = ArrayType(zeros(FT, 1))
+
+    local_interpolated_values = ArrayType(
+        zeros(FT, (num_columns, length(target_zcoords), buffer_length)),
+    )
+    interpolated_values = ArrayType(
+        zeros(FT, (num_columns, length(target_zcoords), buffer_length)),
+    )
+    colons = (:, :)
+
+    return Remapper(
+        comms_ctx,
+        space,
+        nothing, # local_target_hcoords,
+        target_zcoords,
+        nothing, # local_target_hcoords_bitmask,
+        local_horiz_interpolation_weights,
+        local_horiz_indices,
+        vert_interpolation_weights,
+        vert_bounding_indices,
+        local_interpolated_values,
+        field_values,
+        interpolated_values,
+        buffer_length,
+        colons,
+        nothing,
+    )
+end
+
+Remapper(
+    space::Union{Spaces.AbstractPointSpace, Spaces.MultiPointSpace},
+    target_hcoords::Union{AbstractArray, Nothing},
+    target_zcoords::Union{AbstractArray, Nothing};
+    kwargs...,
+) = Remapper(space)
+
+
+Remapper(
+    space::Union{Spaces.AbstractPointSpace, Spaces.MultiPointSpace},
+    args...;
+    kwargs...,
+) =
+    error(
+        "Remapping is not supported for $(nameof(typeof(space))). The space has no horizontal or vertical dimension to interpolate over. Access the field values directly instead",
+    )
 
 """
     _set_interpolated_values!(remapper, field)
@@ -601,7 +692,11 @@ function _set_interpolated_values!(
     )
 end
 
-function _set_interpolated_values!(::SpectralElementRemapping, remapper::Remapper, fields)
+function _set_interpolated_values!(
+    ::Union{Nothing, SpectralElementRemapping},
+    remapper::Remapper,
+    fields,
+)
     _set_interpolated_values!(
         remapper._local_interpolated_values,
         fields,
@@ -837,8 +932,6 @@ function set_interpolated_values_cpu_kernel!(
 )
     space = axes(first(fields))
     FT = Spaces.undertype(space)
-    quad = Spaces.quadrature_style(space)
-    Nq = Quadratures.degrees_of_freedom(quad)
     for (field_index, field) in enumerate(fields)
         field_values = Fields.field_values(field)
 
@@ -851,7 +944,9 @@ function set_interpolated_values_cpu_kernel!(
             for (out_index, h) in enumerate(local_horiz_indices)
                 # If we are no longer in the same element, read the field values again
                 if prev_lidx != h || prev_vindex != vindex
-                    for i in 1:Nq
+                    # The nodes per element are the columns of the
+                    # interpolation matrix
+                    for i in axes(I, 2)
                         scratch_field_values[i] =
                             A * field_values[v_lo, i, 1, h] +
                             B * field_values[v_hi, i, 1, h]
@@ -861,7 +956,7 @@ function set_interpolated_values_cpu_kernel!(
 
                 tmp = zero(FT)
 
-                for i in 1:Nq
+                for i in axes(I, 2)
                     tmp += I[out_index, i] * scratch_field_values[i]
                 end
                 out[out_index, vindex, field_index] = tmp
@@ -1122,7 +1217,11 @@ function interpolate!(
     if only_one_field
         fields = [fields]
     end
-    isa_vertical_space = remapper.space isa Spaces.FiniteDifferenceSpace
+    isa_vertical_space =
+        remapper.space isa Union{
+            Spaces.FiniteDifferenceSpace,
+            Spaces.MultiColumnFiniteDifferenceSpace,
+        }
 
     for field in fields
         axes(field) == remapper.space ||
@@ -1311,6 +1410,17 @@ function interpolate(
     target_zcoords,
     target_hcoords,
     kwargs...,  # e.g. horizontal_method; accepted for uniform API, ignored for vertical-only
+)
+    remapper = Remapper(space; target_zcoords)
+    return interpolate(remapper, field)
+end
+
+function interpolate(
+    field::Fields.Field,
+    space::Spaces.MultiColumnFiniteDifferenceSpace;
+    target_zcoords,
+    target_hcoords,
+    kwargs...,
 )
     remapper = Remapper(space; target_zcoords)
     return interpolate(remapper, field)

--- a/src/Remapping/remapping_utils.jl
+++ b/src/Remapping/remapping_utils.jl
@@ -66,7 +66,8 @@ function vertical_reference_coordinates(space, zcoords)
 
     is_cell_center =
         space isa Spaces.CenterExtrudedFiniteDifferenceSpace ||
-        space isa Spaces.CenterFiniteDifferenceSpace
+        space isa Spaces.CenterFiniteDifferenceSpace ||
+        space isa Spaces.CenterMultiColumnFiniteDifferenceSpace
 
     ξ3s = map(zcoords) do zcoord
         velem = Meshes.containing_element(vert_mesh, zcoord)
@@ -96,6 +97,7 @@ function vertical_bounding_indices(
     space::Union{
         Spaces.FaceExtrudedFiniteDifferenceSpace,
         Spaces.FaceFiniteDifferenceSpace,
+        Spaces.FaceMultiColumnFiniteDifferenceSpace,
     },
     zcoords,
 )
@@ -109,6 +111,7 @@ function vertical_bounding_indices(
     space::Union{
         Spaces.CenterExtrudedFiniteDifferenceSpace,
         Spaces.CenterFiniteDifferenceSpace,
+        Spaces.CenterMultiColumnFiniteDifferenceSpace,
     },
     zcoords,
 )
@@ -154,6 +157,25 @@ end
 function default_target_hcoords(
     space::Spaces.FiniteDifferenceSpace;
     hresolution,
+)
+    return nothing
+end
+
+# Point-cloud columns have no horizontal interpolation
+function default_target_hcoords(
+    space::Union{
+        Spaces.MultiColumnFiniteDifferenceSpace,
+        Spaces.MultiPointSpace,
+    };
+    hresolution = nothing,
+)
+    return nothing
+end
+
+# Point clouds have no vertical extent
+function default_target_zcoords(
+    space::Spaces.MultiPointSpace;
+    zresolution = nothing,
 )
     return nothing
 end

--- a/src/Spaces/multicolumn.jl
+++ b/src/Spaces/multicolumn.jl
@@ -86,6 +86,8 @@ CenterMultiColumnFiniteDifferenceSpace(space::MultiColumnFiniteDifferenceSpace) 
 # so that we return MultiColumnFiniteDifferenceSpace rather than ExtrudedFiniteDifferenceSpace.
 space(refspace::MultiColumnFiniteDifferenceSpace, s::Staggering) =
     MultiColumnFiniteDifferenceSpace(grid(refspace), s)
+space(grid::Grids.ExtrudedMultiPointGrid, s::Staggering) =
+    MultiColumnFiniteDifferenceSpace(grid, s)
 
 function face_space(space::MultiColumnFiniteDifferenceSpace)
     MultiColumnFiniteDifferenceSpace(grid(space), CellFace())
@@ -142,6 +144,7 @@ nlevels(space::MultiColumnFiniteDifferenceSpace) =
 
 horizontal_space(space::MultiColumnFiniteDifferenceSpace) =
     MultiPointSpace(grid(space).horizontal_grid)
+horizontal_space(space::MultiPointSpace) = space
 
 # No DSS / mask machinery needed.
 get_mask(space::MultiPointSpace) = DataLayouts.NoMask()

--- a/test/InputOutput/unit_allspaces_roundtrip.jl
+++ b/test/InputOutput/unit_allspaces_roundtrip.jl
@@ -19,14 +19,6 @@ import Random: seed!
     context = ClimaComms.context()
     seed!(1)
     for space in TU.all_spaces(FT; context)
-        # TODO: InputOutput cannot serialize a MultiColumnFiniteDifferenceSpace
-        # yet: its MultiPointGrid horizontal grid has no topology, which
-        # `write!` requires (`Spaces.topology` errors). Remove this skip once
-        # HDF5 support for multi-point grids lands.
-        if space isa Spaces.MultiColumnFiniteDifferenceSpace
-            @test_skip "HDF5 round-trip on MultiColumnFiniteDifferenceSpace"
-            continue
-        end
         field = Fields.Field(FT, space)
         parent(field) .= rand.(FT)
         Y = Fields.FieldVector(; f = field)

--- a/test/InputOutput/unit_multicolumn.jl
+++ b/test/InputOutput/unit_multicolumn.jl
@@ -1,0 +1,60 @@
+using Test
+import ClimaCore
+using ClimaCore: Fields, Geometry, Grids, CommonSpaces, InputOutput, Spaces
+
+using ClimaComms
+ClimaComms.@import_required_backends
+import Random
+
+const comms_ctx = ClimaComms.SingletonCommsContext(ClimaComms.device())
+filename = tempname(; cleanup = true)
+
+@testset "HDF5 restart test for multi-column point-cloud spaces" begin
+    Random.seed!(42)
+    FT = Float32
+    points = [
+        Geometry.LatLongPoint(FT(0), FT(0)),
+        Geometry.LatLongPoint(FT(10), FT(20)),
+        Geometry.LatLongPoint(FT(-5), FT(90)),
+    ]
+    radius = FT(6.371229e6)
+
+    center_space = CommonSpaces.MultiColumnSpace(
+        FT;
+        points,
+        radius,
+        z_elem = 10,
+        z_min = 0,
+        z_max = 10_000,
+        staggering = Grids.CellCenter(),
+        device = ClimaComms.device(comms_ctx),
+    )
+    face_space = Spaces.face_space(center_space)
+    level_space = Spaces.level(center_space, 1) # MultiPointSpace
+
+    Y = Fields.FieldVector(;
+        c = Fields.Field(FT, center_space),
+        f = Fields.Field(FT, face_space),
+        l = Fields.Field(FT, level_space),
+    )
+    for field in (Y.c, Y.f, Y.l)
+        parent(field) .= rand.(FT)
+    end
+
+    InputOutput.HDF5Writer(filename, comms_ctx) do writer
+        InputOutput.write!(writer, Y, "Y")
+    end
+
+    InputOutput.HDF5Reader(filename, comms_ctx) do reader
+        restart_Y = InputOutput.read_field(reader, "Y")
+        @test axes(restart_Y.c) isa Spaces.CenterMultiColumnFiniteDifferenceSpace
+        @test axes(restart_Y.f) isa Spaces.FaceMultiColumnFiniteDifferenceSpace
+        @test axes(restart_Y.l) isa Spaces.MultiPointSpace
+        hgrid = Spaces.grid(axes(restart_Y.c)).horizontal_grid
+        @test hgrid isa Grids.MultiPointGrid
+        @test hgrid.global_geometry.radius == radius
+        @test Spaces.coordinates_data(Spaces.horizontal_space(axes(restart_Y.c))) ==
+              Spaces.coordinates_data(Spaces.horizontal_space(center_space))
+        @test restart_Y == Y # test if restart is exact
+    end
+end

--- a/test/Remapping/unit_distributed_remapping.jl
+++ b/test/Remapping/unit_distributed_remapping.jl
@@ -953,6 +953,132 @@ if !with_mpi
             @test size(Remapping.interpolate(ccoords.z)) == (30,)
         end
     end
+
+    @testset "Multiple independent columns" begin
+        lats = [0.0, 10.0, -5.0]
+        longs = [0.0, 20.0, 90.0]
+        points = [Geometry.LatLongPoint(lat, long) for (lat, long) in zip(lats, longs)]
+        num_cols = length(points)
+
+        cspace = CommonSpaces.MultiColumnSpace(;
+            points = points,
+            z_elem = 30,
+            z_min = 0.0,
+            z_max = 1000.0,
+            staggering = Spaces.CellCenter(),
+        )
+        fspace = Spaces.FaceMultiColumnFiniteDifferenceSpace(cspace)
+
+        zpts = range(0.0, 1000.0, 21)
+        zcoords = [Geometry.ZPoint(z) for z in zpts]
+
+        # Default target coordinates: no horizontal interpolation for
+        # multi-column spaces, and point-cloud level spaces opt out entirely
+        @test isnothing(Remapping.default_target_hcoords(cspace))
+        @test length(Remapping.default_target_zcoords(cspace)) == 30
+        pcs = Spaces.horizontal_space(cspace)
+        @test isnothing(Remapping.default_target_hcoords(pcs))
+        @test isnothing(Remapping.default_target_zcoords(pcs))
+        lvl_space = Spaces.level(cspace, 1)
+        @test isnothing(Remapping.default_target_hcoords(lvl_space))
+        @test isnothing(Remapping.default_target_zcoords(lvl_space))
+
+        # Spaces with no dimension to interpolate over are not supported
+        @test_throws ErrorException Remapping.Remapper(pcs)
+        @test_throws ErrorException Remapping.Remapper(pcs, nothing, nothing)
+        @test_throws ErrorException Remapping.Remapper(lvl_space)
+        point_space = Spaces.PointSpace(context, Geometry.ZPoint(1.0))
+        @test_throws ErrorException Remapping.Remapper(point_space)
+
+        # Center space
+        cremapper = Remapping.Remapper(
+            cspace;
+            target_zcoords = zcoords,
+            buffer_length = 2,
+        )
+        ccoords = Fields.coordinate_field(cspace)
+        cinterp_z = Remapping.interpolate(cremapper, ccoords.z)
+        # Interpolation is 0th order in the half-cells next to the boundaries
+        cexpected_col = collect(zpts)
+        cexpected_col[1] = 1000.0 * (0 / 30 + 1 / 30) / 2
+        cexpected_col[end] = 1000.0 * (29 / 30 + 30 / 30) / 2
+        cexpected_z = ArrayType([z for _ in 1:num_cols, z in cexpected_col])
+        @test cinterp_z ≈ cexpected_z
+
+        # A field that varies across columns
+        cinterp_latz = Remapping.interpolate(cremapper, sind.(ccoords.lat) .* ccoords.z)
+        cexpected_latz =
+            ArrayType([sind(lat) * z for lat in lats, z in cexpected_col])
+        @test cinterp_latz ≈ cexpected_latz
+
+        # Face space
+        fremapper = Remapping.Remapper(fspace, zcoords; buffer_length = 2)
+        fcoords = Fields.coordinate_field(fspace)
+        finterp_z = Remapping.interpolate(fremapper, fcoords.z)
+        fexpected_z = ArrayType([z for _ in 1:num_cols, z in zpts])
+        @test finterp_z ≈ fexpected_z
+
+        # Remapping three fields (more than the buffer length)
+        cinterp = Remapping.interpolate(
+            cremapper,
+            [ccoords.z, sind.(ccoords.lat) .* ccoords.z, ccoords.z],
+        )
+        @test cexpected_z ≈ cinterp[:, :, 1]
+        @test cexpected_latz ≈ cinterp[:, :, 2]
+        @test cexpected_z ≈ cinterp[:, :, 3]
+
+        # Remapping two fields (same as buffer length)
+        cinterp2 = Remapping.interpolate(
+            cremapper,
+            [ccoords.z, sind.(ccoords.lat) .* ccoords.z],
+        )
+        @test cexpected_z ≈ cinterp2[:, :, 1]
+        @test cexpected_latz ≈ cinterp2[:, :, 2]
+
+        # Remapping in-place
+        dest = ArrayType(zeros(num_cols, 21))
+        Remapping.interpolate!(dest, cremapper, ccoords.z)
+        @test cexpected_z ≈ dest
+
+        Remapping.interpolate!(dest, fremapper, fcoords.z)
+        @test fexpected_z ≈ dest
+
+        dest = ArrayType(zeros(num_cols, 21, 3))
+        Remapping.interpolate!(
+            dest,
+            fremapper,
+            [fcoords.z, fcoords.z, fcoords.z],
+        )
+        @test fexpected_z ≈ dest[:, :, 1]
+        @test fexpected_z ≈ dest[:, :, 2]
+        @test fexpected_z ≈ dest[:, :, 3]
+
+        # Consistency with a single-column remapper
+        vertdomain = Domains.IntervalDomain(
+            Geometry.ZPoint(0.0),
+            Geometry.ZPoint(1000.0);
+            boundary_names = (:bottom, :top),
+        )
+        vertmesh = Meshes.IntervalMesh(vertdomain, nelems = 30)
+        verttopo = Topologies.IntervalTopology(
+            ClimaComms.SingletonCommsContext(ClimaComms.device()),
+            vertmesh,
+        )
+        col_cspace = Spaces.CenterFiniteDifferenceSpace(verttopo)
+        col_remapper =
+            Remapping.Remapper(col_cspace; target_zcoords = zcoords)
+        col_interp_z = Remapping.interpolate(
+            col_remapper,
+            Fields.coordinate_field(col_cspace).z,
+        )
+        for col in 1:num_cols
+            @test cinterp_z[col, :] ≈ col_interp_z
+        end
+
+        # Convenience interpolate (only checking the shape)
+        @test size(Remapping.interpolate(ccoords.z)) == (num_cols, 30)
+        @test size(Remapping.interpolate(fcoords.z)) == (num_cols, 30)
+    end
 end
 
 @testset "Default coordinates" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -165,6 +165,7 @@ unit_tests = [
     UnitTest("InputOutput - hybrid3dcubedsphere"        ,"InputOutput/unit_hybrid3dcubedsphere.jl"; tier = :unit, subsystem = :io),
     UnitTest("InputOutput - hybrid3dcubedsphere_topo"   ,"InputOutput/unit_hybrid3dcubedsphere_topography.jl"; tier = :unit, subsystem = :io),
     UnitTest("InputOutput - finitedifferences"          ,"InputOutput/unit_finitedifference.jl"; tier = :unit, subsystem = :io),
+    UnitTest("InputOutput - multicolumn"                ,"InputOutput/unit_multicolumn.jl"; tier = :unit, subsystem = :io),
     UnitTest("InputOutput - pointspaces"                ,"InputOutput/unit_point.jl"; meta = :cpu_only, tier = :unit, subsystem = :io),
     UnitTest("Array interpolation"                      ,"Remapping/unit_interpolate_array.jl"; tier = :unit, subsystem = :remapping),
     UnitTest("Distributed remapping"                    ,"Remapping/unit_distributed_remapping.jl"; tier = :unit, subsystem = :remapping),


### PR DESCRIPTION
This PR adds the functionality to do vertical interpolation for a multiple column space to get back an array whose size is the number of columns by the number of vertical levels. Horizontal interpolation is not supported for this space.

I asked a LLM to implement this.