### PR TITLE
Reduce compilation time

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -18,8 +18,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# The precompile workload (src/precompile_workload.jl) only cuts interactive
+# first-use latency; CI gains nothing from it and pays its compile time and
+# memory. Under coverage the pkgimage is bypassed, so the workload recompiles
+# under instrumentation and is discarded, so every CI job skips it.
+env:
+  CLIMA_SKIP_PRECOMPILE_WORKLOAD: "true"
+
 jobs:
   test:
+    # Portability across Julia versions and operating systems, uninstrumented.
+    # The 1.10 ubuntu run is instrumented and sharded in the `coverage` job
+    # below, so it is excluded here rather than run twice.
     timeout-minutes: ${{ matrix.os == 'macOS-latest' && 120 || 80 }}
     name: ci ${{ matrix.version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -39,6 +49,9 @@ jobs:
           - ${{ github.event_name == 'push' && 'macos-latest' || '' }}
         exclude:
           - os: ''
+          # Covered by the sharded `coverage` job.
+          - version: '1.10'
+            os: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -50,23 +63,53 @@ jobs:
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
         with:
-          # Only this job's coverage is uploaded. Instrumenting bypasses the
-          # precompiled pkgimages, so an instrumented run takes ~2.5x as long.
-          coverage: ${{ matrix.version == '1.10' && matrix.os == 'ubuntu-latest' }}
+          coverage: false
         env:
-          # Portability check across Julia versions and operating systems, on one
-          # two-core runner each. Buildkite splits the same suite and runs the
-          # tiers excluded here, which repeat their cases or run end-to-end.
+          # Buildkite splits the same suite and runs the tiers excluded here,
+          # which repeat their cases or run end-to-end.
           TEST_EXCLUDE_TIER: "conv,inference,allocs,smoke"
           # `slow` marks the multi-minute tests (see test/tabulated_tests.jl).
           TEST_EXCLUDE_SLOW: "true"
+
+  coverage:
+    # The 1.10 ubuntu run is instrumented for coverage, which bypasses the
+    # pkgimages and takes ~2.5x as long. It is sharded by subsystem so no single
+    # job's time or memory reaches the runner limit. `operators` is about half
+    # the suite, so it is one shard and every other subsystem is the other; the
+    # two shards together cover the suite. Each uploads its own lcov, which
+    # codecov merges for the commit.
+    timeout-minutes: 80
+    name: coverage - ${{ matrix.shard }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: operators
+            filter: "TEST_SUBSYSTEM=operators"
+          - shard: rest
+            filter: "TEST_EXCLUDE_SUBSYSTEM=operators"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: '1.10'
+      - uses: julia-actions/cache@v3
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: Select subsystem shard
+        run: echo "${{ matrix.filter }}" >> "$GITHUB_ENV"
+      - uses: julia-actions/julia-runtest@latest
+        with:
+          coverage: true
+        env:
+          TEST_EXCLUDE_TIER: "conv,inference,allocs,smoke"
+          TEST_EXCLUDE_SLOW: "true"
       - uses: julia-actions/julia-processcoverage@latest
-        if: matrix.version == '1.10' && matrix.os == 'ubuntu-latest'
       - uses: codecov/codecov-action@v7
-        # One expression: `${{ a }} && ${{ b }}` interpolates each half separately
-        # and leaves the string "true && false", which is truthy either way.
-        if: matrix.version == '1.10' && matrix.os == 'ubuntu-latest'
         with:
           files: lcov.info
+          flags: ${{ matrix.shard }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/src/ClimaCore.jl
+++ b/src/ClimaCore.jl
@@ -29,5 +29,6 @@ include("Remapping/Remapping.jl")
 
 include("deprecated.jl")
 include("to_device.jl")
+include("precompile_workload.jl")
 
 end # module

--- a/src/Grids/spectralelement.jl
+++ b/src/Grids/spectralelement.jl
@@ -246,6 +246,236 @@ function get_CoordType2D(topology)
     end
 end
 
+# The "epsilon bubble" correction: the numerical area of the domain (the sum
+# of nodal integration weights times their Jacobians) is not exactly equal to
+# the geometric area (e.g. 4π radius² for the sphere), but the two are
+# required to match. The correction modifies the interior weights of each
+# element so that its numerical area equals the geometric area, approximated
+# by `high_order_elem_area` from a quadrature of twice the order. Linear
+# elements (Nq == 2) have no interior nodes, so the deficit is spread
+# uniformly over all nodes; higher-order elements use the HOMME bubble
+# correction, scaling J at interior nodes only. `@noinline` keeps this branchy
+# block a separately inferred and cached unit of the grid constructor.
+@noinline function apply_bubble_correction!(
+    local_geometry,
+    topology,
+    quadrature_style,
+    global_geometry,
+    autodiff_metric,
+    lidx,
+    elem,
+    elem_area::FT,
+    high_order_elem_area::FT,
+    quad_weights,
+) where {FT}
+    Nq = Quadratures.degrees_of_freedom(quadrature_style)
+    lg_args =
+        (global_geometry, topology, quadrature_style, autodiff_metric, elem)
+    if abs(elem_area - high_order_elem_area) ≤ eps(FT)
+        for i in 1:Nq, j in 1:Nq
+            u, ∂u∂ξ = local_geometry_at_nodal_point(lg_args..., i, j)
+            J = det(parent(∂u∂ξ))
+            WJ = J * quad_weights[i] * quad_weights[j]
+            local_geometry[1, i, j, lidx] = Geometry.LocalGeometry(u, J, WJ, ∂u∂ξ)
+        end
+    else
+        Δarea = high_order_elem_area - elem_area
+        if Nq == 2
+            for i in 1:Nq, j in 1:Nq
+                u, ∂u∂ξ = local_geometry_at_nodal_point(lg_args..., i, j)
+                J = det(parent(∂u∂ξ)) + Δarea / Nq^2
+                WJ = J * quad_weights[i] * quad_weights[j]
+                local_geometry[1, i, j, lidx] =
+                    Geometry.LocalGeometry(u, J, WJ, ∂u∂ξ)
+            end
+        else
+            interior_elem_area = zero(FT)
+            for i in 2:(Nq - 1), j in 2:(Nq - 1)
+                u, ∂u∂ξ = local_geometry_at_nodal_point(lg_args..., i, j)
+                J = det(parent(∂u∂ξ))
+                WJ = J * quad_weights[i] * quad_weights[j]
+                interior_elem_area += WJ
+            end
+            if abs(interior_elem_area) ≤ sqrt(eps(FT))
+                error(
+                    "Bubble correction cannot be performed; sum of inner weights is too small.",
+                )
+            end
+            rel_interior_elem_area_Δ = Δarea / interior_elem_area
+
+            for i in 1:Nq, j in 1:Nq
+                u, ∂u∂ξ = local_geometry_at_nodal_point(lg_args..., i, j)
+                J = det(parent(∂u∂ξ))
+                # Modify J only for interior nodes
+                if i != 1 && j != 1 && i != Nq && j != Nq
+                    J *= (1 + rel_interior_elem_area_Δ)
+                end
+                WJ = J * quad_weights[i] * quad_weights[j]
+                local_geometry[1, i, j, lidx] =
+                    Geometry.LocalGeometry(u, J, WJ, ∂u∂ξ)
+            end
+        end
+    end
+end
+
+@noinline function compute_nodal_local_geometries!(
+    local_geometry,
+    topology,
+    quadrature_style,
+    global_geometry,
+    autodiff_metric,
+    enable_bubble,
+)
+    domain = Topologies.domain(topology)
+    FT = Domains.float_type(domain)
+    Nq = Quadratures.degrees_of_freedom(quadrature_style)
+    _, quad_weights = Quadratures.quadrature_points(FT, quadrature_style)
+
+    if enable_bubble
+        high_order_quadrature_style = Quadratures.GLL{Nq * 2}()
+        high_order_Nq =
+            Quadratures.degrees_of_freedom(high_order_quadrature_style)
+        _, high_order_quad_weights =
+            Quadratures.quadrature_points(FT, high_order_quadrature_style)
+        for (lidx, elem) in enumerate(Topologies.localelems(topology))
+            elem_area = zero(FT)
+            high_order_elem_area = zero(FT)
+            lg_args = (
+                global_geometry,
+                topology,
+                quadrature_style,
+                autodiff_metric,
+                elem,
+            )
+            high_order_lg_args = (
+                global_geometry,
+                topology,
+                high_order_quadrature_style,
+                autodiff_metric,
+                elem,
+            )
+            # high-order quadrature loop for computing the geometric element
+            # face area
+            for i in 1:high_order_Nq, j in 1:high_order_Nq
+                u, ∂u∂ξ =
+                    local_geometry_at_nodal_point(high_order_lg_args..., i, j)
+                J_high_order = det(parent(∂u∂ξ))
+                WJ_high_order =
+                    J_high_order *
+                    high_order_quad_weights[i] *
+                    high_order_quad_weights[j]
+                high_order_elem_area += WJ_high_order
+            end
+            # low-order quadrature loop for computing the numerical element
+            # face area
+            for i in 1:Nq, j in 1:Nq
+                u, ∂u∂ξ = local_geometry_at_nodal_point(lg_args..., i, j)
+                J = det(parent(∂u∂ξ))
+                WJ = J * quad_weights[i] * quad_weights[j]
+                elem_area += WJ
+            end
+            apply_bubble_correction!(
+                local_geometry,
+                topology,
+                quadrature_style,
+                global_geometry,
+                autodiff_metric,
+                lidx,
+                elem,
+                elem_area,
+                high_order_elem_area,
+                quad_weights,
+            )
+        end
+    else
+        for (lidx, elem) in enumerate(Topologies.localelems(topology))
+            lg_args = (
+                global_geometry,
+                topology,
+                quadrature_style,
+                autodiff_metric,
+                elem,
+            )
+            for i in 1:Nq, j in 1:Nq
+                u, ∂u∂ξ = local_geometry_at_nodal_point(lg_args..., i, j)
+                J = det(parent(∂u∂ξ))
+                WJ = J * quad_weights[i] * quad_weights[j]
+                local_geometry[1, i, j, lidx] =
+                    Geometry.LocalGeometry(u, J, WJ, ∂u∂ξ)
+            end
+        end
+    end
+end
+
+@noinline function compute_surface_geometries(
+    ::Type{VIJH},
+    ::Type{SG},
+    ::Type{FT},
+    DA,
+    local_geometry,
+    topology,
+    quad_weights,
+    Nq,
+) where {VIJH, SG, FT}
+    interior_faces = Array(Topologies.interior_faces(topology))
+    internal_surface_geometry =
+        VIJH{SG, 1, Nq, 1, nothing}(Array{FT}, length(interior_faces))
+    for (iface, (lidx⁻, face⁻, lidx⁺, face⁺, reversed)) in
+        enumerate(interior_faces)
+        local_geometry_slab⁻ = slab(local_geometry, 1, lidx⁻)
+        local_geometry_slab⁺ = slab(local_geometry, 1, lidx⁺)
+
+        for q in 1:Nq
+            sgeom⁻ = compute_surface_geometry(
+                local_geometry_slab⁻,
+                quad_weights,
+                face⁻,
+                q,
+                false,
+            )
+            sgeom⁺ = compute_surface_geometry(
+                local_geometry_slab⁺,
+                quad_weights,
+                face⁺,
+                q,
+                reversed,
+            )
+
+            @assert sgeom⁻.sWJ ≈ sgeom⁺.sWJ
+            @assert sgeom⁻.normal ≈ -sgeom⁺.normal
+
+            internal_surface_geometry[1, q, 1, iface] = sgeom⁻
+        end
+    end
+    internal_surface_geometry =
+        DataLayouts.rebuild(internal_surface_geometry, DA)
+
+    boundary_surface_geometries =
+        map(Topologies.boundary_tags(topology)) do boundarytag
+            boundary_faces =
+                Topologies.boundary_faces(topology, boundarytag)
+            boundary_surface_geometry = VIJH{SG, 1, Nq, 1, nothing}(
+                Array{FT},
+                length(boundary_faces),
+            )
+            for (iface, (elem, face)) in enumerate(boundary_faces)
+                local_geometry_slab = slab(local_geometry, 1, elem)
+                for q in 1:Nq
+                    boundary_surface_geometry[1, q, 1, iface] =
+                        compute_surface_geometry(
+                            local_geometry_slab,
+                            quad_weights,
+                            face,
+                            q,
+                            false,
+                        )
+                end
+            end
+            DataLayouts.rebuild(boundary_surface_geometry, DA)
+        end
+    return (internal_surface_geometry, boundary_surface_geometries)
+end
+
 function _SpectralElementGrid2D(
     topology,
     quadrature_style,
@@ -255,21 +485,6 @@ function _SpectralElementGrid2D(
     enable_mask,
     discontinuous,
 ) where {VIJH}
-    # 1. compute localgeom for local elememts
-    # 2. ghost exchange of localgeom
-    # 3. do a round of dss on WJs
-    # 4. compute dss weights (WJ ./ dss(WJ)) (local and ghost)
-
-    # DSS on a field would consist of
-    # 1. copy to send buffers
-    # 2. start exchange
-    # 3. dss of internal connections
-    #  - option for weighting and transformation
-    # 4. finish exchange
-    # 5. dss of ghost connections
-
-    ### How to DSS multiple fields?
-    # 1. allocate buffers externally
     DA = ClimaComms.array_type(topology)
     domain = Topologies.domain(topology)
     FT = Domains.float_type(domain)
@@ -282,179 +497,35 @@ function _SpectralElementGrid2D(
     AIdx = Geometry.coordinate_axis(CoordType2D)
     Nh = Topologies.nlocalelems(topology)
     Nq = Quadratures.degrees_of_freedom(quadrature_style)
-    high_order_quadrature_style = Quadratures.GLL{Nq * 2}()
-    high_order_Nq = Quadratures.degrees_of_freedom(high_order_quadrature_style)
     LG = Geometry.LocalGeometryType(CoordType2D, FT, AIdx)
 
     local_geometry = VIJH{LG, 1, Nq, Nq, nothing}(Array{FT}, Nh)
-
-    _, quad_weights = Quadratures.quadrature_points(FT, quadrature_style)
-    _, high_order_quad_weights =
-        Quadratures.quadrature_points(FT, high_order_quadrature_style)
-    for (lidx, elem) in enumerate(Topologies.localelems(topology))
-        elem_area = zero(FT)
-        high_order_elem_area = zero(FT)
-        Δarea = zero(FT)
-        interior_elem_area = zero(FT)
-        rel_interior_elem_area_Δ = zero(FT)
-        lg_args =
-            (global_geometry, topology, quadrature_style, autodiff_metric, elem)
-        high_order_lg_args = (
-            global_geometry,
-            topology,
-            high_order_quadrature_style,
-            autodiff_metric,
-            elem,
-        )
-        # high-order quadrature loop for computing geometric element face area.
-        for i in 1:high_order_Nq, j in 1:high_order_Nq
-            u, ∂u∂ξ = local_geometry_at_nodal_point(high_order_lg_args..., i, j)
-            J_high_order = det(parent(∂u∂ξ))
-            WJ_high_order =
-                J_high_order *
-                high_order_quad_weights[i] *
-                high_order_quad_weights[j]
-            high_order_elem_area += WJ_high_order
-        end
-        # low-order quadrature loop for computing numerical element face area
-        for i in 1:Nq, j in 1:Nq
-            u, ∂u∂ξ = local_geometry_at_nodal_point(lg_args..., i, j)
-            J = det(parent(∂u∂ξ))
-            WJ = J * quad_weights[i] * quad_weights[j]
-            elem_area += WJ
-            if !enable_bubble
-                local_geometry[1, i, j, lidx] = Geometry.LocalGeometry(u, J, WJ, ∂u∂ξ)
-            end
-        end
-
-        # If enabled, apply bubble correction
-        if enable_bubble
-            if abs(elem_area - high_order_elem_area) ≤ eps(FT)
-                for i in 1:Nq, j in 1:Nq
-                    u, ∂u∂ξ = local_geometry_at_nodal_point(lg_args..., i, j)
-                    J = det(parent(∂u∂ξ))
-                    WJ = J * quad_weights[i] * quad_weights[j]
-                    local_geometry[1, i, j, lidx] = Geometry.LocalGeometry(u, J, WJ, ∂u∂ξ)
-                end
-            else
-                # The idea behind the so-called `bubble_correction` is that
-                # the numerical area of the domain (e.g., the sphere) is given by the sum
-                # of nodal integration weights times their corresponding Jacobians. However,
-                # this discrete sum is not exactly equal to the exact geometric area
-                # (4pi*radius^2 for the sphere). It is required that numerical area = geometric area.
-                # The "epsilon bubble" approach modifies the inner weights in each
-                # element so that geometric and numerical areas of each element match.
-
-                # Compute difference between geometric area of an element and its approximate numerical area
-                Δarea = high_order_elem_area - elem_area
-
-                # Linear elements: Nq == 2 (SpectralElementSpace2D cannot have Nq < 2)
-                # Use uniform bubble correction
-                if Nq == 2
-                    for i in 1:Nq, j in 1:Nq
-                        u, ∂u∂ξ =
-                            local_geometry_at_nodal_point(lg_args..., i, j)
-                        J = det(parent(∂u∂ξ))
-                        J += Δarea / Nq^2
-                        WJ = J * quad_weights[i] * quad_weights[j]
-                        local_geometry[1, i, j, lidx] =
-                            Geometry.LocalGeometry(u, J, WJ, ∂u∂ξ)
-                    end
-                else # Higher-order elements: Use HOMME bubble correction for the interior nodes
-                    for i in 2:(Nq - 1), j in 2:(Nq - 1)
-                        u, ∂u∂ξ =
-                            local_geometry_at_nodal_point(lg_args..., i, j)
-                        J = det(parent(∂u∂ξ))
-                        WJ = J * quad_weights[i] * quad_weights[j]
-                        interior_elem_area += WJ
-                    end
-                    # Check that interior_elem_area is not too small
-                    if abs(interior_elem_area) ≤ sqrt(eps(FT))
-                        error(
-                            "Bubble correction cannot be performed; sum of inner weights is too small.",
-                        )
-                    end
-                    rel_interior_elem_area_Δ = Δarea / interior_elem_area
-
-                    for i in 1:Nq, j in 1:Nq
-                        u, ∂u∂ξ =
-                            local_geometry_at_nodal_point(lg_args..., i, j)
-                        J = det(parent(∂u∂ξ))
-                        # Modify J only for interior nodes
-                        if i != 1 && j != 1 && i != Nq && j != Nq
-                            J *= (1 + rel_interior_elem_area_Δ)
-                        end
-                        WJ = J * quad_weights[i] * quad_weights[j]
-                        # Finally allocate local geometry
-                        local_geometry[1, i, j, lidx] =
-                            Geometry.LocalGeometry(u, J, WJ, ∂u∂ξ)
-                    end
-                end
-            end
-        end
-    end
+    compute_nodal_local_geometries!(
+        local_geometry,
+        topology,
+        quadrature_style,
+        global_geometry,
+        autodiff_metric,
+        enable_bubble,
+    )
 
     SG = Geometry.SurfaceGeometry{
         FT,
         Geometry.LocalVector{FT, AIdx, SVector{2, FT}},
     }
-    interior_faces = Array(Topologies.interior_faces(topology))
-
+    _, quad_weights = Quadratures.quadrature_points(FT, quadrature_style)
     if quadrature_style isa Quadratures.GLL
-        internal_surface_geometry =
-            VIJH{SG, 1, Nq, 1, nothing}(Array{FT}, length(interior_faces))
-        for (iface, (lidx⁻, face⁻, lidx⁺, face⁺, reversed)) in enumerate(interior_faces)
-            local_geometry_slab⁻ = slab(local_geometry, 1, lidx⁻)
-            local_geometry_slab⁺ = slab(local_geometry, 1, lidx⁺)
-
-            for q in 1:Nq
-                sgeom⁻ = compute_surface_geometry(
-                    local_geometry_slab⁻,
-                    quad_weights,
-                    face⁻,
-                    q,
-                    false,
-                )
-                sgeom⁺ = compute_surface_geometry(
-                    local_geometry_slab⁺,
-                    quad_weights,
-                    face⁺,
-                    q,
-                    reversed,
-                )
-
-                @assert sgeom⁻.sWJ ≈ sgeom⁺.sWJ
-                @assert sgeom⁻.normal ≈ -sgeom⁺.normal
-
-                internal_surface_geometry[1, q, 1, iface] = sgeom⁻
-            end
-        end
-        internal_surface_geometry =
-            DataLayouts.rebuild(internal_surface_geometry, DA)
-
-        boundary_surface_geometries =
-            map(Topologies.boundary_tags(topology)) do boundarytag
-                boundary_faces =
-                    Topologies.boundary_faces(topology, boundarytag)
-                boundary_surface_geometry = VIJH{SG, 1, Nq, 1, nothing}(
-                    Array{FT},
-                    length(boundary_faces),
-                )
-                for (iface, (elem, face)) in enumerate(boundary_faces)
-                    local_geometry_slab = slab(local_geometry, 1, elem)
-                    for q in 1:Nq
-                        boundary_surface_geometry[1, q, 1, iface] =
-                            compute_surface_geometry(
-                                local_geometry_slab,
-                                quad_weights,
-                                face,
-                                q,
-                                false,
-                            )
-                    end
-                end
-                DataLayouts.rebuild(boundary_surface_geometry, DA)
-            end
+        (internal_surface_geometry, boundary_surface_geometries) =
+            compute_surface_geometries(
+                VIJH,
+                SG,
+                FT,
+                DA,
+                local_geometry,
+                topology,
+                quad_weights,
+                Nq,
+            )
     else
         internal_surface_geometry = nothing
         boundary_surface_geometries = nothing

--- a/src/precompile_workload.jl
+++ b/src/precompile_workload.jl
@@ -1,0 +1,128 @@
+# Precompile workload for basic grids, spaces, operators, and field
+# broadcasts. `Base.generating_output` does not exist on Julia 1.10, so the
+# underlying C call is used directly (as PrecompileTools does). Developers
+# iterating on ClimaCore can skip the workload with
+# CLIMA_SKIP_PRECOMPILE_WORKLOAD=true.
+#
+# A data layout carries its vertical extent `Nv` and quadrature order in its
+# type, and each distinct broadcast expression compiles a separate kernel, so
+# the workload only removes first-use latency for code whose type parameters
+# match a production run. It therefore uses a 63-level column (centers carry
+# Nv = 63, faces Nv = 64) at GLL{4}, an AMIP resolution, with `NamedTuple`-
+# eltype center and face fields standing in for a prognostic state: a scalar
+# field and a scalar subfield view into a `NamedTuple` field compile to
+# different kernels, so both are exercised. Adding resolutions or broadcast
+# expressions widens the coverage at the cost of package load time.
+if ccall(:jl_generating_output, Cint, ()) == 1 &&
+   get(ENV, "CLIMA_SKIP_PRECOMPILE_WORKLOAD", "false") != "true"
+    let
+        # Centers carry Nv = 63 and faces Nv = 64, an AMIP resolution.
+        nelems = 63
+        for FT in (Float64, Float32)
+            context = ClimaComms.SingletonCommsContext()
+            vdomain = Domains.IntervalDomain(
+                Geometry.ZPoint(FT(0)),
+                Geometry.ZPoint(FT(1));
+                boundary_names = (:bottom, :top),
+            )
+            vmesh = Meshes.IntervalMesh(vdomain, nelems = nelems)
+            vtopology = Topologies.IntervalTopology(context, vmesh)
+            vspace = Spaces.CenterFiniteDifferenceSpace(vtopology)
+
+            hdomain = Domains.SphereDomain(FT(10))
+            hmesh = Meshes.EquiangularCubedSphere(hdomain, 1)
+            htopology = Topologies.Topology2D(context, hmesh)
+            quad = Quadratures.GLL{4}()
+            hspace = Spaces.SpectralElementSpace2D(htopology, quad)
+
+            cspace = Spaces.ExtrudedFiniteDifferenceSpace(
+                hspace,
+                vspace,
+                Hypsography.Flat(),
+            )
+            fspace = Spaces.FaceExtrudedFiniteDifferenceSpace(cspace)
+
+            z = Fields.coordinate_field(cspace).z
+            ff = zeros(fspace)
+
+            # A prognostic-like state: a `NamedTuple` field on centers (density,
+            # energy, and horizontal covariant momentum, the momentum eltype
+            # whose broadcasts and spectral operators dominate downstream
+            # first-use latency) and one on faces (vertical covariant velocity).
+            # The subfield views below are what production tendencies broadcast
+            # over.
+            cstate = @. (;
+                ρ = one(z),
+                ρe = 2 * one(z),
+                uₕ = Geometry.Covariant12Vector(
+                    Geometry.UVVector(one(z), 2 * one(z)),
+                ),
+            )
+            fstate = @. (; w = Geometry.Covariant3Vector(zero(ff)))
+            ρ = cstate.ρ
+            ρe = cstate.ρe
+            uₕ = cstate.uₕ
+            @. ρe = ρ * ρe + 1
+
+            # A standalone scalar field alongside the `ρ` subfield view: the two
+            # drive different broadcast kernels.
+            fc = copy(ρ)
+
+            # Horizontal spectral operators: scalar and vector Laplacians (the
+            # hyperdiffusion atoms), plus the weighted second-pass form, over
+            # the state's subfield views.
+            χ = Base.Broadcast.materialize(Operators.scalar_laplacian(ρ))
+            χu = Base.Broadcast.materialize(Operators.vector_laplacian(uₕ))
+            χw = Base.Broadcast.materialize(
+                Operators.scalar_laplacian(χ; weight = ρ),
+            )
+
+            # Continuous DSS
+            Spaces.weighted_dss!(ρ)
+
+            # Vertical interpolation operators, without and with boundary
+            # conditions
+            I_c2f = Operators.InterpolateC2F()
+            I_f2c = Operators.InterpolateF2C()
+            @. ff = I_c2f(fc)
+            @. fc = I_f2c(ff)
+            I_c2f_extrap = Operators.InterpolateC2F(
+                bottom = Operators.Extrapolate(),
+                top = Operators.Extrapolate(),
+            )
+            @. ff = I_c2f_extrap(fc)
+
+            # Common vertical stencil operators: gradient, flux divergence,
+            # upwind advection, and mass-weighted interpolation
+            G = Operators.GradientC2F(
+                bottom = Operators.SetValue(FT(0)),
+                top = Operators.SetValue(FT(0)),
+            )
+            gf = @. G(fc)
+            wvec = Geometry.WVector
+            D = Operators.DivergenceF2C(
+                bottom = Operators.SetValue(wvec(FT(0))),
+                top = Operators.SetValue(wvec(FT(0))),
+            )
+            w3 = @. wvec(one(ff))
+            dc = @. D(w3)
+            U = Operators.UpwindBiasedProductC2F()
+            up = @. U(w3, fc)
+            WI = Operators.WeightedInterpolateF2C()
+            Jf = ones(fspace)
+            wi = @. WI(Jf, ff)
+
+            # FieldVector broadcasts over the `NamedTuple`-eltype state,
+            # including an aliased in-place update in the vector-safe form a
+            # Runge-Kutta stage uses.
+            X = Fields.FieldVector(c = cstate, f = fstate)
+            Y = similar(X)
+            @. Y = X + FT(0.5) * X
+            Y .-= X
+        end
+        # The topology and grid constructors memoize into the global object
+        # cache; empty it so the workload's objects are not serialized into
+        # the package image (the compiled code is cached either way).
+        Utilities.Cache.clean_cache!()
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -245,22 +245,25 @@ end
 
 # Optional CLI / Environment-based test filtering:
 # e.g. TEST_TIER=unit, TEST_EXCLUDE_TIER=conv,inference, TEST_SUBSYSTEM=operators,
-# TEST_TAG=dg, TEST_FAST=true, TEST_EXCLUDE_SLOW=true
+# TEST_EXCLUDE_SUBSYSTEM=operators, TEST_TAG=dg, TEST_FAST=true,
+# TEST_EXCLUDE_SLOW=true
 let
     tier_filter = get(ENV, "TEST_TIER", nothing)
     exclude_tier_filter = get(ENV, "TEST_EXCLUDE_TIER", nothing)
     subsystem_filter = get(ENV, "TEST_SUBSYSTEM", nothing)
+    exclude_subsystem_filter = get(ENV, "TEST_EXCLUDE_SUBSYSTEM", nothing)
     tag_filter = get(ENV, "TEST_TAG", nothing)
     fast_filter = get(ENV, "TEST_FAST", "false") == "true"
     exclude_slow_filter = get(ENV, "TEST_EXCLUDE_SLOW", "false") == "true"
     if !isnothing(tier_filter) || !isnothing(exclude_tier_filter) ||
-       !isnothing(subsystem_filter) || !isnothing(tag_filter) ||
-       fast_filter || exclude_slow_filter
+       !isnothing(subsystem_filter) || !isnothing(exclude_subsystem_filter) ||
+       !isnothing(tag_filter) || fast_filter || exclude_slow_filter
         filtered = filter_tests(
             unit_tests;
             tier = tier_filter,
             exclude_tier = exclude_tier_filter,
             subsystem = subsystem_filter,
+            exclude_subsystem = exclude_subsystem_filter,
             tag = tag_filter,
             fast = fast_filter,
             exclude_slow = exclude_slow_filter,
@@ -289,6 +292,7 @@ if isempty(unit_tests)
                 "TEST_TIER",
                 "TEST_EXCLUDE_TIER",
                 "TEST_SUBSYSTEM",
+                "TEST_EXCLUDE_SUBSYSTEM",
                 "TEST_TAG",
                 "TEST_FAST",
                 "TEST_EXCLUDE_SLOW",

--- a/test/tabulated_tests.jl
+++ b/test/tabulated_tests.jl
@@ -41,16 +41,20 @@ UnitTest(
 ) = UnitTest(name, filename, 0.0, 0.0, 0.0, 0, meta, tier, subsystem, slow)
 
 """
-    filter_tests(unit_tests::Vector{UnitTest}; tier = nothing, exclude_tier = nothing, subsystem = nothing, tag = nothing, fast::Bool = false, exclude_slow::Bool = false)
+    filter_tests(unit_tests::Vector{UnitTest}; tier = nothing, exclude_tier = nothing, subsystem = nothing, exclude_subsystem = nothing, tag = nothing, fast::Bool = false, exclude_slow::Bool = false)
 
 Filters unit tests based on tier, excluded tier(s) (comma-separated, e.g.
-`"conv,inference"`), subsystem, case-insensitive substring match, or `slow`.
+`"conv,inference"`), subsystem, excluded subsystem(s) (comma-separated),
+case-insensitive substring match, or `slow`. Selecting a subsystem and
+excluding its complement partitions the suite into shards that together cover
+every test (see the sharded coverage job in `.github/workflows/UnitTests.yml`).
 """
 function filter_tests(
     unit_tests::Vector{UnitTest};
     tier = nothing,
     exclude_tier = nothing,
     subsystem = nothing,
+    exclude_subsystem = nothing,
     tag = nothing,
     fast::Bool = false,
     exclude_slow::Bool = false,
@@ -59,6 +63,14 @@ function filter_tests(
         Symbol[]
     else
         [Symbol(strip(s)) for s in split(String(exclude_tier), ","; keepempty = false)]
+    end
+    excluded_subsystems = if isnothing(exclude_subsystem)
+        Symbol[]
+    else
+        [
+            Symbol(strip(s)) for
+            s in split(String(exclude_subsystem), ","; keepempty = false)
+        ]
     end
     return filter(unit_tests) do t
         if fast && t.tier != :unit
@@ -74,6 +86,9 @@ function filter_tests(
             return false
         end
         if !isnothing(subsystem) && t.subsystem != Symbol(subsystem)
+            return false
+        end
+        if t.subsystem in excluded_subsystems
             return false
         end
         if !isnothing(tag)


### PR DESCRIPTION
Stacked on top of #2606.

## Summary

Reduces ClimaCore's compilation latency. Profiling showed ~81% of initial space-creation time was Julia type inference over the grid/space constructors and operator broadcasts; this PR caches that work at package precompilation time and restructures the largest constructor.

*Note: based on #2606 (`ts/perf`); only the last two commits are new.*

1. **Precompilation workload** (`src/precompile_workload.jl`, no new dependencies): exercises small Float32/Float64 instances of interval meshes and FD spaces, cubed-sphere spectral-element grids, extruded center/face spaces, coordinate fields, scalar and covariant-vector broadcasts, the hyperdiffusion Laplaed, vector), continuous DSS, the common vertical

Reduces ClimaCore's first-use (TTFX) latency. Profiling showed ~81% of initial space-creation time was Julia type inference over the grid/space constructors and operator broadcasts; this PR caches that work at package precompilation time and restructures the largest constructor.

*Note: based on #2606 (`ts/perf`); only the last two commits are new.*

1. **Precompilation workload** (`src/precompile_workload.jl`, no new dependencies): exercises small Float32/Float64 instances of interval meshes and FD spaces, cubed-sphere spectral-nter/face spaces, coordinate fields, scalar andcovariant-vector broadcasts, the hyperdiffusion Laplacian atoms (scalar, weighted, vector), continuous DSS, the common vertical stencil operators, and FieldVector broadcasts (includdate). Guarded by the 1.10-compatible`ccall(:jl_generating_output, ...)`; `CLIMA_SKIP_PRECOMPILE_WORKLOAD=true` skips it during development. The global object cache is emptied afterwards so no workload objects are serialized into the package image.
2. **`_SpectralElementGrid2D` modularization**: the monolithic ~200-line constructor is split into `@noinline` units (`compute_nodal_local_geometries!`, `apply_bubble_correction!`, `compute_surface_geometries`), each inferred and cached separately. Also removes wasted work: the high-order quadrature area loop (4× the nodal evaluations) previously ran for every element even with
the bubble correction disabled, its result unused.

## Measurements

Representative downstream first use (fresh session, `z_elem = 10`, `h_elem = 4` — sizes *different* from the workload's):

| | before | after |
|---|---|---|
| Total (load + spaces + fields + operators) | 16.9 s (pre-workload) / 7.3 s | **4.5 s** |
| Scalar / vector spectral operator first use | 1.0 s / 2.3 s | 0.13 s / 0.35 s |
| At workload-matched sizes | — | fully cached (~0 s per operation) |

Package precompilation grows ~28 → ~32 s. No runtime code paths change (construction and broadcast results are bit-identical; sphere, bubble-correction, and allocation test tiers pass).

## Known limitation

`Nv`, `Ni`, `Nj` are static type parameters of the data layouts (only `Nh` is dynamic), so column-dependent code re-infers per new vertical extent — the remaining ~3 s at a novel `z_elem`, dominated by the extruded constructor's two `product_geometry` broadcasts (~1.2 s). The fix would be `Nv`-generic construction ayout variant); proposed as a follow-up item for #2605rather than attempted here.

Co-produced with Gemini and Claude