### PR TITLE
Add horizontal DG operators, CUDA kernels, and unit tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,20 @@ main
   (grids in files written before it existed read back as continuous).
   [2599](https://github.com/CliMA/ClimaCore.jl/pull/2599)
 
+- Introduces horizontal discontinuous-Galerkin (DG) operator support. The
+  discretization-generic machinery lives in `src/Operators/numericalflux.jl`:
+  interior- and boundary-face numerical fluxes and symmetric face liftings on
+  pure-2D and extruded (1D and 2D horizontal) spectral-element spaces, the
+  flux-differencing (split-form / FDDG) volume divergence of Souza et al.
+  (2023), and the device-resident `DGConnectivity` face buffer (with
+  CUDA implementations in the `ClimaCoreCUDAExt` extension). A generic flux
+  library lives in `src/Operators/dg_fluxes.jl`: `CentralNumericalFlux`,
+  `RusanovNumericalFlux`, central-lifting and jump-penalty face functions, and
+  an LDG/SIPG Laplacian for optional scale-selective dissipation.
+  Equation-set-specific fluxes (compressible Euler with Cartesian momentum
+  components) are example code. Operator tests are included as part of
+  `test/runtests.jl`.
+
 v0.15.3
 -------
 

--- a/ext/ClimaCoreCUDAExt.jl
+++ b/ext/ClimaCoreCUDAExt.jl
@@ -28,6 +28,7 @@ include(joinpath("cuda", "operators_sem_shmem.jl"))
 include(joinpath("cuda", "matrix_fields_single_field_solve.jl"))
 include(joinpath("cuda", "matrix_fields_multiple_field_solve.jl"))
 include(joinpath("cuda", "operators_spectral_element.jl"))
+include(joinpath("cuda", "operators_dg.jl"))
 
 # Lift the recursion limit for the device reduce_points, whose recursion over warps
 # and sub-warps forwards kwargs and looks unbounded to the compiler, which would widen

--- a/ext/cuda/operators_dg.jl
+++ b/ext/cuda/operators_dg.jl
@@ -1,0 +1,326 @@
+#=
+CUDA implementations of the DG internal-face and flux-differencing volume
+operators (see src/Operators/numericalflux.jl for the CPU methods and the
+operator contracts).
+
+Kernel design:
+- Flux-differencing volume (`_add_flux_differencing_divergence!`), element-local.
+- Internal-face fluxes (`_add_numerical_flux_internal!`,
+  `_add_lifting_flux_internal!`): two-pass staging + gather, follows `DSS` GPU kernels.
+- `tensor_product!` (cutoff filter): per-element enabling in-place assignment.
+=#
+
+import ClimaCore: Operators, Topologies, Quadratures, Grids, DataLayouts
+import ClimaCore.Operators: DGConnectivity
+
+# ---------------------------------------------------------------------------
+# Flux-differencing volume divergence
+# ---------------------------------------------------------------------------
+
+function Operators._add_flux_differencing_divergence!(
+    ::ClimaComms.CUDADevice,
+    fn2pt::F,
+    dydt,
+    y,
+) where {F}
+    space = axes(dydt)
+    grid = Spaces.grid(space)
+    if grid isa Grids.ExtrudedFiniteDifferenceGrid
+        @assert grid.horizontal_grid isa Grids.SpectralElementGrid2D
+        Nv = Spaces.nlevels(space)
+    else
+        @assert grid isa Grids.SpectralElementGrid2D
+        Nv = 1
+    end
+    quadrature_style = Spaces.quadrature_style(space)
+    Nq = Quadratures.degrees_of_freedom(quadrature_style)
+    FT = Spaces.undertype(space)
+    D = Quadratures.differentiation_matrix(FT, quadrature_style)
+    (_, w) = Quadratures.quadrature_points(FT, quadrature_style)
+    Nh = Topologies.nlocalelems(Spaces.topology(space))
+
+    dydt_data = Fields.field_values(dydt)
+    y_data = Fields.field_values(y)
+    lg_data = Spaces.local_geometry_data(space)
+
+    Nvt = max(1, min(fld(_max_threads_cuda(), Nq * Nq), Nv))
+    args = (dydt_data, y_data, lg_data, fn2pt, D, w, Val(Nq), Nv)
+    auto_launch!(
+        dg_fddg_volume_kernel!,
+        args;
+        threads_s = (Nq, Nq, Nvt),
+        blocks_s = (Nh, cld(Nv, Nvt)),
+    )
+    return dydt
+end
+
+function dg_fddg_volume_kernel!(
+    dydt_data,
+    y_data,
+    lg_data,
+    fn2pt::F,
+    D,
+    w,
+    ::Val{Nq},
+    Nv,
+) where {F, Nq}
+    i = threadIdx().x
+    j = threadIdx().y
+    h = blockIdx().x
+    v = threadIdx().z + (blockIdx().y - Int32(1)) * blockDim().z
+    if v ≤ Nv
+        CI = CartesianIndex
+        y_at = (a, b) -> y_data[CI(v, a, b, h)]
+        lg_at = (a, b) -> lg_data[CI(v, a, b, h)]
+        total = Operators._fd_volume_node_total(
+            fn2pt,
+            y_at,
+            lg_at,
+            D,
+            w,
+            Val(Nq),
+            i,
+            j,
+        )
+        I = CI(v, i, j, h)
+        dydt_data[I] = Operators._fd_add(dydt_data[I], total)
+    end
+    return nothing
+end
+
+# ---------------------------------------------------------------------------
+# Internal-face numerical flux and symmetric lifting (staging + gather)
+# ---------------------------------------------------------------------------
+
+Operators._add_numerical_flux_internal!(
+    ::ClimaComms.CUDADevice,
+    fn::F,
+    dydt,
+    args...,
+) where {F} = _dg_face_apply!(fn, dydt, args, Val(:numflux))
+
+Operators._add_lifting_flux_internal!(
+    ::ClimaComms.CUDADevice,
+    fn::F,
+    dydt,
+    args...,
+) where {F} = _dg_face_apply!(fn, dydt, args, Val(:lifting))
+
+function _dg_face_apply!(fn::F, dydt, args, mode::Val) where {F}
+    space = axes(dydt)
+    grid = Spaces.grid(space)
+    if grid isa Grids.ExtrudedFiniteDifferenceGrid
+        @assert grid.horizontal_grid isa Grids.SpectralElementGrid2D
+        Nv = Spaces.nlevels(space)
+    else
+        @assert grid isa Grids.SpectralElementGrid2D
+        Nv = 1
+    end
+    quadrature_style = Spaces.quadrature_style(space)
+    Nq = Quadratures.degrees_of_freedom(quadrature_style)
+    conn = Operators.dg_connectivity(space)
+    conn.nfaces == 0 && return dydt
+
+    dydt_data = Fields.field_values(dydt)
+    args_data =
+        map(a -> a isa Fields.Field ? Fields.field_values(a) : a, args)
+    T = eltype(dydt_data)
+    DA = ClimaComms.array_type(Spaces.topology(space))
+    nsides = mode isa Val{:lifting} ? 2 : 1
+    staging = DA{T}(undef, Nq, Nv, nsides, conn.nfaces)
+
+    nitemsA = Nq * Nv * conn.nfaces
+    pA = linear_partition(nitemsA, _max_threads_cuda())
+    auto_launch!(
+        dg_face_flux_kernel!,
+        (
+            staging,
+            fn,
+            args_data,
+            conn.faces,
+            conn.sgeom,
+            Val(Nq),
+            Nv,
+            conn.nfaces,
+            mode,
+        );
+        threads_s = pA.threads,
+        blocks_s = pA.blocks,
+    )
+
+    nitemsB = conn.nbnodes * Nv
+    pB = linear_partition(nitemsB, _max_threads_cuda())
+    auto_launch!(
+        dg_face_gather_kernel!,
+        (
+            dydt_data,
+            staging,
+            conn.node_elem,
+            conn.node_i,
+            conn.node_j,
+            conn.node_offset,
+            conn.contrib_face,
+            conn.contrib_side,
+            conn.contrib_q,
+            Nv,
+            conn.nbnodes,
+            mode,
+        );
+        threads_s = pB.threads,
+        blocks_s = pB.blocks,
+    )
+    return dydt
+end
+
+Base.@propagate_inbounds function dg_face_flux_kernel!(
+    staging,
+    fn::F,
+    args_data,
+    faces,
+    sgeom,
+    ::Val{Nq},
+    Nv,
+    nfaces,
+    mode,
+) where {F, Nq}
+    gidx = threadIdx().x + (blockIdx().x - Int32(1)) * blockDim().x
+    @inbounds if gidx ≤ Nq * Nv * nfaces
+        (q, v, f) = Utilities.cart_ind((Nq, Nv, nfaces), gidx).I
+        elem⁻ = faces[1, f]
+        face⁻ = faces[2, f]
+        elem⁺ = faces[3, f]
+        face⁺ = faces[4, f]
+        reversed = faces[5, f] == Int32(1)
+        i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, q, false)
+        i⁺, j⁺ = Topologies.face_node_index(face⁺, Nq, q, reversed)
+        CI = CartesianIndex
+        argvals⁻ = map(
+            a ->
+                a isa DataLayouts.DataLayout ?
+                a[CI(v, i⁻, j⁻, elem⁻)] : a,
+            args_data,
+        )
+        argvals⁺ = map(
+            a ->
+                a isa DataLayouts.DataLayout ?
+                a[CI(v, i⁺, j⁺, elem⁺)] : a,
+            args_data,
+        )
+        sg = sgeom[q, v, f]
+        if mode isa Val{:numflux}
+            val = fn(sg.normal, argvals⁻, argvals⁺)
+            staging[q, v, 1, f] = Operators._fd_scale(sg.sWJ, val)
+        else
+            lift⁻ = fn(sg.normal, argvals⁻, argvals⁺)
+            lift⁺ = fn(-sg.normal, argvals⁺, argvals⁻)
+            staging[q, v, 1, f] = Operators._fd_scale(sg.sWJ, lift⁻)
+            staging[q, v, 2, f] = Operators._fd_scale(sg.sWJ, lift⁺)
+        end
+    end
+    return nothing
+end
+
+function dg_face_gather_kernel!(
+    dydt_data,
+    staging,
+    node_elem,
+    node_i,
+    node_j,
+    node_offset,
+    contrib_face,
+    contrib_side,
+    contrib_q,
+    Nv,
+    nbnodes,
+    mode,
+)
+    gidx = threadIdx().x + (blockIdx().x - Int32(1)) * blockDim().x
+    if gidx ≤ nbnodes * Nv
+        (v, n) = Utilities.cart_ind((Nv, nbnodes), gidx).I
+        e = Int(node_elem[n])
+        i = Int(node_i[n])
+        j = Int(node_j[n])
+        I = CartesianIndex(v, i, j, e)
+        acc = dydt_data[I]
+        for c in Int(node_offset[n]):(Int(node_offset[n + 1]) - 1)
+            f = Int(contrib_face[c])
+            q = Int(contrib_q[c])
+            side = Int(contrib_side[c])
+            if mode isa Val{:numflux}
+                s = staging[q, v, 1, f]
+                # minus side subtracts, plus side adds (antisymmetric flux)
+                acc = Operators._fd_add(
+                    acc,
+                    Operators._fd_scale(side == 1 ? -1 : 1, s),
+                )
+            else
+                # symmetric lifting: each side adds its own lift
+                acc = Operators._fd_add(acc, staging[q, v, side, f])
+            end
+        end
+        dydt_data[I] = acc
+    end
+    return nothing
+end
+
+# ---------------------------------------------------------------------------
+# tensor_product! (cutoff filter); square matrices only
+# ---------------------------------------------------------------------------
+
+function Operators.tensor_product!(
+    out::DataLayouts.VIJHWithF{S, Nv, Nij, Nij, Nh, F, Sc, A},
+    indata::DataLayouts.VIJHWithF{S, Nv, Nij, Nij, Nh, F, Sc, A},
+    M::SMatrix{Nij, Nij},
+) where {S, Nv, Nij, Nh, F, Sc, A <: CUDA.CuArray}
+    Nh_runtime = DataLayouts.nelems(out)
+    @assert Nh_runtime == DataLayouts.nelems(indata)
+    Nvt = max(1, min(fld(_max_threads_cuda(), Nij * Nij), Nv))
+    auto_launch!(
+        dg_tensor_product_kernel!,
+        (out, indata, M, Val(Nij), Val(Nvt), Nv);
+        threads_s = (Nij, Nij, Nvt),
+        blocks_s = (Nh_runtime, cld(Nv, Nvt)),
+    )
+    return out
+end
+
+function Operators.tensor_product!(
+    inout::DataLayouts.VIJHWithF{S, Nv, Nij, Nij, Nh, F, Sc, A},
+    M::SMatrix{Nij, Nij},
+) where {S, Nv, Nij, Nh, F, Sc, A <: CUDA.CuArray}
+    return Operators.tensor_product!(inout, inout, M)
+end
+
+function dg_tensor_product_kernel!(
+    out,
+    indata,
+    M,
+    ::Val{Nij},
+    ::Val{Nvt},
+    Nv,
+) where {Nij, Nvt}
+    S = eltype(out)
+    work = CUDA.CuStaticSharedArray(S, (Nij, Nij, Nvt))
+    i = threadIdx().x
+    j = threadIdx().y
+    k = threadIdx().z
+    h = blockIdx().x
+    v = k + (blockIdx().y - Int32(1)) * blockDim().z
+    CI = CartesianIndex
+    if v ≤ Nv
+        work[i, j, k] = indata[CI(v, i, j, h)]
+    end
+    CUDA.sync_threads()
+    if v ≤ Nv
+        r = Operators._fd_scale(M[i, 1] * M[j, 1], work[1, 1, k])
+        for jj in 1:Nij, ii in 1:Nij
+            (ii == 1 && jj == 1) && continue
+            r = Operators._fd_add(
+                r,
+                Operators._fd_scale(M[i, ii] * M[j, jj], work[ii, jj, k]),
+            )
+        end
+        out[CI(v, i, j, h)] = r
+    end
+    return nothing
+end

--- a/src/Operators/Operators.jl
+++ b/src/Operators/Operators.jl
@@ -9,7 +9,12 @@ import Base.Broadcast: Broadcasted
 import ..slab, ..slab_args, ..column, ..column_args
 import ClimaComms
 import ..Utilities:
-    new, is_auto_broadcastable, add_auto_broadcasters, drop_auto_broadcasters
+    Cache,
+    new,
+    unwrap,
+    is_auto_broadcastable,
+    add_auto_broadcasters,
+    drop_auto_broadcasters
 import ..DebugOnly: call_post_op_callback, post_op_callback
 import ..DataLayouts
 import ..Geometry: Geometry, ⊗
@@ -22,6 +27,7 @@ import ..Fields: Fields, Field
 include("common.jl")
 include("spectralelement.jl")
 include("numericalflux.jl")
+include("dg_fluxes.jl")
 include("finitedifference.jl")
 include("remapping.jl")
 include("integrals.jl")

--- a/src/Operators/dg_fluxes.jl
+++ b/src/Operators/dg_fluxes.jl
@@ -1,0 +1,149 @@
+# Generic DG flux library: reference interface fluxes, face-lifting functions
+# for non-conservative terms, and the LDG/SIPG Laplacian. Equation-set-specific
+# fluxes (compressible Euler, Cartesian-momentum Kennedy-Gruber variants) are
+# expected to live downstream of this module.
+
+"""
+    CentralNumericalFlux(fluxfn)
+
+Evaluates the central numerical flux using `fluxfn`.
+"""
+struct CentralNumericalFlux{F} <: AbstractNumericalFlux
+    fluxfn::F
+end
+
+function (fn::CentralNumericalFlux)(normal, argvals⁻, argvals⁺)
+    F⁻ = add_auto_broadcasters(fn.fluxfn(argvals⁻...))
+    F⁺ = add_auto_broadcasters(fn.fluxfn(argvals⁺...))
+    return ((F⁻ + F⁺) / 2)' * normal
+end
+
+"""
+    RusanovNumericalFlux(fluxfn, wavespeedfn)
+
+Evaluates the Rusanov numerical flux using `fluxfn` with wavespeed `wavespeedfn`
+"""
+struct RusanovNumericalFlux{F, W} <: AbstractNumericalFlux
+    fluxfn::F
+    wavespeedfn::W
+end
+
+function (fn::RusanovNumericalFlux)(normal, argvals⁻, argvals⁺)
+    # AutoBroadcasters keep NamedTuple/vector arithmetic type-stable on GPU.
+    y⁻ = add_auto_broadcasters(argvals⁻[1])
+    y⁺ = add_auto_broadcasters(argvals⁺[1])
+    F⁻ = add_auto_broadcasters(fn.fluxfn(argvals⁻...))
+    F⁺ = add_auto_broadcasters(fn.fluxfn(argvals⁺...))
+    λ = max(fn.wavespeedfn(argvals⁻...), fn.wavespeedfn(argvals⁺...))
+    Favg = ((F⁻ + F⁺) / 2)' * normal
+    return Favg + (λ / 2) * (y⁻ - y⁺)
+end
+
+# ---------------------------------------------------------------------------
+# DG face-function library for non-conservative (vector-invariant) terms
+# ---------------------------------------------------------------------------
+
+"""
+    central_gradient_lift(normal, (q⁻,), (q⁺,))
+
+Symmetric central lifting completing the strong-form DG gradient of a scalar:
+each side adds ``(q^* - q_{side}) n̂_{side}`` with central ``q^*``, i.e.
+``((q⁺ - q⁻)/2)\\,n̂`` on the minus side. Use with
+[`add_lifting_flux_internal!`](@ref) / [`lifting_correction`](@ref).
+"""
+central_gradient_lift(normal, (q⁻,), (q⁺,)) = ((q⁺ - q⁻) / 2) * normal
+
+"""
+    central_curl3_lift(normal, (u⁻, v⁻), (u⁺, v⁺))
+
+Central lifting for the radial component of the horizontal curl:
+``r̂ ⋅ (n̂ × (u^* - u_{side}))`` from the tangential jumps of the orthonormal
+velocity components `(u, v)`.
+"""
+central_curl3_lift(normal, (u⁻, v⁻), (u⁺, v⁺)) =
+    (
+        normal.components.data.:1 * (v⁺ - v⁻) -
+        normal.components.data.:2 * (u⁺ - u⁻)
+    ) / 2
+
+"""
+    jump_penalty_lift(normal, (q⁻, λ⁻), (q⁺, λ⁺))
+
+λ-scaled interface penalty: each side relaxes toward its neighbor at rate
+``\\max(λ⁻, λ⁺)/2``.
+"""
+jump_penalty_lift(normal, (q⁻, λ⁻), (q⁺, λ⁺)) = max(λ⁻, λ⁺) / 2 * (q⁺ - q⁻)
+
+# ---------------------------------------------------------------------------
+# LDG / interior-penalty Laplacian face fluxes
+# Volume term: WJ-weighted κ∇² via (−WJ)·κ·(−wdiv(G)); face −{{κG}}·n + τ[[q]]
+# with G = ∇q.
+# ---------------------------------------------------------------------------
+
+"""
+    ldg_laplacian_tendency(q, ρ_weight, κ, τ)
+
+WJ-normalized interior-penalty Laplacian tendency approximating
+``κ ∇⋅(ρ_{weight} ∇q)`` (or ``κ ∇²q`` when `ρ_weight === nothing`): weak-form
+volume term plus the consistent numerical flux
+``−\\{\\!\\{κ G\\}\\!\\}·n̂ + τ [\\![q]\\!]`` with ``G = ρ_{weight} ∇q``
+(or ``G = ∇q``). See [`LDGLaplacianFlux`](@ref) and
+[`ldg_penalty_parameter`](@ref).
+"""
+function ldg_laplacian_tendency(q, ρ_weight, κ, τ)
+    wdiv = WeakDivergence()
+    grad = Gradient()
+    lgeom = Fields.local_geometry_field(axes(q))
+    residual = similar(q)
+    G = ρ_weight === nothing ? (@. grad(q)) : (@. ρ_weight * grad(q))
+    @. residual = (-lgeom.WJ) * κ * (-wdiv(G))
+    # Face normals are UVVector; raise G to the same basis for G·n̂.
+    G_uv = @. Geometry.UVVector(G)
+    add_ldg_laplacian_flux_internal!(residual, q, G_uv, κ, τ)
+    return residual ./ lgeom.WJ
+end
+
+"""
+    ldg_penalty_parameter(κ, space)
+
+Interior-penalty scaling ``τ = κ (2N_q − 1)^2 / h`` using the horizontal
+spectral-element length scale (works for extruded hybrid spaces).
+"""
+function ldg_penalty_parameter(κ, space)
+    hspace =
+        space isa Spaces.ExtrudedFiniteDifferenceSpace ?
+        Spaces.horizontal_space(space) : space
+    h = Spaces.node_horizontal_length_scale(hspace)
+    Nq = Quadratures.degrees_of_freedom(Spaces.quadrature_style(hspace))
+    return κ * (2 * Nq - 1)^2 / h
+end
+
+"""
+    LDGLaplacianFlux(τ)
+
+Consistent interior-penalty flux for the LDG/SIPG Laplacian. Called through
+[`add_numerical_flux_internal!`](@ref) on a WJ-weighted residual of
+``−∇·F`` with ``F = −κ G`` and ``G = ∇q`` (or ``ρ_{weight} ∇q``). Arguments
+are `(q, G, κ)` on each side, where `G` must share the face-normal
+basis (typically [`Geometry.UVVector`](@ref)); returns
+``−\\{\\!\\{κ G\\}\\!\\}·n̂ + τ[[q]]`` with ``[[q]] = q⁻ − q⁺``.
+"""
+struct LDGLaplacianFlux{T} <: AbstractNumericalFlux
+    τ::T
+end
+
+function (fn::LDGLaplacianFlux)(normal, argvals⁻, argvals⁺)
+    q⁻, G⁻, κ⁻ = argvals⁻[1], argvals⁻[2], argvals⁻[3]
+    q⁺, G⁺, κ⁺ = argvals⁺[1], argvals⁺[2], argvals⁺[3]
+    Favg = -((κ⁻ * G⁻ + κ⁺ * G⁺) / 2)' * normal
+    return Favg + fn.τ * (q⁻ - q⁺)
+end
+
+"""
+    add_ldg_laplacian_flux_internal!(dydt, q, G, κ, τ)
+
+Add consistent LDG/SIPG face coupling
+``−\\{\\!\\{κ G\\}\\!\\}·n̂ + τ[[q]]`` to a WJ-weighted Laplacian residual.
+"""
+add_ldg_laplacian_flux_internal!(dydt, q, G, κ, τ) =
+    add_numerical_flux_internal!(LDGLaplacianFlux(τ), dydt, q, G, κ)

--- a/src/Operators/numericalflux.jl
+++ b/src/Operators/numericalflux.jl
@@ -1,4 +1,68 @@
 """
+    AbstractNumericalFlux
+
+Abstract type for numerical flux functions used in DG methods.
+"""
+abstract type AbstractNumericalFlux end
+
+"""
+    AbstractBoundaryCondition
+
+Abstract type for boundary conditions in DG methods.
+"""
+abstract type AbstractBoundaryCondition end
+
+@inline face_node_index_1d(face, Nq) = face == 1 ? 1 : Nq
+
+# Surface Jacobian weight and outward unit normal for a 1D spectral-element
+# endpoint. For extruded spaces, `local_geometry` should be the product
+# geometry at that horizontal node and vertical level.
+function compute_surface_geometry_1d(local_geometry, face)
+    (; J, ∂ξ∂x) = local_geometry
+    nvec = face == 1 ? (-J * ∂ξ∂x[1, :]) : (J * ∂ξ∂x[1, :])
+    sWJ = LinearAlgebra.norm(nvec)
+    n = nvec / sWJ
+    # Project onto the horizontal orthonormal axis used by plane (x–z) states.
+    n = Geometry.project(Geometry.UWAxis(), n)
+    return Geometry.SurfaceGeometry(sWJ, Geometry.UVector(n.u))
+end
+
+# Surface Jacobian weight and outward unit horizontal normal for a face node
+# (i, j) of a 2D spectral element within an extruded space. `local_geometry`
+# is the product geometry at that horizontal node and vertical level, so `J`
+# carries the vertical measure and `sWJ` is consistent with the 3D `WJ` of the
+# mass-weighted volume residual. The normal is returned in the local
+# orthonormal horizontal frame (`UVVector`): at a shared face node this frame
+# is identical from both sides — including across cubed-sphere panel
+# boundaries, where covariant components are discontinuous.
+function compute_surface_geometry_extruded_2d(
+    local_geometry,
+    quad_weights,
+    face,
+    i,
+    j,
+)
+    (; J, ∂ξ∂x) = local_geometry
+    nvec = if face == 4
+        -J * ∂ξ∂x[1, :] * quad_weights[j]
+    elseif face == 2
+        J * ∂ξ∂x[1, :] * quad_weights[j]
+    elseif face == 1
+        -J * ∂ξ∂x[2, :] * quad_weights[i]
+    elseif face == 3
+        J * ∂ξ∂x[2, :] * quad_weights[i]
+    else
+        error("invalid face index $face")
+    end
+    sWJ = LinearAlgebra.norm(nvec)
+    n = Geometry.project(Geometry.UVAxis(), nvec / sWJ)
+    return Geometry.SurfaceGeometry(sWJ, n)
+end
+
+# Device-dispatch seam (DSS-style): CPU methods live here; the
+# `ClimaComms.CUDADevice` methods are provided by the ClimaCoreCUDAExt
+# extension (ext/cuda/operators_dg.jl).
+"""
     add_numerical_flux_internal!(fn, dydt, args...)
 
 Add the numerical flux at the internal faces of the spectral space mesh.
@@ -23,11 +87,76 @@ See also:
   - [`CentralNumericalFlux`](@ref)
   - [`RusanovNumericalFlux`](@ref)
 """
-function add_numerical_flux_internal!(fn, dydt, args...)
+add_numerical_flux_internal!(fn::F, dydt, args...) where {F} =
+    _add_numerical_flux_internal!(
+        ClimaComms.device(axes(dydt)),
+        fn,
+        dydt,
+        args...,
+    )
+
+_add_numerical_flux_internal!(device, fn::F, dydt, args...) where {F} = error(
+    "add_numerical_flux_internal! is not implemented for $device; load CUDA.jl for CUDADevice support",
+)
+
+# Face residual increments for one interior face node. Shared by numerical
+# flux (antisymmetric) and symmetric lifting; geometry loops pass `mode`.
+@inline function _face_side_increments(
+    ::Val{:numflux},
+    fn::F,
+    sWJ,
+    normal,
+    argvals⁻,
+    argvals⁺,
+) where {F}
+    val = add_auto_broadcasters(fn(normal, argvals⁻, argvals⁺))
+    δ = sWJ * val
+    return (-δ, δ)
+end
+
+@inline function _face_side_increments(
+    ::Val{:lifting},
+    fn::F,
+    sWJ,
+    normal,
+    argvals⁻,
+    argvals⁺,
+) where {F}
+    lift⁻ = add_auto_broadcasters(fn(normal, argvals⁻, argvals⁺))
+    lift⁺ = add_auto_broadcasters(fn(-normal, argvals⁺, argvals⁻))
+    return (sWJ * lift⁻, sWJ * lift⁺)
+end
+
+function _add_numerical_flux_internal!(
+    ::ClimaComms.AbstractCPUDevice,
+    fn::F,
+    dydt,
+    args...,
+) where {F}
+    _add_interior_face_flux!(Val(:numflux), fn, dydt, args...)
+end
+
+# Topology dispatch for CPU interior-face updates (numflux or lifting).
+function _add_interior_face_flux!(mode::Val, fn::F, dydt, args...) where {F}
     space = axes(dydt)
+    grid = Spaces.grid(space)
+    if grid isa Grids.ExtrudedFiniteDifferenceGrid
+        if grid.horizontal_grid isa Grids.SpectralElementGrid1D
+            return _add_interior_face_flux_extruded_1d!(mode, fn, dydt, args...)
+        elseif grid.horizontal_grid isa Grids.SpectralElementGrid2D
+            return _add_interior_face_flux_extruded_2d!(mode, fn, dydt, args...)
+        end
+    end
+    return _add_interior_face_flux_2d!(mode, fn, dydt, args...)
+end
+
+# Pure 2D spectral element space (precomputed internal surface geometry).
+function _add_interior_face_flux_2d!(mode::Val, fn::F, dydt, args...) where {F}
+    space = axes(dydt)
+    grid = Spaces.grid(space)
     Nq = Quadratures.degrees_of_freedom(Spaces.quadrature_style(space))
     topology = Spaces.topology(space)
-    internal_surface_geometry = Spaces.grid(space).internal_surface_geometry
+    internal_surface_geometry = grid.internal_surface_geometry
     dydt_bc = Base.broadcastable(dydt)
     args_bc =
         map(arg -> arg isa Fields.Field ? Base.broadcastable(arg) : arg, args)
@@ -35,13 +164,13 @@ function add_numerical_flux_internal!(fn, dydt, args...)
     for (iface, (elem⁻, face⁻, elem⁺, face⁺, reversed)) in
         enumerate(Topologies.interior_faces(topology))
 
-        internal_surface_geometry_slab = slab(internal_surface_geometry, 1, iface)
+        internal_surface_geometry_slab = slab(internal_surface_geometry, iface)
 
-        arg_slabs⁻ = map(arg -> slab(Fields.todata(arg), 1, elem⁻), args_bc)
-        arg_slabs⁺ = map(arg -> slab(Fields.todata(arg), 1, elem⁺), args_bc)
+        arg_slabs⁻ = map(arg -> slab(Fields.todata(arg), elem⁻), args_bc)
+        arg_slabs⁺ = map(arg -> slab(Fields.todata(arg), elem⁺), args_bc)
 
-        dydt_slab⁻ = slab(Fields.field_values(dydt_bc), 1, elem⁻)
-        dydt_slab⁺ = slab(Fields.field_values(dydt_bc), 1, elem⁺)
+        dydt_slab⁻ = slab(Fields.field_values(dydt_bc), elem⁻)
+        dydt_slab⁺ = slab(Fields.field_values(dydt_bc), elem⁺)
 
         for q in 1:Nq
             sgeom⁻ = internal_surface_geometry_slab[q]
@@ -50,60 +179,203 @@ function add_numerical_flux_internal!(fn, dydt, args...)
             i⁺, j⁺ = Topologies.face_node_index(face⁺, Nq, q, reversed)
 
             argvals⁻ = map(
-                slab -> slab isa DataLayouts.DataLayout ? slab[1, i⁻, j⁻, 1] : slab,
+                slab_ ->
+                    slab_ isa DataLayouts.DataLayout ? slab_[1, i⁻, j⁻, 1] :
+                    slab_,
                 arg_slabs⁻,
             )
             argvals⁺ = map(
-                slab -> slab isa DataLayouts.DataLayout ? slab[1, i⁺, j⁺, 1] : slab,
+                slab_ ->
+                    slab_ isa DataLayouts.DataLayout ? slab_[1, i⁺, j⁺, 1] :
+                    slab_,
                 arg_slabs⁺,
             )
-            numflux⁻ =
-                add_auto_broadcasters(fn(sgeom⁻.normal, argvals⁻, argvals⁺))
 
-            dydt_slab⁻[1, i⁻, j⁻, 1] =
-                dydt_slab⁻[1, i⁻, j⁻, 1] - (sgeom⁻.sWJ * numflux⁻)
-            dydt_slab⁺[1, i⁺, j⁺, 1] =
-                dydt_slab⁺[1, i⁺, j⁺, 1] + (sgeom⁻.sWJ * numflux⁻)
+            δ⁻, δ⁺ = _face_side_increments(
+                mode,
+                fn,
+                sgeom⁻.sWJ,
+                sgeom⁻.normal,
+                argvals⁻,
+                argvals⁺,
+            )
+            dydt_slab⁻[1, i⁻, j⁻, 1] = dydt_slab⁻[1, i⁻, j⁻, 1] + δ⁻
+            dydt_slab⁺[1, i⁺, j⁺, 1] = dydt_slab⁺[1, i⁺, j⁺, 1] + δ⁺
         end
     end
+    return dydt
+end
+
+# Extruded plane: SpectralElementSpace1D × finite-difference vertical.
+# Surface geometry from product local geometry (sWJ carries vertical measure).
+function _add_interior_face_flux_extruded_1d!(
+    mode::Val,
+    fn::F,
+    dydt,
+    args...,
+) where {F}
+    space = axes(dydt)
+    Nq = Quadratures.degrees_of_freedom(Spaces.quadrature_style(space))
+    Nv = Spaces.nlevels(space)
+    topology = Spaces.topology(space)
+    local_geometry = Spaces.local_geometry_data(space)
+
+    dydt_data = Fields.field_values(dydt)
+    args_data = map(
+        arg -> arg isa Fields.Field ? Fields.field_values(arg) : arg,
+        args,
+    )
+
+    for v in 1:Nv
+        for (elem⁻, face⁻, elem⁺, face⁺, _reversed) in
+            Topologies.interior_faces(topology)
+
+            i⁻ = face_node_index_1d(face⁻, Nq)
+            i⁺ = face_node_index_1d(face⁺, Nq)
+
+            lg⁻ = slab(local_geometry, v, elem⁻)[i⁻]
+            sgeom⁻ = compute_surface_geometry_1d(lg⁻, face⁻)
+
+            argvals⁻ = map(args_data) do arg
+                val =
+                    arg isa DataLayouts.AbstractData ?
+                    slab(arg, v, elem⁻)[i⁻] : arg
+                add_auto_broadcasters(val)
+            end
+            argvals⁺ = map(args_data) do arg
+                val =
+                    arg isa DataLayouts.AbstractData ?
+                    slab(arg, v, elem⁺)[i⁺] : arg
+                add_auto_broadcasters(val)
+            end
+
+            δ⁻, δ⁺ = _face_side_increments(
+                mode,
+                fn,
+                sgeom⁻.sWJ,
+                sgeom⁻.normal,
+                argvals⁻,
+                argvals⁺,
+            )
+            dydt_slab⁻ = slab(dydt_data, v, elem⁻)
+            dydt_slab⁺ = slab(dydt_data, v, elem⁺)
+            dydt_slab⁻[i⁻] = dydt_slab⁻[i⁻] + δ⁻
+            dydt_slab⁺[i⁺] = dydt_slab⁺[i⁺] + δ⁺
+        end
+    end
+    return dydt
+end
+
+# Extruded 3D: SpectralElementSpace2D horizontal × finite-difference vertical
+# (e.g. cubed-sphere shell). Normals in local orthonormal UV frame.
+function _add_interior_face_flux_extruded_2d!(
+    mode::Val,
+    fn::F,
+    dydt,
+    args...,
+) where {F}
+    space = axes(dydt)
+    quadrature_style = Spaces.quadrature_style(space)
+    Nq = Quadratures.degrees_of_freedom(quadrature_style)
+    Nv = Spaces.nlevels(space)
+    topology = Spaces.topology(space)
+    local_geometry = Spaces.local_geometry_data(space)
+    FT = Spaces.undertype(space)
+    (_, quad_weights) = Quadratures.quadrature_points(FT, quadrature_style)
+
+    dydt_data = Fields.field_values(dydt)
+    args_data = map(
+        arg -> arg isa Fields.Field ? Fields.field_values(arg) : arg,
+        args,
+    )
+
+    for v in 1:Nv
+        for (elem⁻, face⁻, elem⁺, face⁺, reversed) in
+            Topologies.interior_faces(topology)
+
+            dydt_slab⁻ = slab(dydt_data, v, elem⁻)
+            dydt_slab⁺ = slab(dydt_data, v, elem⁺)
+
+            for q in 1:Nq
+                i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, q, false)
+                i⁺, j⁺ = Topologies.face_node_index(face⁺, Nq, q, reversed)
+
+                lg⁻ = slab(local_geometry, v, elem⁻)[1, i⁻, j⁻, 1]
+                sgeom⁻ = compute_surface_geometry_extruded_2d(
+                    lg⁻,
+                    quad_weights,
+                    face⁻,
+                    i⁻,
+                    j⁻,
+                )
+
+                argvals⁻ = map(args_data) do arg
+                    val =
+                        arg isa DataLayouts.AbstractData ?
+                        slab(arg, v, elem⁻)[1, i⁻, j⁻, 1] : arg
+                    add_auto_broadcasters(val)
+                end
+                argvals⁺ = map(args_data) do arg
+                    val =
+                        arg isa DataLayouts.AbstractData ?
+                        slab(arg, v, elem⁺)[1, i⁺, j⁺, 1] : arg
+                    add_auto_broadcasters(val)
+                end
+
+                δ⁻, δ⁺ = _face_side_increments(
+                    mode,
+                    fn,
+                    sgeom⁻.sWJ,
+                    sgeom⁻.normal,
+                    argvals⁻,
+                    argvals⁺,
+                )
+                dydt_slab⁻[1, i⁻, j⁻, 1] = dydt_slab⁻[1, i⁻, j⁻, 1] + δ⁻
+                dydt_slab⁺[1, i⁺, j⁺, 1] = dydt_slab⁺[1, i⁺, j⁺, 1] + δ⁺
+            end
+        end
+    end
+    return dydt
 end
 
 """
-    CentralNumericalFlux(fluxfn)
+    PeriodicBC <: AbstractBoundaryCondition
 
-Evaluates the central numerical flux using `fluxfn`.
+Periodic boundary condition (handled by topology, no ghost state needed).
 """
-struct CentralNumericalFlux{F}
-    fluxfn::F
-end
-
-function (fn::CentralNumericalFlux)(normal, argvals⁻, argvals⁺)
-    F⁻ = add_auto_broadcasters(fn.fluxfn(argvals⁻...))
-    F⁺ = add_auto_broadcasters(fn.fluxfn(argvals⁺...))
-    return ((F⁻ + F⁺) / 2)' * normal
-end
+struct PeriodicBC <: AbstractBoundaryCondition end
 
 """
-    RusanovNumericalFlux(fluxfn, wavespeedfn)
+    ReflectingWallBC <: AbstractBoundaryCondition
 
-Evaluates the Rusanov numerical flux using `fluxfn` with wavespeed `wavespeedfn`
+Reflecting wall boundary condition (no-normal-flow).
+Reflects normal momentum component; preserves density and potential temperature.
 """
-struct RusanovNumericalFlux{F, W}
-    fluxfn::F
-    wavespeedfn::W
+struct ReflectingWallBC <: AbstractBoundaryCondition end
+
+"""
+    ghost_state(bc::AbstractBoundaryCondition, normal, argvals⁻)
+
+Construct the exterior-side argument tuple for the given BC.
+
+Returns a tuple with the same length as `argvals⁻`, replacing only the
+prognostic state `argvals⁻[1]` with the ghost state; remaining arguments
+(e.g. equation parameters, coordinates) are forwarded unchanged.
+"""
+function ghost_state(::AbstractBoundaryCondition, normal, argvals⁻)
+    error("ghost_state not implemented for this boundary condition")
 end
 
-function (fn::RusanovNumericalFlux)(normal, argvals⁻, argvals⁺)
+function ghost_state(::ReflectingWallBC, normal, argvals⁻)
     y⁻ = argvals⁻[1]
-    y⁺ = argvals⁺[1]
-    F⁻ = add_auto_broadcasters(fn.fluxfn(argvals⁻...))
-    F⁺ = add_auto_broadcasters(fn.fluxfn(argvals⁺...))
-    λ = max(fn.wavespeedfn(argvals⁻...), fn.wavespeedfn(argvals⁺...))
-    return ((F⁻ + F⁺) / 2)' * normal + (λ / 2) * (y⁻ - y⁺)
+    ρu⁺ = y⁻.ρu - 2 * LinearAlgebra.dot(y⁻.ρu, normal) * normal
+    # y⁻ may arrive wrapped in an AutoBroadcaster at element boundaries;
+    # unwrap before merge so we always work with a plain NamedTuple.
+    y⁺ = merge(unwrap(y⁻), (ρu = ρu⁺,))
+    return (y⁺, argvals⁻[2:end]...)
 end
 
-
-function add_numerical_flux_boundary!(fn, dydt, args...)
+function add_numerical_flux_boundary!(fn::F, dydt, args...) where {F}
     space = axes(dydt)
     Nq = Quadratures.degrees_of_freedom(Spaces.quadrature_style(space))
     topology = Spaces.topology(space)
@@ -137,4 +409,429 @@ function add_numerical_flux_boundary!(fn, dydt, args...)
         end
     end
     return dydt
+end
+
+"""
+    add_numerical_flux_boundary!(numflux::AbstractNumericalFlux, bc::AbstractBoundaryCondition, dydt, args...)
+
+Add numerical flux at boundaries using a typed boundary condition.
+Constructs the ghost state via `ghost_state(bc, normal, argvals⁻)` and applies the numerical flux.
+"""
+function add_numerical_flux_boundary!(
+    numflux::AbstractNumericalFlux,
+    bc::AbstractBoundaryCondition,
+    dydt,
+    args...,
+)
+    add_numerical_flux_boundary!(dydt, args...) do normal, argvals⁻
+        argvals⁺ = ghost_state(bc, normal, argvals⁻)
+        numflux(normal, argvals⁻, argvals⁺)
+    end
+end
+
+# ---------------------------------------------------------------------------
+# Symmetric face lifting for non-conservative (gradient / curl) terms
+# ---------------------------------------------------------------------------
+
+"""
+    add_lifting_flux_internal!(fn, dydt, args...)
+
+Add *symmetric* face lifting terms at internal faces — the DG correction for
+non-conservative (gradient / curl) terms, where both sides of a face receive
+their own correction rather than equal-and-opposite fluxes:
+
+    dydt⁻ += sWJ * fn(n̂⁻, argvals⁻, argvals⁺)
+    dydt⁺ += sWJ * fn(n̂⁺, argvals⁺, argvals⁻)
+
+with `n̂⁻ = -n̂⁺` the outward unit normals. For example, the strong-form DG
+gradient of a scalar `q` is completed by `fn(n̂, (q⁻,), (q⁺,)) = ((q⁺ − q⁻)/2) * n̂`
+(the lifting of `(q* − q⁻) n̂` with a central interface value `q*`).
+
+`dydt` must be in mass-weighted residual form (`WJ * ∂Y/∂t`), matching
+[`add_numerical_flux_internal!`](@ref). Implemented for pure 2D spectral
+element spaces and for extruded spaces with 1D (plane) or 2D (e.g.
+cubed-sphere) horizontal spectral elements.
+"""
+add_lifting_flux_internal!(fn::F, dydt, args...) where {F} =
+    _add_lifting_flux_internal!(
+        ClimaComms.device(axes(dydt)),
+        fn,
+        dydt,
+        args...,
+    )
+
+_add_lifting_flux_internal!(device, fn::F, dydt, args...) where {F} = error(
+    "add_lifting_flux_internal! is not implemented for $device; load CUDA.jl for CUDADevice support",
+)
+
+function _add_lifting_flux_internal!(
+    ::ClimaComms.AbstractCPUDevice,
+    fn::F,
+    dydt,
+    args...,
+) where {F}
+    _add_interior_face_flux!(Val(:lifting), fn, dydt, args...)
+end
+
+"""
+    lifting_correction(fn, ::Type{T}, args...)
+
+WJ-normalized DG face-lifting correction field of element type `T`: applies
+[`add_lifting_flux_internal!`](@ref) with face function `fn` to a zero
+residual on the space of `args[1]` and divides by `WJ`. The result is the
+correction to the corresponding element-local strong-form operator.
+"""
+function lifting_correction(fn::F, ::Type{T}, args...) where {F, T}
+    space = axes(args[1])
+    lgeom = Fields.local_geometry_field(space)
+    r = similar(args[1], T)
+    fill!(parent(r), 0)
+    add_lifting_flux_internal!(fn, r, args...)
+    return r ./ lgeom.WJ
+end
+
+# ---------------------------------------------------------------------------
+# Flux-differencing (split-form / FDDG) volume divergence
+# ---------------------------------------------------------------------------
+
+@inline _fd_add(a::NamedTuple, b::NamedTuple) = map(_fd_add, a, b)
+@inline _fd_add(a, b) = a + b
+
+@inline _fd_scale(c, x::NamedTuple) = map(v -> _fd_scale(c, v), x)
+@inline _fd_scale(c, x) = c * x
+
+# Metric-scaled contravariant basis vector J ∂ξʳᵒʷ/∂x, projected onto the
+# local orthonormal horizontal frame (single-valued at shared nodes, including
+# across cubed-sphere panel edges).
+@inline _fd_metric_vector(local_geometry, row) = Geometry.project(
+    Geometry.UVAxis(),
+    local_geometry.J * local_geometry.∂ξ∂x[row, :],
+)
+
+"""
+    add_flux_differencing_divergence!(fn2pt, dydt, y)
+
+Add the horizontal flux-differencing (split-form / FDDG) volume divergence to
+the mass-weighted residual `dydt` (Souza et al. 2023, JAMES, Eqs. 25–30):
+the collocation derivative acts on symmetric two-point fluxes along each
+reference direction.
+
+`fn2pt(nvec_a, nvec_b, y_a, y_b)` returns the two-point flux contracted with
+the (non-unit) nodal metric vectors in the local orthonormal horizontal frame.
+It must be jointly linear in `(nvec_a, nvec_b)`, symmetric under
+`(nvec_a, y_a) ↔ (nvec_b, y_b)`, and consistent
+(`fn2pt(n, n, y, y) == F(y)⋅n`). Kinetic-energy / entropy properties are
+fixed by this choice (e.g. Kennedy–Gruber → KEP).
+
+Stored in weak-equivalent form (strong flux-differencing plus one-sided
+boundary lifts), so it replaces `dydt = hwdiv(F) * (-WJ)` and composes with
+[`add_numerical_flux_internal!`](@ref) to give the FDDG SAT
+``F^* - F(y^-)⋅n̂``. SBP telescoping gives local conservation; global
+conservation follows from antisymmetric interface fluxes.
+
+Supports pure 2D spectral elements and extruded spaces with 2D horizontal
+elements.
+"""
+add_flux_differencing_divergence!(fn2pt::F, dydt, y) where {F} =
+    _add_flux_differencing_divergence!(
+        ClimaComms.device(axes(dydt)),
+        fn2pt,
+        dydt,
+        y,
+    )
+
+_add_flux_differencing_divergence!(device, fn2pt::F, dydt, y) where {F} = error(
+    "add_flux_differencing_divergence! is not implemented for $device; load CUDA.jl for CUDADevice support",
+)
+
+function _add_flux_differencing_divergence!(
+    ::ClimaComms.AbstractCPUDevice,
+    fn2pt::F,
+    dydt,
+    y,
+) where {F}
+    space = axes(dydt)
+    grid = Spaces.grid(space)
+    quadrature_style = Spaces.quadrature_style(space)
+    Nq = Quadratures.degrees_of_freedom(quadrature_style)
+    FT = Spaces.undertype(space)
+    (_, w) = Quadratures.quadrature_points(FT, quadrature_style)
+    D = Quadratures.differentiation_matrix(FT, quadrature_style)
+    topology = Spaces.topology(space)
+    Nh = Topologies.nlocalelems(topology)
+    local_geometry = Spaces.local_geometry_data(space)
+    dydt_data = Fields.field_values(dydt)
+    y_data = Fields.field_values(y)
+
+    if grid isa Grids.ExtrudedFiniteDifferenceGrid
+        @assert grid.horizontal_grid isa Grids.SpectralElementGrid2D
+        Nv = Spaces.nlevels(space)
+        for h in 1:Nh, v in 1:Nv
+            _fd_divergence_slab!(
+                fn2pt,
+                slab(dydt_data, v, h),
+                slab(y_data, v, h),
+                slab(local_geometry, v, h),
+                D,
+                w,
+                Val(Nq),
+            )
+        end
+    else
+        @assert grid isa Grids.SpectralElementGrid2D
+        for h in 1:Nh
+            _fd_divergence_slab!(
+                fn2pt,
+                slab(dydt_data, h),
+                slab(y_data, h),
+                slab(local_geometry, h),
+                D,
+                w,
+                Val(Nq),
+            )
+        end
+    end
+    return dydt
+end
+
+# Per-node flux-differencing body, shared by the CPU slab loop and
+# the CUDA kernel. Returns the
+# mass-weighted contribution (strong-form FD sum with coefficient
+# −2 wᵢ wⱼ D, plus the one-sided consistent-flux boundary lifts of the
+# weak-equivalent form; the outward sWJ·n̂ is ±(J a¹) wⱼ / ±(J a²) wᵢ,
+# matching compute_surface_geometry).
+@inline function _fd_volume_node_total(
+    fn2pt::F,
+    y_at::Y,
+    lg_at::L,
+    D,
+    w,
+    ::Val{Nq},
+    i,
+    j,
+) where {F, Y, L, Nq}
+    lg = lg_at(i, j)
+    Ja1 = _fd_metric_vector(lg, 1)
+    Ja2 = _fd_metric_vector(lg, 2)
+    y_ij = y_at(i, j)
+
+    c1 = -2 * w[i] * w[j] * D[i, 1]
+    total = fn2pt(
+        c1 * Ja1,
+        c1 * _fd_metric_vector(lg_at(1, j), 1),
+        y_ij,
+        y_at(1, j),
+    )
+    c2 = -2 * w[i] * w[j] * D[j, 1]
+    total = _fd_add(
+        total,
+        fn2pt(
+            c2 * Ja2,
+            c2 * _fd_metric_vector(lg_at(i, 1), 2),
+            y_ij,
+            y_at(i, 1),
+        ),
+    )
+    for k in 2:Nq
+        c1 = -2 * w[i] * w[j] * D[i, k]
+        t1 = fn2pt(
+            c1 * Ja1,
+            c1 * _fd_metric_vector(lg_at(k, j), 1),
+            y_ij,
+            y_at(k, j),
+        )
+        c2 = -2 * w[i] * w[j] * D[j, k]
+        t2 = fn2pt(
+            c2 * Ja2,
+            c2 * _fd_metric_vector(lg_at(i, k), 2),
+            y_ij,
+            y_at(i, k),
+        )
+        total = _fd_add(total, _fd_add(t1, t2))
+    end
+
+    i == 1 &&
+        (total = _fd_add(total, fn2pt(-w[j] * Ja1, -w[j] * Ja1, y_ij, y_ij)))
+    i == Nq &&
+        (total = _fd_add(total, fn2pt(w[j] * Ja1, w[j] * Ja1, y_ij, y_ij)))
+    j == 1 &&
+        (total = _fd_add(total, fn2pt(-w[i] * Ja2, -w[i] * Ja2, y_ij, y_ij)))
+    j == Nq &&
+        (total = _fd_add(total, fn2pt(w[i] * Ja2, w[i] * Ja2, y_ij, y_ij)))
+    return total
+end
+
+function _fd_divergence_slab!(
+    fn2pt::F,
+    dydt_slab,
+    y_slab,
+    lg_slab,
+    D,
+    w,
+    ::Val{Nq},
+) where {F, Nq}
+    # `let` rebinds the slabs so the node accessors are type-stable and do not
+    # box; `Val{Nq}` keeps the quadrature size in the type domain so the
+    # shared `_fd_volume_node_total` loop can unroll.
+    let y_slab = y_slab, lg_slab = lg_slab
+        y_at = (a, b) -> y_slab[1, a, b, 1]
+        lg_at = (a, b) -> lg_slab[1, a, b, 1]
+        for j in 1:Nq, i in 1:Nq
+            total = _fd_volume_node_total(
+                fn2pt,
+                y_at,
+                lg_at,
+                D,
+                w,
+                Val(Nq),
+                i,
+                j,
+            )
+            dydt_slab[1, i, j, 1] =
+                dydt_slab[1, i, j, 1] + add_auto_broadcasters(total)
+        end
+    end
+    return dydt_slab
+end
+
+# ---------------------------------------------------------------------------
+# DG connectivity buffer (device-resident; used by the GPU face kernels)
+# ---------------------------------------------------------------------------
+
+"""
+    DGConnectivity
+
+Cached, device-resident connectivity and face geometry for the DG
+internal-face operators (the DSS-buffer analog for DG):
+
+  - `faces`: `5 × nfaces` `Int32` matrix of interior faces
+    `(elem⁻, face⁻, elem⁺, face⁺, reversed)`;
+  - `sgeom`: precomputed [`Geometry.SurfaceGeometry`](@ref) per
+    `(q, level, face)` (level = 1 for pure 2D spaces), evaluated from the
+    minus side exactly as the CPU loops do;
+  - a deterministic gather map from element boundary nodes to their face
+    contributions, in ragged-array form (`node_*`, `node_offset`,
+    `contrib_*`): each boundary node `(elem, i, j)` lists the
+    `(face, side, q)` face-node slots that accumulate into it (2 entries at
+    element corners, 1 elsewhere), sorted at construction so the GPU gather
+    is bitwise deterministic.
+
+Built once per space by [`dg_connectivity`](@ref) and stored with the array
+type of the space's device (`ClimaComms.array_type`).
+"""
+struct DGConnectivity{FA, SG, IV}
+    nfaces::Int
+    nbnodes::Int
+    faces::FA
+    sgeom::SG
+    node_elem::IV
+    node_i::IV
+    node_j::IV
+    node_offset::IV
+    contrib_face::IV
+    contrib_side::IV
+    contrib_q::IV
+end
+
+"""
+    dg_connectivity(space)
+
+Memoized [`DGConnectivity`](@ref) for `space`, keyed on the underlying grid
+and the space type (so center/face extruded spaces get separate buffers).
+Stored in `Utilities.Cache.OBJECT_CACHE` alongside the grid objects, so
+`Utilities.Cache.clean_cache!` releases it (the buffer holds device arrays).
+"""
+function dg_connectivity(space)
+    key = (DGConnectivity, Spaces.grid(space), typeof(space))
+    return get!(() -> build_dg_connectivity(space), Cache.OBJECT_CACHE, key)
+end
+
+function build_dg_connectivity(space)
+    topology = Spaces.topology(space)
+    quadrature_style = Spaces.quadrature_style(space)
+    Nq = Quadratures.degrees_of_freedom(quadrature_style)
+    FT = Spaces.undertype(space)
+    grid = Spaces.grid(space)
+    extruded = grid isa Grids.ExtrudedFiniteDifferenceGrid
+    Nv = extruded ? Spaces.nlevels(space) : 1
+    (_, w) = Quadratures.quadrature_points(FT, quadrature_style)
+    DA = ClimaComms.array_type(topology)
+
+    ifaces = collect(Topologies.interior_faces(topology))
+    nfaces = length(ifaces)
+    faces = Matrix{Int32}(undef, 5, nfaces)
+
+    lg_host = Adapt.adapt(Array, Spaces.local_geometry_data(space))
+    SG = Geometry.SurfaceGeometry{FT, Geometry.UVVector{FT}}
+    sgeom = Array{SG}(undef, Nq, Nv, nfaces)
+
+    # (elem, i, j) → list of (face, side, q); side 1 = minus, 2 = plus
+    contrib = Dict{NTuple{3, Int}, Vector{NTuple{3, Int32}}}()
+    for (f, (elem⁻, face⁻, elem⁺, face⁺, reversed)) in enumerate(ifaces)
+        faces[:, f] .=
+            (elem⁻, face⁻, elem⁺, face⁺, reversed ? Int32(1) : Int32(0))
+        for q in 1:Nq
+            i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, q, false)
+            i⁺, j⁺ = Topologies.face_node_index(face⁺, Nq, q, reversed)
+            push!(
+                get!(() -> NTuple{3, Int32}[], contrib, (elem⁻, i⁻, j⁻)),
+                (Int32(f), Int32(1), Int32(q)),
+            )
+            push!(
+                get!(() -> NTuple{3, Int32}[], contrib, (elem⁺, i⁺, j⁺)),
+                (Int32(f), Int32(2), Int32(q)),
+            )
+            for v in 1:Nv
+                lg =
+                    extruded ?
+                    slab(lg_host, v, elem⁻)[1, i⁻, j⁻, 1] :
+                    slab(lg_host, elem⁻)[1, i⁻, j⁻, 1]
+                sgeom[q, v, f] = compute_surface_geometry_extruded_2d(
+                    lg,
+                    w,
+                    face⁻,
+                    i⁻,
+                    j⁻,
+                )
+            end
+        end
+    end
+
+    bnodes = sort!(collect(keys(contrib)))
+    nbnodes = length(bnodes)
+    node_elem = Vector{Int32}(undef, nbnodes)
+    node_i = Vector{Int32}(undef, nbnodes)
+    node_j = Vector{Int32}(undef, nbnodes)
+    node_offset = Vector{Int32}(undef, nbnodes + 1)
+    contrib_face = Int32[]
+    contrib_side = Int32[]
+    contrib_q = Int32[]
+    node_offset[1] = 1
+    for (n, key) in enumerate(bnodes)
+        (elem, i, j) = key
+        node_elem[n] = elem
+        node_i[n] = i
+        node_j[n] = j
+        entries = sort!(contrib[key])
+        for (f, side, q) in entries
+            push!(contrib_face, f)
+            push!(contrib_side, side)
+            push!(contrib_q, q)
+        end
+        node_offset[n + 1] = node_offset[n] + length(entries)
+    end
+
+    return DGConnectivity(
+        nfaces,
+        nbnodes,
+        DA(faces),
+        DA(sgeom),
+        DA(node_elem),
+        DA(node_i),
+        DA(node_j),
+        DA(node_offset),
+        DA(contrib_face),
+        DA(contrib_side),
+        DA(contrib_q),
+    )
 end

--- a/src/Operators/spectralelement.jl
+++ b/src/Operators/spectralelement.jl
@@ -1481,19 +1481,19 @@ function tensor_product!(
 end
 
 function tensor_product!(
-    out::DataLayouts.VIJHWithF{S, 1, Nij_out, Nij_out},
-    indata::DataLayouts.VIJHWithF{S, 1, Nij_in, Nij_in},
+    out::DataLayouts.VIJHWithF{S, Nv, Nij_out, Nij_out},
+    indata::DataLayouts.VIJHWithF{S, Nv, Nij_in, Nij_in},
     M::SMatrix{Nij_out, Nij_in},
-) where {S, Nij_out, Nij_in}
+) where {S, Nv, Nij_out, Nij_in}
     Nh = size(indata, 4)
     @assert Nh == size(out, 4)
 
     # temporary storage
     temp = MArray{Tuple{1, Nij_out, Nij_in, 1}, S, 4, Nij_out * Nij_in}(undef)
 
-    @inbounds for h in 1:Nh
-        in_slab = slab(indata, 1, h)
-        out_slab = slab(out, 1, h)
+    @inbounds for h in 1:Nh, v in 1:Nv
+        in_slab = slab(indata, v, h)
+        out_slab = slab(out, v, h)
         for j in 1:Nij_in, i in 1:Nij_out
             temp[1, i, j, 1] = rmatmul1(M, in_slab, i, j)
         end
@@ -1545,9 +1545,9 @@ function tensor_product!(
 end
 
 function tensor_product!(
-    inout::DataLayouts.VIJHWithF{S, 1, Nij, Nij},
+    inout::DataLayouts.VIJHWithF{S, Nv, Nij, Nij},
     M::SMatrix{Nij, Nij},
-) where {S, Nij}
+) where {S, Nv, Nij}
     inout_bc = Base.broadcastable(inout)
     tensor_product!(inout_bc, inout_bc, M)
 end

--- a/test/Operators/spectralelement/conv_dg_divergence.jl
+++ b/test/Operators/spectralelement/conv_dg_divergence.jl
@@ -38,7 +38,11 @@ function periodic_plane(::Type{FT}, nelem; L = FT(2π), Nq = 4) where {FT}
     )
     mesh = Meshes.RectilinearMesh(domain, nelem, nelem)
     topology = Topologies.Topology2D(context, mesh)
-    return Spaces.SpectralElementSpace2D(topology, Quadratures.GLL{Nq}())
+    return Spaces.SpectralElementSpace2D(
+        topology,
+        Quadratures.GLL{Nq}();
+        discontinuous = true,
+    )
 end
 
 include("utils_dg.jl") # dg_divergence
@@ -49,6 +53,7 @@ include("utils_dg.jl") # dg_divergence
     errs = zeros(FT, length(nelems))
     for (i, nelem) in enumerate(nelems)
         space = periodic_plane(FT, nelem)
+        @test !Spaces.is_continuous(space)
         coords = Fields.coordinate_field(space)
         uv = @. Geometry.UVVector(sin(coords.x), sin(coords.y))
         div_exact = @. cos(coords.x) + cos(coords.y)

--- a/test/Operators/spectralelement/unit_dg_boundary_fluxes.jl
+++ b/test/Operators/spectralelement/unit_dg_boundary_fluxes.jl
@@ -44,7 +44,11 @@ function channel_space(::Type{FT}; Lx = FT(2π), Ly = FT(2), nelem = 4, Nq = 4) 
     )
     mesh = Meshes.RectilinearMesh(domain, nelem, nelem)
     topology = Topologies.Topology2D(context, mesh)
-    return Spaces.SpectralElementSpace2D(topology, Quadratures.GLL{Nq}())
+    return Spaces.SpectralElementSpace2D(
+        topology,
+        Quadratures.GLL{Nq}();
+        discontinuous = true,
+    )
 end
 
 @testset "DG boundary numerical fluxes" begin
@@ -52,6 +56,7 @@ end
         Lx = FT(2π)
         Ly = FT(2)
         space = channel_space(FT; Lx, Ly)
+        @test !Spaces.is_continuous(space)
         coords = Fields.coordinate_field(space)
         q = ones(space)
 

--- a/test/Operators/spectralelement/unit_dg_stability.jl
+++ b/test/Operators/spectralelement/unit_dg_stability.jl
@@ -43,7 +43,11 @@ function dg_plane_space(::Type{FT}; L = FT(2π), xelem = 4, yelem = 4, Nq = 4) w
     )
     mesh = Meshes.RectilinearMesh(domain, xelem, yelem)
     topology = Topologies.Topology2D(context, mesh)
-    return Spaces.SpectralElementSpace2D(topology, Quadratures.GLL{Nq}())
+    return Spaces.SpectralElementSpace2D(
+        topology,
+        Quadratures.GLL{Nq}();
+        discontinuous = true,
+    )
 end
 
 # A smooth, single-valued scalar and velocity for a given space. The `+ 2`
@@ -68,6 +72,7 @@ end
     TU.@test_precisions FT begin
         for (name, space) in
             (("sphere", dg_sphere_space(FT)), ("plane", dg_plane_space(FT)))
+            @test !Spaces.is_continuous(space)
             lgeom = Fields.local_geometry_field(space)
             q, uv = smooth_state(space)
 
@@ -105,7 +110,9 @@ end
 
                 qd = copy(q)
                 Random.seed!(1234)
-                parent(qd) .+= FT(0.1) .* (rand(FT, size(parent(qd))) .- FT(0.5))
+                qd_cpu = Array(parent(qd))
+                qd_cpu .+= FT(0.1) .* (rand(FT, size(qd_cpu)) .- FT(0.5))
+                copyto!(parent(qd), qd_cpu)
                 rd = similar(qd)
                 fill!(parent(rd), 0)
                 Operators.add_numerical_flux_internal!(dg_jump_penalty, rd, qd)
@@ -120,7 +127,9 @@ end
                 # even across a discontinuity.
                 qd = copy(q)
                 Random.seed!(2024)
-                parent(qd) .+= FT(0.1) .* (rand(FT, size(parent(qd))) .- FT(0.5))
+                qd_cpu = Array(parent(qd))
+                qd_cpu .+= FT(0.1) .* (rand(FT, size(qd_cpu)) .- FT(0.5))
+                copyto!(parent(qd), qd_cpu)
                 uvd = copy(uv)
                 y = map((qi, uvi) -> (; q = qi, uv = uvi), qd, uvd)
                 r = similar(qd)

--- a/test/Operators/spectralelement/unit_extruded_sphere_dg.jl
+++ b/test/Operators/spectralelement/unit_extruded_sphere_dg.jl
@@ -1,0 +1,347 @@
+using Test
+using ClimaComms
+ClimaComms.@import_required_backends
+using LinearAlgebra
+using Random
+using IntervalSets
+import ClimaCore
+import ClimaCore:
+    Fields,
+    Domains,
+    Meshes,
+    Topologies,
+    Spaces,
+    Operators,
+    Geometry,
+    Quadratures
+
+@isdefined(TU) || include(
+    joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl"),
+);
+import .TestUtilities as TU
+
+# DG internal-face flux loops on an extruded cubed-sphere shell
+# (SpectralElementSpace2D horizontal × finite-difference vertical):
+# conservation, consistency at continuous fields, and equivalence of
+# weak divergence + central numerical flux with the strong divergence
+# (validates sWJ and normal scaling).
+
+function extruded_sphere_spaces(
+    ::Type{FT};
+    radius = FT(6.371e6),
+    zmax = FT(30e3),
+    helem = 4,
+    zelem = 4,
+    Nq = 4,
+) where {FT}
+    context = ClimaComms.context()
+    vdomain = Domains.IntervalDomain(
+        Geometry.ZPoint(zero(FT)),
+        Geometry.ZPoint(zmax);
+        boundary_names = (:bottom, :top),
+    )
+    vmesh = Meshes.IntervalMesh(vdomain, nelems = zelem)
+    vtopology = Topologies.IntervalTopology(ClimaComms.device(context), vmesh)
+    vspace = Spaces.CenterFiniteDifferenceSpace(vtopology)
+
+    hdomain = Domains.SphereDomain(radius)
+    hmesh = Meshes.EquiangularCubedSphere(hdomain, helem)
+    htopology = Topologies.Topology2D(context, hmesh)
+    hspace = Spaces.SpectralElementSpace2D(
+        htopology,
+        Quadratures.GLL{Nq}();
+        discontinuous = true,
+    )
+
+    center_space = Spaces.ExtrudedFiniteDifferenceSpace(hspace, vspace)
+    face_space = Spaces.FaceExtrudedFiniteDifferenceSpace(center_space)
+    return center_space, face_space
+end
+
+central_flux(normal, (y⁻,), (y⁺,)) =
+    ((y⁻.q * y⁻.uv + y⁺.q * y⁺.uv) / 2)' * normal
+
+jump_penalty(normal, (q⁻,), (q⁺,)) = (q⁻ - q⁺) / 2
+
+const grad_lift = Operators.central_gradient_lift
+const curl3_lift = Operators.central_curl3_lift
+const jump_lift = Operators.jump_penalty_lift
+
+@noinline function measured_fddg_allocs(fn::F, r, y) where {F}
+    Operators.add_flux_differencing_divergence!(fn, r, y)
+    return @allocated Operators.add_flux_differencing_divergence!(fn, r, y)
+end
+
+@testset "Extruded-sphere DG interface fluxes" begin
+    TU.@test_precisions FT begin
+        tol = FT == Float32 ? FT(1e-4) : FT(1e-10)
+        tol_sum = FT == Float32 ? FT(1e-5) : FT(1e-12)
+
+        center_space, face_space = extruded_sphere_spaces(FT)
+        @test !Spaces.is_continuous(center_space)
+        @test !Spaces.is_continuous(face_space)
+        ccoords = Fields.coordinate_field(center_space)
+        fcoords = Fields.coordinate_field(face_space)
+
+        smooth_scalar(coords) =
+            @. sind(coords.long) * cosd(coords.lat)^2 + coords.z / FT(30e3)
+
+        @testset "penalty flux vanishes for continuous fields (center & face) [$FT]" begin
+            for (space, coords) in
+                ((center_space, ccoords), (face_space, fcoords))
+                q = smooth_scalar(coords)
+                lgeom = Fields.local_geometry_field(space)
+                r = similar(q)
+                r .= 0
+                Operators.add_numerical_flux_internal!(jump_penalty, r, q)
+                rn = @. r / lgeom.WJ
+                @test maximum(abs, parent(rn)) < tol * maximum(abs, parent(q))
+            end
+        end
+
+        @testset "LDG penalty flux vanishes for continuous fields [$FT]" begin
+            # Isolate τ[[q]]: with G ≡ 0 the consistency term drops out, so the
+            # face residual must vanish when [[q]] ≈ 0.
+            q = smooth_scalar(ccoords)
+            grad = Operators.Gradient()
+            lgeom = Fields.local_geometry_field(center_space)
+            G0 = @. Geometry.UVVector(zero(grad(q)))
+            r = similar(q)
+            r .= 0
+            Operators.add_ldg_laplacian_flux_internal!(r, q, G0, FT(1), FT(1))
+            rn = @. r / lgeom.WJ
+            @test maximum(abs, parent(rn)) < tol * maximum(abs, parent(q))
+        end
+
+        @testset "lifting flux (UVVector-valued) vanishes for continuous fields [$FT]" begin
+            q = smooth_scalar(ccoords)
+            lgeom = Fields.local_geometry_field(center_space)
+            r = similar(q, Geometry.UVVector{FT})
+            fill!(parent(r), 0)
+            Operators.add_lifting_flux_internal!(grad_lift, r, q)
+            rn = @. r / lgeom.WJ
+            @test maximum(abs, parent(rn)) < tol * maximum(abs, parent(q))
+        end
+
+        @testset "central_curl3_lift vanishes for continuous fields [$FT]" begin
+            # Radial curl lifting from orthonormal (u, v) components: continuous
+            # tangential fields ⇒ zero interface correction.
+            u = @. cosd(ccoords.long)
+            v = @. -sind(ccoords.long) * sind(ccoords.lat)
+            lgeom = Fields.local_geometry_field(center_space)
+            r = similar(u)
+            fill!(parent(r), 0)
+            Operators.add_lifting_flux_internal!(curl3_lift, r, u, v)
+            rn = @. r / lgeom.WJ
+            scale = max(maximum(abs, parent(u)), maximum(abs, parent(v)))
+            @test maximum(abs, parent(rn)) < tol * scale
+        end
+
+        @testset "jump_penalty_lift vanishes for continuous fields & is sign-definite [$FT]" begin
+            # λ-scaled interface penalty: zero on continuous fields; for a
+            # discontinuous field the lifting energy ∑ q·r is < 0.
+            q = smooth_scalar(ccoords)
+            λ = ones(center_space)
+            lgeom = Fields.local_geometry_field(center_space)
+            rc = similar(q)
+            fill!(parent(rc), 0)
+            Operators.add_lifting_flux_internal!(jump_lift, rc, q, λ)
+            rn = @. rc / lgeom.WJ
+            @test maximum(abs, parent(rn)) < tol * maximum(abs, parent(q))
+
+            qd = copy(q)
+            Random.seed!(42)
+            qd_cpu = Array(parent(qd))
+            qd_cpu .+= FT(0.1) .* (rand(FT, size(qd_cpu)) .- FT(0.5))
+            copyto!(parent(qd), qd_cpu)
+            rd = similar(qd)
+            fill!(parent(rd), 0)
+            Operators.add_lifting_flux_internal!(jump_lift, rd, qd, λ)
+            @test sum(parent(qd) .* parent(rd)) < 0
+        end
+
+        @testset "central numerical flux conserves (node sum zero) [$FT]" begin
+            q = smooth_scalar(ccoords)
+            uv = @. Geometry.UVVector(
+                cosd(ccoords.long),
+                -sind(ccoords.long) * sind(ccoords.lat),
+            )
+            y = map((qi, uvi) -> (; q = qi, uv = uvi), q, uv)
+            r = similar(q)
+            r .= 0
+            Operators.add_numerical_flux_internal!(central_flux, r, y)
+            scale = sum(abs, parent(r))
+            @test abs(sum(parent(r))) < tol_sum * scale
+        end
+
+        @testset "pure-2D sphere: lifting & penalty fluxes vanish [$FT]" begin
+            context = ClimaComms.context()
+            hdomain = Domains.SphereDomain(FT(6.371e6))
+            hmesh = Meshes.EquiangularCubedSphere(hdomain, 4)
+            htopology = Topologies.Topology2D(context, hmesh)
+            hspace = Spaces.SpectralElementSpace2D(
+                htopology,
+                Quadratures.GLL{4}();
+                discontinuous = true,
+            )
+            @test !Spaces.is_continuous(hspace)
+            hcoords = Fields.coordinate_field(hspace)
+            lgeom = Fields.local_geometry_field(hspace)
+
+            q = @. sind(hcoords.long) * cosd(hcoords.lat)^2
+
+            r = similar(q)
+            r .= 0
+            Operators.add_numerical_flux_internal!(jump_penalty, r, q)
+            rn = @. r / lgeom.WJ
+            @test maximum(abs, parent(rn)) < tol * maximum(abs, parent(q))
+
+            rl = similar(q, Geometry.UVVector{FT})
+            fill!(parent(rl), 0)
+            Operators.add_lifting_flux_internal!(grad_lift, rl, q)
+            rln = @. rl / lgeom.WJ
+            @test maximum(abs, parent(rln)) < tol * maximum(abs, parent(q))
+
+            u = @. cosd(hcoords.long)
+            v = @. -sind(hcoords.long) * sind(hcoords.lat)
+            rcurl = similar(q)
+            fill!(parent(rcurl), 0)
+            Operators.add_lifting_flux_internal!(curl3_lift, rcurl, u, v)
+            rcurln = @. rcurl / lgeom.WJ
+            scale = max(maximum(abs, parent(u)), maximum(abs, parent(v)))
+            @test maximum(abs, parent(rcurln)) < tol * scale
+
+            λ = ones(hspace)
+            rj = similar(q)
+            fill!(parent(rj), 0)
+            Operators.add_lifting_flux_internal!(jump_lift, rj, q, λ)
+            rjn = @. rj / lgeom.WJ
+            @test maximum(abs, parent(rjn)) < tol * maximum(abs, parent(q))
+        end
+
+        @testset "flux-differencing: weak-form equivalence on flat rectangle [$FT]" begin
+            # On constant metrics, flux differencing with the arithmetic mean of
+            # pointwise fluxes reduces exactly to the conservative (weak) form.
+            context = ClimaComms.context()
+            L = FT(2e3)
+            rdomain = Domains.RectangleDomain(
+                Geometry.XPoint(zero(FT)) .. Geometry.XPoint(L),
+                Geometry.YPoint(zero(FT)) .. Geometry.YPoint(L),
+                x1periodic = true,
+                x2periodic = true,
+            )
+            rmesh = Meshes.RectilinearMesh(rdomain, 5, 5)
+            rtopology = Topologies.Topology2D(context, rmesh)
+            rspace = Spaces.SpectralElementSpace2D(
+                rtopology,
+                Quadratures.GLL{4}();
+                discontinuous = true,
+            )
+            @test !Spaces.is_continuous(rspace)
+            rcoords = Fields.coordinate_field(rspace)
+            rlgeom = Fields.local_geometry_field(rspace)
+
+            q =
+                @. sin(2 * FT(π) * rcoords.x / L) *
+                   cos(2 * FT(π) * rcoords.y / L) + FT(2)
+            uv = @. Geometry.UVVector(
+                cos(2 * FT(π) * rcoords.x / L),
+                sin(2 * FT(π) * rcoords.y / L),
+            )
+            y = map((qi, uvi) -> (; q = qi, uv = uvi), q, uv)
+
+            central_2pt(nvec_a, nvec_b, a, b) =
+                ((a.q * a.uv)' * nvec_a + (b.q * b.uv)' * nvec_b) / 2
+
+            r_fd = similar(q)
+            r_fd .= 0
+            Operators.add_flux_differencing_divergence!(central_2pt, r_fd, y)
+
+            hwdiv = Operators.WeakDivergence()
+            F = @. q * uv
+            r_weak = @. hwdiv(F) * (-(rlgeom.WJ))
+
+            scale = maximum(abs, parent(r_weak))
+            @test maximum(abs, parent(r_fd .- r_weak)) < tol_sum * scale
+
+            # LDG/SIPG consistency term: for a continuous flux G, weak κ∇·G
+            # plus −{{κG}}·n̂ recovers strong κ∇·G (same SBP as the first-order
+            # central-flux identity). One-sided grad(q) is discontinuous, so use
+            # the analytic gradient of q here.
+            κ = FT(1)
+            τ = FT(0)
+            hdiv = Operators.Divergence()
+            G_uv = @. Geometry.UVVector(
+                (2 * FT(π) / L) *
+                cos(2 * FT(π) * rcoords.x / L) *
+                cos(2 * FT(π) * rcoords.y / L),
+                -(2 * FT(π) / L) *
+                sin(2 * FT(π) * rcoords.x / L) *
+                sin(2 * FT(π) * rcoords.y / L),
+            )
+            G_c12 =
+                Geometry.transform.(Ref(Geometry.Contravariant12Axis()), G_uv)
+            r_ldg = @. (-(rlgeom.WJ)) * κ * (-hwdiv(G_c12))
+            Operators.add_ldg_laplacian_flux_internal!(r_ldg, q, G_uv, κ, τ)
+            r_lap_strong = @. rlgeom.WJ * κ * hdiv(G_c12)
+            scale_lap = maximum(abs, parent(r_lap_strong))
+            @test maximum(abs, parent(r_ldg .- r_lap_strong)) < tol * scale_lap
+
+            # Check allocations
+            allocs = measured_fddg_allocs(central_2pt, r_fd, y)
+            if !(ClimaComms.device() isa ClimaComms.CUDADevice) &&
+               TU.allocation_checks_meaningful()
+                @test allocs == 0
+            end
+        end
+
+        @testset "flux-differencing: per-element telescoping on the sphere [$FT]" begin
+            # By SBP, the FD volume sum and the own-side lifts cancel in the node
+            # sum of every element, for any symmetric consistent two-point flux.
+            q = smooth_scalar(ccoords)
+            uv = @. Geometry.UVVector(
+                cosd(ccoords.long),
+                -sind(ccoords.long) * sind(ccoords.lat),
+            )
+            y = map((qi, uvi) -> (; q = qi, uv = uvi), q, uv)
+
+            kg_2pt(nvec_a, nvec_b, a, b) =
+                ((a.q + b.q) / 2) * ((a.uv' * nvec_a + b.uv' * nvec_b) / 2)
+
+            r = similar(q)
+            r .= 0
+            Operators.add_flux_differencing_divergence!(kg_2pt, r, y)
+            scale = sum(abs, parent(r))
+            @test abs(sum(parent(r))) < tol_sum * scale
+
+            # Check allocations
+            allocs = measured_fddg_allocs(kg_2pt, r, y)
+            if !(ClimaComms.device() isa ClimaComms.CUDADevice) &&
+               TU.allocation_checks_meaningful()
+                @test allocs == 0
+            end
+        end
+
+        @testset "weak divergence + central flux equals strong divergence [$FT]" begin
+            hwdiv = Operators.WeakDivergence()
+            hdiv = Operators.Divergence()
+            lgeom = Fields.local_geometry_field(center_space)
+
+            uv = @. Geometry.UVVector(
+                cosd(ccoords.long),
+                -sind(ccoords.long) * sind(ccoords.lat),
+            )
+            F = Geometry.transform.(Ref(Geometry.Contravariant12Axis()), uv)
+            q = ones(center_space)
+            y = map((qi, uvi) -> (; q = qi, uv = uvi), q, uv)
+
+            dy_mw = @. hwdiv(F) * (-(lgeom.WJ))
+            Operators.add_numerical_flux_internal!(central_flux, dy_mw, y)
+            dy = @. dy_mw / lgeom.WJ
+
+            dy_strong = @. -hdiv(F)
+            scale = maximum(abs, parent(dy_strong))
+            @test maximum(abs, parent(dy .- dy_strong)) < tol * scale
+        end
+    end
+end

--- a/test/Operators/spectralelement/unit_sphere_dg_fluxes.jl
+++ b/test/Operators/spectralelement/unit_sphere_dg_fluxes.jl
@@ -28,10 +28,20 @@ include("utils_dg.jl")  # dg_sphere_space, dg_jump_penalty
 # non-constant states, on both the sphere and a plane — in
 # unit_dg_stability.jl.
 
+# The `for FT` closure below captures `FT::DataType`, so every local derived
+# from it is `Any`-typed and an inline `@allocated` there measures dynamic
+# dispatch, not the operator. This barrier specializes on the concrete
+# argument types, so the measurement runs in a typed frame.
+@noinline function measured_flux_allocs(fn::F, r, q) where {F}
+    Operators.add_numerical_flux_internal!(fn, r, q)
+    return @allocated Operators.add_numerical_flux_internal!(fn, r, q)
+end
+
 @testset "Cubed-Sphere DG Interface Fluxes" begin
     for FT in (Float32, Float64)
         ClimaComms.allowscalar(ClimaComms.device()) do
             space = dg_sphere_space(FT)
+            @test !Spaces.is_continuous(space)
             coords = Fields.coordinate_field(space)
             lgeom = Fields.local_geometry_field(space)
 
@@ -52,9 +62,7 @@ include("utils_dg.jl")  # dg_sphere_space, dg_jump_penalty
                 q = smooth_scalar(coords)
                 r = similar(q)
                 fill!(parent(r), 0)
-                Operators.add_numerical_flux_internal!(dg_jump_penalty, r, q)
-                allocs =
-                    @allocated Operators.add_numerical_flux_internal!(dg_jump_penalty, r, q)
+                allocs = measured_flux_allocs(dg_jump_penalty, r, q)
                 if !(ClimaComms.device() isa ClimaComms.CUDADevice) &&
                    TU.allocation_checks_meaningful()
                     @test allocs == 0

--- a/test/Operators/spectralelement/unit_two_point_fluxes.jl
+++ b/test/Operators/spectralelement/unit_two_point_fluxes.jl
@@ -13,14 +13,13 @@ import ClimaCore:
     Operators,
     Geometry,
     Quadratures
-import ClimaCore.Geometry: ⊗
 
-include("utils_dg.jl")  # dg_sphere_space
+include("utils_dg.jl")  # dg_sphere_space, sw_flux, sw_wavespeed, sw_roeflux
 
 # Two-point DG interface numerical-flux tests using ClimaCore's exported operators:
 # - `Operators.CentralNumericalFlux`
 # - `Operators.RusanovNumericalFlux`
-# - Custom Roe numerical flux (as functor)
+# - Custom Roe numerical flux `sw_roeflux` (from utils_dg.jl)
 #
 # Properties verified:
 #   1. Consistency: dissipation vanishes on single-valued (continuous) fields
@@ -29,87 +28,11 @@ include("utils_dg.jl")  # dg_sphere_space
 # (The zero-allocation sentinel for `add_numerical_flux_internal!` lives in
 # unit_sphere_dg_fluxes.jl.)
 
-function sw_flux(state, p)
-    ρ, ρu, ρθ = state.ρ, state.ρu, state.ρθ
-    u = ρu / ρ
-    FT = eltype(ρ)
-    I_tensor =
-        (Geometry.UVVector(FT(1), FT(0)) ⊗ Geometry.UVVector(FT(1), FT(0))) +
-        (Geometry.UVVector(FT(0), FT(1)) ⊗ Geometry.UVVector(FT(0), FT(1)))
-    return (
-        ρ = ρu,
-        ρu = (ρu ⊗ u) + (p.g * ρ^2 / 2) * I_tensor,
-        ρθ = ρθ * u,
-    )
-end
-
-function sw_wavespeed(state, p)
-    return sqrt(p.g)
-end
-
-function roe_average(ρ⁻, ρ⁺, v⁻, v⁺)
-    return (sqrt(ρ⁻) * v⁻ + sqrt(ρ⁺) * v⁺) / (sqrt(ρ⁻) + sqrt(ρ⁺))
-end
-
-function sw_roeflux(normal, (y⁻, params⁻), (y⁺, params⁺))
-    λ = sqrt(params⁻.g)
-    ρ⁻, ρu⁻, ρθ⁻ = y⁻.ρ, y⁻.ρu, y⁻.ρθ
-    ρ⁺, ρu⁺, ρθ⁺ = y⁺.ρ, y⁺.ρu, y⁺.ρθ
-
-    u⁻ = ρu⁻ / ρ⁻
-    θ⁻ = ρθ⁻ / ρ⁻
-    uₙ⁻ = u⁻' * normal
-
-    u⁺ = ρu⁺ / ρ⁺
-    θ⁺ = ρθ⁺ / ρ⁺
-    uₙ⁺ = u⁺' * normal
-
-    p⁻ = (λ * ρ⁻)^2 * 0.5
-    c⁻ = λ * sqrt(ρ⁻)
-    p⁺ = (λ * ρ⁺)^2 * 0.5
-    c⁺ = λ * sqrt(ρ⁺)
-
-    ρ̄ = sqrt(ρ⁻ * ρ⁺)
-    ū = roe_average(ρ⁻, ρ⁺, u⁻, u⁺)
-    θ̄ = roe_average(ρ⁻, ρ⁺, θ⁻, θ⁺)
-    c̄ = roe_average(ρ⁻, ρ⁺, c⁻, c⁺)
-    ūₙ = ū' * normal
-
-    Δρ = ρ⁺ - ρ⁻
-    Δp = p⁺ - p⁻
-    Δu = u⁺ - u⁻
-    Δρθ = ρθ⁺ - ρθ⁻
-    Δuₙ = Δu' * normal
-
-    c⁻² = 1 / c̄^2
-    w1 = abs(ūₙ - c̄) * (Δp - ρ̄ * c̄ * Δuₙ) * 0.5 * c⁻²
-    w2 = abs(ūₙ + c̄) * (Δp + ρ̄ * c̄ * Δuₙ) * 0.5 * c⁻²
-    w3 = abs(ūₙ) * (Δρ - Δp * c⁻²)
-    w4 = abs(ūₙ) * ρ̄
-    w5 = abs(ūₙ) * (Δρθ - θ̄ * Δp * c⁻²)
-
-    fluxᵀn_ρ = (w1 + w2 + w3) * 0.5
-    fluxᵀn_ρu =
-        (
-            w1 * (ū - c̄ * normal) + w2 * (ū + c̄ * normal) + w3 * ū +
-            w4 * (Δu - Δuₙ * normal)
-        ) * 0.5
-    fluxᵀn_ρθ = ((w1 + w2) * θ̄ + w5) * 0.5
-    Δf = (ρ = -fluxᵀn_ρ, ρu = -fluxᵀn_ρu, ρθ = -fluxᵀn_ρθ)
-
-    F⁻ = sw_flux(y⁻, params⁻)
-    F⁺ = sw_flux(y⁺, params⁺)
-    return (
-        ρ = ((F⁻.ρ + F⁺.ρ) / 2)' * normal + Δf.ρ,
-        ρu = ((F⁻.ρu + F⁺.ρu) / 2)' * normal + Δf.ρu,
-        ρθ = ((F⁻.ρθ + F⁺.ρθ) / 2)' * normal + Δf.ρθ,
-    )
-end
-
 @testset "Two-Point DG Numerical Fluxes on the Sphere" begin
     for FT in (Float32, Float64)
         ClimaComms.allowscalar(ClimaComms.device()) do
             space = dg_sphere_space(FT)
+            @test !Spaces.is_continuous(space)
             coords = Fields.coordinate_field(space)
 
             params = (; g = FT(9.81))

--- a/test/Operators/spectralelement/utils_dg.jl
+++ b/test/Operators/spectralelement/utils_dg.jl
@@ -11,8 +11,11 @@ import ClimaCore:
     Quadratures,
     Spaces,
     Topologies
+import ClimaCore.Geometry: ⊗
 
 # The standard cubed-sphere spectral-element space used by the DG tests.
+# `discontinuous = true` marks the grid as DG (skips DSS; see
+# `test/Spaces/unit_discontinuous_spaces.jl`).
 function dg_sphere_space(
     ::Type{FT};
     radius = FT(6.371e6),
@@ -23,7 +26,11 @@ function dg_sphere_space(
     hdomain = Domains.SphereDomain(radius)
     hmesh = Meshes.EquiangularCubedSphere(hdomain, helem)
     htopology = Topologies.Topology2D(context, hmesh)
-    return Spaces.SpectralElementSpace2D(htopology, Quadratures.GLL{Nq}())
+    return Spaces.SpectralElementSpace2D(
+        htopology,
+        Quadratures.GLL{Nq}();
+        discontinuous = true,
+    )
 end
 
 # Central numerical flux of the physical flux q*u through the face normal,
@@ -50,4 +57,86 @@ function dg_divergence(uv)
     r = @. hwdiv(F) * (-(lgeom.WJ))
     Operators.add_numerical_flux_internal!(dg_central_flux_uv, r, uv)
     return @. -r / lgeom.WJ
+end
+
+# ---------------------------------------------------------------------------
+# Shallow-water physical flux + Roe interface flux (test-local; not Operators)
+# ---------------------------------------------------------------------------
+
+function sw_flux(state, p)
+    ρ, ρu, ρθ = state.ρ, state.ρu, state.ρθ
+    u = ρu / ρ
+    FT = eltype(ρ)
+    I_tensor =
+        (Geometry.UVVector(FT(1), FT(0)) ⊗ Geometry.UVVector(FT(1), FT(0))) +
+        (Geometry.UVVector(FT(0), FT(1)) ⊗ Geometry.UVVector(FT(0), FT(1)))
+    return (
+        ρ = ρu,
+        ρu = (ρu ⊗ u) + (p.g * ρ^2 / 2) * I_tensor,
+        ρθ = ρθ * u,
+    )
+end
+
+sw_wavespeed(state, p) = sqrt(p.g)
+
+roe_average(ρ⁻, ρ⁺, v⁻, v⁺) =
+    (sqrt(ρ⁻) * v⁻ + sqrt(ρ⁺) * v⁺) / (sqrt(ρ⁻) + sqrt(ρ⁺))
+
+"""
+    sw_roeflux(normal, (y⁻, params⁻), (y⁺, params⁺))
+
+Shallow-water Roe numerical flux for the conserved state `(; ρ, ρu, ρθ)`.
+Central flux of `sw_flux` plus Roe dissipation (wave strengths `w1`–`w5`).
+Used by `unit_two_point_fluxes.jl` as a custom functor.
+"""
+function sw_roeflux(normal, (y⁻, params⁻), (y⁺, params⁺))
+    λ = sqrt(params⁻.g)
+    ρ⁻, ρu⁻, ρθ⁻ = y⁻.ρ, y⁻.ρu, y⁻.ρθ
+    ρ⁺, ρu⁺, ρθ⁺ = y⁺.ρ, y⁺.ρu, y⁺.ρθ
+
+    u⁻ = ρu⁻ / ρ⁻
+    θ⁻ = ρθ⁻ / ρ⁻
+    u⁺ = ρu⁺ / ρ⁺
+    θ⁺ = ρθ⁺ / ρ⁺
+
+    p⁻ = (λ * ρ⁻)^2 * 0.5
+    c⁻ = λ * sqrt(ρ⁻)
+    p⁺ = (λ * ρ⁺)^2 * 0.5
+    c⁺ = λ * sqrt(ρ⁺)
+
+    ρ̄ = sqrt(ρ⁻ * ρ⁺)
+    ū = roe_average(ρ⁻, ρ⁺, u⁻, u⁺)
+    θ̄ = roe_average(ρ⁻, ρ⁺, θ⁻, θ⁺)
+    c̄ = roe_average(ρ⁻, ρ⁺, c⁻, c⁺)
+    ūₙ = ū' * normal
+
+    Δρ = ρ⁺ - ρ⁻
+    Δp = p⁺ - p⁻
+    Δu = u⁺ - u⁻
+    Δρθ = ρθ⁺ - ρθ⁻
+    Δuₙ = Δu' * normal
+
+    c⁻² = 1 / c̄^2
+    w1 = abs(ūₙ - c̄) * (Δp - ρ̄ * c̄ * Δuₙ) * 0.5 * c⁻²
+    w2 = abs(ūₙ + c̄) * (Δp + ρ̄ * c̄ * Δuₙ) * 0.5 * c⁻²
+    w3 = abs(ūₙ) * (Δρ - Δp * c⁻²)
+    w4 = abs(ūₙ) * ρ̄
+    w5 = abs(ūₙ) * (Δρθ - θ̄ * Δp * c⁻²)
+
+    fluxᵀn_ρ = (w1 + w2 + w3) * 0.5
+    fluxᵀn_ρu =
+        (
+            w1 * (ū - c̄ * normal) + w2 * (ū + c̄ * normal) + w3 * ū +
+            w4 * (Δu - Δuₙ * normal)
+        ) * 0.5
+    fluxᵀn_ρθ = ((w1 + w2) * θ̄ + w5) * 0.5
+    Δf = (ρ = -fluxᵀn_ρ, ρu = -fluxᵀn_ρu, ρθ = -fluxᵀn_ρθ)
+
+    F⁻ = sw_flux(y⁻, params⁻)
+    F⁺ = sw_flux(y⁺, params⁺)
+    return (
+        ρ = ((F⁻.ρ + F⁺.ρ) / 2)' * normal + Δf.ρ,
+        ρu = ((F⁻.ρu + F⁺.ρu) / 2)' * normal + Δf.ρu,
+        ρθ = ((F⁻.ρθ + F⁺.ρθ) / 2)' * normal + Δf.ρθ,
+    )
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,6 +98,7 @@ unit_tests = [
     UnitTest("Spectral elem - DG sphere fluxes"         ,"Operators/spectralelement/unit_sphere_dg_fluxes.jl"; tier = :unit, subsystem = :operators),
     UnitTest("Spectral elem - DG stability properties"  ,"Operators/spectralelement/unit_dg_stability.jl"; meta = :cpu_only, tier = :unit, subsystem = :operators),
     UnitTest("Spectral elem - DG boundary fluxes"       ,"Operators/spectralelement/unit_dg_boundary_fluxes.jl"; meta = :cpu_only, tier = :unit, subsystem = :operators),
+    UnitTest("Spectral elem - DG extruded sphere"       ,"Operators/spectralelement/unit_extruded_sphere_dg.jl"; tier = :unit, subsystem = :operators),
     UnitTest("Spectral elem - DG divergence conv"       ,"Operators/spectralelement/conv_dg_divergence.jl"; meta = :cpu_only, tier = :conv, subsystem = :operators),
     UnitTest("Operators - broadcast inference"          ,"Operators/inference_operators.jl"; tier = :inference, subsystem = :operators),
     UnitTest("FD ops - zero-allocation stencils"        ,"Operators/finitedifference/allocs_fd_ops.jl"; meta = :cpu_only, tier = :allocs, subsystem = :operators),


### PR DESCRIPTION
1) Add horizontal DG operators (includes CUDA extensions) 
2) Add unit tests for DG operators on extruded sphere grids 
3) Move Roe / Shallow-water flux helpers to utils_dg.jl 

This is the first in a series of PR adding horizontal DG operator support in ClimaCore. 
Co-author : @tapios  (This branch combines ts/dg + as/dg-fluxes)  