### PR TITLE
Use multi prefix naming instead of ensemble

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -299,6 +299,15 @@ main
   Equation-set-specific fluxes (compressible Euler with Cartesian momentum
   components) are example code. Operator tests are included as part of
   `test/runtests.jl`.
+- The "point cloud" types have been renamed to use the `Multi` prefix:
+  - `Grids.PointCloudGrid` is now `Grids.MultiPointGrid`,
+  - `Grids.ExtrudedPointCloudGrid` is `Grids.ExtrudedMultiPointGrid`,
+  - `Spaces.PointCloudSpace` is now `Spaces.MultiPointSpace`,
+  - `CommonGrids.PointColumnEnsembleGrid` is now `CommonGrids.MultiColumnGrid`,
+  - `CommonSpaces.PointColumnEnsembleSpace` is now
+    `CommonSpaces.MultiColumnSpace`.
+  - The old names are available, but deprecated.
+    [2611](https://github.com/CliMA/ClimaCore.jl/pull/2611)
 
 v0.15.3
 -------

--- a/docs/src/APIs/common_grids_api.md
+++ b/docs/src/APIs/common_grids_api.md
@@ -12,5 +12,5 @@ CommonGrids.ColumnGrid
 CommonGrids.Box3DGrid
 CommonGrids.SliceXZGrid
 CommonGrids.RectangleXYGrid
-CommonGrids.PointColumnEnsembleGrid
+CommonGrids.MultiColumnGrid
 ```

--- a/docs/src/APIs/common_spaces_api.md
+++ b/docs/src/APIs/common_spaces_api.md
@@ -12,5 +12,5 @@ CommonSpaces.ColumnSpace
 CommonSpaces.Box3DSpace
 CommonSpaces.SliceXZSpace
 CommonSpaces.RectangleXYSpace
-CommonSpaces.PointColumnEnsembleSpace
+CommonSpaces.MultiColumnSpace
 ```

--- a/docs/src/APIs/grids_api.md
+++ b/docs/src/APIs/grids_api.md
@@ -12,6 +12,7 @@ Grids.FiniteDifferenceGrid
 Grids.ExtrudedFiniteDifferenceGrid
 Grids.SpectralElementGrid1D
 Grids.SpectralElementGrid2D
+Grids.MultiPointGrid
 ```
 
 ## Hypsography

--- a/docs/src/APIs/spaces_api.md
+++ b/docs/src/APIs/spaces_api.md
@@ -52,6 +52,19 @@ Spaces.node_horizontal_length_scale
 Spaces.ExtrudedFiniteDifferenceSpace
 ```
 
+## Point Spaces
+
+```@docs
+Spaces.PointSpace
+```
+
+## Multi-column Spaces
+
+```@docs
+Spaces.MultiPointSpace
+Spaces.MultiColumnFiniteDifferenceSpace
+```
+
 ## Utilities
 
 ```@docs

--- a/src/CommonGrids/CommonGrids.jl
+++ b/src/CommonGrids/CommonGrids.jl
@@ -71,6 +71,7 @@ export ExtrudedCubedSphereGrid,
     Box3DGrid,
     SliceXZGrid,
     RectangleXYGrid,
+    MultiColumnGrid,
     PointColumnEnsembleGrid
 
 import ClimaComms
@@ -705,7 +706,7 @@ function RectangleXYGrid(
 end
 
 """
-    PointColumnEnsembleGrid(
+    MultiColumnGrid(
         ::Type{<:AbstractFloat}; # defaults to Float64
         points::AbstractVector{Geometry.LatLongPoint{FT}},
         z_elem::Integer,
@@ -742,7 +743,7 @@ not supported. Use [`ClimaCore.Fields.bycolumn`](@ref) to iterate over columns.
 ```julia
 using ClimaCore.CommonGrids, ClimaCore.Geometry
 points = [LatLongPoint(0.0, 0.0), LatLongPoint(10.0, 20.0), LatLongPoint(-5.0, 90.0)]
-grid = PointColumnEnsembleGrid(;
+grid = MultiColumnGrid(;
     points = points,
     z_elem = 10,
     z_min = 0,
@@ -751,8 +752,8 @@ grid = PointColumnEnsembleGrid(;
 )
 ```
 """
-PointColumnEnsembleGrid(; kwargs...) = PointColumnEnsembleGrid(Float64; kwargs...)
-function PointColumnEnsembleGrid(
+MultiColumnGrid(; kwargs...) = MultiColumnGrid(Float64; kwargs...)
+function MultiColumnGrid(
     ::Type{FT};
     points::AbstractVector{Geometry.LatLongPoint{FT}},
     z_elem::Integer,
@@ -763,7 +764,7 @@ function PointColumnEnsembleGrid(
     stretch::Meshes.StretchingRule = Meshes.Uniform(),
     z_mesh::Meshes.IntervalMesh = DefaultZMesh(FT; z_min, z_max, z_elem, stretch),
 ) where {FT}
-    h_grid = Grids.PointCloudGrid(points; radius, device)
+    h_grid = Grids.MultiPointGrid(points; radius, device)
     z_topology = Topologies.IntervalTopology(
         ClimaComms.SingletonCommsContext(device),
         z_mesh,
@@ -771,5 +772,8 @@ function PointColumnEnsembleGrid(
     z_grid = Grids.FiniteDifferenceGrid(z_topology)
     return Grids.ExtrudedFiniteDifferenceGrid(h_grid, z_grid)
 end
+
+# Backwards-compatibility alias for the old name.
+Base.@deprecate_binding PointColumnEnsembleGrid MultiColumnGrid false
 
 end # module

--- a/src/CommonSpaces/CommonSpaces.jl
+++ b/src/CommonSpaces/CommonSpaces.jl
@@ -13,6 +13,7 @@ export ExtrudedCubedSphereSpace,
     Box3DSpace,
     SliceXZSpace,
     RectangleXYSpace,
+    MultiColumnSpace,
     PointColumnEnsembleSpace,
     CellCenter,
     CellFace,
@@ -31,7 +32,7 @@ import ..CommonGrids:
     Box3DGrid,
     SliceXZGrid,
     RectangleXYGrid,
-    PointColumnEnsembleGrid
+    MultiColumnGrid
 import ..Spaces: face_space, center_space
 
 
@@ -429,7 +430,7 @@ RectangleXYSpace(::Type{FT}; kwargs...) where {FT} =
     Spaces.SpectralElementSpace2D(RectangleXYGrid(FT; kwargs...))
 
 """
-    PointColumnEnsembleSpace(
+    MultiColumnSpace(
         ::Type{<:AbstractFloat}; # defaults to Float64
         points::AbstractVector{Geometry.LatLongPoint{FT}},
         z_elem::Integer,
@@ -441,9 +442,8 @@ RectangleXYSpace(::Type{FT}; kwargs...) where {FT} =
         staggering::Staggering,
     )
 
-Construct a [`Spaces.ExtrudedFiniteDifferenceSpace`](@ref) (aliased as
-`Spaces.MultiColumnFiniteDifferenceSpace`) for N independent columns at arbitrary (lat, lon)
-locations on a sphere, given:
+Construct a [`Spaces.MultiColumnFiniteDifferenceSpace`](@ref) for N
+independent columns at arbitrary (lat, lon) locations on a sphere, given:
 
   - `FT` the floating-point type (defaults to `Float64`) [`Float32`, `Float64`]
   - `points` a vector of `Geometry.LatLongPoint` specifying each column location
@@ -455,7 +455,7 @@ locations on a sphere, given:
   - `z_mesh` the vertical mesh, defaults to an `Meshes.IntervalMesh` along `z` with given `stretch`
   - `staggering` vertical staggering, can be one of [[`Grids.CellFace`](@ref), [`Grids.CellCenter`](@ref)]
 
-Note that these arguments are all the same as [`CommonGrids.PointColumnEnsembleGrid`](@ref),
+Note that these arguments are all the same as [`CommonGrids.MultiColumnGrid`](@ref),
 except for `staggering`.
 
 # Example usage
@@ -463,7 +463,7 @@ except for `staggering`.
 ```julia
 using ClimaCore.CommonSpaces, ClimaCore.Geometry
 points = [LatLongPoint(0.0, 0.0), LatLongPoint(10.0, 20.0), LatLongPoint(-5.0, 90.0)]
-space = PointColumnEnsembleSpace(;
+space = MultiColumnSpace(;
     points = points,
     z_elem = 10,
     z_min = 0,
@@ -472,12 +472,15 @@ space = PointColumnEnsembleSpace(;
 )
 ```
 """
-function PointColumnEnsembleSpace end
-PointColumnEnsembleSpace(; kwargs...) = PointColumnEnsembleSpace(Float64; kwargs...)
-PointColumnEnsembleSpace(::Type{FT}; staggering::Staggering, kwargs...) where {FT} =
+function MultiColumnSpace end
+MultiColumnSpace(; kwargs...) = MultiColumnSpace(Float64; kwargs...)
+MultiColumnSpace(::Type{FT}; staggering::Staggering, kwargs...) where {FT} =
     Spaces.MultiColumnFiniteDifferenceSpace(
-        PointColumnEnsembleGrid(FT; kwargs...),
+        MultiColumnGrid(FT; kwargs...),
         staggering,
     )
+
+# Backwards-compatibility alias for the old name.
+Base.@deprecate_binding PointColumnEnsembleSpace MultiColumnSpace false
 
 end # module

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -71,7 +71,7 @@ Meshes.domain(grid::AbstractGrid) = Meshes.domain(topology(grid))
 
 include("finitedifference.jl")
 include("spectralelement.jl")
-include("pointcloud.jl")
+include("multipoint.jl")
 include("extruded.jl")
 include("column.jl")
 include("level.jl")
@@ -107,7 +107,7 @@ has_horizontal(::ExtrudedFiniteDifferenceGrid) = true
 has_horizontal(::DeviceSpectralElementGrid2D) = true
 has_horizontal(::SpectralElementGrid2D) = true
 has_horizontal(::SpectralElementGrid1D) = true
-has_horizontal(::PointCloudGrid) = true
+has_horizontal(::MultiPointGrid) = true
 
 """
     has_vertical(::AbstractGrid)
@@ -126,7 +126,7 @@ Retrieve the mask for the grid (defaults to DataLayouts.NoMask).
 """
 get_mask(::AbstractGrid) = DataLayouts.NoMask()
 get_mask(grid::ExtrudedFiniteDifferenceGrid) = grid.horizontal_grid.mask
-get_mask(::ExtrudedFiniteDifferenceGrid{<:PointCloudGrid}) = DataLayouts.NoMask()
+get_mask(::ExtrudedFiniteDifferenceGrid{<:MultiPointGrid}) = DataLayouts.NoMask()
 
 """
     set_mask!(fn::Function, grid)

--- a/src/Grids/extruded.jl
+++ b/src/Grids/extruded.jl
@@ -187,15 +187,17 @@ const ExtrudedRectilinearSpectralElementGrid3D =
     ExtrudedFiniteDifferenceGrid{<:RectilinearSpectralElementGrid2D}
 const ExtrudedCubedSphereSpectralElementGrid3D =
     ExtrudedFiniteDifferenceGrid{<:CubedSphereSpectralElementGrid2D}
-const ExtrudedPointCloudGrid = ExtrudedFiniteDifferenceGrid{<:PointCloudGrid}
+const ExtrudedMultiPointGrid = ExtrudedFiniteDifferenceGrid{<:MultiPointGrid}
+# Backwards-compatibility alias for the old name.
+Base.@deprecate_binding ExtrudedPointCloudGrid ExtrudedMultiPointGrid false
 
 # The show method for `AbstractGrid` calls `topology(grid)`, which errors for
-# a point-cloud horizontal grid, so print the point-cloud fields directly
-function Base.show(io::IO, grid::ExtrudedPointCloudGrid)
+# a multi-point horizontal grid, so print the multi-point fields directly
+function Base.show(io::IO, grid::ExtrudedMultiPointGrid)
     indent = get(io, :indent, 0)
     iio = IOContext(io, :indent => indent + 2)
     println(io, nameof(typeof(grid)), ":")
-    print_pointcloud_horizontal(iio, grid.horizontal_grid, indent)
+    print_multipoint_horizontal(iio, grid.horizontal_grid, indent)
     println(iio)
     println(iio, " "^(indent + 2), "vertical:")
     print(iio, " "^(indent + 4), "mesh: ", vertical_topology(grid).mesh)

--- a/src/Grids/multipoint.jl
+++ b/src/Grids/multipoint.jl
@@ -1,6 +1,6 @@
 
 """
-    PointCloudGrid(
+    MultiPointGrid(
         context :: ClimaComms.AbstractCommsContext,
         points  :: AbstractVector{Geometry.LatLongPoint{FT}},
     )
@@ -9,7 +9,7 @@ A horizontal grid consisting of N arbitrary, disconnected (lat, long) locations
 on a sphere. There is no connectivity between columns; no spectral element
 basis, DSS, or horizontal operators are supported on this grid.
 
-This is the horizontal component used by a "point cloud" extruded space (N
+This is the horizontal component used by a multi-column extruded space (N
 independent columns at user-chosen sphere locations).
 
 The `local_geometry` is stored as a `VIJFH{LG, 1, 1, 1, N}` data layout, with
@@ -19,7 +19,7 @@ tensor](https://en.wikipedia.org/wiki/Metric_tensor#The_round_metric_on_a_sphere
 of a sphere, the horizontal Jacobian `∂x∂ξ` is given by the diagonal matrix
 `diag(R·π/180, R·cosd(lat)·π/180)`, with the determinant `J = R²·cosd(lat)·(π/180)²`.
 """
-struct PointCloudGrid{
+struct MultiPointGrid{
     C <: ClimaComms.AbstractCommsContext,
     GG <: Geometry.AbstractGlobalGeometry,
     LG,
@@ -29,53 +29,53 @@ struct PointCloudGrid{
     local_geometry::LG  # VIJFH{LocalGeometry{(1,2), LatLongPoint{FT}, ...}, 1, 1, 1, N}
 end
 
-Adapt.@adapt_structure PointCloudGrid
+Adapt.@adapt_structure MultiPointGrid
 
-local_geometry_type(::Type{PointCloudGrid{C, GG, LG}}) where {C, GG, LG} =
+local_geometry_type(::Type{MultiPointGrid{C, GG, LG}}) where {C, GG, LG} =
     eltype(LG)
 
-ClimaComms.context(grid::PointCloudGrid) = grid.context
-ClimaComms.device(grid::PointCloudGrid) = ClimaComms.device(grid.context)
+ClimaComms.context(grid::MultiPointGrid) = grid.context
+ClimaComms.device(grid::MultiPointGrid) = ClimaComms.device(grid.context)
 
-topology(::PointCloudGrid) = error(
-    "PointCloudGrid has no topology",
+topology(::MultiPointGrid) = error(
+    "MultiPointGrid has no topology",
 )
 
-local_geometry_data(grid::PointCloudGrid, ::Nothing) = grid.local_geometry
-global_geometry(grid::PointCloudGrid) = grid.global_geometry
+local_geometry_data(grid::MultiPointGrid, ::Nothing) = grid.local_geometry
+global_geometry(grid::MultiPointGrid) = grid.global_geometry
 
-quadrature_style(::PointCloudGrid) = nothing
+quadrature_style(::MultiPointGrid) = nothing
 
 """
-    PointCloudGrid(
+    MultiPointGrid(
         points  :: AbstractVector{Geometry.LatLongPoint{FT}};
         radius  :: Real,
         device  :: ClimaComms.AbstractDevice = ClimaComms.device(),
     )
 
-Convenience constructor: build a `PointCloudGrid` from a vector of
+Convenience constructor: build a `MultiPointGrid` from a vector of
 `LatLongPoint`s and a sphere `radius`. The horizontal metric terms in
 `local_geometry` are set from the sphere geometry at each point:
 `∂x∂ξ = diag(R·π/180, R·cosd(lat)·π/180)`, `J = R²·cosd(lat)·(π/180)²`.
 """
-function PointCloudGrid(
+function MultiPointGrid(
     points::AbstractVector{Geometry.LatLongPoint{FT}};
     radius::Real,
     device::ClimaComms.AbstractDevice = ClimaComms.device(),
 ) where {FT}
-    get!(Cache.OBJECT_CACHE, (PointCloudGrid, copy(points), radius, device)) do
-        _PointCloudGrid(points; radius, device)
+    get!(Cache.OBJECT_CACHE, (MultiPointGrid, copy(points), radius, device)) do
+        _MultiPointGrid(points; radius, device)
     end
 end
 
-function _PointCloudGrid(
+function _MultiPointGrid(
     points::AbstractVector{Geometry.LatLongPoint{FT}};
     radius::Real,
     device::ClimaComms.AbstractDevice = ClimaComms.device(),
 ) where {FT}
     radius > 0 || error("Radius ($radius) must be positive")
 
-    # PointCloudGrid is single-process only; the context is always a
+    # MultiPointGrid is single-process only; the context is always a
     # SingletonCommsContext built from the given device.
     context = ClimaComms.SingletonCommsContext(device)
 
@@ -115,14 +115,14 @@ function _PointCloudGrid(
     end
 
     DA = ClimaComms.array_type(device)
-    return PointCloudGrid(
+    return MultiPointGrid(
         context,
         global_geometry,
         DataLayouts.rebuild(local_geometry, DA),
     )
 end
 
-function print_pointcloud_horizontal(io::IO, grid::PointCloudGrid, indent)
+function print_multipoint_horizontal(io::IO, grid::MultiPointGrid, indent)
     println(io, " "^(indent + 2), "horizontal:")
     print(io, " "^(indent + 4), "context: ")
     Topologies.print_context(io, grid.context)
@@ -136,9 +136,13 @@ function print_pointcloud_horizontal(io::IO, grid::PointCloudGrid, indent)
     print(io, " "^(indent + 4), "radius: ", grid.global_geometry.radius)
 end
 
-function Base.show(io::IO, grid::PointCloudGrid)
+function Base.show(io::IO, grid::MultiPointGrid)
     indent = get(io, :indent, 0)
     iio = IOContext(io, :indent => indent + 2)
     println(io, nameof(typeof(grid)), ":")
-    print_pointcloud_horizontal(iio, grid, indent)
+    print_multipoint_horizontal(iio, grid, indent)
 end
+
+# Backwards-compatibility alias for the old name; deprecated, but old code
+# keeps working. Remove once downstream consumers have migrated.
+Base.@deprecate_binding PointCloudGrid MultiPointGrid false

--- a/src/MatrixFields/matrix_shape.jl
+++ b/src/MatrixFields/matrix_shape.jl
@@ -30,7 +30,7 @@ function matrix_shape(
     matrix_space::Union{
         Spaces.AbstractSpectralElementSpace,
         Spaces.PointSpace,
-        Spaces.PointCloudSpace,
+        Spaces.MultiPointSpace,
     },
 )
     @assert eltype(matrix_field) <: DiagonalMatrixRow

--- a/src/Spaces/multicolumn.jl
+++ b/src/Spaces/multicolumn.jl
@@ -1,40 +1,43 @@
 """
-    PointCloudSpace
+    MultiPointSpace
 
 A horizontal space of N independent (lat, lon) points.  This is the N-column
 analogue of [`PointSpace`](@ref), which is the single-column level space.
 
 Like [`SpectralElementSpace2D`](@ref), the wrapped `grid` is either:
 
-  - a `Grids.PointCloudGrid` which is the level-agnostic horizontal space of a
+  - a `Grids.MultiPointGrid` which is the level-agnostic horizontal space of a
     [`MultiColumnFiniteDifferenceSpace`](@ref) (returned by
-    [`Spaces.horizontal_space`](@ref))
+    `Spaces.horizontal_space`)
   - a `Grids.LevelGrid` of the extruded multi-column grid which is a single
-    vertical level (returned by [`Spaces.level`](@ref)), carrying full 3-D local
+    vertical level (returned by `Spaces.level`), carrying full 3-D local
     geometry.
 """
-struct PointCloudSpace{G <: Grids.AbstractGrid} <: AbstractSpace
+struct MultiPointSpace{G <: Grids.AbstractGrid} <: AbstractSpace
     grid::G
 end
 
-grid(space::PointCloudSpace) = getfield(space, :grid)
-staggering(space::PointCloudSpace) = nothing
+grid(space::MultiPointSpace) = getfield(space, :grid)
+staggering(space::MultiPointSpace) = nothing
 
-space(grid::Grids.PointCloudGrid, ::Nothing) = PointCloudSpace(grid)
-space(grid::Grids.LevelGrid{<:Grids.ExtrudedPointCloudGrid}, ::Nothing) =
-    PointCloudSpace(grid)
+space(grid::Grids.MultiPointGrid, ::Nothing) = MultiPointSpace(grid)
+space(grid::Grids.LevelGrid{<:Grids.ExtrudedMultiPointGrid}, ::Nothing) =
+    MultiPointSpace(grid)
 
-ClimaComms.context(space::PointCloudSpace) =
+ClimaComms.context(space::MultiPointSpace) =
     ClimaComms.context(grid(space))
-ClimaComms.device(space::PointCloudSpace) = ClimaComms.device(grid(space))
+ClimaComms.device(space::MultiPointSpace) = ClimaComms.device(grid(space))
 
-local_geometry_data(space::PointCloudSpace) =
+local_geometry_data(space::MultiPointSpace) =
     local_geometry_data(grid(space), nothing)
-local_geometry_type(::Type{PointCloudSpace{G}}) where {G} =
+local_geometry_type(::Type{MultiPointSpace{G}}) where {G} =
     local_geometry_type(G)
 
-Adapt.adapt_structure(to, space::PointCloudSpace) =
-    PointCloudSpace(Adapt.adapt(to, grid(space)))
+Adapt.adapt_structure(to, space::MultiPointSpace) =
+    MultiPointSpace(Adapt.adapt(to, grid(space)))
+
+# Backwards-compatibility alias for the old name.
+Base.@deprecate_binding PointCloudSpace MultiPointSpace false
 
 """
     MultiColumnFiniteDifferenceSpace
@@ -45,9 +48,9 @@ locations on a sphere.  This is the N-column generalisation of
 
   - The data layout is `VIJFH{LG, Nv, 1, 1, N}` (same vertical structure for every
     column; full 3-D local geometry including lat/lon/z coordinates).
-  - [`Spaces.level`](@ref) returns a [`PointCloudSpace`](@ref) (N points at that
+  - `Spaces.level` returns a [`MultiPointSpace`](@ref) (N points at that
     z-level) rather than a spectral-element horizontal space.
-  - [`Spaces.column`](@ref) returns a single-column
+  - `Spaces.column` returns a single-column
     [`Spaces.FiniteDifferenceSpace`](@ref).
   - [`Fields.bycolumn`](@ref) iterates over each column independently.
 
@@ -97,23 +100,23 @@ Adapt.adapt_structure(to, space::MultiColumnFiniteDifferenceSpace) =
         staggering(space),
     )
 
-issubspace(space1::PointCloudSpace, space2::PointCloudSpace) =
+issubspace(space1::MultiPointSpace, space2::MultiPointSpace) =
     horizontal_grid(grid(space1)) === horizontal_grid(grid(space2))
-issubspace(subspace::PointCloudSpace, space::MultiColumnFiniteDifferenceSpace) =
+issubspace(subspace::MultiPointSpace, space::MultiColumnFiniteDifferenceSpace) =
     grid(subspace) === grid(space).horizontal_grid ||
     (grid(subspace) isa Grids.LevelGrid && grid(subspace).full_grid === grid(space))
 issubspace(subspace::FiniteDifferenceSpace, space::MultiColumnFiniteDifferenceSpace) =
     grid(subspace) === grid(space).vertical_grid ||
     (grid(subspace) isa Grids.ColumnGrid && grid(subspace).full_grid === grid(space))
 
-level(space::PointCloudSpace, v) =
+level(space::MultiPointSpace, v) =
     isone(v) ? space : throw(ArgumentError("Space only has one level"))
 Base.@propagate_inbounds level(space::MultiColumnFiniteDifferenceSpace, v) =
-    PointCloudSpace(level(grid(space), staggered_level_index(space, v)))
+    MultiPointSpace(level(grid(space), staggered_level_index(space, v)))
 
-Base.@propagate_inbounds slab(space::PointCloudSpace, v, h) =
+Base.@propagate_inbounds slab(space::MultiPointSpace, v, h) =
     isone(v) ? slab(space, h) : throw(ArgumentError("Space only has one level"))
-Base.@propagate_inbounds slab(space::PointCloudSpace, h) =
+Base.@propagate_inbounds slab(space::MultiPointSpace, h) =
     PointSpace(ClimaComms.context(space), slab(local_geometry_data(space), h))
 Base.@propagate_inbounds slab(space::MultiColumnFiniteDifferenceSpace, v, h) =
     PointSpace(
@@ -121,12 +124,12 @@ Base.@propagate_inbounds slab(space::MultiColumnFiniteDifferenceSpace, v, h) =
         slab(local_geometry_data(space), integer_level_index(space, v), h),
     )
 
-Base.@propagate_inbounds column(space::PointCloudSpace, indices...) =
+Base.@propagate_inbounds column(space::MultiPointSpace, indices...) =
     PointSpace(ClimaComms.context(space), column(local_geometry_data(space), indices...))
 Base.@propagate_inbounds column(space::MultiColumnFiniteDifferenceSpace, indices...) =
     FiniteDifferenceSpace(column(grid(space), indices...), space.staggering)
 
-ncolumns(space::PointCloudSpace) =
+ncolumns(space::MultiPointSpace) =
     DataLayouts.nelems(local_geometry_data(space))
 
 ncolumns(space::MultiColumnFiniteDifferenceSpace) =
@@ -138,26 +141,26 @@ nlevels(space::MultiColumnFiniteDifferenceSpace) =
     DataLayouts.nlevels(local_geometry_data(space))
 
 horizontal_space(space::MultiColumnFiniteDifferenceSpace) =
-    PointCloudSpace(grid(space).horizontal_grid)
+    MultiPointSpace(grid(space).horizontal_grid)
 
 # No DSS / mask machinery needed.
-get_mask(space::PointCloudSpace) = DataLayouts.NoMask()
+get_mask(space::MultiPointSpace) = DataLayouts.NoMask()
 get_mask(space::MultiColumnFiniteDifferenceSpace) = DataLayouts.NoMask()
 set_mask!(::Any, ::MultiColumnFiniteDifferenceSpace) = nothing
 
 """
     obtain_surface_space(cs::CenterMultiColumnFiniteDifferenceSpace)
 
-Return the [`PointCloudSpace`](@ref) corresponding to the top face (surface) of
+Return the [`MultiPointSpace`](@ref) corresponding to the top face (surface) of
 `cs`.
 """
 obtain_surface_space(cs::CenterMultiColumnFiniteDifferenceSpace) =
     horizontal_space(cs)
 
-function Base.show(io::IO, space::PointCloudSpace)
+function Base.show(io::IO, space::MultiPointSpace)
     indent = get(io, :indent, 0)
     iio = IOContext(io, :indent => indent + 2)
-    println(io, "PointCloudSpace:")
+    println(io, "MultiPointSpace:")
     print(iio, " "^(indent + 2), "context: ")
     Topologies.print_context(iio, ClimaComms.context(space))
     println(iio)

--- a/test/CommonGrids/unit_common_grids.jl
+++ b/test/CommonGrids/unit_common_grids.jl
@@ -2,7 +2,7 @@ import ClimaComms
 ClimaComms.@import_required_backends
 using ClimaCore.CommonGrids
 import ClimaCore.CommonGrids:
-    ExtrudedCubedSphereGrid, CubedSphereGrid, Box3DGrid, PointColumnEnsembleGrid
+    ExtrudedCubedSphereGrid, CubedSphereGrid, Box3DGrid, MultiColumnGrid
 using ClimaCore:
     Geometry,
     Hypsography,
@@ -126,7 +126,7 @@ using Test
     z_elem = 10
     z_min = -10.0
     z_max = 20.0
-    grid = PointColumnEnsembleGrid(;
+    grid = MultiColumnGrid(;
         points,
         z_elem,
         z_min,
@@ -134,7 +134,7 @@ using Test
         radius,
     )
     @test grid isa Grids.ExtrudedFiniteDifferenceGrid
-    @test grid.horizontal_grid isa Grids.PointCloudGrid
+    @test grid.horizontal_grid isa Grids.MultiPointGrid
     @test grid.horizontal_grid.global_geometry.radius == radius
     @test grid.vertical_grid.topology.mesh.domain.coord_max == Geometry.ZPoint(z_max)
     @test grid.vertical_grid.topology.mesh.domain.coord_min == Geometry.ZPoint(z_min)

--- a/test/CommonSpaces/unit_common_spaces.jl
+++ b/test/CommonSpaces/unit_common_spaces.jl
@@ -153,7 +153,7 @@ warp_surface_elev(coord, hc::FT) where {FT} =
     z_min = -10.0
     z_max = 20.0
     staggering = Grids.CellCenter()
-    space = PointColumnEnsembleSpace(;
+    space = MultiColumnSpace(;
         points,
         z_elem,
         z_min,
@@ -164,7 +164,7 @@ warp_surface_elev(coord, hc::FT) where {FT} =
     @test space.staggering isa Grids.CellCenter
     grid = Spaces.grid(space)
     @test grid isa Grids.ExtrudedFiniteDifferenceGrid
-    @test grid.horizontal_grid isa Grids.PointCloudGrid
+    @test grid.horizontal_grid isa Grids.MultiPointGrid
     @test grid.horizontal_grid.global_geometry.radius == radius
     @test grid.vertical_grid.topology.mesh.domain.coord_max == Geometry.ZPoint(z_max)
     @test grid.vertical_grid.topology.mesh.domain.coord_min == Geometry.ZPoint(z_min)
@@ -174,7 +174,7 @@ warp_surface_elev(coord, hc::FT) where {FT} =
           longs
 
     # Test memoization when constructing the same space
-    space2 = PointColumnEnsembleSpace(;
+    space2 = MultiColumnSpace(;
         points = copy(points),
         z_elem,
         z_min,

--- a/test/Fields/unit_field.jl
+++ b/test/Fields/unit_field.jl
@@ -1501,7 +1501,7 @@ end
     FT = Float64
     context = ClimaComms.context(ClimaComms.device())
     for space in (
-        TU.PointColumnEnsembleSpace(FT; context),
+        TU.MultiColumnSpace(FT; context),
         TU.CenterExtrudedFiniteDifferenceSpace(FT; context),
     )
         for subspace in (Spaces.level(space, 1), Spaces.column(space, 1, 1, 1))

--- a/test/InputOutput/unit_allspaces_roundtrip.jl
+++ b/test/InputOutput/unit_allspaces_roundtrip.jl
@@ -20,9 +20,9 @@ import Random: seed!
     seed!(1)
     for space in TU.all_spaces(FT; context)
         # TODO: InputOutput cannot serialize a MultiColumnFiniteDifferenceSpace
-        # yet: its PointCloudGrid horizontal grid has no topology, which
+        # yet: its MultiPointGrid horizontal grid has no topology, which
         # `write!` requires (`Spaces.topology` errors). Remove this skip once
-        # HDF5 support for point-cloud grids lands.
+        # HDF5 support for multi-point grids lands.
         if space isa Spaces.MultiColumnFiniteDifferenceSpace
             @test_skip "HDF5 round-trip on MultiColumnFiniteDifferenceSpace"
             continue

--- a/test/Operators/gpu_edge_cases.jl
+++ b/test/Operators/gpu_edge_cases.jl
@@ -19,7 +19,7 @@ import ClimaCore:
     Geometry,
     Operators,
     Quadratures
-import ClimaCore.CommonSpaces: PointColumnEnsembleSpace, CellCenter
+import ClimaCore.CommonSpaces: MultiColumnSpace, CellCenter
 
 const test_device = ClimaComms.device()
 const cpu_device = ClimaComms.CPUSingleThreaded()
@@ -312,7 +312,7 @@ end
         points = [
             Geometry.LatLongPoint(FT(10i - 40), FT(20i - 80)) for i in 1:7
         ]
-        center_space = PointColumnEnsembleSpace(
+        center_space = MultiColumnSpace(
             FT;
             points,
             z_elem = 8,

--- a/test/TestUtilities/TestUtilities.jl
+++ b/test/TestUtilities/TestUtilities.jl
@@ -264,7 +264,7 @@ function FaceExtrudedFiniteDifferenceSpace(::Type{FT}; kwargs...) where {FT}
     return Spaces.FaceExtrudedFiniteDifferenceSpace(cspace)
 end
 
-function PointColumnEnsembleSpace(::Type{FT}; context, zelem = 10, kwargs...) where {FT}
+function MultiColumnSpace(::Type{FT}; context, zelem = 10, kwargs...) where {FT}
     staggering = Spaces.CellCenter()
     lats = FT.([0.0, 1.0, 2.0])
     longs = FT.([3.0, 4.0, 5.0])
@@ -272,7 +272,7 @@ function PointColumnEnsembleSpace(::Type{FT}; context, zelem = 10, kwargs...) wh
     z_min = -10.0
     z_max = 10.0
     (; device) = context
-    return CommonSpaces.PointColumnEnsembleSpace(
+    return CommonSpaces.MultiColumnSpace(
         FT;
         z_elem = zelem,
         staggering,
@@ -299,7 +299,7 @@ function all_spaces(
         # SpectralElementFiniteDifferenceRectilinearSpace2D(FT; context),
         ColumnCenterFiniteDifferenceSpace(FT; zelem, context),
         ColumnFaceFiniteDifferenceSpace(FT; zelem, context),
-        PointColumnEnsembleSpace(FT; zelem, context),
+        MultiColumnSpace(FT; zelem, context),
         SphereSpectralElementSpace(FT; context),
         CenterExtrudedFiniteDifferenceSpace(FT; zelem, context, helem),
         FaceExtrudedFiniteDifferenceSpace(FT; zelem, context, helem),


### PR DESCRIPTION
closes https://github.com/CliMA/ClimaCore.jl/issues/2597 - I asked a LLM to look through the codebase and rename the space of multiple points/columns to `MultiPoint*` or `MultiColumn*` where `*` is a `Space` or a `Grid`. 