### PR TITLE
Adds infra to mark spaces as DG

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,9 @@ main
   computed. The new queries `Grids.is_continuous(grid)` /
   `Spaces.is_continuous(space)` report the discretization, so downstream
   models can gate DSS on the space itself rather than on the quadrature type.
-  The flag is part of the grid cache key.
+  The flag is part of the grid cache key and is serialized by `InputOutput`
+  (grids in files written before it existed read back as continuous).
+  [2599](https://github.com/CliMA/ClimaCore.jl/pull/2599)
 
 v0.15.3
 -------

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,16 @@ ClimaCore.jl Release Notes
 main
 -------
 
+- Spectral-element grids can be marked as discontinuous-Galerkin function
+  spaces: `SpectralElementGrid1D`/`SpectralElementGrid2D` (and the
+  corresponding `Spaces` constructors) accept `discontinuous = true`. On such
+  grids, `Spaces.weighted_dss!` (and its `start!`/`internal!`/`ghost!` split)
+  is a no-op, `create_dss_buffer` returns `nothing`, and no DSS weights are
+  computed. The new queries `Grids.is_continuous(grid)` /
+  `Spaces.is_continuous(space)` report the discretization, so downstream
+  models can gate DSS on the space itself rather than on the quadrature type.
+  The flag is part of the grid cache key.
+
 v0.15.3
 -------
 

--- a/docs/src/APIs/dss_api.md
+++ b/docs/src/APIs/dss_api.md
@@ -21,5 +21,7 @@ Spaces.weighted_dss_start!
 Spaces.weighted_dss_internal!
 Spaces.weighted_dss_ghost!
 Spaces.weighted_dss!
+Spaces.is_continuous
+Grids.is_continuous
 Spaces.unique_nodes
 ```

--- a/src/Grids/extruded.jl
+++ b/src/Grids/extruded.jl
@@ -126,6 +126,9 @@ end
 
 topology(grid::ExtrudedFiniteDifferenceGrid) = topology(grid.horizontal_grid)
 
+is_continuous(grid::ExtrudedFiniteDifferenceGrid) =
+    is_continuous(grid.horizontal_grid)
+
 ClimaComms.context(grid::ExtrudedFiniteDifferenceGrid) =
     ClimaComms.context(grid.horizontal_grid)
 ClimaComms.device(grid::ExtrudedFiniteDifferenceGrid) =

--- a/src/Grids/spectralelement.jl
+++ b/src/Grids/spectralelement.jl
@@ -3,9 +3,16 @@
 abstract type AbstractSpectralElementGrid <: AbstractGrid end
 
 """
-    SpectralElementGrid1D(mesh::Meshes.IntervalMesh, quadrature_style::Quadratures.QuadratureStyle)
+    SpectralElementGrid1D(
+        topology::Topologies.IntervalTopology,
+        quadrature_style::Quadratures.QuadratureStyle;
+        VIJH,
+        discontinuous::Bool = false,
+    )
 
-A one-dimensional space: within each element the space is represented as a polynomial.
+A one-dimensional grid: within each element the space is represented as a
+polynomial. `discontinuous` marks the grid's function space as discontinuous
+Galerkin (DG); see [`SpectralElementGrid2D`](@ref).
 """
 mutable struct SpectralElementGrid1D{
     T,
@@ -167,8 +174,8 @@ SEM for computing metric terms.
     [`Spaces.weighted_dss!`](@ref) is a no-op on fields over this grid and
     inter-element coupling is instead supplied by DG numerical fluxes (see
     `Operators.add_numerical_flux_internal!`). No DSS weights are computed.
-    The flag is not serialized by `InputOutput`; grids read from HDF5 are
-    continuous.
+    `InputOutput` serializes the flag; grids in files written before it
+    existed read back as continuous.
 
 The idea behind the so-called `bubble_correction` is that the numerical area
 of the domain (e.g., the sphere) is given by the sum of nodal integration weights

--- a/src/Grids/spectralelement.jl
+++ b/src/Grids/spectralelement.jl
@@ -19,6 +19,7 @@ mutable struct SpectralElementGrid1D{
     global_geometry::GG
     local_geometry::LG
     dss_weights::D
+    discontinuous::Bool
 end
 
 Adapt.@adapt_structure SpectralElementGrid1D
@@ -33,16 +34,22 @@ function SpectralElementGrid1D(
     topology::Topologies.IntervalTopology,
     quadrature_style::Quadratures.QuadratureStyle;
     VIJH::Type{<:DataLayouts.VIJHWithF} = DataLayouts.VIJFH,
+    discontinuous::Bool = false,
 )
     get!(
         Cache.OBJECT_CACHE,
-        (SpectralElementGrid1D, topology, quadrature_style),
+        (SpectralElementGrid1D, topology, quadrature_style, discontinuous),
     ) do
-        _SpectralElementGrid1D(topology, quadrature_style, VIJH)
+        _SpectralElementGrid1D(topology, quadrature_style, VIJH; discontinuous)
     end
 end
 
-function _SpectralElementGrid1D(topology, quadrature_style, ::Type{VIJH}) where {VIJH}
+function _SpectralElementGrid1D(
+    topology,
+    quadrature_style,
+    ::Type{VIJH};
+    discontinuous,
+) where {VIJH}
     DA = ClimaComms.array_type(topology)
     global_geometry = Geometry.CartesianGlobalGeometry()
     CoordType = Topologies.coordinate_type(topology)
@@ -85,7 +92,13 @@ function _SpectralElementGrid1D(topology, quadrature_style, ::Type{VIJH}) where 
         quadrature_style,
         global_geometry,
         device_local_geometry,
-        compute_dss_weights(device_local_geometry, topology, quadrature_style),
+        compute_dss_weights(
+            device_local_geometry,
+            topology,
+            quadrature_style,
+            discontinuous,
+        ),
+        discontinuous,
     )
 end
 
@@ -116,6 +129,7 @@ mutable struct SpectralElementGrid2D{
     mask::M
     enable_bubble::Bool
     autodiff_metric::Bool
+    discontinuous::Bool
 end
 
 Adapt.@adapt_structure SpectralElementGrid2D
@@ -132,6 +146,7 @@ local_geometry_type(
         autodiff_metric,
         VIJH,
         enable_mask::Bool,
+        discontinuous::Bool,
     )
 
 Construct a `SpectralElementGrid2D` instance given a `topology` and `quadrature`. The
@@ -147,6 +162,13 @@ SEM for computing metric terms.
   - autodiff_metric: Bool
   - VIJH: subtype of DataLayouts.VIJHWithF with a specific F axis
   - enable_mask: Boolean used to skip operations where the space's mask is 0
+  - discontinuous: Boolean marking the grid's function space as discontinuous
+    Galerkin (DG): no continuity is maintained across element boundaries, so
+    [`Spaces.weighted_dss!`](@ref) is a no-op on fields over this grid and
+    inter-element coupling is instead supplied by DG numerical fluxes (see
+    `Operators.add_numerical_flux_internal!`). No DSS weights are computed.
+    The flag is not serialized by `InputOutput`; grids read from HDF5 are
+    continuous.
 
 The idea behind the so-called `bubble_correction` is that the numerical area
 of the domain (e.g., the sphere) is given by the sum of nodal integration weights
@@ -180,6 +202,7 @@ function SpectralElementGrid2D(
     enable_bubble::Bool = false,
     autodiff_metric::Bool = true,
     enable_mask::Bool = false,
+    discontinuous::Bool = false,
 )
     get!(
         Cache.OBJECT_CACHE,
@@ -191,6 +214,7 @@ function SpectralElementGrid2D(
             autodiff_metric,
             VIJH,
             enable_mask,
+            discontinuous,
         ),
     ) do
         _SpectralElementGrid2D(
@@ -200,6 +224,7 @@ function SpectralElementGrid2D(
             enable_bubble,
             autodiff_metric,
             enable_mask,
+            discontinuous,
         )
     end
 end
@@ -221,6 +246,7 @@ function _SpectralElementGrid2D(
     enable_bubble,
     autodiff_metric,
     enable_mask,
+    discontinuous,
 ) where {VIJH}
     # 1. compute localgeom for local elememts
     # 2. ghost exchange of localgeom
@@ -438,12 +464,18 @@ function _SpectralElementGrid2D(
         quadrature_style,
         global_geometry,
         device_local_geometry,
-        compute_dss_weights(device_local_geometry, topology, quadrature_style),
+        compute_dss_weights(
+            device_local_geometry,
+            topology,
+            quadrature_style,
+            discontinuous,
+        ),
         internal_surface_geometry,
         boundary_surface_geometries,
         mask,
         enable_bubble,
         autodiff_metric,
+        discontinuous,
     )
 end
 
@@ -554,8 +586,9 @@ end
 @inline _orth_axis(::Geometry.LocalGeometry{I}) where {I} =
     Geometry.Components{Geometry.Orthonormal, I}()
 
-function compute_dss_weights(local_geometry, topology, quadrature_style)
-    Quadratures.requires_dss(quadrature_style) || return nothing
+function compute_dss_weights(local_geometry, topology, quadrature_style, discontinuous)
+    !discontinuous && Quadratures.requires_dss(quadrature_style) ||
+        return nothing
 
     # Although the weights are defined as WJ / Σ collocated WJ, we can use J
     # instead of WJ if the weights are symmetric across element boundaries.
@@ -566,6 +599,22 @@ function compute_dss_weights(local_geometry, topology, quadrature_style)
 end
 
 # accessors
+
+"""
+    Grids.is_continuous(grid)
+
+Whether fields on `grid` are members of the continuous (CG) function space:
+shared element-boundary nodes exist (`Quadratures.requires_dss`) and the grid
+is not marked `discontinuous`. Discontinuous (DG) grids skip
+[`Spaces.weighted_dss!`](@ref) and couple elements through numerical fluxes
+instead. Grids with no horizontal spectral elements (e.g. column grids) are
+continuous.
+"""
+is_continuous(grid::AbstractGrid) = true
+is_continuous(grid::SpectralElementGrid1D) =
+    !grid.discontinuous && Quadratures.requires_dss(grid.quadrature_style)
+is_continuous(grid::SpectralElementGrid2D) =
+    !grid.discontinuous && Quadratures.requires_dss(grid.quadrature_style)
 
 topology(grid::AbstractSpectralElementGrid) = grid.topology
 

--- a/src/InputOutput/readers.jl
+++ b/src/InputOutput/readers.jl
@@ -138,6 +138,7 @@ struct HDF5Reader{C <: ClimaComms.AbstractCommsContext}
     mesh_cache::Dict{Any, Any}
     topology_cache::Dict{Any, Any}
     grid_cache::Dict{Any, Any}
+    space_cache::Dict{Any, Any}
 end
 
 function HDF5Reader(
@@ -178,6 +179,7 @@ function HDF5Reader(
         Dict(),
         Dict(),
         Dict(),
+        Dict(),
     )
 end
 
@@ -190,6 +192,7 @@ function Base.close(hdfreader::HDF5Reader)
     empty!(hdfreader.mesh_cache)
     empty!(hdfreader.topology_cache)
     empty!(hdfreader.grid_cache)
+    empty!(hdfreader.space_cache)
     close(hdfreader.file)
     return nothing
 end
@@ -461,8 +464,13 @@ function read_grid_new(reader, name)
             _scan_quadrature_style(attrs(group)["quadrature_type"], npts)
         topology = read_topology(reader, attrs(group)["topology"])
         enable_bubble = get(attrs(group), "bubble", "false") == "true"
+        discontinuous = get(attrs(group), "discontinuous", "false") == "true"
         if type == "SpectralElementGrid1D"
-            return Grids.SpectralElementGrid1D(topology, quadrature_style)
+            return Grids.SpectralElementGrid1D(
+                topology,
+                quadrature_style;
+                discontinuous,
+            )
         else
             enable_mask = haskey(attrs(group), "grid_mask")
             grid = Grids.SpectralElementGrid2D(
@@ -470,11 +478,14 @@ function read_grid_new(reader, name)
                 quadrature_style;
                 enable_bubble,
                 enable_mask,
+                discontinuous,
             )
             if enable_mask
-                mask_type = keys(reader.file["grid_mask"])[1]
-                @assert mask_type == "IJHMask"
-                ds_is_active = reader.file["grid_mask"]["IJHMask"]["is_active"]
+                # the attribute stores the mask's group name ("IJHMask", with
+                # a numbered suffix when a file holds several masks)
+                mask_name = attrs(group)["grid_mask"]
+                @assert startswith(mask_name, "IJHMask")
+                ds_is_active = reader.file["grid_mask"][mask_name]["is_active"]
                 is_active = read_data_layout(ds_is_active, topology)
                 Grids.set_mask!(grid, is_active)
             end

--- a/src/InputOutput/writers.jl
+++ b/src/InputOutput/writers.jl
@@ -62,7 +62,12 @@ end
 struct HDF5Writer{C <: ClimaComms.AbstractCommsContext} <: AbstractWriter
     file::HDF5.File
     context::C
-    cache::Dict{String, String}
+    # written object => its group name; identity-keyed so that two distinct
+    # objects sharing a default name (e.g. a CG and a DG grid, both
+    # "horizontal_grid") get distinct groups instead of silently aliasing
+    cache::IdDict{Any, String}
+    # requested name => times requested, for uniquifying repeated names
+    namecounts::Dict{String, Int}
 end
 
 function HDF5Writer(
@@ -102,12 +107,12 @@ function HDF5Writer(
     else
         write_attribute(file, "ClimaCore version", string(VERSION))
     end
-    cache = Dict{String, String}()
-    return HDF5Writer(file, context, cache)
+    return HDF5Writer(file, context, IdDict{Any, String}(), Dict{String, Int}())
 end
 
 function Base.close(hdfwriter::HDF5Writer)
     empty!(hdfwriter.cache)
+    empty!(hdfwriter.namecounts)
     close(hdfwriter.file)
     return nothing
 end
@@ -138,16 +143,27 @@ Write the object `obj` using `writer`. An optional `preferredname` can be
 provided, otherwise [`defaultname`](@ref) will be used to generate a name. The
 name of the object will be returned.
 
-A cache of domains, meshes, topologies and spaces is kept: if one of these
-objects has already been written, then the file will not be modified: instead
-the name under which the object was first written will be returned. Note that
-`Field`s and `FieldVector`s are _not_ cached, and so can be written multiple
-times.
+A cache of domains, meshes, topologies and grids is kept: if the same object
+has already been written, the file is not modified and the name under which
+the object was first written is returned. Distinct objects that request the
+same name (e.g. two spectral-element grids differing only in a constructor
+flag, both named "horizontal_grid") are written to distinct groups, with a
+`_2`, `_3`, ... suffix appended to later names; references always use the
+returned name. `Field`s and `FieldVector`s are _not_ cached, and so can be
+written multiple times.
 """
 function write!(writer::HDF5Writer, obj, name = defaultname(obj))
-    get!(writer.cache, name) do
-        write_new!(writer, obj, name)
+    get!(writer.cache, obj) do
+        write_new!(writer, obj, unique_name!(writer, name))
     end
+end
+
+# First request for a name keeps it; later requests (necessarily for distinct
+# objects, since identical objects hit the cache) get a numbered suffix.
+function unique_name!(writer::HDF5Writer, name::AbstractString)
+    n = get(writer.namecounts, name, 0) + 1
+    writer.namecounts[name] = n
+    return n == 1 ? String(name) : string(name, "_", n)
 end
 
 # Domains
@@ -369,6 +385,7 @@ function write_new!(
         "quadrature_num_points",
         Quadratures.degrees_of_freedom(Spaces.quadrature_style(grid)),
     )
+    write_attribute(group, "discontinuous", grid.discontinuous ? "true" : "false")
     write_attribute(group, "topology", write!(writer, Spaces.topology(grid)))
     return name
 end
@@ -391,6 +408,7 @@ function write_new!(
         Quadratures.degrees_of_freedom(Spaces.quadrature_style(grid)),
     )
     write_attribute(group, "bubble", grid.enable_bubble ? "true" : "false")
+    write_attribute(group, "discontinuous", grid.discontinuous ? "true" : "false")
     write_attribute(group, "topology", write!(writer, Spaces.topology(grid)))
     if !(grid.mask isa DataLayouts.NoMask)
         write_attribute(
@@ -481,9 +499,12 @@ function write!(
     topology::Topologies.AbstractTopology,
     name::AbstractString = defaultname(mask),
 )
-    group = create_group(writer.file, "grid_mask/$name")
-    write!(writer, group, mask.is_active, "is_active", topology)
-    return name
+    get!(writer.cache, mask) do
+        uname = unique_name!(writer, name)
+        group = create_group(writer.file, "grid_mask/$uname")
+        write!(writer, group, mask.is_active, "is_active", topology)
+        uname
+    end
 end
 
 # write fields

--- a/src/Spaces/Spaces.jl
+++ b/src/Spaces/Spaces.jl
@@ -67,6 +67,19 @@ ClimaComms.device(space::AbstractSpace) = ClimaComms.device(grid(space))
 topology(space::AbstractSpace) = topology(grid(space))
 vertical_topology(space::AbstractSpace) = vertical_topology(grid(space))
 
+"""
+    Spaces.is_continuous(space)
+
+Whether fields on `space` are members of the continuous (CG) function space,
+maintained via [`Spaces.weighted_dss!`](@ref). `false` for discontinuous (DG)
+spaces: spectral-element grids constructed with `discontinuous = true` or
+with a quadrature whose nodes are not shared across element boundaries (e.g.
+`Quadratures.GL`). In those cases, `weighted_dss!` is a no-op, and
+inter-element coupling is supplied by DG numerical fluxes. Downstream models
+can use this to decide whether a stage state needs DSS.
+"""
+is_continuous(space::AbstractSpace) = Grids.is_continuous(grid(space))
+
 
 local_geometry_data(space::AbstractSpace) =
     local_geometry_data(grid(space), staggering(space))

--- a/src/Spaces/dss.jl
+++ b/src/Spaces/dss.jl
@@ -19,7 +19,7 @@ perimeter(space::AbstractSpectralElementSpace) = Topologies.Perimeter2D(
 Creates a [`Topologies.DSSBuffer`](@ref) for the field data corresponding to `data`
 """
 create_dss_buffer(data::DataLayouts.VIJHWithF, space) =
-    isone(size(data, 3)) ? nothing :
+    (!is_continuous(space) || isone(size(data, 3))) ? nothing :
     create_dss_buffer(
         data,
         topology(space),
@@ -49,6 +49,7 @@ end
 
 function weighted_dss_prepare!(data, space, dss_buffer)
     isnothing(dss_buffer) && return nothing
+    is_continuous(space) || return nothing
     device = ClimaComms.device(topology(space))
     hspace = horizontal_space(space)
     dss_transform!(
@@ -92,7 +93,7 @@ representative ghost vertices which store result of "ghost local" DSS are loaded
 """
 function weighted_dss_start!(data, space, dss_buffer)
     isnothing(dss_buffer) && return nothing
-    Quadratures.requires_dss(quadrature_style(space)) || return nothing
+    is_continuous(space) || return nothing
     sizeof(eltype(data)) > 0 || return nothing
     device = ClimaComms.device(topology(space))
     weighted_dss_prepare!(data, space, dss_buffer)
@@ -112,7 +113,7 @@ and perimeter elements to facilitate overlapping of communication with computati
 3). [`Spaces.dss_local!`](@ref) computes the weighted DSS on local vertices and faces.
 """
 function weighted_dss_internal!(data, space, dss_buffer)
-    Quadratures.requires_dss(quadrature_style(space)) || return nothing
+    is_continuous(space) || return nothing
     sizeof(eltype(data)) > 0 || return nothing
     hspace = horizontal_space(space)
     device = ClimaComms.device(topology(hspace))
@@ -168,7 +169,7 @@ This transforms the DSS'd local vectors back to Covariant12 vectors, and copies 
 """
 function weighted_dss_ghost!(data, space, dss_buffer)
     isnothing(dss_buffer) && return data
-    Quadratures.requires_dss(quadrature_style(space)) || return data
+    is_continuous(space) || return data
     sizeof(eltype(data)) > 0 || return data
     ClimaComms.finish(dss_buffer.graph_context)
     hspace = horizontal_space(space)

--- a/test/InputOutput/unit_hdf5.jl
+++ b/test/InputOutput/unit_hdf5.jl
@@ -22,3 +22,19 @@ filename = tempname(pwd())
         @test attributes_read == attributes
     end
 end
+
+@testset "read_space uses the reader's space cache" begin
+    context = ClimaComms.context()
+    filename2 = tempname(pwd())
+    InputOutput.HDF5Writer(filename2, context) do writer
+        InputOutput.HDF5.create_dataset(writer.file, "test", [1, 2, 3])
+    end
+    InputOutput.HDF5Reader(filename2, context) do reader
+        # The legacy `spaces/` read path goes through reader.space_cache; a
+        # missing group must surface as a KeyError from the file lookup, not
+        # as a field error on the reader struct.
+        @test reader.space_cache isa Dict
+        @test_throws KeyError InputOutput.read_space(reader, "nonexistent")
+    end
+    rm(filename2; force = true)
+end

--- a/test/Spaces/unit_discontinuous_spaces.jl
+++ b/test/Spaces/unit_discontinuous_spaces.jl
@@ -14,7 +14,9 @@ import ClimaCore:
     Meshes,
     Quadratures,
     Spaces,
-    Topologies
+    Topologies,
+    InputOutput
+import ClimaCore.Utilities.Cache
 
 FT = Float64
 
@@ -111,4 +113,71 @@ end
     @test parent(f_dg2) == f_before
     Spaces.weighted_dss!(f_dg2 => buffer)
     @test parent(f_dg2) == f_before
+end
+
+# Round-trip a field through HDF5 and report the restart space's continuity.
+# The grids under test are evicted from the object cache first, so the reader
+# reconstructs them from the file attributes rather than returning the cached
+# objects.
+function roundtrip_is_continuous(space)
+    context = ClimaComms.context(space)
+    filename = tempname(; cleanup = true)
+    f = Fields.local_geometry_field(space).J
+    InputOutput.HDF5Writer(filename, context) do writer
+        InputOutput.write!(writer, "f" => f)
+    end
+    grid = Spaces.grid(space)
+    Cache.clean_cache!(grid)
+    grid isa Grids.ExtrudedFiniteDifferenceGrid &&
+        Cache.clean_cache!(grid.horizontal_grid)
+    InputOutput.HDF5Reader(filename, context) do reader
+        Spaces.is_continuous(axes(InputOutput.read_field(reader, "f")))
+    end
+end
+
+function plane_hspace(FT; discontinuous)
+    context = ClimaComms.context()
+    hdomain = Domains.IntervalDomain(
+        Geometry.XPoint(zero(FT)),
+        Geometry.XPoint(FT(1));
+        periodic = true,
+    )
+    hmesh = Meshes.IntervalMesh(hdomain, nelems = 4)
+    htopology = Topologies.IntervalTopology(ClimaComms.device(context), hmesh)
+    return Spaces.SpectralElementSpace1D(
+        htopology,
+        Quadratures.GLL{4}();
+        discontinuous,
+    )
+end
+
+@testset "discontinuous flag survives an InputOutput round-trip" begin
+    @test !roundtrip_is_continuous(dg_space)
+    @test roundtrip_is_continuous(cg_space)
+    # extruded plane spaces cover the SpectralElementGrid1D writer/reader
+    dg_plane, _ = extruded_spaces(plane_hspace(FT; discontinuous = true))
+    cg_plane, _ = extruded_spaces(plane_hspace(FT; discontinuous = false))
+    @test !roundtrip_is_continuous(dg_plane)
+    @test roundtrip_is_continuous(cg_plane)
+end
+
+@testset "CG and DG grids round-trip through a single file" begin
+    # Both grids request the group name "horizontal_grid"; the writer must
+    # give the second one a distinct group instead of aliasing it to the
+    # first, or one field restarts with the wrong discretization.
+    context = ClimaComms.context()
+    filename = tempname(; cleanup = true)
+    f_dg = Fields.local_geometry_field(dg_space).J
+    f_cg = Fields.local_geometry_field(cg_space).J
+    InputOutput.HDF5Writer(filename, context) do writer
+        InputOutput.write!(writer, "f_dg" => f_dg, "f_cg" => f_cg)
+    end
+    Cache.clean_cache!(Spaces.grid(dg_space))
+    Cache.clean_cache!(Spaces.grid(cg_space))
+    InputOutput.HDF5Reader(filename, context) do reader
+        restart_dg = InputOutput.read_field(reader, "f_dg")
+        restart_cg = InputOutput.read_field(reader, "f_cg")
+        @test !Spaces.is_continuous(axes(restart_dg))
+        @test Spaces.is_continuous(axes(restart_cg))
+    end
 end

--- a/test/Spaces/unit_discontinuous_spaces.jl
+++ b/test/Spaces/unit_discontinuous_spaces.jl
@@ -1,0 +1,114 @@
+# Asserts the discontinuous-grid (DG) contract: `discontinuous = true` marks a
+# spectral-element grid as DG, `is_continuous` reports it (also through
+# extruded spaces), and `weighted_dss!` is the identity there while remaining
+# a genuine projection on the continuous twin of the same topology.
+using Test
+using Random
+import ClimaComms
+ClimaComms.@import_required_backends
+import ClimaCore:
+    Domains,
+    Fields,
+    Geometry,
+    Grids,
+    Meshes,
+    Quadratures,
+    Spaces,
+    Topologies
+
+FT = Float64
+
+function sphere_topology(FT; helem = 4)
+    context = ClimaComms.context()
+    domain = Domains.SphereDomain(FT(6.371e6))
+    mesh = Meshes.EquiangularCubedSphere(domain, helem)
+    return Topologies.Topology2D(context, mesh)
+end
+
+function extruded_spaces(hspace; zelem = 4)
+    FT = Spaces.undertype(hspace)
+    vdomain = Domains.IntervalDomain(
+        Geometry.ZPoint(zero(FT)),
+        Geometry.ZPoint(FT(30e3));
+        boundary_names = (:bottom, :top),
+    )
+    vmesh = Meshes.IntervalMesh(vdomain, nelems = zelem)
+    device = ClimaComms.device(ClimaComms.context())
+    vspace = Spaces.CenterFiniteDifferenceSpace(device, vmesh)
+    center = Spaces.ExtrudedFiniteDifferenceSpace(hspace, vspace)
+    return center, Spaces.FaceExtrudedFiniteDifferenceSpace(center)
+end
+
+topology = sphere_topology(FT)
+quad = Quadratures.GLL{4}()
+cg_space = Spaces.SpectralElementSpace2D(topology, quad)
+dg_space = Spaces.SpectralElementSpace2D(topology, quad; discontinuous = true)
+
+@testset "is_continuous and grid caching" begin
+    @test Spaces.is_continuous(cg_space)
+    @test !Spaces.is_continuous(dg_space)
+    # the flag is part of the grid cache key
+    @test Spaces.grid(cg_space) !== Spaces.grid(dg_space)
+    @test Spaces.grid(dg_space).dss_weights === nothing
+
+    # GL quadrature has no shared boundary nodes, so it is DG without the flag
+    gl_space = Spaces.SpectralElementSpace2D(topology, Quadratures.GL{4}())
+    @test !Spaces.is_continuous(gl_space)
+
+    cg_center, cg_face = extruded_spaces(cg_space)
+    dg_center, dg_face = extruded_spaces(dg_space)
+    @test Spaces.is_continuous(cg_center) && Spaces.is_continuous(cg_face)
+    @test !Spaces.is_continuous(dg_center) && !Spaces.is_continuous(dg_face)
+
+    # spaces without horizontal spectral elements are continuous
+    device = ClimaComms.device(ClimaComms.context())
+    vdomain = Domains.IntervalDomain(
+        Geometry.ZPoint(zero(FT)),
+        Geometry.ZPoint(FT(1));
+        boundary_names = (:bottom, :top),
+    )
+    vspace = Spaces.CenterFiniteDifferenceSpace(
+        device,
+        Meshes.IntervalMesh(vdomain, nelems = 4),
+    )
+    @test Spaces.is_continuous(vspace)
+end
+
+# A coordinate-seeded field is smooth but its nodal values differ across
+# element boundaries only after perturbation; perturb per-node so DSS on the
+# CG twin must change the perimeter values.
+function perturbed_field(space)
+    coords = Fields.coordinate_field(space)
+    f = @. sind(coords.long) * cosd(coords.lat)^2
+    Random.seed!(1)
+    perturbation = similar(f)
+    parent(perturbation) .=
+        ClimaComms.array_type(ClimaComms.device(ClimaComms.context()))(
+            rand(FT, size(parent(perturbation))),
+        )
+    return f .+ perturbation
+end
+
+@testset "weighted_dss! is the identity on discontinuous spaces" begin
+    f_dg = perturbed_field(dg_space)
+    f_before = copy(parent(f_dg))
+    @test Spaces.create_dss_buffer(f_dg) === nothing
+    Spaces.weighted_dss!(f_dg)
+    @test parent(f_dg) == f_before
+
+    f_cg = perturbed_field(cg_space)
+    f_before = copy(parent(f_cg))
+    Spaces.weighted_dss!(f_cg)
+    @test parent(f_cg) != f_before
+
+    # the split (start/internal/ghost) and pair paths are gated too
+    f_dg2 = perturbed_field(dg_space)
+    f_before = copy(parent(f_dg2))
+    buffer = Spaces.create_dss_buffer(f_dg2)
+    Spaces.weighted_dss_start!(f_dg2, buffer)
+    Spaces.weighted_dss_internal!(f_dg2, buffer)
+    Spaces.weighted_dss_ghost!(f_dg2, buffer)
+    @test parent(f_dg2) == f_before
+    Spaces.weighted_dss!(f_dg2 => buffer)
+    @test parent(f_dg2) == f_before
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,7 @@ unit_tests = [
     UnitTest("Spaces - exact 2x2 DSS"                   ,"Spaces/unit_dss_exact.jl"; tier = :unit, subsystem = :spaces),
     UnitTest("Spaces - DSS vs grouped reference"        ,"Spaces/unit_dss_reference.jl"; tier = :unit, subsystem = :spaces),
     UnitTest("Spaces - serial CPU DSS"                  ,"Spaces/unit_serial_cpu_dss.jl"; tier = :unit, subsystem = :spaces),
+    UnitTest("Spaces - discontinuous (DG) spaces"       ,"Spaces/unit_discontinuous_spaces.jl"; tier = :unit, subsystem = :spaces),
     UnitTest("Sphere spaces"                            ,"Spaces/unit_sphere_spaces.jl"; tier = :unit, subsystem = :spaces),
     UnitTest("Spaces - high resolution"                 ,"Spaces/unit_high_resolution_space.jl"; tier = :unit, subsystem = :spaces),
     UnitTest("Terrain warp"                             ,"Spaces/unit_terrain_warp.jl"; tier = :unit, subsystem = :spaces, slow = true), # 5.9 min: sweeps npoly/helem up to 10 in 3D


### PR DESCRIPTION
Makes it possible to mark discontinuous-Galerkin function spaces, which makes DSS and related CG operations a no-op (and ClimaAtmos and others can use that property to gate DSS).