### PR TITLE
Meshes/Domains: range-check vertex indices, promote stretching and sphere-radius parameters

### DIFF
--- a/src/Domains/Domains.jl
+++ b/src/Domains/Domains.jl
@@ -163,9 +163,17 @@ coordinate_type(domain::RectangleDomain) = typeof(
     SphereDomain(radius)
 
 A domain representing the surface of a sphere with radius `radius`.
+
+A non-float `radius` is promoted, so `SphereDomain(1000)` gives a
+`SphereDomain{Float64}`.
 """
-struct SphereDomain{FT} <: AbstractDomain where {FT <: AbstractFloat}
+struct SphereDomain{FT <: AbstractFloat} <: AbstractDomain
     radius::FT
+end
+
+function SphereDomain(radius::Real)
+    r = float(radius)
+    return SphereDomain{typeof(r)}(r)
 end
 Base.show(io::IO, domain::SphereDomain) =
     print(io, nameof(typeof(domain)), ": radius = ", domain.radius)

--- a/src/Meshes/common.jl
+++ b/src/Meshes/common.jl
@@ -160,14 +160,39 @@ function vertex_connectivity_matrix(
 end
 
 """
+    Meshes.check_vertex_index(vert, nverts)
+
+Throw an `ArgumentError` unless `1 ≤ vert ≤ nverts`.
+
+The `coordinates(mesh, elem, vert)` methods pick a vertex with a chain of
+`vert == ...` comparisons, so without this check an out-of-range `vert` falls
+through to the last branch and silently returns another vertex's coordinates
+rather than erroring.
+"""
+@inline function check_vertex_index(vert::Integer, nverts::Integer)
+    if !(1 <= vert <= nverts)
+        throw(
+            ArgumentError(
+                "vertex index must be in 1:$nverts, got vert = $vert",
+            ),
+        )
+    end
+    return nothing
+end
+
+"""
     Meshes.coordinates(mesh, elem, vert::Int)
     Meshes.coordinates(mesh, elem, ξ::SVector)
 
 Return the physical coordinates of a point in an element `elem` of `mesh`. The
 position of the point can either be a vertex number `vert` or the coordinates
 `ξ` in the reference element.
+
+Elements of a 2D mesh are quadrilaterals, so `vert` must be in `1:4`; elements
+of a 1D mesh have two vertices, so `vert` must be in `1:2`.
 """
 function coordinates(mesh::AbstractMesh2D, elem, vert::Integer)
+    check_vertex_index(vert, 4)
     FT = Domains.float_type(domain(mesh))
     ξ1 = (vert == 1 || vert == 4) ? FT(-1) : FT(1)
     ξ2 = (vert == 1 || vert == 2) ? FT(-1) : FT(1)

--- a/src/Meshes/cubedsphere.jl
+++ b/src/Meshes/cubedsphere.jl
@@ -221,6 +221,7 @@ function coordinates(
     elem::CartesianIndex{3},
     vert::Integer,
 )
+    check_vertex_index(vert, 4)
     FT = typeof(mesh.domain.radius)
     ne = mesh.ne
     x, y, panel = elem.I

--- a/src/Meshes/interval.jl
+++ b/src/Meshes/interval.jl
@@ -158,6 +158,14 @@ Use uniformly-sized elements.
 """
 struct Uniform <: StretchingRule end
 
+"""
+    Meshes._convert_stretch(FT, stretch)
+
+Convert the parameters of the stretching rule `stretch` to the floating point type `FT`
+"""
+function _convert_stretch end
+_convert_stretch(::Type{FT}, stretch::Uniform) where {FT} = stretch
+
 function IntervalMesh(
     domain::IntervalDomain{CT},
     stretch::Uniform = Uniform();
@@ -202,15 +210,19 @@ struct ExponentialStretching{FT} <: StretchingRule
     H::FT
 end
 
+_convert_stretch(::Type{FT}, stretch::ExponentialStretching) where {FT} =
+    ExponentialStretching{FT}(stretch.H)
+
 function IntervalMesh(
     domain::IntervalDomain{CT},
-    stretch::ExponentialStretching{FT};
+    stretch::ExponentialStretching;
     nelems::Int,
     reverse_mode::Bool = false,
 ) where {CT <: Geometry.Abstract1DPoint{FT}} where {FT}
     if nelems < 1
         throw(ArgumentError("`nelems` must be ≥ 1"))
     end
+    stretch = _convert_stretch(FT, stretch)
     cmin = Geometry.component(domain.coord_min, 1)
     cmax = Geometry.component(domain.coord_max, 1)
     R = cmax - cmin
@@ -253,9 +265,25 @@ struct GeneralizedExponentialStretching{FT} <: StretchingRule
     dz_top::FT
 end
 
+# More specific than the generated `(::FT, ::FT) where {FT}`, so every `Real`
+# pair lands here: call the parametric constructor rather than recursing.
+function GeneralizedExponentialStretching(dz_bottom::Real, dz_top::Real)
+    dz_bottom, dz_top = promote(dz_bottom, dz_top)
+    return GeneralizedExponentialStretching{typeof(dz_bottom)}(
+        dz_bottom,
+        dz_top,
+    )
+end
+
+_convert_stretch(
+    ::Type{FT},
+    stretch::GeneralizedExponentialStretching,
+) where {FT} =
+    GeneralizedExponentialStretching{FT}(stretch.dz_bottom, stretch.dz_top)
+
 function IntervalMesh(
     domain::IntervalDomain{CT},
-    stretch::GeneralizedExponentialStretching{FT};
+    stretch::GeneralizedExponentialStretching;
     nelems::Int,
     FT_solve = Float64,
     tol = 1e-3,
@@ -264,6 +292,7 @@ function IntervalMesh(
     if nelems ≤ 1
         throw(ArgumentError("`nelems` must be ≥ 2"))
     end
+    stretch = _convert_stretch(FT, stretch)
 
     dz_bottom = FT_solve(stretch.dz_bottom)
     dz_top = FT_solve(stretch.dz_top)
@@ -384,9 +413,14 @@ struct HyperbolicTangentStretching{FT} <: StretchingRule
     dz_surface::FT
 end
 
+_convert_stretch(
+    ::Type{FT},
+    stretch::HyperbolicTangentStretching,
+) where {FT} = HyperbolicTangentStretching{FT}(stretch.dz_surface)
+
 function IntervalMesh(
     domain::IntervalDomain{CT},
-    stretch::HyperbolicTangentStretching{FT};
+    stretch::HyperbolicTangentStretching;
     nelems::Int,
     FT_solve = Float64,
     tol::Union{FT, Nothing} = nothing,
@@ -395,6 +429,7 @@ function IntervalMesh(
     if nelems ≤ 1
         throw(ArgumentError("`nelems` must be ≥ 2"))
     end
+    stretch = _convert_stretch(FT, stretch)
 
     dz_surface = FT_solve(stretch.dz_surface)
     tol === nothing && (tol = dz_surface * FT_solve(1e-6))

--- a/src/Meshes/interval.jl
+++ b/src/Meshes/interval.jl
@@ -57,8 +57,10 @@ function element_horizontal_length_scale(mesh::IntervalMesh)
     return (cmax - cmin) / nelements(mesh)
 end
 
-coordinates(mesh::IntervalMesh, elem::Integer, vert::Integer) =
-    mesh.faces[elem + vert - 1]
+function coordinates(mesh::IntervalMesh, elem::Integer, vert::Integer)
+    check_vertex_index(vert, 2)
+    return mesh.faces[elem + vert - 1]
+end
 
 function coordinates(
     mesh::IntervalMesh,

--- a/src/Meshes/rectangle.jl
+++ b/src/Meshes/rectangle.jl
@@ -111,6 +111,7 @@ end
 
 
 function coordinates(mesh::RectilinearMesh, elem::CartesianIndex{2}, vert::Int)
+    check_vertex_index(vert, 4)
     x1, x2 = elem.I
     coord1 = coordinates(mesh.intervalmesh1, x1, vert == 1 || vert == 4 ? 1 : 2)
     coord2 = coordinates(mesh.intervalmesh2, x2, vert == 1 || vert == 2 ? 1 : 2)

--- a/test/Domains/unit_domains.jl
+++ b/test/Domains/unit_domains.jl
@@ -64,6 +64,19 @@ import .TestUtilities as TU
         end
     end
 
+    @testset "SphereDomain radius promotion" begin
+        # An integer radius used to give a `SphereDomain{Int}`, which failed
+        # much later in the quadrature rule (#1468).
+        domain = Domains.SphereDomain(1000)
+        @test domain isa Domains.SphereDomain{Float64}
+        @test domain.radius === 1000.0
+        @test Domains.SphereDomain(1 // 2) isa Domains.SphereDomain{Float64}
+        @test Domains.SphereDomain(1.0f3) isa Domains.SphereDomain{Float32}
+        @test Domains.coordinate_type(Domains.SphereDomain(1000)) ==
+              Geometry.Cartesian123Point{Float64}
+        @test_throws Exception Domains.SphereDomain("1000")
+    end
+
     @testset "IntervalDomain coordinate promotion" begin
         # Mixed-precision endpoints promote to a common coordinate type.
         domain = Domains.IntervalDomain(

--- a/test/Meshes/unit_cubedsphere.jl
+++ b/test/Meshes/unit_cubedsphere.jl
@@ -52,6 +52,19 @@ end
     end
 end
 
+@testset "vertex index range check" begin
+    # Out-of-range vertex indices used to fall through to the last branch of
+    # `coordinates` and silently return vertex 3's coordinates (#1026).
+    mesh = Meshes.EquiangularCubedSphere(Domains.SphereDomain(3.0), 4)
+    elem = CartesianIndex(1, 1, 1)
+    for vert in 1:4
+        @test Meshes.coordinates(mesh, elem, vert) isa Geometry.AbstractPoint
+    end
+    for vert in (-1, 0, 5, 8)
+        @test_throws ArgumentError Meshes.coordinates(mesh, elem, vert)
+    end
+end
+
 @testset "vertex coordinates consistent" begin
     for FT in [Float32, Float64, BigFloat]
         domain = Domains.SphereDomain(FT(5))

--- a/test/Meshes/unit_interval.jl
+++ b/test/Meshes/unit_interval.jl
@@ -389,6 +389,56 @@ end
           Geometry.ZPoint(z_top)
 end
 
+@testset "IntervalMesh stretching parameter promotion" begin
+    # Stretching parameters that are not already of the domain's floating point
+    # type used to raise a `MethodError` (#1434).
+    @test Meshes.GeneralizedExponentialStretching(30, 5000.0) ===
+          Meshes.GeneralizedExponentialStretching(30.0, 5000.0)
+    @test Meshes.GeneralizedExponentialStretching(30.0, 5000) ===
+          Meshes.GeneralizedExponentialStretching(30.0, 5000.0)
+    @test Meshes.GeneralizedExponentialStretching(30.0f0, 5000.0) ===
+          Meshes.GeneralizedExponentialStretching(30.0, 5000.0)
+
+    for FT in (Float32, Float64)
+        domain = Domains.IntervalDomain(
+            Geometry.ZPoint(FT(0)),
+            Geometry.ZPoint(FT(30000));
+            boundary_names = (:bottom, :top),
+        )
+        # the reproducer from the issue
+        int_mesh = Meshes.IntervalMesh(
+            domain,
+            Meshes.GeneralizedExponentialStretching(30, 5000.0);
+            nelems = 20,
+        )
+        float_mesh = Meshes.IntervalMesh(
+            domain,
+            Meshes.GeneralizedExponentialStretching(FT(30), FT(5000));
+            nelems = 20,
+        )
+        @test int_mesh.faces == float_mesh.faces
+        # the stored rule is converted to the domain's float type
+        @test int_mesh.stretch ===
+              Meshes.GeneralizedExponentialStretching{FT}(30, 5000)
+
+        for (int_stretch, float_stretch) in (
+            (
+                Meshes.ExponentialStretching(7500),
+                Meshes.ExponentialStretching(FT(7500)),
+            ),
+            (
+                Meshes.HyperbolicTangentStretching(30),
+                Meshes.HyperbolicTangentStretching(FT(30)),
+            ),
+        )
+            int_mesh = Meshes.IntervalMesh(domain, int_stretch; nelems = 20)
+            float_mesh = Meshes.IntervalMesh(domain, float_stretch; nelems = 20)
+            @test int_mesh.faces == float_mesh.faces
+            @test typeof(int_mesh.stretch) === typeof(float_stretch)
+        end
+    end
+end
+
 @testset "monotonic_check - dispatch" begin
     faces = range(Geometry.XPoint(0), Geometry.XPoint(10); length = 11)
     @test Meshes.monotonic_check(faces) == :no_check

--- a/test/Meshes/unit_interval.jl
+++ b/test/Meshes/unit_interval.jl
@@ -64,8 +64,13 @@ end
     @test_throws BoundsError Meshes.coordinates(mesh, 0, 1)
     @test Meshes.coordinates(mesh, 1, 1) == Geometry.ZPoint(0.0)
     @test Meshes.coordinates(mesh, 2, 2) == Geometry.ZPoint(1.0)
-    @test_throws BoundsError Meshes.coordinates(mesh, 2, 3)
-    @test_throws BoundsError Meshes.coordinates(mesh, 3, 3)
+    # an element of a 1D mesh has 2 vertices; `vert = 3` used to index past
+    # them into the next element's faces, which returned a plausible-looking
+    # coordinate rather than erroring (#1026)
+    @test_throws ArgumentError Meshes.coordinates(mesh, 1, 3)
+    @test_throws ArgumentError Meshes.coordinates(mesh, 2, 3)
+    @test_throws ArgumentError Meshes.coordinates(mesh, 3, 3)
+    @test_throws ArgumentError Meshes.coordinates(mesh, 1, 0)
 end
 
 
@@ -96,8 +101,13 @@ end
     @test_throws BoundsError Meshes.coordinates(mesh, 0, 1)
     @test Meshes.coordinates(mesh, 1, 1) == Geometry.ZPoint(0.0)
     @test Meshes.coordinates(mesh, 2, 2) == Geometry.ZPoint(1.0)
-    @test_throws BoundsError Meshes.coordinates(mesh, 2, 3)
-    @test_throws BoundsError Meshes.coordinates(mesh, 3, 3)
+    # an element of a 1D mesh has 2 vertices; `vert = 3` used to index past
+    # them into the next element's faces, which returned a plausible-looking
+    # coordinate rather than erroring (#1026)
+    @test_throws ArgumentError Meshes.coordinates(mesh, 1, 3)
+    @test_throws ArgumentError Meshes.coordinates(mesh, 2, 3)
+    @test_throws ArgumentError Meshes.coordinates(mesh, 3, 3)
+    @test_throws ArgumentError Meshes.coordinates(mesh, 1, 0)
 end
 
 @testset "IntervalMesh ExponentialStretching" begin
@@ -285,7 +295,7 @@ end
     @test Meshes.coordinates(mesh, 1, 1) == Geometry.ZPoint(-1.0)
     # Test the face element distance at the top of the domain is dz_top
     @test isapprox(
-        Meshes.coordinates(mesh, 1, nelems),
+        Meshes.coordinates(mesh, nelems, 1),
         Geometry.ZPoint(-Geometry.ZPoint(0.02 / 45.0).z),
         rtol = 1e-3,
     )
@@ -313,7 +323,7 @@ end
     )
     # Test the bottom and top of the mesh coordinates are correct
     @test Meshes.coordinates(mesh, 1, 1) == Geometry.ZPoint(0.0)
-    @test Meshes.coordinates(mesh, 1, nelems + 1) ≈ Geometry.ZPoint(1.0)
+    @test Meshes.coordinates(mesh, nelems, 2) ≈ Geometry.ZPoint(1.0)
     # Test the interval of the mesh coordinates at the surface is the same as dz_surface
     @test isapprox(
         Meshes.coordinates(mesh, 1, 2),
@@ -343,10 +353,10 @@ end
     )
     # Test the bottom and top of the mesh coordinates are correct
     @test Meshes.coordinates(mesh, 1, 1) == Geometry.ZPoint(-1.0)
-    @test Meshes.coordinates(mesh, 1, nelems + 1) ≈ Geometry.ZPoint(0.0)
+    @test Meshes.coordinates(mesh, nelems, 2) ≈ Geometry.ZPoint(0.0)
     # Test the interval of the mesh coordinates at the surface is the same as dz_surface
     @test isapprox(
-        Meshes.coordinates(mesh, 1, nelems),
+        Meshes.coordinates(mesh, nelems, 1),
         Geometry.ZPoint(-0.03 / 75.0),
         rtol = 1e-3,
     )
@@ -375,7 +385,7 @@ end
     trunc_mesh = Meshes.truncate_mesh(parent_mesh, trunc_domain)
 
     @test Meshes.coordinates(trunc_mesh, 1, 1) == Geometry.ZPoint(z_bottom)
-    @test Meshes.coordinates(trunc_mesh, 1, length(trunc_mesh.faces)) ==
+    @test Meshes.coordinates(trunc_mesh, Meshes.nelements(trunc_mesh), 2) ==
           Geometry.ZPoint(z_top)
 end
 


### PR DESCRIPTION
**Stack 2/4** — base `tr/geometry-coordinates` (#2612). Next: `tr/space-ndims`.
Review only the last three commits; the first four belong to #2612.

### 1. `Meshes.coordinates` does not range-check the vertex index (#1026)

`coordinates(mesh, elem, vert)` picks a vertex with a chain of `vert == ...`
comparisons, so an out-of-range `vert` fell through to the last branch and
returned *another vertex's* coordinates instead of erroring:

```julia
julia> Meshes.coordinates(mesh, CartesianIndex(1,1,1), 5)   # returns vertex 3
Cartesian123Point(2.5885686283830505, -1.0722202330097799, -1.0722202330097799)
```

Added a shared `check_vertex_index`, called from the `AbstractMesh2D`,
`AbstractCubedSphere` and `RectilinearMesh` methods (`vert ∈ 1:4`).

`IntervalMesh` has the same bug in 1D — `coordinates(mesh, 1, 3)` indexes past
the element's two faces into the next element's, so on a 2-element mesh it
returned element 2's upper face — so it is checked there too (`vert ∈ 1:2`).

**Two things worth a reviewer's attention:**

- This changes the error for an out-of-range 1D `vert` from `BoundsError` to
  `ArgumentError`, which two existing tests asserted on. `ArgumentError` matches
  how `unit_interval.jl` already reports other invalid parameters (`nelems`).
- It turned up **five call sites in the interval tests that were passing a face
  index as `vert`** — `coordinates(mesh, 1, nelems)`, `coordinates(mesh, 1,
  nelems + 1)`, and `vert = 28` in "Truncated IntervalMesh". They only worked
  because the index was unchecked. They are rewritten as the equivalent in-range
  `(elem, vert)` pair; every asserted value is unchanged.

### 2. No `Int`→`Float` promotion for stretching rules (#1434)

`GeneralizedExponentialStretching(30, 5000.0)` raised a `MethodError`, and so
did `IntervalMesh(domain, ExponentialStretching(7500))` on a `Float64` domain —
the rule had no promoting constructor, and the `IntervalMesh` methods pinned the
rule's float type to the domain's with a shared `FT` typevar.

- `GeneralizedExponentialStretching` now promotes mixed parameters. It has to
  call the *parametric* constructor rather than recursing: a `(::Real, ::Real)`
  method is **more** specific than the generated diagonal `(::FT, ::FT) where
  {FT}` (whose typevar is implicitly bounded by `Any`), so every `Real` pair
  dispatches to it and a plain `promote(...)` forward stack-overflows. I hit
  this; the reasoning is in a source comment.
- `IntervalMesh` now accepts a rule of any float type and converts it to the
  domain's via the new `Meshes._convert_stretch`. This also covers a `Float64`
  rule on a `Float32` domain, not just integers. The mesh stores the converted
  rule, so `mesh.stretch` always matches the domain.

### 3. `SphereDomain` does not support `Int`s (#1468)

`SphereDomain(1000)` built a `SphereDomain{Int}`. The intended constraint was
written

```julia
struct SphereDomain{FT} <: AbstractDomain where {FT <: AbstractFloat}
```

where the `where` clause attaches to the (unparameterized) supertype and is
silently discarded — so it never applied. The radius fixes the float type of
everything built on the domain, so this surfaced far away as `no method matching
legendre(::Type{Int64}, ...)` when the space's quadrature rule was built. The
bound is moved onto the type parameter, and a non-float `Real` radius is
promoted rather than rejected.

### Testing

The reproducers from #1434 and #1468 both run; the #1468 sphere space integrates
to 4πR². `Domains`, `Meshes`, `Geometry`, `Spaces`, `Fields`, `InputOutput`
(including `unit_hybrid2dbox_stretched`) and `Remapping` unit tests pass.

Closes #1026, closes #1434, closes #1468

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJ8VbwbMadrhvCtBV3jkjc