### PR TITLE
Add compile-time ndims for spaces and grids

### DIFF
--- a/src/Geometry/localgeometry.jl
+++ b/src/Geometry/localgeometry.jl
@@ -116,3 +116,14 @@ end
 undertype(::Type{<:LocalGeometry{I, C, FT}}) where {I, C, FT} = FT
 undertype(::Type{SurfaceGeometry{FT, N}}) where {FT, N} = FT
 undertype(::Type{<:CoordinateOnlyGeometry{C}}) where {C} = eltype(C)
+
+"""
+    coordinate_type(geom)
+
+The `AbstractPoint` type of the coordinates of the geometry `geom`, which can
+be either an object or a type.
+"""
+coordinate_type(::Type{<:LocalGeometry{I, C}}) where {I, C} = C
+coordinate_type(::Type{<:CoordinateOnlyGeometry{C}}) where {C} = C
+coordinate_type(geom::Union{LocalGeometry, CoordinateOnlyGeometry}) =
+    coordinate_type(typeof(geom))

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -58,6 +58,25 @@ function local_geometry_type end
 # Fallback, but this requires user error-handling
 local_geometry_type(::Type{T}) where {T} = Union{}
 
+"""
+    ndims(grid::AbstractGrid)
+
+The number of spatial dimensions of `grid`.
+
+This is fixed by the type, so it is available at compile time: a
+`FiniteDifferenceGrid` is always 1, a `SpectralElementGrid2D` always 2, an
+`ExtrudedFiniteDifferenceGrid` 2 or 3 depending on its horizontal grid, and so
+on. `Spaces.AbstractSpace` forwards to its grid.
+
+The generic method reads the number of components off the grid's coordinate
+type; grids that are a lower-dimensional view of another grid (`ColumnGrid`,
+`LevelGrid`) override it, since their coordinates keep the full ambient
+dimension of the grid they slice.
+"""
+Base.ndims(grid::AbstractGrid) = ndims(typeof(grid))
+Base.ndims(::Type{G}) where {G <: AbstractGrid} =
+    Geometry.ncomponents(Geometry.coordinate_type(local_geometry_type(G)))
+
 function dss_weights end
 function quadrature_style end
 function vertical_topology end

--- a/src/Grids/column.jl
+++ b/src/Grids/column.jl
@@ -34,6 +34,8 @@ Adapt.@adapt_structure ColumnGrid
 
 local_geometry_type(::Type{<:ColumnGrid{G}}) where {G} = local_geometry_type(G)
 
+Base.ndims(::Type{<:ColumnGrid}) = 1
+
 column(grid::AbstractExtrudedFiniteDifferenceGrid, indices...) = ColumnGrid(grid, indices)
 
 topology(colgrid::ColumnGrid) = vertical_topology(colgrid.full_grid)

--- a/src/Grids/level.jl
+++ b/src/Grids/level.jl
@@ -31,6 +31,8 @@ dss_weights(levelgrid::LevelGrid, _) = dss_weights(levelgrid.full_grid, nothing)
 local_geometry_type(::Type{LevelGrid{G, L}}) where {G, L} =
     local_geometry_type(G)
 
+Base.ndims(::Type{LevelGrid{G, L}}) where {G, L} = ndims(G) - 1
+
 local_geometry_data(levelgrid::LevelGrid{<:Any, Int}, ::Nothing) = level(
     local_geometry_data(levelgrid.full_grid, CellCenter()),
     levelgrid.level,

--- a/src/Grids/spectralelement.jl
+++ b/src/Grids/spectralelement.jl
@@ -68,7 +68,7 @@ end
 Adapt.@adapt_structure SpectralElementGrid1D
 
 local_geometry_type(
-    ::Type{SpectralElementGrid1D{<:Any, <:Any, <:Any, LG}},
+    ::Type{<:SpectralElementGrid1D{<:Any, <:Any, <:Any, LG}},
 ) where {LG} = eltype(LG) # calls eltype from DataLayouts
 
 # non-view grids are cached based on their input arguments
@@ -200,7 +200,7 @@ end
 Adapt.@adapt_structure SpectralElementGrid2D
 
 local_geometry_type(
-    ::Type{SpectralElementGrid2D{<:Any, <:Any, <:Any, LG}},
+    ::Type{<:SpectralElementGrid2D{<:Any, <:Any, <:Any, LG}},
 ) where {LG} = eltype(LG) # calls eltype from DataLayouts
 
 """

--- a/src/Spaces/Spaces.jl
+++ b/src/Spaces/Spaces.jl
@@ -224,6 +224,28 @@ get_mask(space::ExtrudedFiniteDifferenceSpace) =
     get_mask(horizontal_space(space))
 
 """
+    ndims(space::AbstractSpace)
+
+The number of spatial dimensions of `space`.
+
+This is fixed by the type, so it is available at compile time: a
+`CenterFiniteDifferenceSpace` is always 1, a `SpectralElementSpace2D` always 2,
+and an `ExtrudedFiniteDifferenceSpace` is 2 or 3 depending on its horizontal
+space.
+
+```julia
+julia> ndims(Spaces.CenterFiniteDifferenceSpace(grid))
+1
+```
+
+Spaces that are built on a `Grids.AbstractGrid` forward to `ndims` of that
+grid; the rest read the number of components off their coordinate type.
+"""
+Base.ndims(space::AbstractSpace) = ndims(typeof(space))
+Base.ndims(::Type{S}) where {S <: AbstractSpace} =
+    Geometry.ncomponents(Geometry.coordinate_type(local_geometry_type(S)))
+
+"""
     has_vertical(::AbstractSpace)
 
 Returns a bool indicating that the space has a vertical grid.

--- a/src/Spaces/extruded.jl
+++ b/src/Spaces/extruded.jl
@@ -23,6 +23,9 @@ struct ExtrudedFiniteDifferenceSpace{
     staggering::S
 end
 
+Base.ndims(::Type{ExtrudedFiniteDifferenceSpace{G, S}}) where {G, S} =
+    ndims(G)
+
 local_geometry_type(::Type{ExtrudedFiniteDifferenceSpace{G, S}}) where {G, S} =
     local_geometry_type(G)
 

--- a/src/Spaces/finitedifference.jl
+++ b/src/Spaces/finitedifference.jl
@@ -24,6 +24,8 @@ FiniteDifferenceSpace(
     staggering::Staggering,
 ) = FiniteDifferenceSpace(Grids.FiniteDifferenceGrid(topology), staggering)
 
+Base.ndims(::Type{FiniteDifferenceSpace{G, S}}) where {G, S} = ndims(G)
+
 local_geometry_type(::Type{FiniteDifferenceSpace{G, S}}) where {G, S} =
     local_geometry_type(G)
 

--- a/src/Spaces/multicolumn.jl
+++ b/src/Spaces/multicolumn.jl
@@ -30,6 +30,8 @@ ClimaComms.device(space::MultiPointSpace) = ClimaComms.device(grid(space))
 
 local_geometry_data(space::MultiPointSpace) =
     local_geometry_data(grid(space), nothing)
+Base.ndims(::Type{MultiPointSpace{G}}) where {G} = ndims(G)
+
 local_geometry_type(::Type{MultiPointSpace{G}}) where {G} =
     local_geometry_type(G)
 
@@ -64,6 +66,9 @@ struct MultiColumnFiniteDifferenceSpace{
     grid::G
     staggering::S
 end
+
+Base.ndims(::Type{MultiColumnFiniteDifferenceSpace{G, S}}) where {G, S} =
+    ndims(G)
 
 local_geometry_type(::Type{MultiColumnFiniteDifferenceSpace{G, S}}) where {G, S} =
     local_geometry_type(G)

--- a/src/Spaces/spectralelement.jl
+++ b/src/Spaces/spectralelement.jl
@@ -72,6 +72,8 @@ space(grid::Grids.LevelGrid{<:Grids.ExtrudedSpectralElementGrid2D}, ::Nothing) =
     SpectralElementSpace1D(grid)
 grid(space::SpectralElementSpace1D) = getfield(space, :grid)
 
+Base.ndims(::Type{SpectralElementSpace1D{G}}) where {G} = ndims(G)
+
 local_geometry_type(::Type{SpectralElementSpace1D{G}}) where {G} =
     local_geometry_type(G)
 
@@ -123,6 +125,8 @@ space(grid::Grids.SpectralElementGrid2D, ::Nothing) =
     SpectralElementSpace2D(grid)
 space(grid::Grids.LevelGrid{<:Grids.ExtrudedSpectralElementGrid3D}, ::Nothing) =
     SpectralElementSpace2D(grid)
+
+Base.ndims(::Type{SpectralElementSpace2D{G}}) where {G} = ndims(G)
 
 local_geometry_type(::Type{SpectralElementSpace2D{G}}) where {G} =
     local_geometry_type(G)

--- a/test/Spaces/unit_spaces.jl
+++ b/test/Spaces/unit_spaces.jl
@@ -4,11 +4,13 @@ using StaticArrays, IntervalSets, LinearAlgebra
 import Adapt
 ClimaComms.@import_required_backends
 
+import ClimaCore
 import ClimaCore:
     slab,
     Domains,
     Meshes,
     Topologies,
+    Grids,
     Spaces,
     Quadratures,
     Fields,
@@ -20,6 +22,11 @@ import ClimaCore:
 
 using ClimaCore.CommonSpaces
 using ClimaCore.Utilities.Cache
+
+@isdefined(TU) || include(
+    joinpath(pkgdir(ClimaCore), "test", "TestUtilities", "TestUtilities.jl"),
+);
+import .TestUtilities as TU;
 
 on_gpu = ClimaComms.device() isa ClimaComms.CUDADevice
 
@@ -649,5 +656,82 @@ end
         @test data_dss[1, 1, 1, :, 4] ==
               data[1, Nij, Nij, :, 1] .+ data[1, 1, Nij, :, 2] .+
               data[1, Nij, 1, :, 3] .+ data[1, 1, 1, :, 4]
+    end
+end
+
+@testset "ndims" begin
+    FT = Float64
+    context = ClimaComms.context()
+
+    # 1D
+    zgrid = Grids.FiniteDifferenceGrid(
+        Topologies.IntervalTopology(
+            context,
+            Meshes.IntervalMesh(
+                Domains.IntervalDomain(
+                    Geometry.ZPoint(FT(0)),
+                    Geometry.ZPoint(FT(1000));
+                    boundary_names = (:bottom, :top),
+                );
+                nelems = 10,
+            ),
+        ),
+    )
+    center_space = Spaces.CenterFiniteDifferenceSpace(zgrid)
+    face_space = Spaces.FaceFiniteDifferenceSpace(zgrid)
+    @test ndims(center_space) == 1
+    @test ndims(face_space) == 1
+
+    # 1D horizontal, and the 2D extrusion of it
+    xtopology = Topologies.IntervalTopology(
+        context,
+        Meshes.IntervalMesh(
+            Domains.IntervalDomain(
+                Geometry.XPoint(FT(0)),
+                Geometry.XPoint(FT(1));
+                periodic = true,
+            );
+            nelems = 4,
+        ),
+    )
+    space_1d = Spaces.SpectralElementSpace1D(xtopology, Quadratures.GLL{4}())
+    @test ndims(space_1d) == 1
+    @test ndims(Spaces.ExtrudedFiniteDifferenceSpace(space_1d, center_space)) ==
+          2
+
+    # 2D horizontal, and the 3D extrusion of it
+    sphere_topology = Topologies.Topology2D(
+        context,
+        Meshes.EquiangularCubedSphere(Domains.SphereDomain(FT(6.371e6)), 4),
+    )
+    space_2d =
+        Spaces.SpectralElementSpace2D(sphere_topology, Quadratures.GLL{4}())
+    space_3d = Spaces.ExtrudedFiniteDifferenceSpace(space_2d, center_space)
+    @test ndims(space_2d) == 2
+    @test ndims(space_3d) == 3
+
+    # a column is 1D and a level drops the vertical dimension, even though
+    # both keep the ambient coordinate type of the space they slice
+    @test ndims(Spaces.column(space_3d, 1, 1, 1)) == 1
+    @test ndims(Spaces.level(space_3d, 1)) == 2
+
+    # `ndims` is fixed by the type, so it is a compile-time constant
+    for space in (center_space, space_1d, space_2d, space_3d)
+        @test ndims(typeof(space)) == ndims(space)
+        @test @inferred(ndims(space)) == ndims(space)
+        @test (@allocated ndims(space)) == 0
+    end
+
+    # every space TestUtilities knows about answers, and agrees with the
+    # number of components of its coordinates
+    for space in TU.all_spaces(FT; context)
+        @test ndims(space) isa Int
+        is_slice =
+            !(space isa Spaces.PointSpace) &&
+            Spaces.grid(space) isa Union{Grids.ColumnGrid, Grids.LevelGrid}
+        if !is_slice
+            @test ndims(space) ==
+                  Geometry.ncomponents(eltype(Spaces.coordinates_data(space)))
+        end
     end
 end


### PR DESCRIPTION
**Stack 3/4** — base `tr/meshes-fixes` (#2613). Next: `tr/gradc2f-docs`.
Review only the last three commits.

### `ndims` for a `Space` (#2206)

The number of spatial dimensions of a space is fixed by its type, but there was
no way to ask for it — `ndims(space)` was a `MethodError`.

`Base.ndims` is now defined on both `Spaces.AbstractSpace` and
`Grids.AbstractGrid`, and on their **types**, so it is a compile-time constant
(the tests assert `@inferred` and `@allocated == 0`).

Spaces built on a grid forward to the grid, mirroring how `local_geometry_type`
is already defined per space type. The generic grid method reads the number of
components off the grid's coordinate type, via a new `Geometry.coordinate_type`
accessor on `LocalGeometry`/`CoordinateOnlyGeometry` that mirrors the existing
`undertype`. That makes it correct for every space without enumerating them.

`ColumnGrid` and `LevelGrid` override it. Both keep the coordinate type of the
grid they slice, so the generic rule would report the **ambient** dimension: a
column of a 3D space would be 3 rather than 1, contradicting the
`ndims(::CenterFiniteDifferenceSpace) == 1` the issue asks for.

I went with a single `Int` rather than the `(n_horizontal, n_vertical)` tuple the
issue floats as an alternative — `has_horizontal`/`has_vertical` already answer
that question, and `ndims` matching `Base`'s meaning seems more useful.

### Drive-by: `local_geometry_type` for `SpectralElementGrid1D` (separate commit)

Found while wiring this up. The method was written for `SpectralElementGrid1D{T,
Q, GG, LG}`, but the struct carries a fifth `D` (dss weights) parameter, so it
**never matched** and every call fell through to the
`local_geometry_type(::Type{T}) = Union{}` fallback. It is matched on `<:` now,
so a future parameter cannot silently reintroduce this. Currently latent — the
one caller that would notice, `InputOutput`, only uses it for point spaces — but
`ndims` depends on it.

### Testing

New `ndims` testset in `test/Spaces/unit_spaces.jl`, 38/38: explicit 1D/2D/3D
spaces, columns and levels, the compile-time checks, and a sweep over every space
`TestUtilities.all_spaces` knows about, cross-checked against the number of
components of each space's coordinates. `Spaces`, `Meshes`, `Domains`,
`Geometry`, `Fields`, `InputOutput` and `Remapping` unit tests pass.

Closes #2206

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJ8VbwbMadrhvCtBV3jkjc