### PR TITLE
Geometry: fix YZPoint typo, make Points composable

### DIFF
--- a/src/Geometry/coordinates.jl
+++ b/src/Geometry/coordinates.jl
@@ -161,7 +161,7 @@ _coordinate(p::XZPoint, ::Val{2}) = ZPoint(p.z)
 
 _coordinate_type(::Type{YZPoint{FT}}, ::Val{1}) where {FT} = YPoint{FT}
 _coordinate_type(::Type{YZPoint{FT}}, ::Val{2}) where {FT} = ZPoint{FT}
-_coordinate(p::YZPoint, ::Val{1}) = YPoint(p.x)
+_coordinate(p::YZPoint, ::Val{1}) = YPoint(p.y)
 _coordinate(p::YZPoint, ::Val{2}) = ZPoint(p.z)
 
 _coordinate_type(::Type{XYZPoint{FT}}, ::Val{1}) where {FT} = XPoint{FT}

--- a/src/Geometry/coordinates.jl
+++ b/src/Geometry/coordinates.jl
@@ -139,6 +139,29 @@ product_coordinates(latlongp::LatLongPoint, zp::ZPoint) =
 product_coordinates(latlongp::LatLongPoint, pressure_p::PPoint) =
     LatLongPPoint(promote(latlongp.lat, latlongp.long, pressure_p.p)...)
 
+XYPoint(xp::XPoint, yp::YPoint) = product_coordinates(xp, yp)
+XZPoint(xp::XPoint, zp::ZPoint) = product_coordinates(xp, zp)
+YZPoint(yp::YPoint, zp::ZPoint) = product_coordinates(yp, zp)
+
+XYZPoint(xyp::XYPoint, zp::ZPoint) = product_coordinates(xyp, zp)
+XYZPoint(xp::XPoint, yp::YPoint, zp::ZPoint) =
+    product_coordinates(product_coordinates(xp, yp), zp)
+
+LatLongPoint(latp::LatPoint, longp::LongPoint) =
+    product_coordinates(latp, longp)
+LatLongPoint(longp::LongPoint, latp::LatPoint) =
+    product_coordinates(longp, latp)
+
+LatLongZPoint(latlongp::LatLongPoint, zp::ZPoint) =
+    product_coordinates(latlongp, zp)
+LatLongZPoint(latp::LatPoint, longp::LongPoint, zp::ZPoint) =
+    product_coordinates(product_coordinates(latp, longp), zp)
+
+LatLongPPoint(latlongp::LatLongPoint, pp::PPoint) =
+    product_coordinates(latlongp, pp)
+LatLongPPoint(latp::LatPoint, longp::LongPoint, pp::PPoint) =
+    product_coordinates(product_coordinates(latp, longp), pp)
+
 component(p::AbstractPoint{FT}, i::Symbol) where {FT} = getfield(p, i)::FT
 component(p::AbstractPoint{FT}, i::Integer) where {FT} = getfield(p, i)::FT
 

--- a/test/Geometry/unit_geometry.jl
+++ b/test/Geometry/unit_geometry.jl
@@ -39,12 +39,13 @@ using LinearAlgebra, StaticArrays
     @test Geometry.LongPoint(1.0) <= Geometry.LongPoint(1.0f0)
 end
 
-@testset "2D XY,XZ Points" begin
+@testset "2D XY,XZ,YZ Points" begin
 
     for FT in (Float32, Float64, BigFloat)
         for pt in (
             Geometry.XYPoint(one(FT), zero(FT)),
             Geometry.XZPoint(one(FT), zero(FT)),
+            Geometry.YZPoint(one(FT), zero(FT)),
         )
             @test Geometry.ncomponents(pt) == 2
             @test Geometry.components(pt) isa SVector{2, FT}
@@ -53,10 +54,14 @@ end
             @test Geometry.component(pt, 1) == one(FT)
             @test Geometry.component(pt, 2) == zero(FT)
             @test_throws Exception Geometry.component(pt, 3)
-            @test Geometry.coordinate(pt, 1) == Geometry.XPoint(one(FT))
             if pt isa Geometry.XYPoint
+                @test Geometry.coordinate(pt, 1) == Geometry.XPoint(one(FT))
                 @test Geometry.coordinate(pt, 2) == Geometry.YPoint(zero(FT))
             elseif pt isa Geometry.XZPoint
+                @test Geometry.coordinate(pt, 1) == Geometry.XPoint(one(FT))
+                @test Geometry.coordinate(pt, 2) == Geometry.ZPoint(zero(FT))
+            elseif pt isa Geometry.YZPoint
+                @test Geometry.coordinate(pt, 1) == Geometry.YPoint(one(FT))
                 @test Geometry.coordinate(pt, 2) == Geometry.ZPoint(zero(FT))
             end
             @test_throws Exception Geometry.coordinate(pt, 3)

--- a/test/Geometry/unit_geometry.jl
+++ b/test/Geometry/unit_geometry.jl
@@ -113,6 +113,78 @@ end
     end
 end
 
+@testset "Composable Points" begin
+
+    for FT in (Float32, Float64, BigFloat)
+        x, y, z, p = FT(1), FT(2), FT(3), FT(4)
+        lat, long = FT(30), FT(-45)
+
+        @test Geometry.XYPoint(Geometry.XPoint(x), Geometry.YPoint(y)) ===
+              Geometry.XYPoint(x, y)
+        @test Geometry.XZPoint(Geometry.XPoint(x), Geometry.ZPoint(z)) ===
+              Geometry.XZPoint(x, z)
+        @test Geometry.YZPoint(Geometry.YPoint(y), Geometry.ZPoint(z)) ===
+              Geometry.YZPoint(y, z)
+
+        @test Geometry.XYZPoint(Geometry.XYPoint(x, y), Geometry.ZPoint(z)) ===
+              Geometry.XYZPoint(x, y, z)
+        @test Geometry.XYZPoint(
+            Geometry.XPoint(x),
+            Geometry.YPoint(y),
+            Geometry.ZPoint(z),
+        ) === Geometry.XYZPoint(x, y, z)
+
+        # `LatLongPoint` accepts its two parts in either order
+        @test Geometry.LatLongPoint(
+            Geometry.LatPoint(lat),
+            Geometry.LongPoint(long),
+        ) === Geometry.LatLongPoint(lat, long)
+        @test Geometry.LatLongPoint(
+            Geometry.LongPoint(long),
+            Geometry.LatPoint(lat),
+        ) === Geometry.LatLongPoint(lat, long)
+
+        @test Geometry.LatLongZPoint(
+            Geometry.LatLongPoint(lat, long),
+            Geometry.ZPoint(z),
+        ) === Geometry.LatLongZPoint(lat, long, z)
+        @test Geometry.LatLongZPoint(
+            Geometry.LatPoint(lat),
+            Geometry.LongPoint(long),
+            Geometry.ZPoint(z),
+        ) === Geometry.LatLongZPoint(lat, long, z)
+
+        @test Geometry.LatLongPPoint(
+            Geometry.LatLongPoint(lat, long),
+            Geometry.PPoint(p),
+        ) === Geometry.LatLongPPoint(lat, long, p)
+        @test Geometry.LatLongPPoint(
+            Geometry.LatPoint(lat),
+            Geometry.LongPoint(long),
+            Geometry.PPoint(p),
+        ) === Geometry.LatLongPPoint(lat, long, p)
+    end
+
+    # components of mixed float type are promoted, as in `product_coordinates`
+    @test Geometry.XYPoint(Geometry.XPoint(1.0f0), Geometry.YPoint(2.0)) ===
+          Geometry.XYPoint(1.0, 2.0)
+    @test Geometry.XYZPoint(
+        Geometry.XPoint(1.0f0),
+        Geometry.YPoint(2.0),
+        Geometry.ZPoint(3.0f0),
+    ) === Geometry.XYZPoint(1.0, 2.0, 3.0)
+
+    # composing mismatched axes is still an error
+    @test_throws MethodError Geometry.XYPoint(
+        Geometry.YPoint(1.0),
+        Geometry.XPoint(2.0),
+    )
+    @test_throws MethodError Geometry.XZPoint(
+        Geometry.XPoint(1.0),
+        Geometry.YPoint(2.0),
+    )
+end
+
 @testset "Vectors" begin
     wᵢ = Geometry.Covariant12Vector(1.0, 2.0)
     vʲ = Geometry.Contravariant12Vector(3.0, 4.0)


### PR DESCRIPTION
**Stack 1/4** — base `main`. Next: #2613 (`tr/meshes-fixes`).

Two self-contained `Geometry/coordinates.jl` fixes, one commit each.

> **Note:** this previously also carried a fix for #1936 (`_coordinate` /
> `_coordinate_type` for `LatLong` points). That commit has been dropped —
> the lat/long axis order needs a decision that is being deferred. See below.

### 1. `YZPoint` field typo (not filed)

`_coordinate(p::YZPoint, ::Val{1})` read `p.x`, but `YZPoint`'s fields are `y`
and `z`:

```julia
julia> Geometry.coordinate(Geometry.YZPoint(1.0, 2.0), 1)
ERROR: type YZPoint has no field x
```

That breaks `Meshes.containing_element`/`reference_coordinates` for any
`RectilinearMesh` built from a Y interval and a Z interval. The 2D point testset
only exercised `XYPoint` and `XZPoint`, which is why it was never caught;
`YZPoint` is added to it.

### 2. Make `Point`s composable (#1476)

`XYPoint(XPoint(1.0), YPoint(2.0))` was a `MethodError`. Added constructors that
compose a point from its lower-dimensional parts for the `XY`/`XZ`/`YZ`, `XYZ`
and `LatLong`/`LatLongZ`/`LatLongP` families. They forward to the existing
`product_coordinates`, so mixed component types promote
(`XYPoint(XPoint(1.0f0), YPoint(2.0)) === XYPoint(1.0, 2.0)`) and composing
mismatched axes stays a `MethodError`. `LatLongPoint` takes its two parts in
either order, mirroring `product_coordinates`.

Cartesian points are left alone: `product_coordinates` has no methods for them,
so composing them is a larger change than this issue asks for.

### Why #1936 was dropped

`LatLongPoint`'s axis order is genuinely ambiguous, because both
`product_coordinates(::LatPoint, ::LongPoint)` and the reverse produce a
`LatLongPoint`, and the two real consumers disagree:

| | `intervalmesh1` | needs `Val{1}` → |
| --- | --- | --- |
| ClimaDiagnostics (`islatlonbox`) | Lat | `LatPoint` |
| #1936's reporter (their stack trace) | Long | `LongPoint` |

ClimaDiagnostics also *pirates* these exact signatures as an explicit
"Workaround for ClimaCore #1936"
([netcdf_writer_coordinates.jl:781-784](https://github.com/CliMA/ClimaDiagnostics.jl/blob/3e5bad4556a13c6bb6ffc9619a539caf4fab1315/src/netcdf_writer_coordinates.jl#L781-L784)),
mapping `Val{1}` to `LatPoint`. Whichever order ClimaCore picks, loading
ClimaDiagnostics silently redefines `_coordinate` and leaves it disagreeing with
`_coordinate_type`. So fixing #1936 needs a decision on the canonical order plus
a coordinated removal of that workaround, which is out of scope here.

### Testing

`test/Geometry/unit_geometry.jl` passes (new testsets: `2D XY,XZ,YZ Points`
99/99, `Composable Points` 37/37). `Domains`, `Meshes`, `Spaces`, `Fields`,
`InputOutput` and `Remapping` unit tests all pass.

Closes #1476

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJ8VbwbMadrhvCtBV3jkjc