### PR TITLE
Thread the CG/DG discretization through CommonGrids and CommonSpaces

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,19 @@ ClimaCore.jl Release Notes
 main
 -------
 
+- ![][badge-✨feature/enhancement] The `CommonGrids` and `CommonSpaces`
+  constructors that build a horizontal spectral-element grid
+  (`ExtrudedCubedSphereGrid`, `CubedSphereGrid`, `Box3DGrid`, `SliceXZGrid`,
+  `RectangleXYGrid` and the matching `*Space` constructors) accept a
+  `discretization` keyword and forward it to the grid, so a discontinuous
+  space is built with `discretization = Grids.DG()`; when omitted, the
+  discretization follows the quadrature as for the grid constructors. The
+  `Spaces.SpectralElementSpace1D` / `SpectralElementSpace2D` docstrings name
+  the keywords they forward, and `examples/plane/bickleyjet.jl` builds both of
+  its spaces with `CommonSpaces.RectangleXYSpace` instead of assembling the
+  domain, mesh and topology by hand.
+  PR [2621](https://github.com/CliMA/ClimaCore.jl/pull/2621)
+
 - ![][badge-🔥behavioralΔ] The two Bickley-jet examples `examples/plane/
   bickleyjet_cg.jl` and `examples/plane/bickleyjet_dg.jl` are replaced by the
   single driver `examples/plane/bickleyjet.jl`, which takes the

--- a/examples/plane/bickleyjet.jl
+++ b/examples/plane/bickleyjet.jl
@@ -40,16 +40,8 @@
 using ClimaComms
 using LinearAlgebra
 
-import ClimaCore:
-    Domains,
-    Fields,
-    Geometry,
-    Grids,
-    Meshes,
-    Operators,
-    Spaces,
-    Quadratures,
-    Topologies
+import ClimaCore: Fields, Geometry, Grids, Operators, Spaces, Quadratures
+import ClimaCore.CommonSpaces: RectangleXYSpace
 import ClimaCore.Geometry: ⊗
 
 import ClimaTimeSteppers as CTS
@@ -105,35 +97,32 @@ if !is_periodic && discretization isa Grids.CG
            impose it through the operators.")
 end
 
-domain = Domains.RectangleDomain(
-    Domains.IntervalDomain(
-        Geometry.XPoint(-2π),
-        Geometry.XPoint(2π),
-        periodic = true,
-    ),
-    Domains.IntervalDomain(
-        Geometry.YPoint(-2π),
-        Geometry.YPoint(2π),
-        periodic = is_periodic,
-        boundary_names = is_periodic ? nothing : (:south, :north),
-    ),
-)
-
 n1, n2 = 16, 16
 Nq = 4
-mesh = Meshes.RectilinearMesh(domain, n1, n2)
-grid_topology = Topologies.Topology2D(context, mesh)
-quad = Quadratures.GLL{Nq}()
-space = Spaces.SpectralElementSpace2D(grid_topology, quad; discretization)
 
-# Over-integration space, on the same discretization as the model space.
+# `CommonSpaces.RectangleXYSpace` builds the domain, mesh, topology and grid
+# from the geometry in one call, and takes `discretization` alongside it. A
+# non-periodic direction gets its boundary names (`:south`, `:north`) from the
+# constructor.
+geometry = (;
+    x_min = -2π,
+    x_max = 2π,
+    y_min = -2π,
+    y_max = 2π,
+    x_elem = n1,
+    y_elem = n2,
+    periodic_x = true,
+    periodic_y = is_periodic,
+    context,
+)
+space = RectangleXYSpace(; geometry..., n_quad_points = Nq, discretization)
+
+# Over-integration space, on the same discretization as the model space. Only
+# the quadrature differs, and topologies are cached on their mesh, so this
+# shares the topology of `space` and `Interpolate`/`Restrict` accept the pair.
 Ispace =
     iszero(config.Nqh) ? nothing :
-    Spaces.SpectralElementSpace2D(
-        grid_topology,
-        Quadratures.GLL{config.Nqh}();
-        discretization,
-    )
+    RectangleXYSpace(; geometry..., n_quad_points = config.Nqh, discretization)
 
 function init_state(coord, p)
     x, y = coord.x, coord.y

--- a/src/CommonGrids/CommonGrids.jl
+++ b/src/CommonGrids/CommonGrids.jl
@@ -102,6 +102,7 @@ import .Helpers.DefaultRectangleXYMesh
         hypsography_fun = (h_grid, z_grid) -> Grids.Flat(),
         global_geometry::Geometry.AbstractGlobalGeometry = Geometry.ShallowSphericalGlobalGeometry{FT}(radius),
         quad::Quadratures.QuadratureStyle = Quadratures.GLL{n_quad_points}(),
+        discretization::Union{Nothing, Grids.Discretization} = nothing,
         h_mesh = Meshes.EquiangularCubedSphere(Domains.SphereDomain{FT}(radius), h_elem),
         h_topology::Topologies.AbstractDistributedTopology = Topologies.Topology2D(context, h_mesh),
         VIJH = DataLayouts.VIJFH,
@@ -126,6 +127,7 @@ A convenience constructor, which builds an
   - `hypsography_fun` a function or callable object (`hypsography_fun(h_grid, z_grid) -> hypsography`) for constructing the hypsography model.
   - `global_geometry` the global geometry (defaults to [`Geometry.CartesianGlobalGeometry`](@ref))
   - `quad` the quadrature style (defaults to `Quadratures.GLL{n_quad_points}`)
+  - `discretization` the Galerkin discretization of the horizontal spectral-element grid: `Grids.CG()`, continuous across element boundaries with DSS, or `Grids.DG()`, discontinuous with interface numerical fluxes. When omitted (`nothing`) it follows the quadrature: `CG()` for GLL nodes, `DG()` for quadratures whose nodes are not shared between elements. See [`Grids.SpectralElementGrid2D`](@ref).
   - `h_mesh` the horizontal mesh (defaults to `Meshes.EquiangularCubedSphere`)
   - `h_topology` the horizontal topology (defaults to `Topologies.Topology2D`)
   - `VIJH` the horizontal DataLayout type (defaults to `DataLayouts.VIJFH`). This parameter describes how data is arranged in memory. See [`Grids.SpectralElementGrid2D`](@ref) for its use.
@@ -169,6 +171,7 @@ function ExtrudedCubedSphereGrid(
         radius,
     ),
     quad::Quadratures.QuadratureStyle = Quadratures.GLL{n_quad_points}(),
+    discretization::Union{Nothing, Grids.Discretization} = nothing,
     h_mesh = Meshes.EquiangularCubedSphere(
         Domains.SphereDomain{FT}(radius),
         h_elem,
@@ -198,6 +201,7 @@ function ExtrudedCubedSphereGrid(
         VIJH,
         enable_bubble,
         enable_mask,
+        discretization,
     )
     z_topology = Topologies.IntervalTopology(
         ClimaComms.SingletonCommsContext(device),
@@ -221,6 +225,7 @@ end
         device::ClimaComms.AbstractDevice = ClimaComms.device(),
         context::ClimaComms.AbstractCommsContext = ClimaComms.context(device),
         quad::Quadratures.QuadratureStyle = Quadratures.GLL{n_quad_points}(),
+        discretization::Union{Nothing, Grids.Discretization} = nothing,
         h_mesh = Meshes.EquiangularCubedSphere(Domains.SphereDomain{FT}(radius), h_elem),
         h_topology::Topologies.AbstractDistributedTopology = Topologies.Topology2D(context, h_mesh),
         VIJH = DataLayouts.VIJFH,
@@ -237,6 +242,7 @@ A convenience constructor, which builds a
   - `device` the `ClimaComms.device`
   - `context` the `ClimaComms.context`
   - `quad` the quadrature style (defaults to `Quadratures.GLL{n_quad_points}`)
+  - `discretization` the Galerkin discretization of the horizontal spectral-element grid: `Grids.CG()`, continuous across element boundaries with DSS, or `Grids.DG()`, discontinuous with interface numerical fluxes. When omitted (`nothing`) it follows the quadrature: `CG()` for GLL nodes, `DG()` for quadratures whose nodes are not shared between elements. See [`Grids.SpectralElementGrid2D`](@ref).
   - `h_mesh` the horizontal mesh (defaults to `Meshes.EquiangularCubedSphere`)
   - `h_topology` the horizontal topology (defaults to `Topologies.Topology2D`)
   - `VIJH` the horizontal DataLayout type (defaults to `DataLayouts.VIJFH`). This parameter describes how data is arranged in memory. See [`Grids.SpectralElementGrid2D`](@ref) for its use.
@@ -259,6 +265,7 @@ function CubedSphereGrid(
     device::ClimaComms.AbstractDevice = ClimaComms.device(),
     context::ClimaComms.AbstractCommsContext = ClimaComms.context(device),
     quad::Quadratures.QuadratureStyle = Quadratures.GLL{n_quad_points}(),
+    discretization::Union{Nothing, Grids.Discretization} = nothing,
     h_mesh = Meshes.EquiangularCubedSphere(
         Domains.SphereDomain{FT}(radius),
         h_elem,
@@ -277,6 +284,7 @@ function CubedSphereGrid(
         quad;
         VIJH,
         enable_mask,
+        discretization,
     )
 end
 
@@ -355,6 +363,7 @@ end
         hypsography_fun = (h_grid, z_grid) -> Grids.Flat(),
         global_geometry::Geometry.AbstractGlobalGeometry = Geometry.CartesianGlobalGeometry(),
         quad::Quadratures.QuadratureStyle = Quadratures.GLL{n_quad_points}(),
+        discretization::Union{Nothing, Grids.Discretization} = nothing,
         VIJH = DataLayouts.VIJFH,
         [h_topology::Topologies.AbstractDistributedTopology], # optional
         [z_mesh::Meshes.IntervalMesh], # optional
@@ -385,6 +394,7 @@ A convenience constructor, which builds a
   - `hypsography_fun` a function or callable object (`hypsography_fun(h_grid, z_grid) -> hypsography`) for constructing the hypsography model.
   - `global_geometry` the global geometry (defaults to [`Geometry.CartesianGlobalGeometry`](@ref))
   - `quad` the quadrature style (defaults to `Quadratures.GLL{n_quad_points}`)
+  - `discretization` the Galerkin discretization of the horizontal spectral-element grid: `Grids.CG()`, continuous across element boundaries with DSS, or `Grids.DG()`, discontinuous with interface numerical fluxes. When omitted (`nothing`) it follows the quadrature: `CG()` for GLL nodes, `DG()` for quadratures whose nodes are not shared between elements. See [`Grids.SpectralElementGrid2D`](@ref).
   - `h_topology` the horizontal topology (defaults to `Topologies.Topology2D`)
   - `z_mesh` the vertical mesh, defaults to an `Meshes.IntervalMesh` along `z` with given `stretch`
   - `enable_bubble` enables the "bubble correction" for more accurate element areas when computing the spectral element space. See [`Grids.SpectralElementGrid2D`](@ref) for more information.
@@ -433,6 +443,7 @@ function Box3DGrid(
     hypsography_fun = (h_grid, z_grid) -> Grids.Flat(),
     global_geometry::Geometry.AbstractGlobalGeometry = Geometry.CartesianGlobalGeometry(),
     quad::Quadratures.QuadratureStyle = Quadratures.GLL{n_quad_points}(),
+    discretization::Union{Nothing, Grids.Discretization} = nothing,
     h_topology::Topologies.AbstractDistributedTopology = Topologies.Topology2D(
         context,
         DefaultRectangleXYMesh(
@@ -478,6 +489,7 @@ function Box3DGrid(
         VIJH,
         enable_bubble,
         enable_mask,
+        discretization,
     )
     z_topology = Topologies.IntervalTopology(
         ClimaComms.SingletonCommsContext(device),
@@ -509,6 +521,7 @@ end
         hypsography_fun = (h_grid, z_grid) -> Grids.Flat(),
         global_geometry::Geometry.AbstractGlobalGeometry = Geometry.CartesianGlobalGeometry(),
         quad::Quadratures.QuadratureStyle = Quadratures.GLL{n_quad_points}(),
+        discretization::Union{Nothing, Grids.Discretization} = nothing,
     )
 
 A convenience constructor, which builds a
@@ -531,6 +544,7 @@ A convenience constructor, which builds a
   - `hypsography_fun` a function or callable object (`hypsography_fun(h_grid, z_grid) -> hypsography`) for constructing the hypsography model.
   - `global_geometry` the global geometry (defaults to [`Geometry.CartesianGlobalGeometry`](@ref))
   - `quad` the quadrature style (defaults to `Quadratures.GLL{n_quad_points}`)
+  - `discretization` the Galerkin discretization of the horizontal spectral-element grid: `Grids.CG()`, continuous across element boundaries with DSS, or `Grids.DG()`, discontinuous with interface numerical fluxes. When omitted (`nothing`) it follows the quadrature: `CG()` for GLL nodes, `DG()` for quadratures whose nodes are not shared between elements. See [`Grids.SpectralElementGrid2D`](@ref).
 
 # Example usage
 
@@ -565,6 +579,7 @@ function SliceXZGrid(
     hypsography_fun = (h_grid, z_grid) -> Grids.Flat(),
     global_geometry::Geometry.AbstractGlobalGeometry = Geometry.CartesianGlobalGeometry(),
     quad::Quadratures.QuadratureStyle = Quadratures.GLL{n_quad_points}(),
+    discretization::Union{Nothing, Grids.Discretization} = nothing,
     VIJH::Type{<:DataLayouts.VIJHWithF} = DataLayouts.VIJFH,
     h_mesh::Meshes.IntervalMesh = DefaultSliceXMesh(
         FT;
@@ -588,7 +603,7 @@ function SliceXZGrid(
         h_mesh,
     )
     h_grid =
-        Grids.SpectralElementGrid1D(h_topology, quad; VIJH)
+        Grids.SpectralElementGrid1D(h_topology, quad; VIJH, discretization)
     z_topology = Topologies.IntervalTopology(
         ClimaComms.SingletonCommsContext(device),
         z_mesh,
@@ -619,6 +634,7 @@ end
         hypsography::Grids.HypsographyAdaption = Grids.Flat(),
         global_geometry::Geometry.AbstractGlobalGeometry = Geometry.CartesianGlobalGeometry(),
         quad::Quadratures.QuadratureStyle = Quadratures.GLL{n_quad_points}(),
+        discretization::Union{Nothing, Grids.Discretization} = nothing,
         enable_mask::Bool = false,
     )
 
@@ -640,6 +656,7 @@ A convenience constructor, which builds a
   - `hypsography_fun` a function or callable object (`hypsography_fun(h_grid, z_grid) -> hypsography`) for constructing the hypsography model.
   - `global_geometry` the global geometry (defaults to [`Geometry.CartesianGlobalGeometry`](@ref))
   - `quad` the quadrature style (defaults to `Quadratures.GLL{n_quad_points}`)
+  - `discretization` the Galerkin discretization of the horizontal spectral-element grid: `Grids.CG()`, continuous across element boundaries with DSS, or `Grids.DG()`, discontinuous with interface numerical fluxes. When omitted (`nothing`) it follows the quadrature: `CG()` for GLL nodes, `DG()` for quadratures whose nodes are not shared between elements. See [`Grids.SpectralElementGrid2D`](@ref).
   - `enable_mask` enables a horizontal mask, for skipping operations on specified
     columns via `set_mask!`.
 
@@ -677,6 +694,7 @@ function RectangleXYGrid(
     hypsography::Grids.HypsographyAdaption = Grids.Flat(),
     global_geometry::Geometry.AbstractGlobalGeometry = Geometry.CartesianGlobalGeometry(),
     quad::Quadratures.QuadratureStyle = Quadratures.GLL{n_quad_points}(),
+    discretization::Union{Nothing, Grids.Discretization} = nothing,
     VIJH::Type{<:DataLayouts.VIJHWithF} = DataLayouts.VIJFH,
     h_topology::Topologies.AbstractDistributedTopology = Topologies.Topology2D(
         context,
@@ -702,6 +720,7 @@ function RectangleXYGrid(
         VIJH,
         enable_bubble,
         enable_mask,
+        discretization,
     )
 end
 

--- a/src/CommonSpaces/CommonSpaces.jl
+++ b/src/CommonSpaces/CommonSpaces.jl
@@ -51,6 +51,7 @@ import ..Spaces: face_space, center_space
         hypsography_fun = (h_grid, z_grid) -> Grids.Flat(),
         global_geometry::Geometry.AbstractGlobalGeometry = Geometry.ShallowSphericalGlobalGeometry{FT}(radius),
         quad::Quadratures.QuadratureStyle = Quadratures.GLL{n_quad_points}(),
+        discretization::Union{Nothing, Grids.Discretization} = nothing,
         h_mesh = Meshes.EquiangularCubedSphere(Domains.SphereDomain{FT}(radius), h_elem),
         h_topology::Topologies.AbstractDistributedTopology = Topologies.Topology2D(context, h_mesh),
         VIJH = DataLayouts.VIJFH,
@@ -75,6 +76,7 @@ cubed sphere configuration, given:
   - `hypsography_fun` a function or callable object (`hypsography_fun(h_grid, z_grid) -> hypsography`) for constructing the hypsography model.
   - `global_geometry` the global geometry (defaults to [`Geometry.CartesianGlobalGeometry`](@ref))
   - `quad` the quadrature style (defaults to `Quadratures.GLL{n_quad_points}`)
+  - `discretization` the Galerkin discretization of the horizontal spectral-element grid: `Grids.CG()`, continuous across element boundaries with DSS, or `Grids.DG()`, discontinuous with interface numerical fluxes. When omitted (`nothing`) it follows the quadrature: `CG()` for GLL nodes, `DG()` for quadratures whose nodes are not shared between elements. See [`Grids.SpectralElementGrid2D`](@ref).
   - `h_mesh` the horizontal mesh (defaults to `Meshes.EquiangularCubedSphere`)
   - `h_topology` the horizontal topology (defaults to `Topologies.Topology2D`)
   - `VIJH` the horizontal DataLayout type (defaults to `DataLayouts.VIJFH`). This parameter describes how data is arranged in memory. See [`Grids.SpectralElementGrid2D`](@ref) for its use.
@@ -139,6 +141,7 @@ ExtrudedCubedSphereSpace(
         device::ClimaComms.AbstractDevice = ClimaComms.device(),
         context::ClimaComms.AbstractCommsContext = ClimaComms.context(device),
         quad::Quadratures.QuadratureStyle = Quadratures.GLL{n_quad_points}(),
+        discretization::Union{Nothing, Grids.Discretization} = nothing,
         h_mesh = Meshes.EquiangularCubedSphere(Domains.SphereDomain{FT}(radius), h_elem),
         h_topology::Topologies.AbstractDistributedTopology = Topologies.Topology2D(context, h_mesh),
         VIJH = DataLayouts.VIJFH,
@@ -154,6 +157,7 @@ cubed sphere configuration, given:
   - `device` the `ClimaComms.device`
   - `context` the `ClimaComms.context`
   - `quad` the quadrature style (defaults to `Quadratures.GLL{n_quad_points}`)
+  - `discretization` the Galerkin discretization of the horizontal spectral-element grid: `Grids.CG()`, continuous across element boundaries with DSS, or `Grids.DG()`, discontinuous with interface numerical fluxes. When omitted (`nothing`) it follows the quadrature: `CG()` for GLL nodes, `DG()` for quadratures whose nodes are not shared between elements. See [`Grids.SpectralElementGrid2D`](@ref).
   - `h_mesh` the horizontal mesh (defaults to `Meshes.EquiangularCubedSphere`)
   - `h_topology` the horizontal topology (defaults to `Topologies.Topology2D`)
   - `VIJH` the horizontal DataLayout type (defaults to `DataLayouts.VIJFH`). This parameter describes how data is arranged in memory. See [`Grids.SpectralElementGrid2D`](@ref) for its use.
@@ -242,6 +246,7 @@ ColumnSpace(::Type{FT}; staggering::Staggering, kwargs...) where {FT} =
         hypsography_fun = (h_grid, z_grid) -> Grids.Flat(),
         global_geometry::Geometry.AbstractGlobalGeometry = Geometry.CartesianGlobalGeometry(),
         quad::Quadratures.QuadratureStyle = Quadratures.GLL{n_quad_points}(),
+        discretization::Union{Nothing, Grids.Discretization} = nothing,
         VIJH = DataLayouts.VIJFH,
         [h_topology::Topologies.AbstractDistributedTopology], # optional
         [z_mesh::Meshes.IntervalMesh], # optional
@@ -270,6 +275,7 @@ configuration, given:
   - `hypsography_fun` a function or callable object (`hypsography_fun(h_grid, z_grid) -> hypsography`) for constructing the hypsography model.
   - `global_geometry` the global geometry (defaults to [`Geometry.CartesianGlobalGeometry`](@ref))
   - `quad` the quadrature style (defaults to `Quadratures.GLL{n_quad_points}`)
+  - `discretization` the Galerkin discretization of the horizontal spectral-element grid: `Grids.CG()`, continuous across element boundaries with DSS, or `Grids.DG()`, discontinuous with interface numerical fluxes. When omitted (`nothing`) it follows the quadrature: `CG()` for GLL nodes, `DG()` for quadratures whose nodes are not shared between elements. See [`Grids.SpectralElementGrid2D`](@ref).
   - `h_topology` the horizontal topology (defaults to `Topologies.Topology2D`)
   - `z_mesh` the vertical mesh, defaults to an `Meshes.IntervalMesh` along `z` with given `stretch`
   - `enable_bubble` enables the "bubble correction" for more accurate element areas when computing the spectral element space. See [`Grids.SpectralElementGrid2D`](@ref) for more information.
@@ -322,6 +328,7 @@ Box3DSpace(::Type{FT}; staggering::Staggering, kwargs...) where {FT} =
         hypsography_fun = (h_grid, z_grid) -> Grids.Flat(),
         global_geometry::Geometry.AbstractGlobalGeometry = Geometry.CartesianGlobalGeometry(),
         quad::Quadratures.QuadratureStyle = Quadratures.GLL{n_quad_points}(),
+        discretization::Union{Nothing, Grids.Discretization} = nothing,
         staggering::Staggering
     )
 
@@ -343,6 +350,7 @@ configuration, given:
   - `hypsography_fun` a function or callable object (`hypsography_fun(h_grid, z_grid) -> hypsography`) for constructing the hypsography model.
   - `global_geometry` the global geometry (defaults to [`Geometry.CartesianGlobalGeometry`](@ref))
   - `quad` the quadrature style (defaults to `Quadratures.GLL{n_quad_points}`)
+  - `discretization` the Galerkin discretization of the horizontal spectral-element grid: `Grids.CG()`, continuous across element boundaries with DSS, or `Grids.DG()`, discontinuous with interface numerical fluxes. When omitted (`nothing`) it follows the quadrature: `CG()` for GLL nodes, `DG()` for quadratures whose nodes are not shared between elements. See [`Grids.SpectralElementGrid2D`](@ref).
   - `staggering` vertical staggering, can be one of [[`Grids.CellFace`](@ref), [`Grids.CellCenter`](@ref)]
 
 Note that these arguments are all the same as [`CommonGrids.SliceXZGrid`](@ref),
@@ -387,6 +395,7 @@ SliceXZSpace(::Type{FT}; staggering::Staggering, kwargs...) where {FT} =
         hypsography::Grids.HypsographyAdaption = Grids.Flat(),
         global_geometry::Geometry.AbstractGlobalGeometry = Geometry.CartesianGlobalGeometry(),
         quad::Quadratures.QuadratureStyle = Quadratures.GLL{n_quad_points}(),
+        discretization::Union{Nothing, Grids.Discretization} = nothing,
     )
 
 Construct a [`Spaces.SpectralElementSpace2D`](@ref) space for a 2D rectangular
@@ -406,6 +415,7 @@ configuration, given:
   - `hypsography_fun` a function or callable object (`hypsography_fun(h_grid, z_grid) -> hypsography`) for constructing the hypsography model.
   - `global_geometry` the global geometry (defaults to [`Geometry.CartesianGlobalGeometry`](@ref))
   - `quad` the quadrature style (defaults to `Quadratures.GLL{n_quad_points}`)
+  - `discretization` the Galerkin discretization of the horizontal spectral-element grid: `Grids.CG()`, continuous across element boundaries with DSS, or `Grids.DG()`, discontinuous with interface numerical fluxes. When omitted (`nothing`) it follows the quadrature: `CG()` for GLL nodes, `DG()` for quadratures whose nodes are not shared between elements. See [`Grids.SpectralElementGrid2D`](@ref).
 
 # Example usage
 

--- a/src/DebugOnly/DebugOnly.jl
+++ b/src/DebugOnly/DebugOnly.jl
@@ -118,7 +118,7 @@ same.
 To allow combining mismatched spaces, override this function so that it returns
 `true`.
 
-!!! warn
+!!! warning
 
     `ClimaCore` checks for consistency of spaces to protect you from non-sense
     results. If you disable this check, you are responsible to ensure that the

--- a/src/Operators/dg_fluxes.jl
+++ b/src/Operators/dg_fluxes.jl
@@ -6,7 +6,19 @@
 """
     CentralNumericalFlux(fluxfn)
 
-Evaluates the central numerical flux using `fluxfn`.
+Interface numerical flux `((F⁻ + F⁺) / 2)' * normal`, the average of the
+physical flux `fluxfn(args...)` on the two sides of a face. It adds no
+dissipation, so an advection-dominated DG run with it is unstable; use
+[`RusanovNumericalFlux`](@ref) for a dissipative alternative built from the
+same `fluxfn`. Callable as `numflux(normal, argvals⁻, argvals⁺)`, the
+contract of [`add_numerical_flux_interior!`](@ref).
+
+# Examples
+
+```julia
+numflux = Operators.CentralNumericalFlux(physical_flux)
+completion = Operators.tendency_completion(dydt; numflux)
+```
 """
 struct CentralNumericalFlux{F} <: AbstractNumericalFlux
     fluxfn::F
@@ -21,7 +33,23 @@ end
 """
     RusanovNumericalFlux(fluxfn, wavespeedfn)
 
-Evaluates the Rusanov numerical flux using `fluxfn` with wavespeed `wavespeedfn`
+Interface numerical flux `((F⁻ + F⁺) / 2)' * normal + (λ / 2) * (y⁻ - y⁺)`:
+the central flux of `fluxfn(args...)` plus a jump penalty with
+`λ = max(wavespeedfn(args⁻...), wavespeedfn(args⁺...))`, an upper bound on the
+normal signal speed. The penalty is the dissipation that keeps a DG transport
+scheme stable; `wavespeedfn` may overestimate the speed at the cost of extra
+dissipation. Callable as `numflux(normal, argvals⁻, argvals⁺)`, the contract
+of [`add_numerical_flux_interior!`](@ref); the first argument value on each
+side is the state `y`.
+
+# Examples
+
+```julia
+sw_flux(y, p) = (; ρ = y.ρu, ρu = (y.ρu ⊗ (y.ρu / y.ρ)) + (p.g * y.ρ^2 / 2) * I)
+sw_wavespeed(y, p) = sqrt(p.g * y.ρ) + norm(y.ρu / y.ρ)
+numflux = Operators.RusanovNumericalFlux(sw_flux, sw_wavespeed)
+completion = Operators.tendency_completion(dydt; numflux)
+```
 """
 struct RusanovNumericalFlux{F, W} <: AbstractNumericalFlux
     fluxfn::F

--- a/src/Operators/laplacians.jl
+++ b/src/Operators/laplacians.jl
@@ -25,6 +25,17 @@ Each call owns its result on both discretizations, so any number of results
 may be live at once. The DG result is a fresh `Field`; in a tendency, where
 that allocation is not wanted, use [`scalar_laplacian!`](@ref) to write into a
 caller-owned field instead.
+
+# Examples
+
+Fourth-order hyperdiffusion `∇⁴χ` on either discretization:
+
+```julia
+∇²χ = similar(χ)
+Operators.scalar_laplacian!(∇²χ, χ)
+Spaces.weighted_dss!(∇²χ)          # no-op on DG
+@. dydt -= ν * Operators.scalar_laplacian(∇²χ)
+```
 """
 scalar_laplacian(χ; weight = nothing) =
     scalar_laplacian(Spaces.discretization(axes(χ)), χ, weight)

--- a/src/Spaces/pointspace.jl
+++ b/src/Spaces/pointspace.jl
@@ -5,7 +5,10 @@ local_geometry_data(space::AbstractPointSpace) = space.local_geometry
 """
     PointSpace <: AbstractSpace
 
-A zero-dimensional space.
+A zero-dimensional space: a single point, the horizontal space of one column
+(`Spaces.level` of a [`FiniteDifferenceSpace`](@ref)). For `N` disconnected
+horizontal points see [`MultiPointSpace`](@ref), and for `N` independent
+columns see [`MultiColumnFiniteDifferenceSpace`](@ref).
 """
 struct PointSpace{
     C <: ClimaComms.AbstractCommsContext,

--- a/src/Spaces/spectralelement.jl
+++ b/src/Spaces/spectralelement.jl
@@ -49,12 +49,19 @@ end
 
 # 1D
 """
-    SpectralElementSpace1D(grid::SpectralElementGrid1D)
+    SpectralElementSpace1D(grid::Grids.SpectralElementGrid1D)
     SpectralElementSpace1D(
         topology::Topologies.IntervalTopology,
         quadrature_style::Quadratures.QuadratureStyle;
+        discretization = nothing,
         kwargs...
     )
+
+A one-dimensional spectral-element space. The second form builds the
+[`Grids.SpectralElementGrid1D`](@ref) and forwards `kwargs` to it;
+`discretization = Grids.DG()` makes the space discontinuous across element
+boundaries, and omitting it follows the quadrature. Read the choice back with
+[`Spaces.discretization`](@ref).
 """
 struct SpectralElementSpace1D{G} <: AbstractSpectralElementSpace
     grid::G
@@ -82,12 +89,32 @@ end
 
 # 2D
 """
-    SpectralElementSpace2D(grid::SpectralElementGrid1D)
+    SpectralElementSpace2D(grid::Grids.SpectralElementGrid2D)
     SpectralElementSpace2D(
         topology::Topologies.Topology2D,
         quadrature_style::Quadratures.QuadratureStyle;
+        discretization = nothing,
         kwargs...,
     )
+
+A two-dimensional spectral-element space. The second form builds the
+[`Grids.SpectralElementGrid2D`](@ref) and forwards `kwargs` to it
+(`discretization`, `enable_bubble`, `enable_mask`, `autodiff_metric`, `VIJH`);
+`discretization = Grids.DG()` makes the space discontinuous across element
+boundaries, so [`Spaces.weighted_dss!`](@ref) is a no-op and inter-element
+coupling goes through numerical fluxes. Omitting it follows the quadrature.
+Read the choice back with [`Spaces.discretization`](@ref).
+
+# Examples
+
+```julia
+space = Spaces.SpectralElementSpace2D(topology, Quadratures.GLL{4}())
+dg_space = Spaces.SpectralElementSpace2D(
+    topology,
+    Quadratures.GLL{4}();
+    discretization = Grids.DG(),
+)
+```
 """
 struct SpectralElementSpace2D{G} <: AbstractSpectralElementSpace
     grid::G

--- a/test/CommonSpaces/unit_common_spaces.jl
+++ b/test/CommonSpaces/unit_common_spaces.jl
@@ -143,6 +143,82 @@ warp_surface_elev(coord, hc::FT) where {FT} =
     @test grid isa Grids.SpectralElementGrid2D
     @test Grids.topology(grid).mesh isa Meshes.RectilinearMesh
 
+    # `discretization` reaches the horizontal spectral-element grid through
+    # every constructor that builds one; omitted, it follows the quadrature,
+    # so GLL nodes give CG.
+    @test Spaces.discretization(space) === Grids.CG()
+    dg_space = RectangleXYSpace(
+        FT;
+        x_min = FT(0),
+        x_max = FT(1),
+        y_min = FT(0),
+        y_max = FT(1),
+        periodic_x = true,
+        periodic_y = true,
+        n_quad_points = 4,
+        x_elem = 3,
+        y_elem = 4,
+        discretization = Grids.DG(),
+    )
+    @test Spaces.discretization(dg_space) === Grids.DG()
+    @test !Spaces.is_continuous(dg_space)
+    dg_space = ExtrudedCubedSphereSpace(
+        FT;
+        z_elem = 10,
+        z_min = FT(0),
+        z_max = FT(1),
+        radius = FT(10),
+        h_elem = 10,
+        n_quad_points = 4,
+        staggering = CellCenter(),
+        discretization = Grids.DG(),
+    )
+    @test Spaces.discretization(dg_space) === Grids.DG()
+    @test Spaces.discretization(Spaces.horizontal_space(dg_space)) ===
+          Grids.DG()
+    dg_space = CubedSphereSpace(
+        FT;
+        radius = FT(10),
+        n_quad_points = 4,
+        h_elem = 10,
+        discretization = Grids.DG(),
+    )
+    @test Spaces.discretization(dg_space) === Grids.DG()
+    dg_space = Box3DSpace(
+        FT;
+        z_elem = 10,
+        x_min = FT(0),
+        x_max = FT(1),
+        y_min = FT(0),
+        y_max = FT(1),
+        z_min = FT(0),
+        z_max = FT(10),
+        periodic_x = true,
+        periodic_y = true,
+        n_quad_points = 4,
+        x_elem = 3,
+        y_elem = 4,
+        staggering = CellCenter(),
+        discretization = Grids.DG(),
+    )
+    @test Spaces.discretization(dg_space) === Grids.DG()
+    if !(ClimaComms.device() isa ClimaComms.CUDADevice)
+        dg_space = SliceXZSpace(
+            FT;
+            z_elem = 10,
+            x_min = FT(0),
+            x_max = FT(1),
+            z_min = FT(0),
+            z_max = FT(1),
+            periodic_x = true,
+            n_quad_points = 4,
+            x_elem = 4,
+            staggering = CellCenter(),
+            discretization = Grids.DG(),
+        )
+        @test Spaces.discretization(dg_space) === Grids.DG()
+    end
+
     lats = [0.0, 3.0, 5.0]
     longs = [0.0, 4.0, 7.0]
     points = [


### PR DESCRIPTION
## Purpose

Small enabling changes for DG/CG switching:

- `CommonGrids`/`CommonSpaces` constructors that build a horizontal spectral-element grid accept `discretization = Grids.DG()`. Simplifies building a DG space (rather than going through the low-level `Domain → Mesh → Topology → Space` path), as shown in Bickley jet example.
- Docstring fixes: `SpectralElementSpace1D/2D` name the keywords they forward; `CentralNumericalFlux` and `RusanovNumericalFlux` state their formulas, the caller contract, and an example; additional example for `scalar_laplacian`; `PointSpace` disambiguates itself from `MultiPointSpace` and `MultiColumnFiniteDifferenceSpace`