### PR TITLE
Enable MPI for DG and improve performance by limiting ghost exchange to faces

### DIFF
--- a/.buildkite/Manifest.toml
+++ b/.buildkite/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.11"
+julia_version = "1.10.10"
 manifest_format = "2.0"
 project_hash = "19194cb825213fa6ff692385eb4c7eed7f946f0f"
 
@@ -347,9 +347,9 @@ weakdeps = ["CUDA", "MPI"]
 
 [[deps.ClimaCore]]
 deps = ["Adapt", "BandedMatrices", "BlockArrays", "ClimaComms", "ClimaInterpolations", "CubedSphere", "DataStructures", "ForwardDiff", "GaussQuadrature", "GilbertCurves", "HDF5", "InteractiveUtils", "IntervalSets", "KrylovKit", "LLVM", "LazyBroadcast", "LinearAlgebra", "MultiBroadcastFusion", "NVTX", "PkgVersion", "Random", "RootSolvers", "SparseArrays", "StaticArrays", "Statistics", "UnrolledUtilities"]
-path = ".."
+path = "/Users/tapio/Desktop/Code/ClimaCore.jl"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
-version = "0.15.1"
+version = "0.15.3"
 weakdeps = ["CUDA", "GPUCompiler", "Krylov"]
 
     [deps.ClimaCore.extensions]
@@ -1321,7 +1321,7 @@ version = "1.1.10"
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.1010+0"
+version = "2.28.2+1"
 
 [[deps.Measures]]
 git-tree-sha1 = "b513cedd20d9c914783d8ad83d08120702bf2c77"
@@ -1351,7 +1351,7 @@ uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2025.12.2"
+version = "2023.1.10"
 
 [[deps.MultiBroadcastFusion]]
 git-tree-sha1 = "4157ffb36526a275f644a3fbe378850e5eb1b470"
@@ -1429,7 +1429,7 @@ version = "0.3.24+0"
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.23+5"
+version = "0.3.23+4"
 
 [[deps.OpenLibm_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -2381,7 +2381,7 @@ version = "1.52.0+1"
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.6.1+0"
+version = "17.4.0+2"
 
 [[deps.x264_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]

--- a/.buildkite/Manifest.toml
+++ b/.buildkite/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.10"
+julia_version = "1.10.11"
 manifest_format = "2.0"
 project_hash = "19194cb825213fa6ff692385eb4c7eed7f946f0f"
 
@@ -347,9 +347,9 @@ weakdeps = ["CUDA", "MPI"]
 
 [[deps.ClimaCore]]
 deps = ["Adapt", "BandedMatrices", "BlockArrays", "ClimaComms", "ClimaInterpolations", "CubedSphere", "DataStructures", "ForwardDiff", "GaussQuadrature", "GilbertCurves", "HDF5", "InteractiveUtils", "IntervalSets", "KrylovKit", "LLVM", "LazyBroadcast", "LinearAlgebra", "MultiBroadcastFusion", "NVTX", "PkgVersion", "Random", "RootSolvers", "SparseArrays", "StaticArrays", "Statistics", "UnrolledUtilities"]
-path = "/Users/tapio/Desktop/Code/ClimaCore.jl"
+path = ".."
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
-version = "0.15.3"
+version = "0.15.1"
 weakdeps = ["CUDA", "GPUCompiler", "Krylov"]
 
     [deps.ClimaCore.extensions]
@@ -1321,7 +1321,7 @@ version = "1.1.10"
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.2+1"
+version = "2.28.1010+0"
 
 [[deps.Measures]]
 git-tree-sha1 = "b513cedd20d9c914783d8ad83d08120702bf2c77"
@@ -1351,7 +1351,7 @@ uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2023.1.10"
+version = "2025.12.2"
 
 [[deps.MultiBroadcastFusion]]
 git-tree-sha1 = "4157ffb36526a275f644a3fbe378850e5eb1b470"
@@ -1429,7 +1429,7 @@ version = "0.3.24+0"
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.23+4"
+version = "0.3.23+5"
 
 [[deps.OpenLibm_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -2381,7 +2381,7 @@ version = "1.52.0+1"
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.4.0+2"
+version = "17.6.1+0"
 
 [[deps.x264_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -359,6 +359,52 @@ steps:
           slurm_ntasks: 2
           modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
 
+      - label: "Unit: distributed DG operators (2 ranks)"
+        key: unit_distributed_dg2
+        retry: *retry_policy
+        command: "srun julia --color=yes --check-bounds=yes --project=.buildkite test/Operators/spectralelement/distributed/ddg2.jl"
+        env:
+          CLIMACOMMS_CONTEXT: "MPI"
+        agents:
+          slurm_ntasks: 2
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
+
+      - label: "Unit: distributed DG operators (3 ranks)"
+        key: unit_distributed_dg3
+        retry: *retry_policy
+        command: "srun julia --color=yes --check-bounds=yes --project=.buildkite test/Operators/spectralelement/distributed/ddg3.jl"
+        env:
+          CLIMACOMMS_CONTEXT: "MPI"
+        agents:
+          slurm_ntasks: 3
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
+
+      - label: "Unit: cuda distributed DG operators (2 ranks)"
+        key: gpu_distributed_dg2
+        retry: *retry_policy
+        command: "srun julia --color=yes --check-bounds=yes --project=.buildkite test/Operators/spectralelement/distributed/ddg2.jl"
+        timeout_in_minutes: 15
+        env:
+          CLIMACOMMS_CONTEXT: "MPI"
+          CLIMACOMMS_DEVICE: "CUDA"
+        agents:
+          slurm_ntasks: 2
+          slurm_gpus: 2
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
+
+      - label: "Unit: cuda distributed DG operators (3 ranks)"
+        key: gpu_distributed_dg3
+        retry: *retry_policy
+        command: "srun julia --color=yes --check-bounds=yes --project=.buildkite test/Operators/spectralelement/distributed/ddg3.jl"
+        timeout_in_minutes: 15
+        env:
+          CLIMACOMMS_CONTEXT: "MPI"
+          CLIMACOMMS_DEVICE: "CUDA"
+        agents:
+          slurm_ntasks: 3
+          slurm_gpus: 3
+          modules: mpiwrapper/2024_05_27 climacommon/2024_10_10
+
       - label: "Unit: distributed dss3"
         key: unit_distributed_dss3
         retry: *retry_policy

--- a/NEWS.md
+++ b/NEWS.md
@@ -181,6 +181,33 @@ main
   along with small level fields holding the boundary rows' values.
   `MatrixFields.operator_matrix` now reports `LinVanLeerC2F` as a
   nonlinear operator instead of failing with a `MethodError`.
+- The discontinuous-Galerkin (DG) face operators
+  (`Operators.add_numerical_flux_internal!` and
+  `Operators.add_lifting_flux_internal!`) now run correctly on distributed
+  (MPI) `Topology2D` spaces. Faces that straddle a rank boundary
+  (`Topologies.ghost_faces`) were previously skipped, so partition-boundary
+  elements got no interface flux; each rank now completes its own side after a
+  face-strip halo exchange (`Topologies.GhostFaceExchange`), which ships only
+  the `Nq` face-node values of each rank-boundary face — `~Nq×` less data
+  than a whole-element halo — between face-sharing neighbours only.
+  Validated by 2- and 3-rank CPU equivalence tests (each rank's result matches
+  the element-local strong-divergence reference at partition-boundary nodes).
+  On the GPU, the ghost faces go through the same exchange, started before the
+  interior-face kernels (overlapping communication with compute) and completed
+  by a ghost staging + gather kernel pair over
+  `Operators.dg_ghost_connectivity`; the 2- and 3-rank tests also run on CUDA
+  in Buildkite. One halo exchange can be shared by several face-operator
+  calls in the same tendency evaluation: start it with
+  `Operators.start_dg_ghost_exchange(args...)` and pass the returned handle
+  to each operator via the `ghost_exchange` keyword — the first consumer
+  completes the exchange and the others read the same recv strips, so each
+  halo message is sent once instead of once per operator.
+
+- `Operators.add_numerical_flux_boundary!` now has CUDA kernels (one-sided
+  staging + gather over `Operators.dg_boundary_connectivity`); it previously
+  fell back to the CPU slab loop, which requires scalar indexing on device
+  arrays. Nodes at domain corners accumulate the contributions of both their
+  boundary faces deterministically through the gather map.
 
 - Spectral-element grids can be marked as discontinuous-Galerkin function
   spaces: `SpectralElementGrid1D`/`SpectralElementGrid2D` (and the

--- a/NEWS.md
+++ b/NEWS.md
@@ -181,33 +181,20 @@ main
   along with small level fields holding the boundary rows' values.
   `MatrixFields.operator_matrix` now reports `LinVanLeerC2F` as a
   nonlinear operator instead of failing with a `MethodError`.
-- The discontinuous-Galerkin (DG) face operators
-  (`Operators.add_numerical_flux_internal!` and
-  `Operators.add_lifting_flux_internal!`) now run correctly on distributed
-  (MPI) `Topology2D` spaces. Faces that straddle a rank boundary
-  (`Topologies.ghost_faces`) were previously skipped, so partition-boundary
-  elements got no interface flux; each rank now completes its own side after a
-  face-strip halo exchange (`Topologies.GhostFaceExchange`), which ships only
-  the `Nq` face-node values of each rank-boundary face — `~Nq×` less data
-  than a whole-element halo — between face-sharing neighbours only.
-  Validated by 2- and 3-rank CPU equivalence tests (each rank's result matches
-  the element-local strong-divergence reference at partition-boundary nodes).
-  On the GPU, the ghost faces go through the same exchange, started before the
-  interior-face kernels (overlapping communication with compute) and completed
-  by a ghost staging + gather kernel pair over
-  `Operators.dg_ghost_connectivity`; the 2- and 3-rank tests also run on CUDA
-  in Buildkite. One halo exchange can be shared by several face-operator
-  calls in the same tendency evaluation: start it with
-  `Operators.start_dg_ghost_exchange(args...)` and pass the returned handle
-  to each operator via the `ghost_exchange` keyword — the first consumer
-  completes the exchange and the others read the same recv strips, so each
-  halo message is sent once instead of once per operator.
 
-- `Operators.add_numerical_flux_boundary!` now has CUDA kernels (one-sided
-  staging + gather over `Operators.dg_boundary_connectivity`); it previously
-  fell back to the CPU slab loop, which requires scalar indexing on device
-  arrays. Nodes at domain corners accumulate the contributions of both their
-  boundary faces deterministically through the gather map.
+- The DG face operators (`Operators.add_numerical_flux_internal!` and
+  `Operators.add_lifting_flux_internal!`) now run on distributed (MPI)
+  `Topology2D` spaces: each rank completes its rank-boundary
+  (`Topologies.ghost_faces`) side through a face-strip halo exchange
+  (`Topologies.GhostFaceExchange`) that ships only the `Nq` face-node values
+  per face, on both CPU and CUDA. Several operators in one tendency evaluation
+  can share a single exchange via `Operators.start_dg_ghost_exchange(args...)`
+  and the `ghost_exchange` keyword. Covered by 2- and 3-rank CPU and CUDA
+  tests.
+
+- `Operators.add_numerical_flux_boundary!` now has CUDA kernels (staging +
+  gather over `Operators.dg_boundary_connectivity`), so it no longer needs
+  scalar indexing on device arrays.
 
 - Spectral-element grids can be marked as discontinuous-Galerkin function
   spaces: `SpectralElementGrid1D`/`SpectralElementGrid2D` (and the

--- a/NEWS.md
+++ b/NEWS.md
@@ -188,9 +188,9 @@ main
   (`Topologies.ghost_faces`) side through a face-strip halo exchange
   (`Topologies.GhostFaceExchange`) that ships only the `Nq` face-node values
   per face, on both CPU and CUDA. Several operators in one tendency evaluation
-  can share a single exchange via `Operators.start_dg_ghost_exchange(args...)`
-  and the `ghost_exchange` keyword. Covered by 2- and 3-rank CPU and CUDA
-  tests.
+  can share a single exchange by passing the handle returned by
+  `Operators.start_dg_ghost_exchange(args...)` as a leading argument. Covered
+  by 2- and 3-rank CPU and CUDA tests.
 
 - `Operators.add_numerical_flux_boundary!` now has CUDA kernels (staging +
   gather over `Operators.dg_boundary_connectivity`), so it no longer needs

--- a/docs/src/operators.md
+++ b/docs/src/operators.md
@@ -128,6 +128,46 @@ SetDivergence
 Extrapolate
 ```
 
+## Discontinuous Galerkin operators
+
+Face and volume operators for discontinuous-Galerkin (DG) discretizations on
+spectral-element spaces marked with `discontinuous = true`. The face operators
+act on a mass-weighted residual (`WJ * ∂Y/∂t`) and complete the weak-form (or
+flux-differencing) volume terms at element interfaces.
+
+```@docs
+add_numerical_flux_internal!
+add_numerical_flux_boundary!
+add_lifting_flux_internal!
+lifting_correction
+add_flux_differencing_divergence!
+add_ldg_laplacian_flux_internal!
+ldg_laplacian_tendency
+ldg_penalty_parameter
+start_dg_ghost_exchange
+DGGhostExchange
+```
+
+### Numerical fluxes and face lifts
+
+```@docs
+AbstractNumericalFlux
+CentralNumericalFlux
+RusanovNumericalFlux
+LDGLaplacianFlux
+central_gradient_lift
+central_curl3_lift
+jump_penalty_lift
+```
+
+### DG boundary conditions
+
+```@docs
+ghost_state
+PeriodicBC
+ReflectingWallBC
+```
+
 ## Integrals
 
 ```@docs

--- a/ext/cuda/operators_dg.jl
+++ b/ext/cuda/operators_dg.jl
@@ -35,11 +35,10 @@ function Operators._add_flux_differencing_divergence!(
     grid = Spaces.grid(space)
     if grid isa Grids.ExtrudedFiniteDifferenceGrid
         @assert grid.horizontal_grid isa Grids.SpectralElementGrid2D
-        Nv = Spaces.nlevels(space)
     else
         @assert grid isa Grids.SpectralElementGrid2D
-        Nv = 1
     end
+    Nv = Spaces.nlevels(space)
     quadrature_style = Spaces.quadrature_style(space)
     Nq = Quadratures.degrees_of_freedom(quadrature_style)
     FT = Spaces.undertype(space)
@@ -128,27 +127,35 @@ function Operators._start_dg_ghost_exchange_handle(
     topology = Spaces.topology(space)
     ClimaComms.context(topology) isa ClimaComms.SingletonCommsContext &&
         return Operators.NO_DG_GHOST_EXCHANGE
-    grid = Spaces.grid(space)
-    Nv =
-        grid isa Grids.ExtrudedFiniteDifferenceGrid ? Spaces.nlevels(space) :
-        1
+    Nv = Spaces.nlevels(space)
     Nq = Quadratures.degrees_of_freedom(Spaces.quadrature_style(space))
     args_data =
         unrolled_map(a -> a isa Fields.Field ? Fields.field_values(a) : a, args)
     bufs = ntuple(Val(length(args_data))) do i
         a = args_data[i]
         a isa DataLayouts.DataLayout || return nothing
-        ex = Operators._dg_face_exchange(space, a, i)
-        isnothing(ex) && return nothing
+        Operators._dg_face_exchange(space, a, i)
+    end
+    Operators._claim_dg_face_exchanges!(bufs)
+    foreach(ntuple(identity, Val(length(args_data)))) do i
+        ex = bufs[i]
+        isnothing(ex) && return
         nstrips = length(ex.slot_lidx)
         p = linear_partition(Nq * Nv * nstrips, _max_threads_cuda())
         auto_launch!(
             dg_face_pack_kernel!,
-            (ex.send_data, a, ex.slot_lidx, ex.slot_face, Val(Nq), Nv, nstrips);
+            (
+                ex.send_data,
+                args_data[i],
+                ex.slot_lidx,
+                ex.slot_face,
+                Val(Nq),
+                Nv,
+                nstrips,
+            );
             threads_s = p.threads,
             blocks_s = p.blocks,
         )
-        ex
     end
     # MPI reads the device-side send buffers on the host timeline, so the
     # pack kernels must have completed (the DSS-start pattern).
@@ -176,11 +183,10 @@ function _dg_face_apply!(
     grid = Spaces.grid(space)
     if grid isa Grids.ExtrudedFiniteDifferenceGrid
         @assert grid.horizontal_grid isa Grids.SpectralElementGrid2D
-        Nv = Spaces.nlevels(space)
     else
         @assert grid isa Grids.SpectralElementGrid2D
-        Nv = 1
     end
+    Nv = Spaces.nlevels(space)
     quadrature_style = Spaces.quadrature_style(space)
     Nq = Quadratures.degrees_of_freedom(quadrature_style)
     conn = Operators.dg_connectivity(space)
@@ -493,11 +499,10 @@ function _dg_boundary_apply!(fn::F, dydt, args) where {F}
     grid = Spaces.grid(space)
     if grid isa Grids.ExtrudedFiniteDifferenceGrid
         @assert grid.horizontal_grid isa Grids.SpectralElementGrid2D
-        Nv = Spaces.nlevels(space)
     else
         @assert grid isa Grids.SpectralElementGrid2D
-        Nv = 1
     end
+    Nv = Spaces.nlevels(space)
     Nq = Quadratures.degrees_of_freedom(Spaces.quadrature_style(space))
 
     dydt_data = Fields.field_values(dydt)

--- a/ext/cuda/operators_dg.jl
+++ b/ext/cuda/operators_dg.jl
@@ -101,19 +101,19 @@ end
 
 Operators._add_numerical_flux_internal!(
     ::ClimaComms.CUDADevice,
+    ghost_exchange,
     fn::F,
     dydt,
-    args...;
-    ghost_exchange = nothing,
-) where {F} = _dg_face_apply!(fn, dydt, args, Val(:numflux); ghost_exchange)
+    args...,
+) where {F} = _dg_face_apply!(ghost_exchange, fn, dydt, args, Val(:numflux))
 
 Operators._add_lifting_flux_internal!(
     ::ClimaComms.CUDADevice,
+    ghost_exchange,
     fn::F,
     dydt,
-    args...;
-    ghost_exchange = nothing,
-) where {F} = _dg_face_apply!(fn, dydt, args, Val(:lifting); ghost_exchange)
+    args...,
+) where {F} = _dg_face_apply!(ghost_exchange, fn, dydt, args, Val(:lifting))
 
 # The face-strip halo exchange starts before the interior-face kernels, so the
 # communication overlaps with the interior compute; each argument is packed by
@@ -171,13 +171,7 @@ Operators._dg_shared_or_start(
     ::Nothing,
 ) = Operators._start_dg_ghost_exchange_handle(device, space, args)
 
-function _dg_face_apply!(
-    fn::F,
-    dydt,
-    args,
-    mode::Val;
-    ghost_exchange = nothing,
-) where {F}
+function _dg_face_apply!(ghost_exchange, fn::F, dydt, args, mode::Val) where {F}
     space = axes(dydt)
     topology = Spaces.topology(space)
     grid = Spaces.grid(space)

--- a/ext/cuda/operators_dg.jl
+++ b/ext/cuda/operators_dg.jl
@@ -7,11 +7,19 @@ Kernel design:
 - Flux-differencing volume (`_add_flux_differencing_divergence!`), element-local.
 - Internal-face fluxes (`_add_numerical_flux_internal!`,
   `_add_lifting_flux_internal!`): two-pass staging + gather, follows `DSS` GPU kernels.
+- Ghost (inter-rank) faces: face-strip halo exchange
+  (`Topologies.GhostFaceExchange`, one pack kernel per argument) started
+  before the interior kernels (overlapping communication with compute), then
+  the same staging + gather over `Operators.dg_ghost_connectivity`, with the
+  plus side read from the recv strips.
+- Boundary faces (`_add_numerical_flux_boundary!`): one-sided staging + the
+  same gather, over `Operators.dg_boundary_connectivity`.
 - `tensor_product!` (cutoff filter): per-element enabling in-place assignment.
 =#
 
 import ClimaCore: Operators, Topologies, Quadratures, Grids, DataLayouts
 import ClimaCore.Operators: DGConnectivity
+import UnrolledUtilities: unrolled_map
 
 # ---------------------------------------------------------------------------
 # Flux-differencing volume divergence
@@ -96,18 +104,75 @@ Operators._add_numerical_flux_internal!(
     ::ClimaComms.CUDADevice,
     fn::F,
     dydt,
-    args...,
-) where {F} = _dg_face_apply!(fn, dydt, args, Val(:numflux))
+    args...;
+    ghost_exchange = nothing,
+) where {F} = _dg_face_apply!(fn, dydt, args, Val(:numflux); ghost_exchange)
 
 Operators._add_lifting_flux_internal!(
     ::ClimaComms.CUDADevice,
     fn::F,
     dydt,
-    args...,
-) where {F} = _dg_face_apply!(fn, dydt, args, Val(:lifting))
+    args...;
+    ghost_exchange = nothing,
+) where {F} = _dg_face_apply!(fn, dydt, args, Val(:lifting); ghost_exchange)
 
-function _dg_face_apply!(fn::F, dydt, args, mode::Val) where {F}
+# The face-strip halo exchange starts before the interior-face kernels, so the
+# communication overlaps with the interior compute; each argument is packed by
+# a single kernel. See `Operators.start_dg_ghost_exchange` and
+# `Topologies.GhostFaceExchange` for the exchange semantics.
+function Operators._start_dg_ghost_exchange_handle(
+    ::ClimaComms.CUDADevice,
+    space,
+    args,
+)
+    topology = Spaces.topology(space)
+    ClimaComms.context(topology) isa ClimaComms.SingletonCommsContext &&
+        return Operators.NO_DG_GHOST_EXCHANGE
+    grid = Spaces.grid(space)
+    Nv =
+        grid isa Grids.ExtrudedFiniteDifferenceGrid ? Spaces.nlevels(space) :
+        1
+    Nq = Quadratures.degrees_of_freedom(Spaces.quadrature_style(space))
+    args_data =
+        unrolled_map(a -> a isa Fields.Field ? Fields.field_values(a) : a, args)
+    bufs = ntuple(Val(length(args_data))) do i
+        a = args_data[i]
+        a isa DataLayouts.DataLayout || return nothing
+        ex = Operators._dg_face_exchange(space, a, i)
+        isnothing(ex) && return nothing
+        nstrips = length(ex.slot_lidx)
+        p = linear_partition(Nq * Nv * nstrips, _max_threads_cuda())
+        auto_launch!(
+            dg_face_pack_kernel!,
+            (ex.send_data, a, ex.slot_lidx, ex.slot_face, Val(Nq), Nv, nstrips);
+            threads_s = p.threads,
+            blocks_s = p.blocks,
+        )
+        ex
+    end
+    # MPI reads the device-side send buffers on the host timeline, so the
+    # pack kernels must have completed (the DSS-start pattern).
+    Spaces.cuda_synchronize(ClimaComms.device(space); blocking = true)
+    foreach(ex -> isnothing(ex) || ClimaComms.start(ex.graph_context), bufs)
+    return Operators.DGGhostExchange(bufs)
+end
+
+Operators._dg_shared_or_start(
+    device::ClimaComms.CUDADevice,
+    space,
+    args,
+    ::Nothing,
+) = Operators._start_dg_ghost_exchange_handle(device, space, args)
+
+function _dg_face_apply!(
+    fn::F,
+    dydt,
+    args,
+    mode::Val;
+    ghost_exchange = nothing,
+) where {F}
     space = axes(dydt)
+    topology = Spaces.topology(space)
     grid = Spaces.grid(space)
     if grid isa Grids.ExtrudedFiniteDifferenceGrid
         @assert grid.horizontal_grid isa Grids.SpectralElementGrid2D
@@ -119,57 +184,156 @@ function _dg_face_apply!(fn::F, dydt, args, mode::Val) where {F}
     quadrature_style = Spaces.quadrature_style(space)
     Nq = Quadratures.degrees_of_freedom(quadrature_style)
     conn = Operators.dg_connectivity(space)
-    conn.nfaces == 0 && return dydt
+    distributed =
+        !(ClimaComms.context(topology) isa ClimaComms.SingletonCommsContext)
+    gconn = distributed ? Operators.dg_ghost_connectivity(space) : nothing
+    !distributed && conn.nfaces == 0 && return dydt
 
     dydt_data = Fields.field_values(dydt)
     args_data =
-        map(a -> a isa Fields.Field ? Fields.field_values(a) : a, args)
+        unrolled_map(a -> a isa Fields.Field ? Fields.field_values(a) : a, args)
     T = eltype(dydt_data)
-    DA = ClimaComms.array_type(Spaces.topology(space))
-    nsides = mode isa Val{:lifting} ? 2 : 1
-    staging = DA{T}(undef, Nq, Nv, nsides, conn.nfaces)
+    DA = ClimaComms.array_type(topology)
 
-    nitemsA = Nq * Nv * conn.nfaces
-    pA = linear_partition(nitemsA, _max_threads_cuda())
-    auto_launch!(
-        dg_face_flux_kernel!,
-        (
-            staging,
-            fn,
-            args_data,
-            conn.faces,
-            conn.sgeom,
-            Val(Nq),
-            Nv,
-            conn.nfaces,
-            mode,
-        );
-        threads_s = pA.threads,
-        blocks_s = pA.blocks,
+    ghost = Operators._dg_shared_or_start(
+        ClimaComms.device(space),
+        space,
+        args,
+        ghost_exchange,
     )
 
-    nitemsB = conn.nbnodes * Nv
-    pB = linear_partition(nitemsB, _max_threads_cuda())
-    auto_launch!(
-        dg_face_gather_kernel!,
-        (
-            dydt_data,
-            staging,
-            conn.node_elem,
-            conn.node_i,
-            conn.node_j,
-            conn.node_offset,
-            conn.contrib_face,
-            conn.contrib_side,
-            conn.contrib_q,
-            Nv,
-            conn.nbnodes,
-            mode,
-        );
-        threads_s = pB.threads,
-        blocks_s = pB.blocks,
-    )
+    if conn.nfaces > 0
+        nsides = mode isa Val{:lifting} ? 2 : 1
+        staging = Operators._dg_staging_buffer(space, T, nsides, conn.nfaces)
+
+        nitemsA = Nq * Nv * conn.nfaces
+        pA = linear_partition(nitemsA, _max_threads_cuda())
+        auto_launch!(
+            dg_face_flux_kernel!,
+            (
+                staging,
+                fn,
+                args_data,
+                conn.faces,
+                conn.sgeom,
+                Val(Nq),
+                Nv,
+                conn.nfaces,
+                mode,
+            );
+            threads_s = pA.threads,
+            blocks_s = pA.blocks,
+        )
+
+        nitemsB = conn.nbnodes * Nv
+        pB = linear_partition(nitemsB, _max_threads_cuda())
+        auto_launch!(
+            dg_face_gather_kernel!,
+            (
+                dydt_data,
+                staging,
+                conn.node_elem,
+                conn.node_i,
+                conn.node_j,
+                conn.node_offset,
+                conn.contrib_face,
+                conn.contrib_side,
+                conn.contrib_q,
+                Nv,
+                conn.nbnodes,
+                mode,
+            );
+            threads_s = pB.threads,
+            blocks_s = pB.blocks,
+        )
+    end
+
+    ghost_bufs = Operators._consume_dg_ghost_exchange!(ghost)
+    if !isnothing(ghost_bufs)
+        isnothing(gconn) && return dydt
+        recv = unrolled_map(
+            ex -> isnothing(ex) ? nothing : ex.recv_data,
+            ghost_bufs,
+        )
+
+        # Only the minus side is staged (the mirror ghost face on the
+        # neighbouring rank accumulates the other side), so one staging slot
+        # per face node serves both modes, and the gather kernel is reused
+        # with the ghost gather map, whose contributions are all side 1.
+        gstaging = Operators._dg_ghost_staging_buffer(space, T, gconn.nfaces)
+
+        nitemsC = Nq * Nv * gconn.nfaces
+        pC = linear_partition(nitemsC, _max_threads_cuda())
+        auto_launch!(
+            dg_ghost_face_flux_kernel!,
+            (
+                gstaging,
+                fn,
+                args_data,
+                recv,
+                gconn.faces,
+                gconn.sgeom,
+                Val(Nq),
+                Nv,
+                gconn.nfaces,
+            );
+            threads_s = pC.threads,
+            blocks_s = pC.blocks,
+        )
+
+        nitemsD = gconn.nbnodes * Nv
+        pD = linear_partition(nitemsD, _max_threads_cuda())
+        auto_launch!(
+            dg_face_gather_kernel!,
+            (
+                dydt_data,
+                gstaging,
+                gconn.node_elem,
+                gconn.node_i,
+                gconn.node_j,
+                gconn.node_offset,
+                gconn.contrib_face,
+                gconn.contrib_side,
+                gconn.contrib_q,
+                Nv,
+                gconn.nbnodes,
+                mode,
+            );
+            threads_s = pD.threads,
+            blocks_s = pD.blocks,
+        )
+    end
     return dydt
+end
+
+# Shared prologue for the two face-flux kernels: decode face `f` at node `q`
+# and level `v`, gather the minus-side argument values, and fetch the surface
+# geometry. Returns the plus-side node index `(idx⁺, i⁺, j⁺)` — where `idx⁺`
+# is a local element (interior) or a ghost receive index (ghost), both in the
+# third `faces` row — for the caller to read the plus-side values from.
+# `@propagate_inbounds` so the caller's `@inbounds` reaches the array accesses.
+Base.@propagate_inbounds function _dg_flux_minus(
+    args_data,
+    faces,
+    sgeom,
+    ::Val{Nq},
+    q,
+    v,
+    f,
+) where {Nq}
+    elem⁻ = Int(faces[1, f])
+    face⁻ = Int(faces[2, f])
+    idx⁺ = Int(faces[3, f])
+    face⁺ = Int(faces[4, f])
+    reversed = faces[5, f] == Int32(1)
+    i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, q, false)
+    i⁺, j⁺ = Topologies.face_node_index(face⁺, Nq, q, reversed)
+    CI = CartesianIndex
+    argvals⁻ = unrolled_map(
+        a -> a isa DataLayouts.DataLayout ? a[CI(v, i⁻, j⁻, elem⁻)] : a,
+        args_data,
+    )
+    return sgeom[q, v, f], argvals⁻, idx⁺, i⁺, j⁺
 end
 
 Base.@propagate_inbounds function dg_face_flux_kernel!(
@@ -186,27 +350,13 @@ Base.@propagate_inbounds function dg_face_flux_kernel!(
     gidx = threadIdx().x + (blockIdx().x - Int32(1)) * blockDim().x
     @inbounds if gidx ≤ Nq * Nv * nfaces
         (q, v, f) = Utilities.cart_ind((Nq, Nv, nfaces), gidx).I
-        elem⁻ = faces[1, f]
-        face⁻ = faces[2, f]
-        elem⁺ = faces[3, f]
-        face⁺ = faces[4, f]
-        reversed = faces[5, f] == Int32(1)
-        i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, q, false)
-        i⁺, j⁺ = Topologies.face_node_index(face⁺, Nq, q, reversed)
+        sg, argvals⁻, elem⁺, i⁺, j⁺ =
+            _dg_flux_minus(args_data, faces, sgeom, Val(Nq), q, v, f)
         CI = CartesianIndex
-        argvals⁻ = map(
-            a ->
-                a isa DataLayouts.DataLayout ?
-                a[CI(v, i⁻, j⁻, elem⁻)] : a,
+        argvals⁺ = unrolled_map(
+            a -> a isa DataLayouts.DataLayout ? a[CI(v, i⁺, j⁺, elem⁺)] : a,
             args_data,
         )
-        argvals⁺ = map(
-            a ->
-                a isa DataLayouts.DataLayout ?
-                a[CI(v, i⁺, j⁺, elem⁺)] : a,
-            args_data,
-        )
-        sg = sgeom[q, v, f]
         if mode isa Val{:numflux}
             val = fn(sg.normal, argvals⁻, argvals⁺)
             staging[q, v, 1, f] = Operators._fd_scale(sg.sWJ, val)
@@ -216,6 +366,68 @@ Base.@propagate_inbounds function dg_face_flux_kernel!(
             staging[q, v, 1, f] = Operators._fd_scale(sg.sWJ, lift⁻)
             staging[q, v, 2, f] = Operators._fd_scale(sg.sWJ, lift⁺)
         end
+    end
+    return nothing
+end
+
+# Pack one argument's ghost-face strips for the `Topologies.GhostFaceExchange`
+# (the single-kernel analog of `Topologies.fill_face_send_buffer!`): strip `s`
+# holds the `Nq` face-node values of local face `(slot_lidx[s], slot_face[s])`,
+# in the face's natural node order.
+function dg_face_pack_kernel!(
+    send_data,
+    data,
+    slot_lidx,
+    slot_face,
+    ::Val{Nq},
+    Nv,
+    nstrips,
+) where {Nq}
+    gidx = threadIdx().x + (blockIdx().x - Int32(1)) * blockDim().x
+    if gidx ≤ Nq * Nv * nstrips
+        (q, v, s) = Utilities.cart_ind((Nq, Nv, nstrips), gidx).I
+        i, j = Topologies.face_node_index(Int(slot_face[s]), Nq, q, false)
+        CI = CartesianIndex
+        send_data[CI(v, q, 1, s)] = data[CI(v, i, j, Int(slot_lidx[s]))]
+    end
+    return nothing
+end
+
+# Ghost-face variant of `dg_face_flux_kernel!`: the plus side is read from the
+# recv strips of each argument's ghost exchange — the third `faces` row holds
+# the strip slot, and the value at loop node `q` is strip node
+# `reversed ? Nq - q + 1 : q` (the sender packs in its natural face order) —
+# instead of a local element; arguments without a recv buffer are identical on
+# both sides. Only the minus side is staged — `fn(n̂⁻, ·⁻, ·⁺)` is the staged
+# value for both the antisymmetric numerical flux and the symmetric lifting,
+# and the gather kernel applies the mode-dependent sign at side 1 — so no
+# `mode` argument is needed.
+function dg_ghost_face_flux_kernel!(
+    staging,
+    fn::F,
+    args_data,
+    recv_data,
+    faces,
+    sgeom,
+    ::Val{Nq},
+    Nv,
+    nfaces,
+) where {F, Nq}
+    gidx = threadIdx().x + (blockIdx().x - Int32(1)) * blockDim().x
+    if gidx ≤ Nq * Nv * nfaces
+        (q, v, f) = Utilities.cart_ind((Nq, Nv, nfaces), gidx).I
+        sg, argvals⁻, slot, _i⁺, _j⁺ =
+            _dg_flux_minus(args_data, faces, sgeom, Val(Nq), q, v, f)
+        reversed = faces[5, f] == Int32(1)
+        q′ = reversed ? Nq - q + 1 : q
+        CI = CartesianIndex
+        argvals⁺ = unrolled_map(
+            (a, r) -> isnothing(r) ? a : r[CI(v, q′, 1, slot)],
+            args_data,
+            recv_data,
+        )
+        staging[q, v, 1, f] =
+            Operators._fd_scale(sg.sWJ, fn(sg.normal, argvals⁻, argvals⁺))
     end
     return nothing
 end
@@ -264,6 +476,104 @@ function dg_face_gather_kernel!(
 end
 
 # ---------------------------------------------------------------------------
+# Boundary-face numerical flux (staging + gather)
+# ---------------------------------------------------------------------------
+
+Operators._add_numerical_flux_boundary!(
+    ::ClimaComms.CUDADevice,
+    fn::F,
+    dydt,
+    args...,
+) where {F} = _dg_boundary_apply!(fn, dydt, args)
+
+function _dg_boundary_apply!(fn::F, dydt, args) where {F}
+    space = axes(dydt)
+    bconn = Operators.dg_boundary_connectivity(space)
+    isnothing(bconn) && return dydt
+    grid = Spaces.grid(space)
+    if grid isa Grids.ExtrudedFiniteDifferenceGrid
+        @assert grid.horizontal_grid isa Grids.SpectralElementGrid2D
+        Nv = Spaces.nlevels(space)
+    else
+        @assert grid isa Grids.SpectralElementGrid2D
+        Nv = 1
+    end
+    Nq = Quadratures.degrees_of_freedom(Spaces.quadrature_style(space))
+
+    dydt_data = Fields.field_values(dydt)
+    args_data =
+        unrolled_map(a -> a isa Fields.Field ? Fields.field_values(a) : a, args)
+    T = eltype(dydt_data)
+    staging = Operators._dg_boundary_staging_buffer(space, T, bconn.nfaces)
+
+    nitemsA = Nq * Nv * bconn.nfaces
+    pA = linear_partition(nitemsA, _max_threads_cuda())
+    auto_launch!(
+        dg_boundary_face_flux_kernel!,
+        (staging, fn, args_data, bconn.faces, bconn.sgeom, Val(Nq), Nv, bconn.nfaces);
+        threads_s = pA.threads,
+        blocks_s = pA.blocks,
+    )
+
+    # The gather kernel in `:numflux` mode subtracts side-1 staging, which is
+    # the boundary accumulation `dydt -= sWJ * fn(n̂, ·⁻)` (all boundary
+    # contributions are side 1).
+    nitemsB = bconn.nbnodes * Nv
+    pB = linear_partition(nitemsB, _max_threads_cuda())
+    auto_launch!(
+        dg_face_gather_kernel!,
+        (
+            dydt_data,
+            staging,
+            bconn.node_elem,
+            bconn.node_i,
+            bconn.node_j,
+            bconn.node_offset,
+            bconn.contrib_face,
+            bconn.contrib_side,
+            bconn.contrib_q,
+            Nv,
+            bconn.nbnodes,
+            Val(:numflux),
+        );
+        threads_s = pB.threads,
+        blocks_s = pB.blocks,
+    )
+    return dydt
+end
+
+# Boundary faces have no plus side and no `reversed` flag (the `faces` matrix
+# holds `(elem⁻, face⁻)` rows only), so this does not share `_dg_flux_minus`
+# with the interior/ghost kernels.
+function dg_boundary_face_flux_kernel!(
+    staging,
+    fn::F,
+    args_data,
+    faces,
+    sgeom,
+    ::Val{Nq},
+    Nv,
+    nfaces,
+) where {F, Nq}
+    gidx = threadIdx().x + (blockIdx().x - Int32(1)) * blockDim().x
+    if gidx ≤ Nq * Nv * nfaces
+        (q, v, f) = Utilities.cart_ind((Nq, Nv, nfaces), gidx).I
+        elem⁻ = Int(faces[1, f])
+        face⁻ = Int(faces[2, f])
+        i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, q, false)
+        CI = CartesianIndex
+        argvals⁻ = unrolled_map(
+            a -> a isa DataLayouts.DataLayout ? a[CI(v, i⁻, j⁻, elem⁻)] : a,
+            args_data,
+        )
+        sg = sgeom[q, v, f]
+        staging[q, v, 1, f] =
+            Operators._fd_scale(sg.sWJ, fn(sg.normal, argvals⁻))
+    end
+    return nothing
+end
+
+# ---------------------------------------------------------------------------
 # tensor_product! (cutoff filter); square matrices only
 # ---------------------------------------------------------------------------
 
@@ -300,7 +610,7 @@ function dg_tensor_product_kernel!(
     Nv,
 ) where {Nij, Nvt}
     S = eltype(out)
-    work = CUDA.CuStaticSharedArray(S, (Nij, Nij, Nvt))
+    work = DataLayouts.scoped_static_array(ThisBlock(), S, (Nij, Nij, Nvt))
     i = threadIdx().x
     j = threadIdx().y
     k = threadIdx().z
@@ -310,7 +620,7 @@ function dg_tensor_product_kernel!(
     if v ≤ Nv
         work[i, j, k] = indata[CI(v, i, j, h)]
     end
-    CUDA.sync_threads()
+    DataLayouts.synchronize(ThisBlock())
     if v ≤ Nv
         r = Operators._fd_scale(M[i, 1] * M[j, 1], work[1, 1, k])
         for jj in 1:Nij, ii in 1:Nij

--- a/src/Operators/Operators.jl
+++ b/src/Operators/Operators.jl
@@ -23,7 +23,7 @@ import ..Topologies
 import ..Meshes
 import ..Grids
 import ..Fields: Fields, Field
-import UnrolledUtilities: unrolled_map
+import UnrolledUtilities: unrolled_map, unrolled_filter
 
 include("common.jl")
 include("spectralelement.jl")

--- a/src/Operators/Operators.jl
+++ b/src/Operators/Operators.jl
@@ -23,6 +23,7 @@ import ..Topologies
 import ..Meshes
 import ..Grids
 import ..Fields: Fields, Field
+import UnrolledUtilities: unrolled_map
 
 include("common.jl")
 include("spectralelement.jl")

--- a/src/Operators/common.jl
+++ b/src/Operators/common.jl
@@ -8,6 +8,22 @@ called directly, but can be broadcasted over `Field`s.
 """
 abstract type AbstractOperator end
 
+"""
+    AbstractBoundaryCondition
+
+Supertype for boundary conditions of both the finite-difference and the
+discontinuous-Galerkin operators.
+
+Boundary conditions for [`FiniteDifferenceOperator`](@ref)s should define:
+
+  - [`boundary_width`](@ref)
+  - [`stencil_left_boundary`](@ref)
+  - [`stencil_right_boundary`](@ref)
+
+Boundary conditions for the DG numerical-flux operators (see
+[`add_numerical_flux_boundary!`](@ref)) should define [`ghost_state`](@ref).
+"""
+abstract type AbstractBoundaryCondition end
 
 """
     return_space(::Op, spaces...)

--- a/src/Operators/dg_fluxes.jl
+++ b/src/Operators/dg_fluxes.jl
@@ -144,6 +144,15 @@ end
 
 Add consistent LDG/SIPG face coupling
 ``−\\{\\!\\{κ G\\}\\!\\}·n̂ + τ[[q]]`` to a WJ-weighted Laplacian residual.
+Accepts a shared [`start_dg_ghost_exchange`](@ref) handle started on
+`(q, G, κ)`.
 """
-add_ldg_laplacian_flux_internal!(dydt, q, G, κ, τ) =
-    add_numerical_flux_internal!(LDGLaplacianFlux(τ), dydt, q, G, κ)
+add_ldg_laplacian_flux_internal!(dydt, q, G, κ, τ; ghost_exchange = nothing) =
+    add_numerical_flux_internal!(
+        LDGLaplacianFlux(τ),
+        dydt,
+        q,
+        G,
+        κ;
+        ghost_exchange,
+    )

--- a/src/Operators/dg_fluxes.jl
+++ b/src/Operators/dg_fluxes.jl
@@ -144,15 +144,23 @@ end
 
 Add consistent LDG/SIPG face coupling
 ``−\\{\\!\\{κ G\\}\\!\\}·n̂ + τ[[q]]`` to a WJ-weighted Laplacian residual.
-Accepts a shared [`start_dg_ghost_exchange`](@ref) handle started on
-`(q, G, κ)`.
+The method with a leading `ghost_exchange` consumes a shared
+[`start_dg_ghost_exchange`](@ref) handle started on `(q, G, κ)`.
 """
-add_ldg_laplacian_flux_internal!(dydt, q, G, κ, τ; ghost_exchange = nothing) =
-    add_numerical_flux_internal!(
-        LDGLaplacianFlux(τ),
-        dydt,
-        q,
-        G,
-        κ;
-        ghost_exchange,
-    )
+add_ldg_laplacian_flux_internal!(dydt, q, G, κ, τ) =
+    add_numerical_flux_internal!(LDGLaplacianFlux(τ), dydt, q, G, κ)
+add_ldg_laplacian_flux_internal!(
+    ghost_exchange::DGGhostExchange,
+    dydt,
+    q,
+    G,
+    κ,
+    τ,
+) = add_numerical_flux_internal!(
+    ghost_exchange,
+    LDGLaplacianFlux(τ),
+    dydt,
+    q,
+    G,
+    κ,
+)

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -82,20 +82,6 @@ Base.@propagate_inbounds function Geometry.LocalGeometry(
     return @inbounds local_geom[v, i, j, h]
 end
 
-
-"""
-    AbstractBoundaryCondition
-
-An abstract type for boundary conditions for [`FiniteDifferenceOperator`](@ref)s.
-
-Subtypes should define:
-
-  - [`boundary_width`](@ref)
-  - [`stencil_left_boundary`](@ref)
-  - [`stencil_right_boundary`](@ref)
-"""
-abstract type AbstractBoundaryCondition end
-
 strip_space(bc::AbstractBoundaryCondition, parent_space) =
     hasproperty(bc, :val) ?
     unionall_type(typeof(bc))(strip_space(bc.val, parent_space)) : bc

--- a/src/Operators/numericalflux.jl
+++ b/src/Operators/numericalflux.jl
@@ -422,10 +422,12 @@ function _start_dg_ghost_exchange(space, args)
     ghost_bufs = ntuple(Val(length(args_local))) do i
         a = args_local[i]
         a isa DataLayouts.DataLayout || return nothing
-        ex = _dg_face_exchange(space, a, i)
-        isnothing(ex) && return nothing
-        Topologies.fill_face_send_buffer!(a, ex)
-        ex
+        _dg_face_exchange(space, a, i)
+    end
+    _claim_dg_face_exchanges!(ghost_bufs)
+    foreach(ntuple(identity, Val(length(args_local)))) do i
+        ex = ghost_bufs[i]
+        isnothing(ex) || Topologies.fill_face_send_buffer!(args_local[i], ex)
     end
     foreach(
         ex -> isnothing(ex) || ClimaComms.start(ex.graph_context),
@@ -466,29 +468,32 @@ function _finish_dg_ghost_faces!(
     )
     # The slot schedule is identical across the exchanged arguments; with no
     # exchanged argument (all `recv` entries `nothing`), slots are never read.
-    exs = filter(!isnothing, ghost_bufs)
+    exs = unrolled_filter(!isnothing, ghost_bufs)
     face_slot = isempty(exs) ? nothing : first(exs).face_slot
 
+    # The face-node indices are structurally in bounds: `i⁻`, `j⁻`, and `q′`
+    # come from `face_node_index` over 1:Nq, and elements and strip slots come
+    # from the topology's ghost-face list and schedule.
     for v in 1:Nv
         for (f, (elem⁻, face⁻, _ridx⁺, _face⁺, reversed)) in enumerate(gfaces)
-            dydt_slab⁻ = slab(dydt_data, v, elem⁻)
-            lg_slab⁻ = slab(local_geometry, v, elem⁻)
+            dydt_slab⁻ = @inbounds slab(dydt_data, v, elem⁻)
+            lg_slab⁻ = @inbounds slab(local_geometry, v, elem⁻)
             slot = isnothing(face_slot) ? 0 : Int(face_slot[f])
             arg_slabs⁻ = unrolled_map(
                 a ->
                     a isa DataLayouts.DataLayout ?
-                    slab(a, v, elem⁻) : a,
+                    (@inbounds slab(a, v, elem⁻)) : a,
                 args_local,
             )
             recv_slabs⁺ = unrolled_map(
-                r -> isnothing(r) ? nothing : slab(r, v, slot),
+                r -> isnothing(r) ? nothing : (@inbounds slab(r, v, slot)),
                 recv,
             )
             for q in 1:Nq
                 i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, q, false)
                 q′ = reversed ? Nq - q + 1 : q
 
-                lg⁻ = lg_slab⁻[1, i⁻, j⁻, 1]
+                lg⁻ = @inbounds lg_slab⁻[1, i⁻, j⁻, 1]
                 sgeom⁻ = compute_surface_geometry_extruded_2d(
                     lg⁻,
                     quad_weights,
@@ -500,12 +505,13 @@ function _finish_dg_ghost_faces!(
                 argvals⁻ = unrolled_map(
                     slab_ ->
                         slab_ isa DataLayouts.DataLayout ?
-                        slab_[1, i⁻, j⁻, 1] : slab_,
+                        (@inbounds slab_[1, i⁻, j⁻, 1]) : slab_,
                     arg_slabs⁻,
                 )
                 argvals⁺ = unrolled_map(
                     (a, r_slab) ->
-                        isnothing(r_slab) ? a : r_slab[1, q′, 1, 1],
+                        isnothing(r_slab) ? a :
+                        (@inbounds r_slab[1, q′, 1, 1]),
                     args_local,
                     recv_slabs⁺,
                 )
@@ -519,7 +525,8 @@ function _finish_dg_ghost_faces!(
                     argvals⁻,
                     argvals⁺,
                 )
-                dydt_slab⁻[1, i⁻, j⁻, 1] = dydt_slab⁻[1, i⁻, j⁻, 1] + δ⁻
+                @inbounds dydt_slab⁻[1, i⁻, j⁻, 1] =
+                    dydt_slab⁻[1, i⁻, j⁻, 1] + δ⁻
             end
         end
     end
@@ -562,9 +569,11 @@ Contract: every operator receiving the handle must be called with the same
 counts throw; two same-typed fields swapped in place cannot be detected. The
 handle covers one exchange round — start a fresh one whenever an argument's
 values change (e.g. each stage), and pass a started handle to at least one
-operator call before starting the next round on the same arguments. Returns a
-no-op handle on single-process contexts, so calling code needs no
-distributed-vs-single branch.
+operator call before starting the next round: the underlying buffers are
+shared per argument type and position on a space (also across *distinct*
+fields of the same type), and starting a round while another is in flight
+throws. Returns a no-op handle on single-process contexts, so calling code
+needs no distributed-vs-single branch.
 """
 @inline start_dg_ghost_exchange(args...) =
     start_dg_ghost_exchange(_extract_field_space(args...), args...)
@@ -598,16 +607,18 @@ end
     return ghost_exchange
 end
 
-# Complete the exchange on first consumption; later consumers get the recv
-# strips as-is. Returns `nothing` for a no-op (single-process) handle.
+# Complete the exchange on first consumption (releasing the in-flight latch
+# of each buffer); later consumers get the recv strips as-is. Returns
+# `nothing` for a no-op (single-process) handle.
 @inline function _consume_dg_ghost_exchange!(ghost::DGGhostExchange)
     bufs = ghost.bufs
     isnothing(bufs) && return nothing
     if !ghost.finished[]
-        foreach(
-            ex -> isnothing(ex) || ClimaComms.finish(ex.graph_context),
-            bufs,
-        )
+        foreach(bufs) do ex
+            isnothing(ex) && return
+            ClimaComms.finish(ex.graph_context)
+            ex.in_flight[] = false
+        end
         ghost.finished[] = true
     end
     return bufs
@@ -652,7 +663,11 @@ end
 # tendency evaluation and eventually alias the tag of a live graph context.
 # The argument position `i` is part of the key because same-typed arguments in
 # one call each need their own send buffer. `nothing` (no ghost faces) is a
-# valid cached value, hence the `:missing` sentinel.
+# valid cached value, hence the `:missing` sentinel. The key is deliberately
+# not specific to the field instance — keying on identity would mint a graph
+# context (and burn an MPI tag) per field ever exchanged — so distinct fields
+# of the same type at the same position share one buffer; the in-flight latch
+# below makes an overlapping second use an error instead of data corruption.
 function _dg_face_exchange(space, data, i)
     key = (Topologies.GhostFaceExchange, Spaces.grid(space), typeof(data), i)
     ex = get(Cache.OBJECT_CACHE, key, :missing)
@@ -661,6 +676,29 @@ function _dg_face_exchange(space, data, i)
         Cache.OBJECT_CACHE[key] = ex
     end
     return ex
+end
+
+# Claim the exchanges' buffers for one round (released by
+# `_consume_dg_ghost_exchange!`): a second start before the first round is
+# consumed — e.g. `start_dg_ghost_exchange(a)` then
+# `start_dg_ghost_exchange(b)` for same-typed fields `a` and `b` — would
+# overwrite the in-flight send strips and double-start the graph context.
+# All latches are checked before any is set, so a rejected start leaves
+# every buffer (including those of its other arguments) untouched.
+function _claim_dg_face_exchanges!(ghost_bufs)
+    foreach(ntuple(identity, Val(length(ghost_bufs)))) do i
+        ex = ghost_bufs[i]
+        isnothing(ex) && return
+        ex.in_flight[] && error(
+            "the DG ghost-face exchange for operator argument $i is still \
+             in flight; pass the previously started handle to a face \
+             operator (consuming it) before starting a new exchange. \
+             Exchange buffers are shared by all fields of the same type at \
+             the same argument position on a space.",
+        )
+    end
+    foreach(ex -> isnothing(ex) || (ex.in_flight[] = true), ghost_bufs)
+    return nothing
 end
 """
     PeriodicBC <: AbstractBoundaryCondition
@@ -710,7 +748,9 @@ mesh:
 per boundary face node, where `normal` is the outward unit normal and
 `argvals⁻` is the tuple of values of `args` at that node. `dydt` must be in
 mass-weighted residual form (`WJ * ∂Y/∂t`), matching
-[`add_numerical_flux_internal!`](@ref). No-op on domains without boundary
+[`add_numerical_flux_internal!`](@ref). Implemented for pure 2D spectral
+element spaces and extruded spaces with 2D horizontal spectral elements
+(``sWJ`` then carries the vertical measure). No-op on domains without boundary
 faces (e.g. the sphere).
 """
 @inline add_numerical_flux_boundary!(fn::F, dydt, args...) where {F} =
@@ -732,38 +772,63 @@ function _add_numerical_flux_boundary!(
     args...,
 ) where {F}
     space = axes(dydt)
-    Nq = Quadratures.degrees_of_freedom(Spaces.quadrature_style(space))
+    grid = Spaces.grid(space)
+    if grid isa Grids.ExtrudedFiniteDifferenceGrid &&
+       grid.horizontal_grid isa Grids.SpectralElementGrid1D
+        error(
+            "add_numerical_flux_boundary! is not implemented for extruded \
+             spaces with 1D horizontal spectral elements",
+        )
+    end
+    quadrature_style = Spaces.quadrature_style(space)
+    Nq = Quadratures.degrees_of_freedom(quadrature_style)
+    Nv = Spaces.nlevels(space)
+    FT = Spaces.undertype(space)
+    (_, quad_weights) = Quadratures.quadrature_points(FT, quadrature_style)
     topology = Spaces.topology(space)
-    boundary_surface_geometries = Spaces.grid(space).boundary_surface_geometries
-    dydt_bc = Base.broadcastable(dydt)
-    args_bc =
-        unrolled_map(arg -> arg isa Fields.Field ? Base.broadcastable(arg) : arg, args)
+    # The surface geometry is built from the product local geometry (like the
+    # interior extruded-2D loop), so `sWJ` carries the vertical measure on
+    # extruded spaces; for pure-2D spaces this matches the grid's precomputed
+    # `boundary_surface_geometries`.
+    local_geometry = Spaces.local_geometry_data(space)
+    dydt_data = Fields.field_values(dydt)
+    args_data = unrolled_map(
+        arg -> arg isa Fields.Field ? Fields.field_values(arg) : arg,
+        args,
+    )
 
-    for (iboundary, boundarytag) in
-        enumerate(Topologies.boundary_tags(topology))
-        for (iface, (elem⁻, face⁻)) in
-            enumerate(Topologies.boundary_faces(topology, boundarytag))
-            boundary_surface_geometry_slab =
-                slab(boundary_surface_geometries[iboundary], 1, iface)
-
-            arg_slabs⁻ =
-                unrolled_map(arg -> slab(Fields.todata(arg), 1, elem⁻), args_bc)
-            dydt_slab⁻ = slab(Fields.field_values(dydt_bc), 1, elem⁻)
-            for q in 1:Nq
-                sgeom⁻ = boundary_surface_geometry_slab[q]
-                i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, q, false)
-                argvals⁻ = unrolled_map(
-                    slab ->
-                        slab isa DataLayouts.DataLayout ?
-                        slab[1, i⁻, j⁻, 1] : slab,
-                    arg_slabs⁻,
+    for boundarytag in Topologies.boundary_tags(topology)
+        for (elem⁻, face⁻) in Topologies.boundary_faces(topology, boundarytag)
+            for v in 1:Nv
+                dydt_slab⁻ = slab(dydt_data, v, elem⁻)
+                lg_slab⁻ = slab(local_geometry, v, elem⁻)
+                arg_slabs⁻ = unrolled_map(
+                    a ->
+                        a isa DataLayouts.DataLayout ? slab(a, v, elem⁻) : a,
+                    args_data,
                 )
-                # Wrap so a multi-field (NamedTuple/vector) flux value scales
-                # and subtracts elementwise, matching the interior loops and
-                # the GPU boundary kernel's `_fd_scale`.
-                numflux⁻ = add_auto_broadcasters(fn(sgeom⁻.normal, argvals⁻))
-                dydt_slab⁻[1, i⁻, j⁻, 1] =
-                    dydt_slab⁻[1, i⁻, j⁻, 1] - (sgeom⁻.sWJ * numflux⁻)
+                for q in 1:Nq
+                    i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, q, false)
+                    sgeom⁻ = compute_surface_geometry_extruded_2d(
+                        lg_slab⁻[1, i⁻, j⁻, 1],
+                        quad_weights,
+                        face⁻,
+                        i⁻,
+                        j⁻,
+                    )
+                    argvals⁻ = unrolled_map(
+                        slab_ ->
+                            slab_ isa DataLayouts.DataLayout ?
+                            slab_[1, i⁻, j⁻, 1] : slab_,
+                        arg_slabs⁻,
+                    )
+                    # Wrap so a multi-field (NamedTuple/vector) flux value
+                    # scales and subtracts elementwise, matching the interior
+                    # loops and the GPU boundary kernel's `_fd_scale`.
+                    numflux⁻ = add_auto_broadcasters(fn(sgeom⁻.normal, argvals⁻))
+                    dydt_slab⁻[1, i⁻, j⁻, 1] =
+                        dydt_slab⁻[1, i⁻, j⁻, 1] - (sgeom⁻.sWJ * numflux⁻)
+                end
             end
         end
     end
@@ -1126,10 +1191,7 @@ function _dg_staging_buffer(
     buf = get(Cache.OBJECT_CACHE, key, nothing)
     if isnothing(buf)
         Nq = Quadratures.degrees_of_freedom(Spaces.quadrature_style(space))
-        grid = Spaces.grid(space)
-        Nv =
-            grid isa Grids.ExtrudedFiniteDifferenceGrid ?
-            Spaces.nlevels(space) : 1
+        Nv = Spaces.nlevels(space)
         DA = ClimaComms.array_type(Spaces.topology(space))
         buf = DA{T}(undef, Nq, Nv, nsides, nfaces)
         Cache.OBJECT_CACHE[key] = buf
@@ -1148,9 +1210,7 @@ function build_dg_connectivity(space)
     quadrature_style = Spaces.quadrature_style(space)
     Nq = Quadratures.degrees_of_freedom(quadrature_style)
     FT = Spaces.undertype(space)
-    grid = Spaces.grid(space)
-    extruded = grid isa Grids.ExtrudedFiniteDifferenceGrid
-    Nv = extruded ? Spaces.nlevels(space) : 1
+    Nv = Spaces.nlevels(space)
     (_, w) = Quadratures.quadrature_points(FT, quadrature_style)
     DA = ClimaComms.array_type(topology)
 
@@ -1179,10 +1239,7 @@ function build_dg_connectivity(space)
                 (Int32(f), Int32(2), Int32(q)),
             )
             for v in 1:Nv
-                lg =
-                    extruded ?
-                    slab(lg_host, v, elem⁻)[1, i⁻, j⁻, 1] :
-                    slab(lg_host, elem⁻)[1, i⁻, j⁻, 1]
+                lg = slab(lg_host, v, elem⁻)[1, i⁻, j⁻, 1]
                 sgeom[q, v, f] = compute_surface_geometry_extruded_2d(
                     lg,
                     w,
@@ -1271,9 +1328,7 @@ function build_dg_ghost_connectivity(space)
     quadrature_style = Spaces.quadrature_style(space)
     Nq = Quadratures.degrees_of_freedom(quadrature_style)
     FT = Spaces.undertype(space)
-    grid = Spaces.grid(space)
-    extruded = grid isa Grids.ExtrudedFiniteDifferenceGrid
-    Nv = extruded ? Spaces.nlevels(space) : 1
+    Nv = Spaces.nlevels(space)
     (_, w) = Quadratures.quadrature_points(FT, quadrature_style)
     DA = ClimaComms.array_type(topology)
 
@@ -1295,10 +1350,7 @@ function build_dg_ghost_connectivity(space)
                 (Int32(f), Int32(1), Int32(q)),
             )
             for v in 1:Nv
-                lg =
-                    extruded ?
-                    slab(lg_host, v, elem⁻)[1, i⁻, j⁻, 1] :
-                    slab(lg_host, elem⁻)[1, i⁻, j⁻, 1]
+                lg = slab(lg_host, v, elem⁻)[1, i⁻, j⁻, 1]
                 sgeom[q, v, f] = compute_surface_geometry_extruded_2d(
                     lg,
                     w,
@@ -1343,9 +1395,7 @@ function build_dg_boundary_connectivity(space)
     quadrature_style = Spaces.quadrature_style(space)
     Nq = Quadratures.degrees_of_freedom(quadrature_style)
     FT = Spaces.undertype(space)
-    grid = Spaces.grid(space)
-    extruded = grid isa Grids.ExtrudedFiniteDifferenceGrid
-    Nv = extruded ? Spaces.nlevels(space) : 1
+    Nv = Spaces.nlevels(space)
     (_, w) = Quadratures.quadrature_points(FT, quadrature_style)
     DA = ClimaComms.array_type(topology)
 
@@ -1365,9 +1415,7 @@ function build_dg_boundary_connectivity(space)
                 (Int32(f), Int32(1), Int32(q)),
             )
             for v in 1:Nv
-                lg =
-                    extruded ? slab(lg_host, v, elem⁻)[1, i⁻, j⁻, 1] :
-                    slab(lg_host, elem⁻)[1, i⁻, j⁻, 1]
+                lg = slab(lg_host, v, elem⁻)[1, i⁻, j⁻, 1]
                 sgeom[q, v, f] = compute_surface_geometry_extruded_2d(
                     lg,
                     w,

--- a/src/Operators/numericalflux.jl
+++ b/src/Operators/numericalflux.jl
@@ -52,11 +52,27 @@ function compute_surface_geometry_extruded_2d(
     return Geometry.SurfaceGeometry(sWJ, n)
 end
 
+"""
+    DGGhostExchange
+
+Handle for one round of the DG ghost-face halo exchange, shared across face
+operators — see [`start_dg_ghost_exchange`](@ref). The first operator that
+consumes the handle completes the exchange (`ClimaComms.finish`); later
+consumers read the same recv strips.
+"""
+struct DGGhostExchange{B}
+    bufs::B
+    finished::Base.RefValue{Bool}
+end
+DGGhostExchange(bufs) = DGGhostExchange(bufs, Ref(false))
+const NO_DG_GHOST_EXCHANGE = DGGhostExchange(nothing, Ref(true))
+
 # Device-dispatch seam (DSS-style): CPU methods live here; the
 # `ClimaComms.CUDADevice` methods are provided by the ClimaCoreCUDAExt
 # extension (ext/cuda/operators_dg.jl).
 """
     add_numerical_flux_internal!(fn, dydt, args...)
+    add_numerical_flux_internal!(ghost_exchange, fn, dydt, args...)
 
 Add the numerical flux at the internal faces of the spectral space mesh.
 
@@ -75,28 +91,63 @@ For consistency, it should satisfy the property that
 
     fn(normal, argvals⁻, argvals⁺) == -fn(-normal, argvals⁺, argvals⁻)
 
+The method with a leading `ghost_exchange` consumes a shared halo exchange
+from [`start_dg_ghost_exchange`](@ref) on distributed spaces.
+
 See also:
 
   - [`CentralNumericalFlux`](@ref)
   - [`RusanovNumericalFlux`](@ref)
 """
+add_numerical_flux_internal!(fn::F, dydt, args...) where {F} =
+    _add_numerical_flux_internal!(
+        ClimaComms.device(axes(dydt)),
+        nothing,
+        fn,
+        dydt,
+        args...,
+    )
 add_numerical_flux_internal!(
+    ghost_exchange::DGGhostExchange,
     fn::F,
     dydt,
-    args...;
-    ghost_exchange = nothing,
+    args...,
 ) where {F} = _add_numerical_flux_internal!(
     ClimaComms.device(axes(dydt)),
+    ghost_exchange,
     fn,
     dydt,
-    args...;
-    ghost_exchange,
+    args...,
 )
 
-_add_numerical_flux_internal!(device, fn::F, dydt, args...; kwargs...) where {F} =
-    error(
-        "add_numerical_flux_internal! is not implemented for $device; load CUDA.jl for CUDADevice support",
-    )
+_add_numerical_flux_internal!(
+    device,
+    ghost_exchange,
+    fn::F,
+    dydt,
+    args...,
+) where {F} = error(
+    "add_numerical_flux_internal! is not implemented for $device; load CUDA.jl for CUDADevice support",
+)
+
+# One-step argument access for the CPU face loops: `Field` and data-layout
+# arguments are read at node `(i, j)` of level `v` in element `h` (`(i,)` for
+# 1D horizontal elements); other arguments (e.g. equation parameters) pass
+# through. Each face node then needs a single `unrolled_map` from `args` to
+# values — a chain of Field→data→slab→value maps compiles one generated-map
+# instantiation per stage, with the latency that entails. The indices are
+# structurally in bounds: they come from `face_node_index` over `1:Nq` and
+# the topology's face lists.
+@inline _face_node_value(arg::Fields.Field, v, i, j, h) =
+    _face_node_value(Fields.field_values(arg), v, i, j, h)
+@inline _face_node_value(arg::DataLayouts.DataLayout, v, i, j, h) =
+    @inbounds slab(arg, v, h)[1, i, j, 1]
+@inline _face_node_value(arg, v, i, j, h) = arg
+@inline _face_node_value_1d(arg::Fields.Field, v, i, h) =
+    _face_node_value_1d(Fields.field_values(arg), v, i, h)
+@inline _face_node_value_1d(arg::DataLayouts.DataLayout, v, i, h) =
+    @inbounds slab(arg, v, h)[i]
+@inline _face_node_value_1d(arg, v, i, h) = arg
 
 # Face residual increments for one interior face node. Shared by numerical
 # flux (antisymmetric) and symmetric lifting; geometry loops pass `mode`.
@@ -127,24 +178,25 @@ end
 end
 function _add_numerical_flux_internal!(
     ::ClimaComms.AbstractCPUDevice,
+    ghost_exchange,
     fn::F,
     dydt,
-    args...;
-    ghost_exchange = nothing,
+    args...,
 ) where {F}
-    _add_interior_face_flux!(Val(:numflux), fn, dydt, args...; ghost_exchange)
+    _add_interior_face_flux!(Val(:numflux), ghost_exchange, fn, dydt, args...)
 end
 
 # Topology dispatch for CPU interior-face updates (numflux or lifting). The
-# ghost-face halo exchange is started (or a shared handle checked) before the
-# interior loops so communication overlaps the local face work, and finished
-# afterwards by the ghost-face loop in `_finish_dg_ghost_faces!`.
+# ghost-face halo exchange is started (or the shared `ghost_exchange` handle
+# checked) before the interior loops so communication overlaps the local face
+# work, and finished afterwards by the ghost-face loop in
+# `_finish_dg_ghost_faces!`.
 function _add_interior_face_flux!(
     mode::Val,
+    ghost_exchange,
     fn::F,
     dydt,
-    args...;
-    ghost_exchange = nothing,
+    args...,
 ) where {F}
     space = axes(dydt)
     grid = Spaces.grid(space)
@@ -175,9 +227,7 @@ function _add_interior_face_flux_2d!(mode::Val, fn::F, dydt, args...) where {F}
     Nq = Quadratures.degrees_of_freedom(Spaces.quadrature_style(space))
     topology = Spaces.topology(space)
     internal_surface_geometry = grid.internal_surface_geometry
-    dydt_bc = Base.broadcastable(dydt)
-    args_bc =
-        unrolled_map(arg -> arg isa Fields.Field ? Base.broadcastable(arg) : arg, args)
+    dydt_data = Fields.field_values(dydt)
 
     for (iface, (elem⁻, face⁻, elem⁺, face⁺, reversed)) in
         enumerate(Topologies.interior_faces(topology))
@@ -185,13 +235,8 @@ function _add_interior_face_flux_2d!(mode::Val, fn::F, dydt, args...) where {F}
         internal_surface_geometry_slab =
             slab(internal_surface_geometry, 1, iface)
 
-        arg_slabs⁻ =
-            unrolled_map(arg -> slab(Fields.todata(arg), 1, elem⁻), args_bc)
-        arg_slabs⁺ =
-            unrolled_map(arg -> slab(Fields.todata(arg), 1, elem⁺), args_bc)
-
-        dydt_slab⁻ = slab(Fields.field_values(dydt_bc), 1, elem⁻)
-        dydt_slab⁺ = slab(Fields.field_values(dydt_bc), 1, elem⁺)
+        dydt_slab⁻ = slab(dydt_data, 1, elem⁻)
+        dydt_slab⁺ = slab(dydt_data, 1, elem⁺)
 
         for q in 1:Nq
             sgeom⁻ = internal_surface_geometry_slab[q]
@@ -200,16 +245,12 @@ function _add_interior_face_flux_2d!(mode::Val, fn::F, dydt, args...) where {F}
             i⁺, j⁺ = Topologies.face_node_index(face⁺, Nq, q, reversed)
 
             argvals⁻ = unrolled_map(
-                slab_ ->
-                    slab_ isa DataLayouts.DataLayout ? slab_[1, i⁻, j⁻, 1] :
-                    slab_,
-                arg_slabs⁻,
+                arg -> _face_node_value(arg, 1, i⁻, j⁻, elem⁻),
+                args,
             )
             argvals⁺ = unrolled_map(
-                slab_ ->
-                    slab_ isa DataLayouts.DataLayout ? slab_[1, i⁺, j⁺, 1] :
-                    slab_,
-                arg_slabs⁺,
+                arg -> _face_node_value(arg, 1, i⁺, j⁺, elem⁺),
+                args,
             )
 
             δ⁻, δ⁺ = _face_side_increments(
@@ -242,10 +283,6 @@ function _add_interior_face_flux_extruded_1d!(
     local_geometry = Spaces.local_geometry_data(space)
 
     dydt_data = Fields.field_values(dydt)
-    args_data = unrolled_map(
-        arg -> arg isa Fields.Field ? Fields.field_values(arg) : arg,
-        args,
-    )
 
     for v in 1:Nv
         for (elem⁻, face⁻, elem⁺, face⁺, _reversed) in
@@ -257,14 +294,14 @@ function _add_interior_face_flux_extruded_1d!(
             lg⁻ = slab(local_geometry, v, elem⁻)[i⁻]
             sgeom⁻ = compute_surface_geometry_1d(lg⁻, face⁻)
 
-            argvals⁻ = unrolled_map(args_data) do arg
-                arg isa DataLayouts.AbstractData ?
-                slab(arg, v, elem⁻)[i⁻] : arg
-            end
-            argvals⁺ = unrolled_map(args_data) do arg
-                arg isa DataLayouts.AbstractData ?
-                slab(arg, v, elem⁺)[i⁺] : arg
-            end
+            argvals⁻ = unrolled_map(
+                arg -> _face_node_value_1d(arg, v, i⁻, elem⁻),
+                args,
+            )
+            argvals⁺ = unrolled_map(
+                arg -> _face_node_value_1d(arg, v, i⁺, elem⁺),
+                args,
+            )
 
             δ⁻, δ⁺ = _face_side_increments(
                 mode,
@@ -301,10 +338,6 @@ function _add_interior_face_flux_extruded_2d!(
     (_, quad_weights) = Quadratures.quadrature_points(FT, quadrature_style)
 
     dydt_data = Fields.field_values(dydt)
-    args_data = unrolled_map(
-        arg -> arg isa Fields.Field ? Fields.field_values(arg) : arg,
-        args,
-    )
 
     for v in 1:Nv
         for (elem⁻, face⁻, elem⁺, face⁺, reversed) in
@@ -313,18 +346,6 @@ function _add_interior_face_flux_extruded_2d!(
             dydt_slab⁻ = slab(dydt_data, v, elem⁻)
             dydt_slab⁺ = slab(dydt_data, v, elem⁺)
             lg_slab⁻ = slab(local_geometry, v, elem⁻)
-            arg_slabs⁻ = unrolled_map(
-                arg ->
-                    arg isa DataLayouts.AbstractData ?
-                    slab(arg, v, elem⁻) : arg,
-                args_data,
-            )
-            arg_slabs⁺ = unrolled_map(
-                arg ->
-                    arg isa DataLayouts.AbstractData ?
-                    slab(arg, v, elem⁺) : arg,
-                args_data,
-            )
 
             for q in 1:Nq
                 i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, q, false)
@@ -340,16 +361,12 @@ function _add_interior_face_flux_extruded_2d!(
                 )
 
                 argvals⁻ = unrolled_map(
-                    slab_ ->
-                        slab_ isa DataLayouts.AbstractData ?
-                        slab_[1, i⁻, j⁻, 1] : slab_,
-                    arg_slabs⁻,
+                    arg -> _face_node_value(arg, v, i⁻, j⁻, elem⁻),
+                    args,
                 )
                 argvals⁺ = unrolled_map(
-                    slab_ ->
-                        slab_ isa DataLayouts.AbstractData ?
-                        slab_[1, i⁺, j⁺, 1] : slab_,
-                    arg_slabs⁺,
+                    arg -> _face_node_value(arg, v, i⁺, j⁺, elem⁺),
+                    args,
                 )
 
                 δ⁻, δ⁺ = _face_side_increments(
@@ -388,20 +405,6 @@ end
 # Handles pure 2D (`Nv == 1`) and extruded 2D-horizontal spaces, with the
 # geometry built as in the interior extruded-2D loop.
 
-"""
-    DGGhostExchange
-
-Handle for one round of the DG ghost-face halo exchange, shared across face
-operators — see [`start_dg_ghost_exchange`](@ref). The first operator that
-consumes the handle completes the exchange (`ClimaComms.finish`); later
-consumers read the same recv strips.
-"""
-struct DGGhostExchange{B}
-    bufs::B
-    finished::Base.RefValue{Bool}
-end
-DGGhostExchange(bufs) = DGGhostExchange(bufs, Ref(false))
-const NO_DG_GHOST_EXCHANGE = DGGhostExchange(nothing, Base.RefValue{Bool}(true))
 
 function _start_dg_ghost_exchange(space, args)
     topology = Spaces.topology(space)
@@ -458,16 +461,9 @@ function _finish_dg_ghost_faces!(
     (_, quad_weights) = Quadratures.quadrature_points(FT, quadrature_style)
     local_geometry = Spaces.local_geometry_data(space)
     dydt_data = Fields.field_values(dydt)
-    args_local = unrolled_map(
-        arg -> arg isa Fields.Field ? Fields.field_values(arg) : arg,
-        args,
-    )
-    recv = unrolled_map(
-        ex -> isnothing(ex) ? nothing : ex.recv_data,
-        ghost_bufs,
-    )
     # The slot schedule is identical across the exchanged arguments; with no
-    # exchanged argument (all `recv` entries `nothing`), slots are never read.
+    # exchanged argument (an argument's `ghost_bufs` entry is `nothing`),
+    # slots are never read.
     exs = unrolled_filter(!isnothing, ghost_bufs)
     face_slot = isempty(exs) ? nothing : first(exs).face_slot
 
@@ -479,16 +475,6 @@ function _finish_dg_ghost_faces!(
             dydt_slab⁻ = @inbounds slab(dydt_data, v, elem⁻)
             lg_slab⁻ = @inbounds slab(local_geometry, v, elem⁻)
             slot = isnothing(face_slot) ? 0 : Int(face_slot[f])
-            arg_slabs⁻ = unrolled_map(
-                a ->
-                    a isa DataLayouts.DataLayout ?
-                    (@inbounds slab(a, v, elem⁻)) : a,
-                args_local,
-            )
-            recv_slabs⁺ = unrolled_map(
-                r -> isnothing(r) ? nothing : (@inbounds slab(r, v, slot)),
-                recv,
-            )
             for q in 1:Nq
                 i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, q, false)
                 q′ = reversed ? Nq - q + 1 : q
@@ -503,17 +489,17 @@ function _finish_dg_ghost_faces!(
                 )
 
                 argvals⁻ = unrolled_map(
-                    slab_ ->
-                        slab_ isa DataLayouts.DataLayout ?
-                        (@inbounds slab_[1, i⁻, j⁻, 1]) : slab_,
-                    arg_slabs⁻,
+                    arg -> _face_node_value(arg, v, i⁻, j⁻, elem⁻),
+                    args,
                 )
+                # A non-exchanged argument (no strip buffer) is identical on
+                # both sides.
                 argvals⁺ = unrolled_map(
-                    (a, r_slab) ->
-                        isnothing(r_slab) ? a :
-                        (@inbounds r_slab[1, q′, 1, 1]),
-                    args_local,
-                    recv_slabs⁺,
+                    (arg, ex) ->
+                        isnothing(ex) ? arg :
+                        (@inbounds slab(ex.recv_data, v, slot)[1, q′, 1, 1]),
+                    args,
+                    ghost_bufs,
                 )
 
                 # Only δ⁻ is used; the plus side lives on the neighbour rank.
@@ -556,10 +542,10 @@ shared by several operator calls in the same tendency evaluation:
 
     ex = Operators.start_dg_ghost_exchange(y)
     # ... element-local volume terms (the exchange overlaps them) ...
-    Operators.add_numerical_flux_internal!(numflux, dydt, y; ghost_exchange = ex)
-    Operators.add_lifting_flux_internal!(lift, dydt2, y; ghost_exchange = ex)
+    Operators.add_numerical_flux_internal!(ex, numflux, dydt, y)
+    Operators.add_lifting_flux_internal!(ex, lift, dydt2, y)
 
-Without the keyword each operator performs its own exchange, so an RHS that
+Without the leading handle each operator performs its own exchange, so an RHS that
 applies several face operators to the same state sends every halo message
 once per operator; a shared exchange sends each once. The space is taken from
 the first `Field` in `args`, or passed as a leading argument.
@@ -792,21 +778,12 @@ function _add_numerical_flux_boundary!(
     # `boundary_surface_geometries`.
     local_geometry = Spaces.local_geometry_data(space)
     dydt_data = Fields.field_values(dydt)
-    args_data = unrolled_map(
-        arg -> arg isa Fields.Field ? Fields.field_values(arg) : arg,
-        args,
-    )
 
     for boundarytag in Topologies.boundary_tags(topology)
         for (elem⁻, face⁻) in Topologies.boundary_faces(topology, boundarytag)
             for v in 1:Nv
                 dydt_slab⁻ = slab(dydt_data, v, elem⁻)
                 lg_slab⁻ = slab(local_geometry, v, elem⁻)
-                arg_slabs⁻ = unrolled_map(
-                    a ->
-                        a isa DataLayouts.DataLayout ? slab(a, v, elem⁻) : a,
-                    args_data,
-                )
                 for q in 1:Nq
                     i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, q, false)
                     sgeom⁻ = compute_surface_geometry_extruded_2d(
@@ -817,10 +794,8 @@ function _add_numerical_flux_boundary!(
                         j⁻,
                     )
                     argvals⁻ = unrolled_map(
-                        slab_ ->
-                            slab_ isa DataLayouts.DataLayout ?
-                            slab_[1, i⁻, j⁻, 1] : slab_,
-                        arg_slabs⁻,
+                        arg -> _face_node_value(arg, v, i⁻, j⁻, elem⁻),
+                        args,
                     )
                     # Wrap so a multi-field (NamedTuple/vector) flux value
                     # scales and subtracts elementwise, matching the interior
@@ -858,6 +833,7 @@ end
 
 """
     add_lifting_flux_internal!(fn, dydt, args...)
+    add_lifting_flux_internal!(ghost_exchange, fn, dydt, args...)
 
 Add *symmetric* face lifting terms at internal faces — the DG correction for
 non-conservative (gradient / curl) terms, where both sides of a face receive
@@ -873,34 +849,49 @@ gradient of a scalar `q` is completed by `fn(n̂, (q⁻,), (q⁺,)) = ((q⁺ −
 `dydt` must be in mass-weighted residual form (`WJ * ∂Y/∂t`), matching
 [`add_numerical_flux_internal!`](@ref). Implemented for pure 2D spectral
 element spaces and for extruded spaces with 1D (plane) or 2D (e.g.
-cubed-sphere) horizontal spectral elements.
+cubed-sphere) horizontal spectral elements. The method with a leading
+`ghost_exchange` consumes a shared halo exchange from
+[`start_dg_ghost_exchange`](@ref) on distributed spaces.
 """
+add_lifting_flux_internal!(fn::F, dydt, args...) where {F} =
+    _add_lifting_flux_internal!(
+        ClimaComms.device(axes(dydt)),
+        nothing,
+        fn,
+        dydt,
+        args...,
+    )
 add_lifting_flux_internal!(
+    ghost_exchange::DGGhostExchange,
     fn::F,
     dydt,
-    args...;
-    ghost_exchange = nothing,
+    args...,
 ) where {F} = _add_lifting_flux_internal!(
     ClimaComms.device(axes(dydt)),
+    ghost_exchange,
     fn,
     dydt,
-    args...;
-    ghost_exchange,
+    args...,
 )
 
-_add_lifting_flux_internal!(device, fn::F, dydt, args...; kwargs...) where {F} =
-    error(
-        "add_lifting_flux_internal! is not implemented for $device; load CUDA.jl for CUDADevice support",
-    )
+_add_lifting_flux_internal!(
+    device,
+    ghost_exchange,
+    fn::F,
+    dydt,
+    args...,
+) where {F} = error(
+    "add_lifting_flux_internal! is not implemented for $device; load CUDA.jl for CUDADevice support",
+)
 
 function _add_lifting_flux_internal!(
     ::ClimaComms.AbstractCPUDevice,
+    ghost_exchange,
     fn::F,
     dydt,
-    args...;
-    ghost_exchange = nothing,
+    args...,
 ) where {F}
-    _add_interior_face_flux!(Val(:lifting), fn, dydt, args...; ghost_exchange)
+    _add_interior_face_flux!(Val(:lifting), ghost_exchange, fn, dydt, args...)
 end
 
 """

--- a/src/Operators/numericalflux.jl
+++ b/src/Operators/numericalflux.jl
@@ -177,18 +177,21 @@ function _add_interior_face_flux_2d!(mode::Val, fn::F, dydt, args...) where {F}
     internal_surface_geometry = grid.internal_surface_geometry
     dydt_bc = Base.broadcastable(dydt)
     args_bc =
-        map(arg -> arg isa Fields.Field ? Base.broadcastable(arg) : arg, args)
+        unrolled_map(arg -> arg isa Fields.Field ? Base.broadcastable(arg) : arg, args)
 
     for (iface, (elem⁻, face⁻, elem⁺, face⁺, reversed)) in
         enumerate(Topologies.interior_faces(topology))
 
-        internal_surface_geometry_slab = slab(internal_surface_geometry, iface)
+        internal_surface_geometry_slab =
+            slab(internal_surface_geometry, 1, iface)
 
-        arg_slabs⁻ = map(arg -> slab(Fields.todata(arg), elem⁻), args_bc)
-        arg_slabs⁺ = map(arg -> slab(Fields.todata(arg), elem⁺), args_bc)
+        arg_slabs⁻ =
+            unrolled_map(arg -> slab(Fields.todata(arg), 1, elem⁻), args_bc)
+        arg_slabs⁺ =
+            unrolled_map(arg -> slab(Fields.todata(arg), 1, elem⁺), args_bc)
 
-        dydt_slab⁻ = slab(Fields.field_values(dydt_bc), elem⁻)
-        dydt_slab⁺ = slab(Fields.field_values(dydt_bc), elem⁺)
+        dydt_slab⁻ = slab(Fields.field_values(dydt_bc), 1, elem⁻)
+        dydt_slab⁺ = slab(Fields.field_values(dydt_bc), 1, elem⁺)
 
         for q in 1:Nq
             sgeom⁻ = internal_surface_geometry_slab[q]
@@ -196,13 +199,13 @@ function _add_interior_face_flux_2d!(mode::Val, fn::F, dydt, args...) where {F}
             i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, q, false)
             i⁺, j⁺ = Topologies.face_node_index(face⁺, Nq, q, reversed)
 
-            argvals⁻ = map(
+            argvals⁻ = unrolled_map(
                 slab_ ->
                     slab_ isa DataLayouts.DataLayout ? slab_[1, i⁻, j⁻, 1] :
                     slab_,
                 arg_slabs⁻,
             )
-            argvals⁺ = map(
+            argvals⁺ = unrolled_map(
                 slab_ ->
                     slab_ isa DataLayouts.DataLayout ? slab_[1, i⁺, j⁺, 1] :
                     slab_,
@@ -239,7 +242,7 @@ function _add_interior_face_flux_extruded_1d!(
     local_geometry = Spaces.local_geometry_data(space)
 
     dydt_data = Fields.field_values(dydt)
-    args_data = map(
+    args_data = unrolled_map(
         arg -> arg isa Fields.Field ? Fields.field_values(arg) : arg,
         args,
     )
@@ -254,17 +257,13 @@ function _add_interior_face_flux_extruded_1d!(
             lg⁻ = slab(local_geometry, v, elem⁻)[i⁻]
             sgeom⁻ = compute_surface_geometry_1d(lg⁻, face⁻)
 
-            argvals⁻ = map(args_data) do arg
-                val =
-                    arg isa DataLayouts.AbstractData ?
-                    slab(arg, v, elem⁻)[i⁻] : arg
-                add_auto_broadcasters(val)
+            argvals⁻ = unrolled_map(args_data) do arg
+                arg isa DataLayouts.AbstractData ?
+                slab(arg, v, elem⁻)[i⁻] : arg
             end
-            argvals⁺ = map(args_data) do arg
-                val =
-                    arg isa DataLayouts.AbstractData ?
-                    slab(arg, v, elem⁺)[i⁺] : arg
-                add_auto_broadcasters(val)
+            argvals⁺ = unrolled_map(args_data) do arg
+                arg isa DataLayouts.AbstractData ?
+                slab(arg, v, elem⁺)[i⁺] : arg
             end
 
             δ⁻, δ⁺ = _face_side_increments(
@@ -302,7 +301,7 @@ function _add_interior_face_flux_extruded_2d!(
     (_, quad_weights) = Quadratures.quadrature_points(FT, quadrature_style)
 
     dydt_data = Fields.field_values(dydt)
-    args_data = map(
+    args_data = unrolled_map(
         arg -> arg isa Fields.Field ? Fields.field_values(arg) : arg,
         args,
     )
@@ -313,12 +312,25 @@ function _add_interior_face_flux_extruded_2d!(
 
             dydt_slab⁻ = slab(dydt_data, v, elem⁻)
             dydt_slab⁺ = slab(dydt_data, v, elem⁺)
+            lg_slab⁻ = slab(local_geometry, v, elem⁻)
+            arg_slabs⁻ = unrolled_map(
+                arg ->
+                    arg isa DataLayouts.AbstractData ?
+                    slab(arg, v, elem⁻) : arg,
+                args_data,
+            )
+            arg_slabs⁺ = unrolled_map(
+                arg ->
+                    arg isa DataLayouts.AbstractData ?
+                    slab(arg, v, elem⁺) : arg,
+                args_data,
+            )
 
             for q in 1:Nq
                 i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, q, false)
                 i⁺, j⁺ = Topologies.face_node_index(face⁺, Nq, q, reversed)
 
-                lg⁻ = slab(local_geometry, v, elem⁻)[1, i⁻, j⁻, 1]
+                lg⁻ = lg_slab⁻[1, i⁻, j⁻, 1]
                 sgeom⁻ = compute_surface_geometry_extruded_2d(
                     lg⁻,
                     quad_weights,
@@ -327,18 +339,18 @@ function _add_interior_face_flux_extruded_2d!(
                     j⁻,
                 )
 
-                argvals⁻ = map(args_data) do arg
-                    val =
-                        arg isa DataLayouts.AbstractData ?
-                        slab(arg, v, elem⁻)[1, i⁻, j⁻, 1] : arg
-                    add_auto_broadcasters(val)
-                end
-                argvals⁺ = map(args_data) do arg
-                    val =
-                        arg isa DataLayouts.AbstractData ?
-                        slab(arg, v, elem⁺)[1, i⁺, j⁺, 1] : arg
-                    add_auto_broadcasters(val)
-                end
+                argvals⁻ = unrolled_map(
+                    slab_ ->
+                        slab_ isa DataLayouts.AbstractData ?
+                        slab_[1, i⁻, j⁻, 1] : slab_,
+                    arg_slabs⁻,
+                )
+                argvals⁺ = unrolled_map(
+                    slab_ ->
+                        slab_ isa DataLayouts.AbstractData ?
+                        slab_[1, i⁺, j⁺, 1] : slab_,
+                    arg_slabs⁺,
+                )
 
                 δ⁻, δ⁺ = _face_side_increments(
                     mode,
@@ -359,37 +371,22 @@ end
 # Distributed (MPI) ghost faces
 # ---------------------------------------------------------------------------
 
-# Add the face contributions on ghost faces — faces whose "plus" element is
-# owned by another rank. `Topologies.interior_faces` covers only local-local
-# faces, so the loops above skip these; here each rank completes its own
-# ("minus") side.
+# Ghost faces — those whose "plus" element is owned by another rank — are
+# skipped by `Topologies.interior_faces`, so the interior loops above miss
+# them. Here each rank completes its own ("minus") side, reading the neighbour
+# values from the `Topologies.GhostFaceExchange` recv strips (see there for the
+# slot pairing and node order).
 #
-# The neighbour ("plus") face values are exchanged as `Nq`-node face strips
-# through `Topologies.GhostFaceExchange` (see there for the slot pairing and
-# node-order conventions): the strip for the ghost face at position `f` of
-# `Topologies.ghost_faces` sits at slot `face_slot[f]` of `recv_data`, and the
-# plus-side value at loop node `q` is strip node `q′ = reversed ? Nq - q + 1 :
-# q` (strips are packed in the sender's natural face order).
+# Writing only the minus side is exact: the mirror ghost face on the
+# neighbouring rank writes its own minus side, and the two match the
+# single-rank result because the normal is single-valued up to sign
+# (`n̂⁺ = -n̂⁻`), `sWJ` is single-valued on a conforming face, and the flux is
+# antisymmetric (`fn(n̂, a, b) == -fn(-n̂, b, a)`). So the minus-side increment
+# of `_face_side_increments` (numflux or lifting, as in the interior loops) is
+# applied and its plus side is dropped.
 #
-# Only the minus side is written. The mirror ghost face on the neighbouring
-# rank writes its own minus side, and the two agree with the single-rank
-# result because the outward normal is single-valued up to sign in the local
-# orthonormal frame (`n̂⁺ = -n̂⁻`), `sWJ` is single-valued on a conforming
-# face, and the flux is antisymmetric (`fn(n̂, a, b) == -fn(-n̂, b, a)`) — the
-# operator contract. The minus-side increment of `_face_side_increments` is
-# applied (`mode` is `Val(:numflux)` or `Val(:lifting)`, as in the interior
-# loops); the plus-side increment belongs to the mirror face on the
-# neighbouring rank. No-op on single-process contexts and on ranks with no
-# ghost faces:
-# the strip exchange involves only face-sharing neighbour pairs (both sides of
-# each pair have mirrored ghost faces), so a rank with none shares no exchange
-# with any peer and can skip it safely.
-#
-# Handles pure 2D spectral-element spaces (`Nv == 1`) and extruded spaces with
-# 2D horizontal spectral elements; the geometry is built the same way as the
-# interior extruded-2D loop, which matches the grid's precomputed
-# `internal_surface_geometry` for the pure-2D case. Ghost exchange is started
-# before the interior-face loops to overlap communication with compute.
+# Handles pure 2D (`Nv == 1`) and extruded 2D-horizontal spaces, with the
+# geometry built as in the interior extruded-2D loop.
 
 """
     DGGhostExchange
@@ -475,12 +472,23 @@ function _finish_dg_ghost_faces!(
     for v in 1:Nv
         for (f, (elem⁻, face⁻, _ridx⁺, _face⁺, reversed)) in enumerate(gfaces)
             dydt_slab⁻ = slab(dydt_data, v, elem⁻)
+            lg_slab⁻ = slab(local_geometry, v, elem⁻)
             slot = isnothing(face_slot) ? 0 : Int(face_slot[f])
+            arg_slabs⁻ = unrolled_map(
+                a ->
+                    a isa DataLayouts.DataLayout ?
+                    slab(a, v, elem⁻) : a,
+                args_local,
+            )
+            recv_slabs⁺ = unrolled_map(
+                r -> isnothing(r) ? nothing : slab(r, v, slot),
+                recv,
+            )
             for q in 1:Nq
                 i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, q, false)
                 q′ = reversed ? Nq - q + 1 : q
 
-                lg⁻ = slab(local_geometry, v, elem⁻)[1, i⁻, j⁻, 1]
+                lg⁻ = lg_slab⁻[1, i⁻, j⁻, 1]
                 sgeom⁻ = compute_surface_geometry_extruded_2d(
                     lg⁻,
                     quad_weights,
@@ -490,16 +498,16 @@ function _finish_dg_ghost_faces!(
                 )
 
                 argvals⁻ = unrolled_map(
-                    a ->
-                        a isa DataLayouts.DataLayout ?
-                        slab(a, v, elem⁻)[1, i⁻, j⁻, 1] : a,
-                    args_local,
+                    slab_ ->
+                        slab_ isa DataLayouts.DataLayout ?
+                        slab_[1, i⁻, j⁻, 1] : slab_,
+                    arg_slabs⁻,
                 )
                 argvals⁺ = unrolled_map(
-                    (a, r) ->
-                        isnothing(r) ? a : slab(r, v, slot)[1, q′, 1, 1],
+                    (a, r_slab) ->
+                        isnothing(r_slab) ? a : r_slab[1, q′, 1, 1],
                     args_local,
-                    recv,
+                    recv_slabs⁺,
                 )
 
                 # Only δ⁻ is used; the plus side lives on the neighbour rank.
@@ -736,19 +744,23 @@ function _add_numerical_flux_boundary!(
         for (iface, (elem⁻, face⁻)) in
             enumerate(Topologies.boundary_faces(topology, boundarytag))
             boundary_surface_geometry_slab =
-                surface_geometry_slab =
-                    slab(boundary_surface_geometries[iboundary], 1, iface)
+                slab(boundary_surface_geometries[iboundary], 1, iface)
 
-            arg_slabs⁻ = unrolled_map(arg -> slab(Fields.todata(arg), 1, elem⁻), args_bc)
+            arg_slabs⁻ =
+                unrolled_map(arg -> slab(Fields.todata(arg), 1, elem⁻), args_bc)
             dydt_slab⁻ = slab(Fields.field_values(dydt_bc), 1, elem⁻)
             for q in 1:Nq
                 sgeom⁻ = boundary_surface_geometry_slab[q]
                 i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, q, false)
                 argvals⁻ = unrolled_map(
                     slab ->
-                        slab isa DataLayouts.DataLayout ? slab[1, i⁻, j⁻, 1] : slab,
+                        slab isa DataLayouts.DataLayout ?
+                        slab[1, i⁻, j⁻, 1] : slab,
                     arg_slabs⁻,
                 )
+                # Wrap so a multi-field (NamedTuple/vector) flux value scales
+                # and subtracts elementwise, matching the interior loops and
+                # the GPU boundary kernel's `_fd_scale`.
                 numflux⁻ = add_auto_broadcasters(fn(sgeom⁻.normal, argvals⁻))
                 dydt_slab⁻[1, i⁻, j⁻, 1] =
                     dydt_slab⁻[1, i⁻, j⁻, 1] - (sgeom⁻.sWJ * numflux⁻)

--- a/src/Operators/numericalflux.jl
+++ b/src/Operators/numericalflux.jl
@@ -5,13 +5,6 @@ Abstract type for numerical flux functions used in DG methods.
 """
 abstract type AbstractNumericalFlux end
 
-"""
-    AbstractBoundaryCondition
-
-Abstract type for boundary conditions in DG methods.
-"""
-abstract type AbstractBoundaryCondition end
-
 @inline face_node_index_1d(face, Nq) = face == 1 ? 1 : Nq
 
 # Surface Jacobian weight and outward unit normal for a 1D spectral-element
@@ -87,17 +80,23 @@ See also:
   - [`CentralNumericalFlux`](@ref)
   - [`RusanovNumericalFlux`](@ref)
 """
-add_numerical_flux_internal!(fn::F, dydt, args...) where {F} =
-    _add_numerical_flux_internal!(
-        ClimaComms.device(axes(dydt)),
-        fn,
-        dydt,
-        args...,
-    )
-
-_add_numerical_flux_internal!(device, fn::F, dydt, args...) where {F} = error(
-    "add_numerical_flux_internal! is not implemented for $device; load CUDA.jl for CUDADevice support",
+add_numerical_flux_internal!(
+    fn::F,
+    dydt,
+    args...;
+    ghost_exchange = nothing,
+) where {F} = _add_numerical_flux_internal!(
+    ClimaComms.device(axes(dydt)),
+    fn,
+    dydt,
+    args...;
+    ghost_exchange,
 )
+
+_add_numerical_flux_internal!(device, fn::F, dydt, args...; kwargs...) where {F} =
+    error(
+        "add_numerical_flux_internal! is not implemented for $device; load CUDA.jl for CUDADevice support",
+    )
 
 # Face residual increments for one interior face node. Shared by numerical
 # flux (antisymmetric) and symmetric lifting; geometry loops pass `mode`.
@@ -126,28 +125,47 @@ end
     lift⁺ = add_auto_broadcasters(fn(-normal, argvals⁺, argvals⁻))
     return (sWJ * lift⁻, sWJ * lift⁺)
 end
-
 function _add_numerical_flux_internal!(
     ::ClimaComms.AbstractCPUDevice,
     fn::F,
     dydt,
-    args...,
+    args...;
+    ghost_exchange = nothing,
 ) where {F}
-    _add_interior_face_flux!(Val(:numflux), fn, dydt, args...)
+    _add_interior_face_flux!(Val(:numflux), fn, dydt, args...; ghost_exchange)
 end
 
-# Topology dispatch for CPU interior-face updates (numflux or lifting).
-function _add_interior_face_flux!(mode::Val, fn::F, dydt, args...) where {F}
+# Topology dispatch for CPU interior-face updates (numflux or lifting). The
+# ghost-face halo exchange is started (or a shared handle checked) before the
+# interior loops so communication overlaps the local face work, and finished
+# afterwards by the ghost-face loop in `_finish_dg_ghost_faces!`.
+function _add_interior_face_flux!(
+    mode::Val,
+    fn::F,
+    dydt,
+    args...;
+    ghost_exchange = nothing,
+) where {F}
     space = axes(dydt)
     grid = Spaces.grid(space)
-    if grid isa Grids.ExtrudedFiniteDifferenceGrid
-        if grid.horizontal_grid isa Grids.SpectralElementGrid1D
-            return _add_interior_face_flux_extruded_1d!(mode, fn, dydt, args...)
-        elseif grid.horizontal_grid isa Grids.SpectralElementGrid2D
-            return _add_interior_face_flux_extruded_2d!(mode, fn, dydt, args...)
-        end
+    if grid isa Grids.ExtrudedFiniteDifferenceGrid &&
+       grid.horizontal_grid isa Grids.SpectralElementGrid1D
+        # 1D horizontal topologies are single-process; a passed handle is
+        # necessarily a no-op one and needs no consumption.
+        return _add_interior_face_flux_extruded_1d!(mode, fn, dydt, args...)
     end
-    return _add_interior_face_flux_2d!(mode, fn, dydt, args...)
+    ghost = _dg_shared_or_start(
+        ClimaComms.device(space),
+        space,
+        args,
+        ghost_exchange,
+    )
+    if grid isa Grids.ExtrudedFiniteDifferenceGrid
+        _add_interior_face_flux_extruded_2d!(mode, fn, dydt, args...)
+    else
+        _add_interior_face_flux_2d!(mode, fn, dydt, args...)
+    end
+    return _finish_dg_ghost_faces!(mode, fn, dydt, args, ghost)
 end
 
 # Pure 2D spectral element space (precomputed internal surface geometry).
@@ -337,7 +355,305 @@ function _add_interior_face_flux_extruded_2d!(
     end
     return dydt
 end
+# ---------------------------------------------------------------------------
+# Distributed (MPI) ghost faces
+# ---------------------------------------------------------------------------
 
+# Add the face contributions on ghost faces — faces whose "plus" element is
+# owned by another rank. `Topologies.interior_faces` covers only local-local
+# faces, so the loops above skip these; here each rank completes its own
+# ("minus") side.
+#
+# The neighbour ("plus") face values are exchanged as `Nq`-node face strips
+# through `Topologies.GhostFaceExchange` (see there for the slot pairing and
+# node-order conventions): the strip for the ghost face at position `f` of
+# `Topologies.ghost_faces` sits at slot `face_slot[f]` of `recv_data`, and the
+# plus-side value at loop node `q` is strip node `q′ = reversed ? Nq - q + 1 :
+# q` (strips are packed in the sender's natural face order).
+#
+# Only the minus side is written. The mirror ghost face on the neighbouring
+# rank writes its own minus side, and the two agree with the single-rank
+# result because the outward normal is single-valued up to sign in the local
+# orthonormal frame (`n̂⁺ = -n̂⁻`), `sWJ` is single-valued on a conforming
+# face, and the flux is antisymmetric (`fn(n̂, a, b) == -fn(-n̂, b, a)`) — the
+# operator contract. The minus-side increment of `_face_side_increments` is
+# applied (`mode` is `Val(:numflux)` or `Val(:lifting)`, as in the interior
+# loops); the plus-side increment belongs to the mirror face on the
+# neighbouring rank. No-op on single-process contexts and on ranks with no
+# ghost faces:
+# the strip exchange involves only face-sharing neighbour pairs (both sides of
+# each pair have mirrored ghost faces), so a rank with none shares no exchange
+# with any peer and can skip it safely.
+#
+# Handles pure 2D spectral-element spaces (`Nv == 1`) and extruded spaces with
+# 2D horizontal spectral elements; the geometry is built the same way as the
+# interior extruded-2D loop, which matches the grid's precomputed
+# `internal_surface_geometry` for the pure-2D case. Ghost exchange is started
+# before the interior-face loops to overlap communication with compute.
+
+"""
+    DGGhostExchange
+
+Handle for one round of the DG ghost-face halo exchange, shared across face
+operators — see [`start_dg_ghost_exchange`](@ref). The first operator that
+consumes the handle completes the exchange (`ClimaComms.finish`); later
+consumers read the same recv strips.
+"""
+struct DGGhostExchange{B}
+    bufs::B
+    finished::Base.RefValue{Bool}
+end
+DGGhostExchange(bufs) = DGGhostExchange(bufs, Ref(false))
+const NO_DG_GHOST_EXCHANGE = DGGhostExchange(nothing, Base.RefValue{Bool}(true))
+
+function _start_dg_ghost_exchange(space, args)
+    topology = Spaces.topology(space)
+    # `nothing` (not an empty tuple) marks "no exchange started": a zero-
+    # argument call on a distributed context returns `()` from the `ntuple`
+    # below and must still run the ghost-face loop in
+    # `_finish_dg_ghost_faces!`.
+    ClimaComms.context(topology) isa ClimaComms.SingletonCommsContext &&
+        return nothing
+
+    # Exchange the ghost elements of every data argument through memoized
+    # ghost buffers (non-data arguments, e.g. equation parameters, are
+    # identical on both sides).
+    args_local = unrolled_map(
+        arg -> arg isa Fields.Field ? Fields.field_values(arg) : arg,
+        args,
+    )
+    ghost_bufs = ntuple(Val(length(args_local))) do i
+        a = args_local[i]
+        a isa DataLayouts.DataLayout || return nothing
+        ex = _dg_face_exchange(space, a, i)
+        isnothing(ex) && return nothing
+        Topologies.fill_face_send_buffer!(a, ex)
+        ex
+    end
+    foreach(
+        ex -> isnothing(ex) || ClimaComms.start(ex.graph_context),
+        ghost_bufs,
+    )
+    return ghost_bufs
+end
+
+function _finish_dg_ghost_faces!(
+    mode::Val,
+    fn::F,
+    dydt,
+    args,
+    ghost::DGGhostExchange,
+) where {F}
+    ghost_bufs = _consume_dg_ghost_exchange!(ghost)
+    isnothing(ghost_bufs) && return dydt
+
+    space = axes(dydt)
+    topology = Spaces.topology(space)
+    gfaces = Topologies.ghost_faces(topology)
+    isempty(gfaces) && return dydt
+
+    quadrature_style = Spaces.quadrature_style(space)
+    Nq = Quadratures.degrees_of_freedom(quadrature_style)
+    Nv = Spaces.nlevels(space)
+    FT = Spaces.undertype(space)
+    (_, quad_weights) = Quadratures.quadrature_points(FT, quadrature_style)
+    local_geometry = Spaces.local_geometry_data(space)
+    dydt_data = Fields.field_values(dydt)
+    args_local = unrolled_map(
+        arg -> arg isa Fields.Field ? Fields.field_values(arg) : arg,
+        args,
+    )
+    recv = unrolled_map(
+        ex -> isnothing(ex) ? nothing : ex.recv_data,
+        ghost_bufs,
+    )
+    # The slot schedule is identical across the exchanged arguments; with no
+    # exchanged argument (all `recv` entries `nothing`), slots are never read.
+    exs = filter(!isnothing, ghost_bufs)
+    face_slot = isempty(exs) ? nothing : first(exs).face_slot
+
+    for v in 1:Nv
+        for (f, (elem⁻, face⁻, _ridx⁺, _face⁺, reversed)) in enumerate(gfaces)
+            dydt_slab⁻ = slab(dydt_data, v, elem⁻)
+            slot = isnothing(face_slot) ? 0 : Int(face_slot[f])
+            for q in 1:Nq
+                i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, q, false)
+                q′ = reversed ? Nq - q + 1 : q
+
+                lg⁻ = slab(local_geometry, v, elem⁻)[1, i⁻, j⁻, 1]
+                sgeom⁻ = compute_surface_geometry_extruded_2d(
+                    lg⁻,
+                    quad_weights,
+                    face⁻,
+                    i⁻,
+                    j⁻,
+                )
+
+                argvals⁻ = unrolled_map(
+                    a ->
+                        a isa DataLayouts.DataLayout ?
+                        slab(a, v, elem⁻)[1, i⁻, j⁻, 1] : a,
+                    args_local,
+                )
+                argvals⁺ = unrolled_map(
+                    (a, r) ->
+                        isnothing(r) ? a : slab(r, v, slot)[1, q′, 1, 1],
+                    args_local,
+                    recv,
+                )
+
+                # Only δ⁻ is used; the plus side lives on the neighbour rank.
+                δ⁻, _ = _face_side_increments(
+                    mode,
+                    fn,
+                    sgeom⁻.sWJ,
+                    sgeom⁻.normal,
+                    argvals⁻,
+                    argvals⁺,
+                )
+                dydt_slab⁻[1, i⁻, j⁻, 1] = dydt_slab⁻[1, i⁻, j⁻, 1] + δ⁻
+            end
+        end
+    end
+    return dydt
+end
+
+_add_dg_ghost_faces!(mode::Val, fn::F, dydt, args) where {F} =
+    _finish_dg_ghost_faces!(
+        mode,
+        fn,
+        dydt,
+        args,
+        DGGhostExchange(_start_dg_ghost_exchange(axes(dydt), args)),
+    )
+
+@inline _extract_field_space(a::Fields.Field, rest...) = axes(a)
+@inline _extract_field_space(a, rest...) = _extract_field_space(rest...)
+@inline _extract_field_space() =
+    error("start_dg_ghost_exchange requires at least one Field argument")
+
+"""
+    start_dg_ghost_exchange(args...)
+    start_dg_ghost_exchange(space, args...)
+
+Start the ghost-face halo exchange of the DG face operators once, to be
+shared by several operator calls in the same tendency evaluation:
+
+    ex = Operators.start_dg_ghost_exchange(y)
+    # ... element-local volume terms (the exchange overlaps them) ...
+    Operators.add_numerical_flux_internal!(numflux, dydt, y; ghost_exchange = ex)
+    Operators.add_lifting_flux_internal!(lift, dydt2, y; ghost_exchange = ex)
+
+Without the keyword each operator performs its own exchange, so an RHS that
+applies several face operators to the same state sends every halo message
+once per operator; a shared exchange sends each once. The space is taken from
+the first `Field` in `args`, or passed as a leading argument.
+
+Contract: every operator receiving the handle must be called with the same
+`args` (the same fields, in the same order). Mismatched argument types or
+counts throw; two same-typed fields swapped in place cannot be detected. The
+handle covers one exchange round — start a fresh one whenever an argument's
+values change (e.g. each stage), and pass a started handle to at least one
+operator call before starting the next round on the same arguments. Returns a
+no-op handle on single-process contexts, so calling code needs no
+distributed-vs-single branch.
+"""
+@inline start_dg_ghost_exchange(args...) =
+    start_dg_ghost_exchange(_extract_field_space(args...), args...)
+
+@inline function start_dg_ghost_exchange(space::Spaces.AbstractSpace, args...)
+    return _start_dg_ghost_exchange_handle(
+        ClimaComms.device(space),
+        space,
+        args,
+    )
+end
+
+@inline function _start_dg_ghost_exchange_handle(
+    ::ClimaComms.AbstractCPUDevice,
+    space,
+    args,
+)
+    bufs = _start_dg_ghost_exchange(space, args)
+    isnothing(bufs) && return NO_DG_GHOST_EXCHANGE
+    return DGGhostExchange(bufs)
+end
+
+# The exchange to use for one face-operator call: the operator's own (started
+# here) unless a shared handle was passed, which is checked against the
+# operator's arguments. The `::Nothing` methods are device-specific (the CUDA
+# method, in ext/cuda/operators_dg.jl, packs with kernels).
+@inline _dg_shared_or_start(device::ClimaComms.AbstractCPUDevice, space, args, ::Nothing) =
+    _start_dg_ghost_exchange_handle(device, space, args)
+@inline function _dg_shared_or_start(device, space, args, ghost_exchange::DGGhostExchange)
+    _check_dg_ghost_exchange(space, args, ghost_exchange)
+    return ghost_exchange
+end
+
+# Complete the exchange on first consumption; later consumers get the recv
+# strips as-is. Returns `nothing` for a no-op (single-process) handle.
+@inline function _consume_dg_ghost_exchange!(ghost::DGGhostExchange)
+    bufs = ghost.bufs
+    isnothing(bufs) && return nothing
+    if !ghost.finished[]
+        foreach(
+            ex -> isnothing(ex) || ClimaComms.finish(ex.graph_context),
+            bufs,
+        )
+        ghost.finished[] = true
+    end
+    return bufs
+end
+
+# A shared exchange must have been started with the arguments the consuming
+# operator receives. The exchanges are memoized per (grid, data type,
+# position), so recomputing them here is a few dictionary hits; equal-typed
+# fields swapped in place map to the same exchange objects and cannot be
+# detected — that part of the contract stays with the caller.
+function _check_dg_ghost_exchange(space, args, ghost::DGGhostExchange)
+    bufs = ghost.bufs
+    isnothing(bufs) && return nothing
+    args_local = unrolled_map(
+        arg -> arg isa Fields.Field ? Fields.field_values(arg) : arg,
+        args,
+    )
+    length(args_local) == length(bufs) || error(
+        "shared DG ghost exchange was started with $(length(bufs)) \
+         arguments, but the consuming operator received $(length(args_local))",
+    )
+    foreach(ntuple(identity, Val(length(bufs)))) do i
+        a = args_local[i]
+        expected =
+            a isa DataLayouts.DataLayout ? _dg_face_exchange(space, a, i) :
+            nothing
+        expected === bufs[i] || error(
+            "shared DG ghost exchange does not match operator argument $i: \
+             start_dg_ghost_exchange must receive the same arguments (same \
+             fields, same order) as every operator that consumes it",
+        )
+    end
+    return nothing
+end
+
+# Memoized `Topologies.GhostFaceExchange` for the `i`-th exchanged argument
+# of a DG ghost-face call, keyed like `dg_connectivity` (so
+# `Utilities.Cache.clean_cache!` releases it). The exchange is created once
+# per key, matching the create-once pattern of the limiter and DSS buffers:
+# each `ClimaComms.graph_context` draws a fresh MPI tag from a counter that
+# wraps at 32767, so an exchange per call would reallocate the strips every
+# tendency evaluation and eventually alias the tag of a live graph context.
+# The argument position `i` is part of the key because same-typed arguments in
+# one call each need their own send buffer. `nothing` (no ghost faces) is a
+# valid cached value, hence the `:missing` sentinel.
+function _dg_face_exchange(space, data, i)
+    key = (Topologies.GhostFaceExchange, Spaces.grid(space), typeof(data), i)
+    ex = get(Cache.OBJECT_CACHE, key, :missing)
+    if ex === :missing
+        ex = Topologies.create_ghost_face_exchange(data, Spaces.topology(space))
+        Cache.OBJECT_CACHE[key] = ex
+    end
+    return ex
+end
 """
     PeriodicBC <: AbstractBoundaryCondition
 
@@ -375,14 +691,45 @@ function ghost_state(::ReflectingWallBC, normal, argvals⁻)
     return (y⁺, argvals⁻[2:end]...)
 end
 
-function add_numerical_flux_boundary!(fn::F, dydt, args...) where {F}
+"""
+    add_numerical_flux_boundary!(fn, dydt, args...)
+
+Add the numerical flux at the domain-boundary faces of the spectral space
+mesh:
+
+    dydt -= sWJ * fn(normal, argvals⁻)
+
+per boundary face node, where `normal` is the outward unit normal and
+`argvals⁻` is the tuple of values of `args` at that node. `dydt` must be in
+mass-weighted residual form (`WJ * ∂Y/∂t`), matching
+[`add_numerical_flux_internal!`](@ref). No-op on domains without boundary
+faces (e.g. the sphere).
+"""
+@inline add_numerical_flux_boundary!(fn::F, dydt, args...) where {F} =
+    _add_numerical_flux_boundary!(
+        ClimaComms.device(axes(dydt)),
+        fn,
+        dydt,
+        args...,
+    )
+
+_add_numerical_flux_boundary!(device, fn::F, dydt, args...) where {F} = error(
+    "add_numerical_flux_boundary! is not implemented for $device; load CUDA.jl for CUDADevice support",
+)
+
+function _add_numerical_flux_boundary!(
+    ::ClimaComms.AbstractCPUDevice,
+    fn::F,
+    dydt,
+    args...,
+) where {F}
     space = axes(dydt)
     Nq = Quadratures.degrees_of_freedom(Spaces.quadrature_style(space))
     topology = Spaces.topology(space)
     boundary_surface_geometries = Spaces.grid(space).boundary_surface_geometries
     dydt_bc = Base.broadcastable(dydt)
     args_bc =
-        map(arg -> arg isa Fields.Field ? Base.broadcastable(arg) : arg, args)
+        unrolled_map(arg -> arg isa Fields.Field ? Base.broadcastable(arg) : arg, args)
 
     for (iboundary, boundarytag) in
         enumerate(Topologies.boundary_tags(topology))
@@ -392,12 +739,12 @@ function add_numerical_flux_boundary!(fn::F, dydt, args...) where {F}
                 surface_geometry_slab =
                     slab(boundary_surface_geometries[iboundary], 1, iface)
 
-            arg_slabs⁻ = map(arg -> slab(Fields.todata(arg), 1, elem⁻), args_bc)
+            arg_slabs⁻ = unrolled_map(arg -> slab(Fields.todata(arg), 1, elem⁻), args_bc)
             dydt_slab⁻ = slab(Fields.field_values(dydt_bc), 1, elem⁻)
             for q in 1:Nq
                 sgeom⁻ = boundary_surface_geometry_slab[q]
                 i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, q, false)
-                argvals⁻ = map(
+                argvals⁻ = unrolled_map(
                     slab ->
                         slab isa DataLayouts.DataLayout ? slab[1, i⁻, j⁻, 1] : slab,
                     arg_slabs⁻,
@@ -428,7 +775,6 @@ function add_numerical_flux_boundary!(
         numflux(normal, argvals⁻, argvals⁺)
     end
 end
-
 # ---------------------------------------------------------------------------
 # Symmetric face lifting for non-conservative (gradient / curl) terms
 # ---------------------------------------------------------------------------
@@ -452,25 +798,32 @@ gradient of a scalar `q` is completed by `fn(n̂, (q⁻,), (q⁺,)) = ((q⁺ −
 element spaces and for extruded spaces with 1D (plane) or 2D (e.g.
 cubed-sphere) horizontal spectral elements.
 """
-add_lifting_flux_internal!(fn::F, dydt, args...) where {F} =
-    _add_lifting_flux_internal!(
-        ClimaComms.device(axes(dydt)),
-        fn,
-        dydt,
-        args...,
-    )
-
-_add_lifting_flux_internal!(device, fn::F, dydt, args...) where {F} = error(
-    "add_lifting_flux_internal! is not implemented for $device; load CUDA.jl for CUDADevice support",
+add_lifting_flux_internal!(
+    fn::F,
+    dydt,
+    args...;
+    ghost_exchange = nothing,
+) where {F} = _add_lifting_flux_internal!(
+    ClimaComms.device(axes(dydt)),
+    fn,
+    dydt,
+    args...;
+    ghost_exchange,
 )
+
+_add_lifting_flux_internal!(device, fn::F, dydt, args...; kwargs...) where {F} =
+    error(
+        "add_lifting_flux_internal! is not implemented for $device; load CUDA.jl for CUDADevice support",
+    )
 
 function _add_lifting_flux_internal!(
     ::ClimaComms.AbstractCPUDevice,
     fn::F,
     dydt,
-    args...,
+    args...;
+    ghost_exchange = nothing,
 ) where {F}
-    _add_interior_face_flux!(Val(:lifting), fn, dydt, args...)
+    _add_interior_face_flux!(Val(:lifting), fn, dydt, args...; ghost_exchange)
 end
 
 """
@@ -489,7 +842,6 @@ function lifting_correction(fn::F, ::Type{T}, args...) where {F, T}
     add_lifting_flux_internal!(fn, r, args...)
     return r ./ lgeom.WJ
 end
-
 # ---------------------------------------------------------------------------
 # Flux-differencing (split-form / FDDG) volume divergence
 # ---------------------------------------------------------------------------
@@ -693,7 +1045,6 @@ function _fd_divergence_slab!(
     end
     return dydt_slab
 end
-
 # ---------------------------------------------------------------------------
 # DG connectivity buffer (device-resident; used by the GPU face kernels)
 # ---------------------------------------------------------------------------
@@ -718,6 +1069,8 @@ internal-face operators (the DSS-buffer analog for DG):
 
 Built once per space by [`dg_connectivity`](@ref) and stored with the array
 type of the space's device (`ClimaComms.array_type`).
+[`dg_ghost_connectivity`](@ref) builds the same structure over the ghost
+(inter-rank) faces, with the meanings documented there.
 """
 struct DGConnectivity{FA, SG, IV}
     nfaces::Int
@@ -745,6 +1098,38 @@ function dg_connectivity(space)
     key = (DGConnectivity, Spaces.grid(space), typeof(space))
     return get!(() -> build_dg_connectivity(space), Cache.OBJECT_CACHE, key)
 end
+
+# Memoized device staging array of shape `(Nq, Nv, nsides, nfaces)` for the GPU
+# face kernels, keyed (and released by `clean_cache!`) alongside the space's
+# connectivity. `tag` separates the interior (`nsides` 1 or 2) and ghost
+# (`nsides == 1`) buffers, which the same operator call uses in turn.
+function _dg_staging_buffer(
+    space,
+    ::Type{T},
+    nsides,
+    nfaces;
+    tag = :DGStagingBuffer,
+) where {T}
+    key = (tag, Spaces.grid(space), typeof(space), T, nsides, nfaces)
+    buf = get(Cache.OBJECT_CACHE, key, nothing)
+    if isnothing(buf)
+        Nq = Quadratures.degrees_of_freedom(Spaces.quadrature_style(space))
+        grid = Spaces.grid(space)
+        Nv =
+            grid isa Grids.ExtrudedFiniteDifferenceGrid ?
+            Spaces.nlevels(space) : 1
+        DA = ClimaComms.array_type(Spaces.topology(space))
+        buf = DA{T}(undef, Nq, Nv, nsides, nfaces)
+        Cache.OBJECT_CACHE[key] = buf
+    end
+    return buf
+end
+
+_dg_ghost_staging_buffer(space, ::Type{T}, nfaces) where {T} =
+    _dg_staging_buffer(space, T, 1, nfaces; tag = :DGGhostStagingBuffer)
+
+_dg_boundary_staging_buffer(space, ::Type{T}, nfaces) where {T} =
+    _dg_staging_buffer(space, T, 1, nfaces; tag = :DGBoundaryStagingBuffer)
 
 function build_dg_connectivity(space)
     topology = Spaces.topology(space)
@@ -797,6 +1182,14 @@ function build_dg_connectivity(space)
         end
     end
 
+    return DGConnectivity(nfaces, faces, sgeom, contrib, DA)
+end
+
+# Assemble a `DGConnectivity` from the host-side face matrix, surface
+# geometry, and `(elem, i, j) → [(face, side, q), ...]` contribution map: the
+# contributions of each boundary node are sorted so the GPU gather is bitwise
+# deterministic, then everything is adapted to the device array type `DA`.
+function DGConnectivity(nfaces, faces, sgeom, contrib, DA)
     bnodes = sort!(collect(keys(contrib)))
     nbnodes = length(bnodes)
     node_elem = Vector{Int32}(undef, nbnodes)
@@ -834,4 +1227,145 @@ function build_dg_connectivity(space)
         DA(contrib_side),
         DA(contrib_q),
     )
+end
+
+"""
+    dg_ghost_connectivity(space)
+
+Memoized [`DGConnectivity`](@ref) over the topology's ghost (inter-rank)
+faces, or `nothing` when there are none. The entries differ from
+[`dg_connectivity`](@ref) in two ways: the third `faces` row holds the strip
+slot into the recv buffer of a `Topologies.GhostFaceExchange` (the plus-side
+value at loop node `q` is strip node `reversed ? Nq - q + 1 : q`) rather than
+a local element, and the gather map contains only minus-side contributions
+(`side == 1`) — the mirror ghost face on the neighbouring rank accumulates
+the other side (see `_add_dg_ghost_faces!` for the operator contract that
+makes the two sides consistent).
+"""
+function dg_ghost_connectivity(space)
+    key = (DGConnectivity, :ghost, Spaces.grid(space), typeof(space))
+    conn = get(Cache.OBJECT_CACHE, key, :missing)
+    if conn === :missing
+        conn = build_dg_ghost_connectivity(space)
+        Cache.OBJECT_CACHE[key] = conn
+    end
+    return conn
+end
+
+function build_dg_ghost_connectivity(space)
+    topology = Spaces.topology(space)
+    gfaces = Topologies.ghost_faces(topology)
+    isempty(gfaces) && return nothing
+    quadrature_style = Spaces.quadrature_style(space)
+    Nq = Quadratures.degrees_of_freedom(quadrature_style)
+    FT = Spaces.undertype(space)
+    grid = Spaces.grid(space)
+    extruded = grid isa Grids.ExtrudedFiniteDifferenceGrid
+    Nv = extruded ? Spaces.nlevels(space) : 1
+    (_, w) = Quadratures.quadrature_points(FT, quadrature_style)
+    DA = ClimaComms.array_type(topology)
+
+    nfaces = length(gfaces)
+    faces = Matrix{Int32}(undef, 5, nfaces)
+    lg_host = Adapt.adapt(Array, Spaces.local_geometry_data(space))
+    SG = Geometry.SurfaceGeometry{FT, Geometry.UVVector{FT}}
+    sgeom = Array{SG}(undef, Nq, Nv, nfaces)
+
+    (; face_slot) = Topologies.ghost_face_schedule(topology)
+    contrib = Dict{NTuple{3, Int}, Vector{NTuple{3, Int32}}}()
+    for (f, (elem⁻, face⁻, _ridx⁺, face⁺, reversed)) in enumerate(gfaces)
+        faces[:, f] .=
+            (elem⁻, face⁻, face_slot[f], face⁺, reversed ? Int32(1) : Int32(0))
+        for q in 1:Nq
+            i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, q, false)
+            push!(
+                get!(() -> NTuple{3, Int32}[], contrib, (elem⁻, i⁻, j⁻)),
+                (Int32(f), Int32(1), Int32(q)),
+            )
+            for v in 1:Nv
+                lg =
+                    extruded ?
+                    slab(lg_host, v, elem⁻)[1, i⁻, j⁻, 1] :
+                    slab(lg_host, elem⁻)[1, i⁻, j⁻, 1]
+                sgeom[q, v, f] = compute_surface_geometry_extruded_2d(
+                    lg,
+                    w,
+                    face⁻,
+                    i⁻,
+                    j⁻,
+                )
+            end
+        end
+    end
+
+    return DGConnectivity(nfaces, faces, sgeom, contrib, DA)
+end
+
+"""
+    dg_boundary_connectivity(space)
+
+Memoized [`DGConnectivity`](@ref) over the topology's boundary faces (all
+boundary tags, concatenated in `Topologies.boundary_tags` order), or `nothing`
+when there are none (e.g. on the sphere). Boundary faces have no plus side:
+`faces` holds `(elem⁻, face⁻)` rows only, and the gather map contains only
+minus-side contributions — a node at a domain corner receives one contribution
+from each of its two boundary faces.
+"""
+function dg_boundary_connectivity(space)
+    key = (DGConnectivity, :boundary, Spaces.grid(space), typeof(space))
+    conn = get(Cache.OBJECT_CACHE, key, :missing)
+    if conn === :missing
+        conn = build_dg_boundary_connectivity(space)
+        Cache.OBJECT_CACHE[key] = conn
+    end
+    return conn
+end
+
+function build_dg_boundary_connectivity(space)
+    topology = Spaces.topology(space)
+    bfaces = Tuple{Int, Int}[]
+    for boundarytag in Topologies.boundary_tags(topology)
+        append!(bfaces, Topologies.boundary_faces(topology, boundarytag))
+    end
+    isempty(bfaces) && return nothing
+    quadrature_style = Spaces.quadrature_style(space)
+    Nq = Quadratures.degrees_of_freedom(quadrature_style)
+    FT = Spaces.undertype(space)
+    grid = Spaces.grid(space)
+    extruded = grid isa Grids.ExtrudedFiniteDifferenceGrid
+    Nv = extruded ? Spaces.nlevels(space) : 1
+    (_, w) = Quadratures.quadrature_points(FT, quadrature_style)
+    DA = ClimaComms.array_type(topology)
+
+    nfaces = length(bfaces)
+    faces = Matrix{Int32}(undef, 2, nfaces)
+    lg_host = Adapt.adapt(Array, Spaces.local_geometry_data(space))
+    SG = Geometry.SurfaceGeometry{FT, Geometry.UVVector{FT}}
+    sgeom = Array{SG}(undef, Nq, Nv, nfaces)
+
+    contrib = Dict{NTuple{3, Int}, Vector{NTuple{3, Int32}}}()
+    for (f, (elem⁻, face⁻)) in enumerate(bfaces)
+        faces[:, f] .= (elem⁻, face⁻)
+        for q in 1:Nq
+            i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, q, false)
+            push!(
+                get!(() -> NTuple{3, Int32}[], contrib, (elem⁻, i⁻, j⁻)),
+                (Int32(f), Int32(1), Int32(q)),
+            )
+            for v in 1:Nv
+                lg =
+                    extruded ? slab(lg_host, v, elem⁻)[1, i⁻, j⁻, 1] :
+                    slab(lg_host, elem⁻)[1, i⁻, j⁻, 1]
+                sgeom[q, v, f] = compute_surface_geometry_extruded_2d(
+                    lg,
+                    w,
+                    face⁻,
+                    i⁻,
+                    j⁻,
+                )
+            end
+        end
+    end
+
+    return DGConnectivity(nfaces, faces, sgeom, contrib, DA)
 end

--- a/src/Topologies/dss_transform.jl
+++ b/src/Topologies/dss_transform.jl
@@ -149,8 +149,11 @@ Base.@propagate_inbounds dss_untransform(
     Geometry.project(ax, targ, local_geometry)
 end
 
-# currently only used in limiters (but not actually functional)
-# see https://github.com/CliMA/ClimaCore.jl/issues/1511
+# Whole-element halo exchange: `send_data`/`recv_data` hold entire neighbour
+# elements (indexed by `sidx`/`ridx`), in contrast to the perimeter-only
+# `DSSBuffer` and the face-strip `GhostFaceExchange`. Used by the
+# quasimonotone limiter (whose distributed test does not exercise the
+# exchange; see issue #1511).
 struct GhostBuffer{G, D}
     graph_context::G
     send_data::D
@@ -207,6 +210,162 @@ function fill_send_buffer!(
     data_array = parent(data)
     for (sidx, lidx) in enumerate(topology.send_elem_lidx)
         selectdim(send_array, h_dim, sidx) .= selectdim(data_array, h_dim, lidx)
+    end
+    return nothing
+end
+
+"""
+    GhostFaceExchange
+
+Face-strip halo exchange for the DG ghost-face operators: ships only the `Nq`
+face-node values (per level and field component) of each rank-boundary face,
+instead of whole neighbour elements — the face analog of the perimeter-only
+`DSSBuffer`. Only face-sharing neighbours participate; vertex-only halo
+neighbours are excluded on both sides of each pair, so participation is
+symmetric by construction.
+
+`send_data`/`recv_data` are `(Nv, Nq, 1, nstrips)` layouts with one strip per
+entry of [`ghost_faces`](@ref): slot `s` of `send_data` holds this rank's own
+("minus") side of a shared face, and slot `s` of `recv_data` receives the
+neighbouring rank's side of the same face. Both ranks assign slots by sorting
+their shared faces by neighbour pid and then by the canonical face key (the
+ordered pair of `(global element, face)` of the two sides), which both ranks
+can compute, so the `k`-th strip sent within a pair is the `k`-th strip the
+peer expects. Strips are packed in the sending face's natural node order
+(`face_node_index(face, Nq, q, false)`); a receiver whose face is `reversed`
+relative to the sender reads node `q` at strip index `Nq - q + 1`.
+
+Fields:
+
+  - `graph_context`: the `ClimaComms` exchange over face-sharing neighbours;
+  - `send_data`, `recv_data`: the strip layouts described above;
+  - `slot_lidx`, `slot_face`: strip slot → local element and face, stored with
+    the topology's array type for the device-side pack;
+  - `face_slot`: position in [`ghost_faces`](@ref) order → strip slot (host
+    vector; consumed when building face connectivity on the host).
+"""
+struct GhostFaceExchange{G, D, IV}
+    graph_context::G
+    send_data::D
+    recv_data::D
+    slot_lidx::IV
+    slot_face::IV
+    face_slot::Vector{Int32}
+end
+
+# Strip schedule shared by every `GhostFaceExchange` on a topology: for each
+# entry of `ghost_faces(topology)` (in order), its strip slot, and for each
+# slot the local (element, face) to pack, plus the per-neighbour strip counts.
+# The counts are symmetric within each pair (the peer's `ghost_faces` mirrors
+# ours face by face), so they serve as both send and receive lengths.
+function ghost_face_schedule(topology::Topology2D)
+    gfaces = ghost_faces(topology)
+    n = length(gfaces)
+    sort_keys = Vector{NTuple{5, Int}}(undef, n)
+    for (f, (lidx, face, ridx, oface, _reversed)) in enumerate(gfaces)
+        gidx = topology.local_elem_gidx[lidx]
+        ogidx = topology.recv_elem_gidx[ridx]
+        pid = topology.elempid[ogidx]
+        sort_keys[f] =
+            (gidx, face) < (ogidx, oface) ? (pid, gidx, face, ogidx, oface) :
+            (pid, ogidx, oface, gidx, face)
+    end
+    perm = sortperm(sort_keys)
+    face_slot = Vector{Int32}(undef, n)
+    slot_lidx = Vector{Int32}(undef, n)
+    slot_face = Vector{Int32}(undef, n)
+    pids = Int[]
+    counts = Int[]
+    for (slot, f) in enumerate(perm)
+        face_slot[f] = slot
+        slot_lidx[slot] = gfaces[f][1]
+        slot_face[slot] = gfaces[f][2]
+        pid = sort_keys[f][1]
+        if isempty(pids) || pids[end] != pid
+            push!(pids, pid)
+            push!(counts, 0)
+        end
+        counts[end] += 1
+    end
+    return (; face_slot, slot_lidx, slot_face, pids, counts)
+end
+
+"""
+    create_ghost_face_exchange(data, topology)
+
+Construct the [`GhostFaceExchange`](@ref) for exchanging the ghost-face strips
+of `data` (see there for the slot and node-order conventions). Returns
+`nothing` on single-process contexts and on ranks with no ghost faces — with
+face-strip granularity a rank with no ghost faces shares no exchange with any
+neighbour, so it can skip the exchange without stranding a peer.
+"""
+create_ghost_face_exchange(data, topology::AbstractTopology) = nothing
+
+function create_ghost_face_exchange(
+    data::DataLayouts.VIJHWithF,
+    topology::Topology2D,
+)
+    ClimaComms.context(topology) isa ClimaComms.SingletonCommsContext &&
+        return nothing
+    isempty(ghost_faces(topology)) && return nothing
+    (; face_slot, slot_lidx, slot_face, pids, counts) =
+        ghost_face_schedule(topology)
+    nstrips = length(slot_lidx)
+    S = eltype(data)
+    FT = eltype(parent(data))
+    (Nv, Nq, _, _) = size(data)
+    DA = ClimaComms.array_type(topology)
+    send_data = DataLayouts.rebuild(
+        DataLayouts.VIJFH{S, Nv, Nq, 1, nothing}(Array{FT}, nstrips),
+        DA,
+    )
+    recv_data = DataLayouts.rebuild(
+        DataLayouts.VIJFH{S, Nv, Nq, 1, nothing}(Array{FT}, nstrips),
+        DA,
+    )
+    k = stride(parent(send_data), DataLayouts.f_dim(send_data) == 5 ? 4 : 5)
+    graph_context = ClimaComms.graph_context(
+        topology.context,
+        parent(send_data),
+        k .* counts,
+        pids,
+        parent(recv_data),
+        k .* counts,
+        pids,
+    )
+    return GhostFaceExchange(
+        graph_context,
+        send_data,
+        recv_data,
+        DA(slot_lidx),
+        DA(slot_face),
+        face_slot,
+    )
+end
+
+"""
+    fill_face_send_buffer!(data, exchange::GhostFaceExchange)
+
+Load the send strips of `exchange` with the face-node values of `data`, in
+each face's natural node order. Host loop — the CUDA path packs with a single
+kernel instead (see `ext/cuda/operators_dg.jl`).
+"""
+function fill_face_send_buffer!(
+    data::DataLayouts.DataLayout,
+    exchange::GhostFaceExchange,
+)
+    (Nv, Nq, _, nstrips) = size(exchange.send_data)
+    for s in 1:nstrips
+        lidx = Int(exchange.slot_lidx[s])
+        face = Int(exchange.slot_face[s])
+        for v in 1:Nv
+            data_slab = slab(data, v, lidx)
+            send_slab = slab(exchange.send_data, v, s)
+            for q in 1:Nq
+                i, j = face_node_index(face, Nq, q, false)
+                send_slab[1, q, 1, 1] = data_slab[1, i, j, 1]
+            end
+        end
     end
     return nothing
 end

--- a/src/Topologies/dss_transform.jl
+++ b/src/Topologies/dss_transform.jl
@@ -251,6 +251,12 @@ struct GhostFaceExchange{G, D, IV}
     slot_lidx::IV
     slot_face::IV
     face_slot::Vector{Int32}
+    # Exchanges are memoized per (space, data type, argument position), so
+    # distinct fields of the same type share this object; the latch is set at
+    # fill and cleared at finish, turning an overlapping second start — which
+    # would overwrite the in-flight send strips and double-start the graph
+    # context — into an error.
+    in_flight::Base.RefValue{Bool}
 end
 
 # Strip schedule shared by every `GhostFaceExchange` on a topology: for each
@@ -340,6 +346,7 @@ function create_ghost_face_exchange(
         DA(slot_lidx),
         DA(slot_face),
         face_slot,
+        Ref(false),
     )
 end
 

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -204,15 +204,15 @@ with special handling of `DataType` fields to avoid errors during compilation.
 
 # Examples
 
-```jldoctest; setup = :(import ClimaCore.Utilities: new), filter = r"\\d+"
-julia> new(Int)
-4889520192
+```jldoctest; setup = :(import ClimaCore.Utilities: new)
+julia> new(Int) isa Int
+true
 
 julia> new(Complex{Int}, (1, 2))
 1 + 2im
 
-julia> new(@NamedTuple{a::Type{Int}, b::Int, c::Complex{Int}})
-(a = Int64, b = 4889520192, c = 6162822528 + 8036417625im)
+julia> new(@NamedTuple{a::Type{Int}, b::Int, c::Complex{Int}}).a
+Int64
 
 julia> new(@NamedTuple{a::DataType, b::Int, c::Complex{Int}}, (Int, 1, 1 + 2im))
 (a = Int64, b = 1, c = 1 + 2im)

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -204,15 +204,15 @@ with special handling of `DataType` fields to avoid errors during compilation.
 
 # Examples
 
-```jldoctest; setup = :(import ClimaCore.Utilities: new)
-julia> new(Int) isa Int
-true
+```jldoctest; setup = :(import ClimaCore.Utilities: new), filter = r"-?\\d+"
+julia> new(Int)
+4889520192
 
 julia> new(Complex{Int}, (1, 2))
 1 + 2im
 
-julia> new(@NamedTuple{a::Type{Int}, b::Int, c::Complex{Int}}).a
-Int64
+julia> new(@NamedTuple{a::Type{Int}, b::Int, c::Complex{Int}})
+(a = Int64, b = 4889520192, c = 6162822528 + 8036417625im)
 
 julia> new(@NamedTuple{a::DataType, b::Int, c::Complex{Int}}, (Int, 1, 1 + 2im))
 (a = Int64, b = 1, c = 1 + 2im)

--- a/test/Integration/smoke_bickley_jet_cg_dg.jl
+++ b/test/Integration/smoke_bickley_jet_cg_dg.jl
@@ -156,36 +156,30 @@ end
         end
 
         @testset "Discontinuous Galerkin (DG) Integration [$FT]" begin
-            # `add_numerical_flux_internal!` iterates interior faces with host
-            # scalar indexing, so the DG interface-flux path is CPU-only.
-            if ClimaComms.device() isa ClimaComms.CUDADevice
-                @test_skip "DG interface flux (add_numerical_flux_internal!) is CPU-only"
-            else
-                y = copy(y0)
-                dydt = similar(y)
-                y_stage = similar(y)
-                numflux = Operators.RusanovNumericalFlux(sw_flux, sw_wavespeed)
+            y = copy(y0)
+            dydt = similar(y)
+            y_stage = similar(y)
+            numflux = Operators.RusanovNumericalFlux(sw_flux, sw_wavespeed)
 
-                # Warmup step
-                shallow_water_rhs_dg!(dydt, y, (space, params, numflux), FT(0))
+            # Warmup step
+            shallow_water_rhs_dg!(dydt, y, (space, params, numflux), FT(0))
 
-                # Run SSPRK steps
-                for step in 1:nsteps
-                    rk_step!(
-                        shallow_water_rhs_dg!,
-                        y,
-                        dydt,
-                        y_stage,
-                        (space, params, numflux),
-                        dt,
-                    )
-                end
-
-                # Verify mass conservation
-                mass_final = sum(y.ρ)
-                tol = FT == Float32 ? 1e-4 : 1e-10
-                @test isapprox(mass_final, mass0, rtol = tol)
+            # Run SSPRK steps
+            for step in 1:nsteps
+                rk_step!(
+                    shallow_water_rhs_dg!,
+                    y,
+                    dydt,
+                    y_stage,
+                    (space, params, numflux),
+                    dt,
+                )
             end
+
+            # Verify mass conservation
+            mass_final = sum(y.ρ)
+            tol = FT == Float32 ? 1e-4 : 1e-10
+            @test isapprox(mass_final, mass0, rtol = tol)
         end
     end
 end

--- a/test/Operators/spectralelement/distributed/ddg2.jl
+++ b/test/Operators/spectralelement/distributed/ddg2.jl
@@ -1,0 +1,6 @@
+include("ddg_setup.jl")
+
+@testset "distributed DG operators (2 ranks)" begin
+    run_ddg_tests(Float64)
+    run_ddg_tests(Float32)
+end

--- a/test/Operators/spectralelement/distributed/ddg3.jl
+++ b/test/Operators/spectralelement/distributed/ddg3.jl
@@ -1,0 +1,6 @@
+include("ddg_setup.jl")
+
+@testset "distributed DG operators (3 ranks)" begin
+    run_ddg_tests(Float64)
+    run_ddg_tests(Float32)
+end

--- a/test/Operators/spectralelement/distributed/ddg_setup.jl
+++ b/test/Operators/spectralelement/distributed/ddg_setup.jl
@@ -1,0 +1,273 @@
+#=
+Shared setup for the distributed (MPI) discontinuous-Galerkin operator tests,
+launched at a fixed rank count (see ddg2.jl / ddg3.jl):
+
+    CLIMACOMMS_CONTEXT=MPI mpiexec -n 2 julia --project=... ddg2.jl
+
+On a distributed cubed sphere, faces that straddle a rank boundary live in
+`Topologies.ghost_faces` and are completed by the ghost-face exchange in
+`add_numerical_flux_internal!` / `add_lifting_flux_internal!`. The checks are
+per-local-node comparisons against element-local reference operators, so a
+wrong (or skipped) ghost exchange shows up as a mismatch at the
+partition-boundary elements without any cross-rank gather.
+=#
+using Test
+import ClimaComms
+ClimaComms.@import_required_backends
+include("../utils_dg.jl")
+
+const context = ClimaComms.context()
+const pid, nprocs = ClimaComms.init(context)
+
+# Global (cross-rank) sum of a scalar field's parent array.
+allsum(field) = ClimaComms.allreduce(context, sum(parent(field)), +)
+
+function run_ddg_tests(::Type{FT}) where {FT}
+    tol = FT == Float32 ? FT(1e-4) : FT(1e-10)
+    space = dg_sphere_space(FT; context)
+    topology = Spaces.topology(space)
+
+    # This test is only meaningful when the partition actually cuts faces.
+    nghost = length(Topologies.ghost_faces(topology))
+    nghost_global = ClimaComms.allreduce(context, nghost, +)
+    if ClimaComms.iamroot(context)
+        @info "distributed DG" nprocs FT local_ghost_faces = nghost total = nghost_global
+    end
+    # the ghost-face path is exercised only when the partition cuts faces
+    nprocs > 1 && @test nghost_global > 0
+
+    coords = Fields.coordinate_field(space)
+    lgeom = Fields.local_geometry_field(space)
+
+    uv = @. Geometry.UVVector(
+        cosd(coords.long),
+        -sind(coords.long) * sind(coords.lat),
+    )
+
+    @testset "weak divergence + central flux == strong divergence [$FT, $nprocs ranks]" begin
+        # `hdiv` (strong spectral divergence) is element-local and therefore
+        # correct on every rank, including partition-boundary elements. The
+        # weak form plus the central numerical flux reconstructs it only if the
+        # flux couples the true neighbour across the rank boundary, so this
+        # comparison at every local node tests the ghost exchange directly.
+        hwdiv = Operators.WeakDivergence()
+        hdiv = Operators.Divergence()
+        F = Geometry.transform.(Ref(Geometry.Contravariant12Axis()), uv)
+        q = ones(space)
+        y = map((qi, uvi) -> (; q = qi, uv = uvi), q, uv)
+
+        dy_mw = @. hwdiv(F) * (-(lgeom.WJ))
+        Operators.add_numerical_flux_internal!(dg_central_flux, dy_mw, y)
+        dy = @. dy_mw / lgeom.WJ
+
+        dy_strong = @. -hdiv(F)
+        err = maximum(abs, parent(dy) .- parent(dy_strong))
+        scale = maximum(abs, parent(dy_strong))
+        err_global = ClimaComms.allreduce(context, err, max)
+        scale_global = ClimaComms.allreduce(context, scale, max)
+        @test err_global < tol * scale_global
+    end
+
+    @testset "central numerical flux conserves globally [$FT, $nprocs ranks]" begin
+        # Each interior face adds ∓sWJ·flux to its two nodes; across ranks the
+        # ghost-face contributions are the missing halves, so the global node
+        # sum of the residual is zero to round-off only if they are included.
+        q = @. sind(coords.long) * cosd(coords.lat)^2
+        y = map((qi, uvi) -> (; q = qi, uv = uvi), q, uv)
+        r = similar(q)
+        r .= 0
+        Operators.add_numerical_flux_internal!(dg_central_flux, r, y)
+        total = allsum(r)
+        scale = ClimaComms.allreduce(context, sum(abs, parent(r)), +)
+        cons_tol = FT == Float32 ? FT(1e-5) : FT(1e-10)
+        @test abs(total) < cons_tol * scale
+    end
+
+    @testset "penalty numerical flux vanishes for continuous fields [$FT, $nprocs ranks]" begin
+        # A single-valued field has no jump, so the jump-penalty numerical flux
+        # must vanish at every node — including partition-boundary nodes, where
+        # the jump is computed against the received ghost value.
+        q = @. sind(coords.long) * cosd(coords.lat)^2
+        r = similar(q)
+        r .= 0
+        Operators.add_numerical_flux_internal!(dg_jump_penalty, r, q)
+        rn = @. r / lgeom.WJ
+        err = maximum(abs, parent(rn))
+        err_global = ClimaComms.allreduce(context, err, max)
+        qmax = ClimaComms.allreduce(context, maximum(abs, parent(q)), max)
+        @test err_global < tol * qmax
+    end
+
+    @testset "two-argument jump penalty vanishes [$FT, $nprocs ranks]" begin
+        # Two same-typed Field arguments get separate ghost buffers (keyed by
+        # argument position); if they aliased, the second fill would overwrite
+        # the first field's halo and the jump would not vanish.
+        two_field_jump(normal, (q⁻, s⁻), (q⁺, s⁺)) =
+            ((q⁻ + s⁻) - (q⁺ + s⁺)) / 2
+        q = @. sind(coords.long) * cosd(coords.lat)^2
+        s = @. cosd(coords.long) * cosd(coords.lat)
+        r = similar(q)
+        r .= 0
+        Operators.add_numerical_flux_internal!(two_field_jump, r, q, s)
+        rn = @. r / lgeom.WJ
+        err = maximum(abs, parent(rn))
+        err_global = ClimaComms.allreduce(context, err, max)
+        qmax = ClimaComms.allreduce(context, maximum(abs, parent(q)), max)
+        @test err_global < tol * qmax
+    end
+
+    @testset "shared ghost exchange across face operators [$FT, $nprocs ranks]" begin
+        # One exchange feeds the numerical flux and the lifting; both results
+        # must be bitwise identical to each operator exchanging on its own.
+        lift_q(normal, (y⁻,), (y⁺,)) = ((y⁺.q - y⁻.q) / 2) * normal
+        q = @. sind(coords.long) * cosd(coords.lat)^2
+        y = map((qi, uvi) -> (; q = qi, uv = uvi), q, uv)
+
+        r_ref = similar(q)
+        r_ref .= 0
+        Operators.add_numerical_flux_internal!(dg_central_flux, r_ref, y)
+        l_ref = similar(q, Geometry.UVVector{FT})
+        fill!(parent(l_ref), 0)
+        Operators.add_lifting_flux_internal!(lift_q, l_ref, y)
+
+        ex = Operators.start_dg_ghost_exchange(y)
+        r = similar(q)
+        r .= 0
+        Operators.add_numerical_flux_internal!(
+            dg_central_flux,
+            r,
+            y;
+            ghost_exchange = ex,
+        )
+        l = similar(q, Geometry.UVVector{FT})
+        fill!(parent(l), 0)
+        Operators.add_lifting_flux_internal!(
+            lift_q,
+            l,
+            y;
+            ghost_exchange = ex,
+        )
+        @test parent(r) == parent(r_ref)
+        @test parent(l) == parent(l_ref)
+
+        # A handle started on different arguments is rejected (detectable
+        # only where ghost strips exist, i.e. on distributed ranks with
+        # ghost faces).
+        if nghost > 0
+            ex2 = Operators.start_dg_ghost_exchange(y)
+            r2 = similar(q)
+            r2 .= 0
+            @test_throws ErrorException Operators.add_numerical_flux_internal!(
+                dg_jump_penalty,
+                r2,
+                q;
+                ghost_exchange = ex2,
+            )
+            # Consume the started exchange so the next round on `y` finds
+            # its buffers idle.
+            Operators.add_numerical_flux_internal!(
+                dg_central_flux,
+                r2,
+                y;
+                ghost_exchange = ex2,
+            )
+        end
+    end
+
+    @testset "ghost connectivity gather matches CPU ghost path [$FT, $nprocs ranks]" begin
+        # Host emulation of the GPU ghost algorithm (exchange, stage
+        # sWJ·fn(n̂⁻, ·⁻, ·⁺) per ghost face node, gather with the minus-side
+        # map), compared against the CPU ghost-face loop. Validates
+        # `Operators.dg_ghost_connectivity` and the staging/gather semantics
+        # of the CUDA ghost kernels without a GPU.
+        # Skipped on GPU devices: the emulation indexes host-style, and the
+        # CPU ghost loop it compares against is host-only. The GPU runs of
+        # this file exercise the CUDA ghost kernels through the operator
+        # testsets instead.
+        gconn = Operators.dg_ghost_connectivity(space)
+        if nprocs == 1
+            @test isnothing(gconn)
+        elseif ClimaComms.device(space) isa ClimaComms.AbstractCPUDevice
+            q = @. sind(coords.long) * cosd(coords.lat)^2
+            y = map((qi, uvi) -> (; q = qi, uv = uvi), q, uv)
+            r_ghost = similar(q)
+            fill!(parent(r_ghost), 0)
+            Operators._add_dg_ghost_faces!(
+                Val(:numflux),
+                dg_central_flux,
+                r_ghost,
+                (y,),
+            )
+
+            y_data = Fields.field_values(y)
+            ex = Operators._dg_face_exchange(space, y_data, 1)
+            Topologies.fill_face_send_buffer!(y_data, ex)
+            ClimaComms.start(ex.graph_context)
+            ClimaComms.finish(ex.graph_context)
+
+            Nq = Quadratures.degrees_of_freedom(
+                Spaces.quadrature_style(space),
+            )
+            staging = Array{FT}(undef, Nq, gconn.nfaces)
+            for f in 1:gconn.nfaces, qq in 1:Nq
+                elem⁻ = Int(gconn.faces[1, f])
+                face⁻ = Int(gconn.faces[2, f])
+                slot = Int(gconn.faces[3, f])
+                reversed = gconn.faces[5, f] == 1
+                i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, qq, false)
+                q′ = reversed ? Nq - qq + 1 : qq
+                sg = gconn.sgeom[qq, 1, f]
+                y⁻ = y_data[CartesianIndex(1, i⁻, j⁻, elem⁻)]
+                y⁺ = ex.recv_data[CartesianIndex(1, q′, 1, slot)]
+                staging[qq, f] =
+                    sg.sWJ * dg_central_flux(sg.normal, (y⁻,), (y⁺,))
+            end
+
+            @test all(==(1), Array(gconn.contrib_side))
+            r_em = similar(q)
+            fill!(parent(r_em), 0)
+            r_data = Fields.field_values(r_em)
+            for n in 1:gconn.nbnodes
+                I = CartesianIndex(
+                    1,
+                    Int(gconn.node_i[n]),
+                    Int(gconn.node_j[n]),
+                    Int(gconn.node_elem[n]),
+                )
+                acc = r_data[I]
+                for c in
+                    Int(gconn.node_offset[n]):(Int(gconn.node_offset[n + 1]) - 1)
+
+                    acc -= staging[Int(gconn.contrib_q[c]), Int(gconn.contrib_face[c])]
+                end
+                r_data[I] = acc
+            end
+
+            err = maximum(abs, parent(r_em) .- parent(r_ghost))
+            scale = maximum(abs, parent(r_ghost))
+            err_global = ClimaComms.allreduce(context, err, max)
+            scale_global = ClimaComms.allreduce(context, scale, max)
+            @test err_global < tol * scale_global
+        end
+    end
+
+    @testset "central lifting vanishes for continuous fields [$FT, $nprocs ranks]" begin
+        # Exercises the symmetric-lifting ghost path (the `+` accumulation):
+        # the central gradient lift is a jump, so it vanishes on a single-valued
+        # field only if the partition-boundary jump uses the received ghost
+        # value.
+        q = @. sind(coords.long) * cosd(coords.lat)^2
+        r = similar(q, Geometry.UVVector{FT})
+        fill!(parent(r), 0)
+        Operators.add_lifting_flux_internal!(
+            Operators.central_gradient_lift,
+            r,
+            q,
+        )
+        rn = @. r / lgeom.WJ
+        err = maximum(abs, parent(rn))
+        err_global = ClimaComms.allreduce(context, err, max)
+        qmax = ClimaComms.allreduce(context, maximum(abs, parent(q)), max)
+        @test err_global < tol * qmax
+    end
+end

--- a/test/Operators/spectralelement/distributed/ddg_setup.jl
+++ b/test/Operators/spectralelement/distributed/ddg_setup.jl
@@ -133,20 +133,10 @@ function run_ddg_tests(::Type{FT}) where {FT}
         ex = Operators.start_dg_ghost_exchange(y)
         r = similar(q)
         r .= 0
-        Operators.add_numerical_flux_internal!(
-            dg_central_flux,
-            r,
-            y;
-            ghost_exchange = ex,
-        )
+        Operators.add_numerical_flux_internal!(ex, dg_central_flux, r, y)
         l = similar(q, Geometry.UVVector{FT})
         fill!(parent(l), 0)
-        Operators.add_lifting_flux_internal!(
-            lift_q,
-            l,
-            y;
-            ghost_exchange = ex,
-        )
+        Operators.add_lifting_flux_internal!(ex, lift_q, l, y)
         @test parent(r) == parent(r_ref)
         @test parent(l) == parent(l_ref)
 
@@ -158,18 +148,18 @@ function run_ddg_tests(::Type{FT}) where {FT}
             r2 = similar(q)
             r2 .= 0
             @test_throws ErrorException Operators.add_numerical_flux_internal!(
+                ex2,
                 dg_jump_penalty,
                 r2,
-                q;
-                ghost_exchange = ex2,
+                q,
             )
             # Consume the started exchange so the next round on `y` finds
             # its buffers idle.
             Operators.add_numerical_flux_internal!(
+                ex2,
                 dg_central_flux,
                 r2,
-                y;
-                ghost_exchange = ex2,
+                y,
             )
 
             # Distinct fields of the same type share exchange buffers, so
@@ -181,19 +171,9 @@ function run_ddg_tests(::Type{FT}) where {FT}
             @test_throws ErrorException Operators.start_dg_ghost_exchange(q2)
             r3 = similar(q)
             r3 .= 0
-            Operators.add_numerical_flux_internal!(
-                dg_jump_penalty,
-                r3,
-                q;
-                ghost_exchange = ex3,
-            )
+            Operators.add_numerical_flux_internal!(ex3, dg_jump_penalty, r3, q)
             ex4 = Operators.start_dg_ghost_exchange(q2)
-            Operators.add_numerical_flux_internal!(
-                dg_jump_penalty,
-                r3,
-                q2;
-                ghost_exchange = ex4,
-            )
+            Operators.add_numerical_flux_internal!(ex4, dg_jump_penalty, r3, q2)
         end
     end
 

--- a/test/Operators/spectralelement/distributed/ddg_setup.jl
+++ b/test/Operators/spectralelement/distributed/ddg_setup.jl
@@ -171,6 +171,29 @@ function run_ddg_tests(::Type{FT}) where {FT}
                 y;
                 ghost_exchange = ex2,
             )
+
+            # Distinct fields of the same type share exchange buffers, so
+            # starting a second round while one is in flight throws instead
+            # of overwriting the in-flight send strips; after the first
+            # round is consumed, a round on the other field works.
+            q2 = @. cosd(coords.long) * cosd(coords.lat)
+            ex3 = Operators.start_dg_ghost_exchange(q)
+            @test_throws ErrorException Operators.start_dg_ghost_exchange(q2)
+            r3 = similar(q)
+            r3 .= 0
+            Operators.add_numerical_flux_internal!(
+                dg_jump_penalty,
+                r3,
+                q;
+                ghost_exchange = ex3,
+            )
+            ex4 = Operators.start_dg_ghost_exchange(q2)
+            Operators.add_numerical_flux_internal!(
+                dg_jump_penalty,
+                r3,
+                q2;
+                ghost_exchange = ex4,
+            )
         end
     end
 

--- a/test/Operators/spectralelement/unit_dg_boundary_fluxes.jl
+++ b/test/Operators/spectralelement/unit_dg_boundary_fluxes.jl
@@ -122,6 +122,32 @@ end
             @test sum(parent(rb)) ≈ -c * (2 * Lx + 2 * Ly) rtol = sqrt(eps(FT))
         end
 
+        @testset "Extruded channel: constant flux integrates over the walls [$FT]" begin
+            # On an extruded (channel × z) space, `sWJ` carries the vertical
+            # measure, so a constant boundary flux integrates to
+            # −c · (wall length × height) summed over both walls.
+            zmax = FT(3)
+            zdomain = Domains.IntervalDomain(
+                Geometry.ZPoint(zero(FT)),
+                Geometry.ZPoint(zmax);
+                boundary_names = (:bottom, :top),
+            )
+            vspace = Spaces.CenterFiniteDifferenceSpace(
+                ClimaComms.device(),
+                Meshes.IntervalMesh(zdomain, nelems = 5),
+            )
+            xspace = Spaces.ExtrudedFiniteDifferenceSpace(
+                channel_space(FT; Lx, Ly),
+                vspace,
+            )
+            c = FT(3)
+            rx = zeros(xspace)
+            qx = ones(xspace)
+            const_flux(normal, (q⁻,)) = c
+            Operators.add_numerical_flux_boundary!(const_flux, rx, qx)
+            @test sum(parent(rx)) ≈ -c * 2 * Lx * zmax rtol = sqrt(eps(FT))
+        end
+
         @testset "Multi-field (NamedTuple) boundary flux [$FT]" begin
             # A flux returning a NamedTuple must scale and subtract per field,
             # like the interior loops and the GPU boundary kernel: its `a`

--- a/test/Operators/spectralelement/unit_dg_boundary_fluxes.jl
+++ b/test/Operators/spectralelement/unit_dg_boundary_fluxes.jl
@@ -122,6 +122,28 @@ end
             @test sum(parent(rb)) ≈ -c * (2 * Lx + 2 * Ly) rtol = sqrt(eps(FT))
         end
 
+        @testset "Multi-field (NamedTuple) boundary flux [$FT]" begin
+            # A flux returning a NamedTuple must scale and subtract per field,
+            # like the interior loops and the GPU boundary kernel: its `a`
+            # component must match the scalar-flux path, and the zero-flux `b`
+            # component must stay zero.
+            box = channel_space(FT; Lx, Ly, x1periodic = false)
+            coords = Fields.coordinate_field(box)
+            a = @. sin(coords.x) + cos(coords.y)
+            b = ones(box)
+            y = map((ai, bi) -> (; a = ai, b = bi), a, b)
+            r = similar(y)
+            fill!(parent(r), 0)
+            nt_flux(normal, (y⁻,)) = (; a = y⁻.a, b = zero(y⁻.b))
+            Operators.add_numerical_flux_boundary!(nt_flux, r, y)
+
+            r_a = zeros(box)
+            scalar_flux(normal, (q⁻,)) = q⁻
+            Operators.add_numerical_flux_boundary!(scalar_flux, r_a, a)
+            @test parent(r.a) ≈ parent(r_a) rtol = sqrt(eps(FT))
+            @test all(iszero, parent(r.b))
+        end
+
         @testset "boundary connectivity gather matches CPU path [$FT]" begin
             # Host emulation of the GPU boundary algorithm (stage
             # sWJ·fn(n̂, ·⁻) per boundary face node, gather with the

--- a/test/Operators/spectralelement/unit_dg_boundary_fluxes.jl
+++ b/test/Operators/spectralelement/unit_dg_boundary_fluxes.jl
@@ -32,13 +32,25 @@ import .TestUtilities as TU
 #   3. The residual is nonzero only at nodes on the domain boundary.
 #   4. Boundary normals are outward: a flux f = ĵ·n̂ is −1 on the south wall
 #      and +1 on the north wall, so the two walls contribute ±Lx.
+#   5. On a box bounded on all four sides, the constant flux integrates to
+#      −c·perimeter; the corner nodes accumulate one contribution from each
+#      of their two boundary faces (the multi-contribution gather path on
+#      the GPU).
 
-function channel_space(::Type{FT}; Lx = FT(2π), Ly = FT(2), nelem = 4, Nq = 4) where {FT}
+function channel_space(
+    ::Type{FT};
+    Lx = FT(2π),
+    Ly = FT(2),
+    nelem = 4,
+    Nq = 4,
+    x1periodic = true,
+) where {FT}
     context = ClimaComms.SingletonCommsContext()
     domain = Domains.RectangleDomain(
         Geometry.XPoint{FT}(zero(Lx)) .. Geometry.XPoint{FT}(Lx),
         Geometry.YPoint{FT}(-Ly / 2) .. Geometry.YPoint{FT}(Ly / 2);
-        x1periodic = true,
+        x1periodic,
+        x1boundary = x1periodic ? nothing : (:west, :east),
         x2periodic = false,
         x2boundary = (:south, :north),
     )
@@ -98,6 +110,75 @@ end
             # north (n̂ = +ĵ, f = +1) gains -sWJ; each wall has length Lx.
             @test sum(Array(parent(r))[south]) ≈ Lx rtol = sqrt(eps(FT))
             @test sum(Array(parent(r))[north]) ≈ -Lx rtol = sqrt(eps(FT))
+        end
+
+        @testset "Fully bounded box: constant flux over the perimeter [$FT]" begin
+            box = channel_space(FT; Lx, Ly, x1periodic = false)
+            c = FT(3)
+            rb = zeros(box)
+            qb = ones(box)
+            const_flux(normal, (q⁻,)) = c
+            Operators.add_numerical_flux_boundary!(const_flux, rb, qb)
+            @test sum(parent(rb)) ≈ -c * (2 * Lx + 2 * Ly) rtol = sqrt(eps(FT))
+        end
+
+        @testset "boundary connectivity gather matches CPU path [$FT]" begin
+            # Host emulation of the GPU boundary algorithm (stage
+            # sWJ·fn(n̂, ·⁻) per boundary face node, gather with the
+            # minus-side map), compared against the CPU boundary loop;
+            # validates `Operators.dg_boundary_connectivity` — including the
+            # two-contribution corner nodes of the box — without a GPU.
+            # Skipped on GPU devices, where the operator testsets above
+            # exercise the CUDA kernels themselves.
+            if ClimaComms.device(space) isa ClimaComms.AbstractCPUDevice
+                box = channel_space(FT; Lx, Ly, x1periodic = false)
+                bconn = Operators.dg_boundary_connectivity(box)
+                @test !isnothing(bconn)
+                @test all(==(1), Array(bconn.contrib_side))
+                coords_b = Fields.coordinate_field(box)
+                qb = @. sin(coords_b.x) + cos(coords_b.y)
+                flux(normal, (q⁻,)) =
+                    q⁻ * (Geometry.UVVector(FT(1), FT(1))' * normal)
+                r_ref = zeros(box)
+                Operators.add_numerical_flux_boundary!(flux, r_ref, qb)
+
+                q_data = Fields.field_values(qb)
+                Nq = Quadratures.degrees_of_freedom(
+                    Spaces.quadrature_style(box),
+                )
+                staging = Array{FT}(undef, Nq, bconn.nfaces)
+                for f in 1:bconn.nfaces, qq in 1:Nq
+                    elem⁻ = Int(bconn.faces[1, f])
+                    face⁻ = Int(bconn.faces[2, f])
+                    i⁻, j⁻ = Topologies.face_node_index(face⁻, Nq, qq, false)
+                    sg = bconn.sgeom[qq, 1, f]
+                    q⁻ = q_data[CartesianIndex(1, i⁻, j⁻, elem⁻)]
+                    staging[qq, f] = sg.sWJ * flux(sg.normal, (q⁻,))
+                end
+                r_em = zeros(box)
+                r_data = Fields.field_values(r_em)
+                for n in 1:bconn.nbnodes
+                    I = CartesianIndex(
+                        1,
+                        Int(bconn.node_i[n]),
+                        Int(bconn.node_j[n]),
+                        Int(bconn.node_elem[n]),
+                    )
+                    acc = r_data[I]
+                    for c in
+                        Int(bconn.node_offset[n]):(Int(bconn.node_offset[n + 1]) - 1)
+
+                        acc -= staging[
+                            Int(bconn.contrib_q[c]),
+                            Int(bconn.contrib_face[c]),
+                        ]
+                    end
+                    r_data[I] = acc
+                end
+                err = maximum(abs, parent(r_em) .- parent(r_ref))
+                scale = max(maximum(abs, parent(r_ref)), one(FT))
+                @test err ≤ sqrt(eps(FT)) * scale
+            end
         end
     end
 end

--- a/test/Operators/spectralelement/unit_extruded_plane_dg.jl
+++ b/test/Operators/spectralelement/unit_extruded_plane_dg.jl
@@ -1,0 +1,193 @@
+using Test
+using ClimaComms
+ClimaComms.@import_required_backends
+using LinearAlgebra
+using Random
+import ClimaCore
+import ClimaCore:
+    Fields, Domains, Meshes, Topologies, Spaces, Operators, Geometry, Quadratures
+
+@isdefined(TU) || include(
+    joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl"),
+);
+import .TestUtilities as TU
+
+# DG internal-face flux loops on an extruded plane x–z shell
+# (`SpectralElementSpace1D` horizontal × finite-difference vertical): the
+# 1D-horizontal counterpart of unit_extruded_sphere_dg.jl. This exercises
+# `add_numerical_flux_internal_extruded_1d!` and the extruded-1D branch of
+# `add_lifting_flux_internal!`, whose `UVector`-normal surface geometry and
+# 1D face-node indexing are otherwise only run by the plane FDDG examples.
+# (Flux-differencing and the LDG Laplacian are 2D-horizontal only.)
+
+function extruded_plane_spaces(
+    ::Type{FT};
+    xmax = FT(2π),
+    zmax = FT(1),
+    xelem = 8,
+    zelem = 5,
+    Nq = 4,
+) where {FT}
+    context = ClimaComms.context()
+    device = ClimaComms.device(context)
+    xdomain = Domains.IntervalDomain(
+        Geometry.XPoint(zero(FT)),
+        Geometry.XPoint(xmax);
+        periodic = true,
+    )
+    htopology =
+        Topologies.IntervalTopology(device, Meshes.IntervalMesh(xdomain, nelems = xelem))
+    hspace = Spaces.SpectralElementSpace1D(
+        htopology,
+        Quadratures.GLL{Nq}();
+        discontinuous = true,
+    )
+
+    zdomain = Domains.IntervalDomain(
+        Geometry.ZPoint(zero(FT)),
+        Geometry.ZPoint(zmax);
+        boundary_names = (:bottom, :top),
+    )
+    vspace = Spaces.CenterFiniteDifferenceSpace(
+        device,
+        Meshes.IntervalMesh(zdomain, nelems = zelem),
+    )
+
+    center_space = Spaces.ExtrudedFiniteDifferenceSpace(hspace, vspace)
+    face_space = Spaces.FaceExtrudedFiniteDifferenceSpace(center_space)
+    return center_space, face_space
+end
+
+# Central flux of the physical flux q·u through the (plane x) face normal; the
+# velocity is a `UVector`, matching the 1D-horizontal surface geometry.
+central_flux(normal, (y⁻,), (y⁺,)) =
+    ((y⁻.q * y⁻.uv + y⁺.q * y⁺.uv) / 2)' * normal
+
+jump_penalty(normal, (q⁻,), (q⁺,)) = (q⁻ - q⁺) / 2
+
+const grad_lift = Operators.central_gradient_lift
+const jump_lift = Operators.jump_penalty_lift
+
+if ClimaComms.device() isa ClimaComms.CUDADevice
+    @testset "Extruded-plane (x–z) DG interface fluxes" begin
+        # `_dg_face_apply!` (ext/cuda/operators_dg.jl) requires a 2D
+        # horizontal grid; the extruded-1D face operators run on CPU only.
+        @test_skip "extruded-1D DG face operators have no CUDA kernels"
+    end
+else
+    @testset "Extruded-plane (x–z) DG interface fluxes" begin
+        TU.@test_precisions FT begin
+            tol = FT == Float32 ? FT(1e-4) : FT(1e-10)
+            tol_sum = FT == Float32 ? FT(1e-5) : FT(1e-12)
+
+            center_space, face_space = extruded_plane_spaces(FT)
+            @test !Spaces.is_continuous(center_space)
+            @test !Spaces.is_continuous(face_space)
+            ccoords = Fields.coordinate_field(center_space)
+            fcoords = Fields.coordinate_field(face_space)
+
+            smooth_scalar(coords) = @. sin(coords.x) + coords.z / FT(2)
+
+            @testset "weak divergence + central flux == strong divergence [$FT]" begin
+                # The strong spectral divergence is element-local; the weak
+                # form plus the central numerical flux reconstructs it at
+                # every node only if the face term carries the correct sWJ
+                # and outward normal, so this pins the
+                # `compute_surface_geometry_1d` scaling that the vanishing
+                # and conservation testsets below cannot see.
+                hwdiv = Operators.WeakDivergence()
+                hdiv = Operators.Divergence()
+                lgeom = Fields.local_geometry_field(center_space)
+                q = smooth_scalar(ccoords)
+                uv = @. Geometry.UVector(cos(ccoords.x))
+                y = map((qi, uvi) -> (; q = qi, uv = uvi), q, uv)
+                F = @. Geometry.transform(
+                    Geometry.Contravariant1Axis(),
+                    q * uv,
+                )
+                dy_mw = @. hwdiv(F) * (-(lgeom.WJ))
+                Operators.add_numerical_flux_internal!(central_flux, dy_mw, y)
+                dy = @. dy_mw / lgeom.WJ
+                dy_strong = @. -hdiv(F)
+                err = maximum(abs, parent(dy) .- parent(dy_strong))
+                @test err < tol * maximum(abs, parent(dy_strong))
+            end
+
+            @testset "penalty flux vanishes for continuous fields (center & face) [$FT]" begin
+                for (space, coords) in
+                    ((center_space, ccoords), (face_space, fcoords))
+                    q = smooth_scalar(coords)
+                    lgeom = Fields.local_geometry_field(space)
+                    r = similar(q)
+                    r .= 0
+                    Operators.add_numerical_flux_internal!(jump_penalty, r, q)
+                    rn = @. r / lgeom.WJ
+                    @test maximum(abs, parent(rn)) <
+                          tol * maximum(abs, parent(q))
+                end
+            end
+
+            @testset "lifting flux (UVector-valued) vanishes for continuous fields [$FT]" begin
+                q = smooth_scalar(ccoords)
+                lgeom = Fields.local_geometry_field(center_space)
+                r = similar(q, Geometry.UVector{FT})
+                fill!(parent(r), 0)
+                Operators.add_lifting_flux_internal!(grad_lift, r, q)
+                rn = @. r / lgeom.WJ
+                @test maximum(abs, parent(rn)) < tol * maximum(abs, parent(q))
+            end
+
+            @testset "jump_penalty_lift vanishes for continuous fields & is sign-definite [$FT]" begin
+                # λ-scaled interface penalty: zero on continuous fields; for a
+                # discontinuous field the lifting energy ∑ q·r is < 0.
+                q = smooth_scalar(ccoords)
+                λ = ones(center_space)
+                lgeom = Fields.local_geometry_field(center_space)
+                rc = similar(q)
+                fill!(parent(rc), 0)
+                Operators.add_lifting_flux_internal!(jump_lift, rc, q, λ)
+                rn = @. rc / lgeom.WJ
+                @test maximum(abs, parent(rn)) < tol * maximum(abs, parent(q))
+
+                qd = copy(q)
+                Random.seed!(42)
+                qd_cpu = Array(parent(qd))
+                qd_cpu .+= FT(0.1) .* (rand(FT, size(qd_cpu)) .- FT(0.5))
+                copyto!(parent(qd), qd_cpu)
+                rd = similar(qd)
+                fill!(parent(rd), 0)
+                Operators.add_lifting_flux_internal!(jump_lift, rd, qd, λ)
+                @test sum(parent(qd) .* parent(rd)) < 0
+            end
+
+            @testset "central numerical flux conserves (node sum zero) [$FT]" begin
+                # On the periodic-x plane, each interior face adds ∓sWJ·flux
+                # to its two nodes, so the total node sum of the residual is
+                # zero.
+                q = smooth_scalar(ccoords)
+                uv = @. Geometry.UVector(cos(ccoords.x))
+                y = map((qi, uvi) -> (; q = qi, uv = uvi), q, uv)
+                r = similar(q)
+                r .= 0
+                Operators.add_numerical_flux_internal!(central_flux, r, y)
+                scale = sum(abs, parent(r))
+                @test abs(sum(parent(r))) < tol_sum * scale
+            end
+
+            @testset "two-argument penalty vanishes for continuous fields [$FT]" begin
+                # Exercises the multi-argument face gather (two Field
+                # arguments).
+                two_field_jump(normal, (q⁻, s⁻), (q⁺, s⁺)) =
+                    ((q⁻ + s⁻) - (q⁺ + s⁺)) / 2
+                q = smooth_scalar(ccoords)
+                s = @. cos(ccoords.x)
+                lgeom = Fields.local_geometry_field(center_space)
+                r = similar(q)
+                r .= 0
+                Operators.add_numerical_flux_internal!(two_field_jump, r, q, s)
+                rn = @. r / lgeom.WJ
+                @test maximum(abs, parent(rn)) < tol * maximum(abs, parent(q))
+            end
+        end
+    end
+end

--- a/test/Operators/spectralelement/utils_dg.jl
+++ b/test/Operators/spectralelement/utils_dg.jl
@@ -15,14 +15,15 @@ import ClimaCore.Geometry: ⊗
 
 # The standard cubed-sphere spectral-element space used by the DG tests.
 # `discontinuous = true` marks the grid as DG (skips DSS; see
-# `test/Spaces/unit_discontinuous_spaces.jl`).
+# `test/Spaces/unit_discontinuous_spaces.jl`). The distributed tests pass an
+# MPI `context` to partition the sphere across ranks.
 function dg_sphere_space(
     ::Type{FT};
     radius = FT(6.371e6),
     helem = 4,
     Nq = 4,
+    context = ClimaComms.SingletonCommsContext(),
 ) where {FT}
-    context = ClimaComms.SingletonCommsContext()
     hdomain = Domains.SphereDomain(radius)
     hmesh = Meshes.EquiangularCubedSphere(hdomain, helem)
     htopology = Topologies.Topology2D(context, hmesh)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -99,6 +99,7 @@ unit_tests = [
     UnitTest("Spectral elem - DG stability properties"  ,"Operators/spectralelement/unit_dg_stability.jl"; meta = :cpu_only, tier = :unit, subsystem = :operators),
     UnitTest("Spectral elem - DG boundary fluxes"       ,"Operators/spectralelement/unit_dg_boundary_fluxes.jl"; meta = :cpu_only, tier = :unit, subsystem = :operators),
     UnitTest("Spectral elem - DG extruded sphere"       ,"Operators/spectralelement/unit_extruded_sphere_dg.jl"; tier = :unit, subsystem = :operators),
+    UnitTest("Spectral elem - DG extruded plane"        ,"Operators/spectralelement/unit_extruded_plane_dg.jl"; tier = :unit, subsystem = :operators),
     UnitTest("Spectral elem - DG divergence conv"       ,"Operators/spectralelement/conv_dg_divergence.jl"; meta = :cpu_only, tier = :conv, subsystem = :operators),
     UnitTest("Operators - broadcast inference"          ,"Operators/inference_operators.jl"; tier = :inference, subsystem = :operators),
     UnitTest("FD ops - zero-allocation stencils"        ,"Operators/finitedifference/allocs_fd_ops.jl"; meta = :cpu_only, tier = :allocs, subsystem = :operators),
@@ -203,6 +204,8 @@ unit_tests = [
     # (see .buildkite/pipeline.yml).
     UnitTest("Distributed - topology (4 ranks)"         ,"Topologies/dtopo4.jl"; meta = :distributed, tier = :unit, subsystem = :topologies),
     UnitTest("Distributed - DSS (2 ranks)"              ,"Spaces/distributed/ddss2.jl"; meta = :distributed, tier = :unit, subsystem = :spaces),
+    UnitTest("Distributed - DG operators (2 ranks)"     ,"Operators/spectralelement/distributed/ddg2.jl"; meta = :distributed, tier = :unit, subsystem = :operators),
+    UnitTest("Distributed - DG operators (3 ranks)"     ,"Operators/spectralelement/distributed/ddg3.jl"; meta = :distributed, tier = :unit, subsystem = :operators),
     UnitTest("Distributed - DSS (3 ranks)"              ,"Spaces/distributed/ddss3.jl"; meta = :distributed, tier = :unit, subsystem = :spaces),
     UnitTest("Distributed - DSS (4 ranks)"              ,"Spaces/distributed/ddss4.jl"; meta = :distributed, tier = :unit, subsystem = :spaces),
     UnitTest("Distributed - gather (4 ranks)"           ,"Spaces/distributed/gather4.jl"; meta = :distributed, tier = :unit, subsystem = :spaces),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,8 +96,8 @@ unit_tests = [
     # scoped `allowscalar` (the two below) or are :cpu_only (the three after).
     UnitTest("Spectral elem - DG two-point fluxes"      ,"Operators/spectralelement/unit_two_point_fluxes.jl"; tier = :unit, subsystem = :operators),
     UnitTest("Spectral elem - DG sphere fluxes"         ,"Operators/spectralelement/unit_sphere_dg_fluxes.jl"; tier = :unit, subsystem = :operators),
-    UnitTest("Spectral elem - DG stability properties"  ,"Operators/spectralelement/unit_dg_stability.jl"; meta = :cpu_only, tier = :unit, subsystem = :operators),
-    UnitTest("Spectral elem - DG boundary fluxes"       ,"Operators/spectralelement/unit_dg_boundary_fluxes.jl"; meta = :cpu_only, tier = :unit, subsystem = :operators),
+    UnitTest("Spectral elem - DG stability properties"  ,"Operators/spectralelement/unit_dg_stability.jl"; tier = :unit, subsystem = :operators),
+    UnitTest("Spectral elem - DG boundary fluxes"       ,"Operators/spectralelement/unit_dg_boundary_fluxes.jl"; tier = :unit, subsystem = :operators),
     UnitTest("Spectral elem - DG extruded sphere"       ,"Operators/spectralelement/unit_extruded_sphere_dg.jl"; tier = :unit, subsystem = :operators),
     UnitTest("Spectral elem - DG extruded plane"        ,"Operators/spectralelement/unit_extruded_plane_dg.jl"; tier = :unit, subsystem = :operators),
     UnitTest("Spectral elem - DG divergence conv"       ,"Operators/spectralelement/conv_dg_divergence.jl"; meta = :cpu_only, tier = :conv, subsystem = :operators),


### PR DESCRIPTION
Adds multi-rank distributed MPI support for DG operators for CPU and CUDA, along with communication optimizations and zero-allocation improvements:

1. **Distributed DG Support (CPU & GPU)**
   - Implemented distributed halo exchange and ghost-face kernels for DG operators (`add_numerical_flux_internal!`, `add_lifting_flux_internal!`, and `add_numerical_flux_boundary!`) across CPU and CUDA backends.
2. **Compact Face-Strip Halo Exchanges**
   - Replaced full-element slab communication with face-only halo buffers (`Topologies.GhostFaceExchange`), exchanging only the $N_q$ boundary face nodes rather than $N_q \times N_q$ full elements.
3. **Computation/Communication Overlap**
   - Structured halo exchanges so non-blocking communication is initiated before interior-face loops/kernels and completed just before ghost-face application, overlapping communication with local compute (20-30% performance improvement on 4 ranks).
4. **Shared Halo Exchanges Across Operators**
   - Added `Operators.start_dg_ghost_exchange(args...)` and the `ghost_exchange` keyword argument, enabling multiple face operators in the same stage (e.g., numerical flux and lifting flux) to reuse a single round of halo exchange.
5. **Zero-Allocation Operators**
   - Replaced tuple `map` calls with `UnrolledUtilities.unrolled_map` and introduced a constant no-op exchange handle (`NO_DG_GHOST_EXCHANGE`) for singleton comms contexts, achieving 0 heap allocations across CPU DG volume, numerical flux, lifting flux, and boundary flux operators.