### PR TITLE
Accelerate tensor divergence (and minor robustness fixes)

### DIFF
--- a/docs/src/operators.md
+++ b/docs/src/operators.md
@@ -140,11 +140,6 @@ The Laplacian below couples elements two ways: [`SIPGLaplacianFlux`](@ref) at
 the faces, and a jump correction folded into the volume divergence. Including
 both ensures order of accuracy is maintained with a symmetric operator.
 
-[`cartesian_tensor_divergence`](@ref) computes the divergence of a rank-2 flux
-tensor (e.g. the momentum flux `ρu⊗u`). The weak `Divergence` is computed
-by rotating the momentum axis into the global Cartesian basis, where the Christoffel symbols
-outside the derivative are absent.
-
 ```@docs
 add_numerical_flux_interior!
 add_numerical_flux_boundary!
@@ -176,14 +171,20 @@ NumericalFluxCompletion
 ```
 
 [`cartesian_tensor_divergence`](@ref) uses this same switch to compute the
-divergence of a rank-2 flux tensor (e.g. the momentum flux `ρu⊗u`) on
-either discretization. The weak `Divergence` drops the Christoffel terms
+horizontal divergence of a rank-2 flux tensor (e.g. the momentum flux `ρu⊗u`)
+on either discretization. The weak `Divergence` drops the Christoffel terms
 `Γⁱ_jk Tʲᵏ` on the tensor's momentum axis on a curved space; the helper first
 rotates that momentum axis into the global Cartesian basis (where the
 Christoffel symbols vanish), then applies `Divergence` and completes the
 interfaces with the supplied completion, so the plain operator becomes exact on
 both CG and DG. Casting the conservation law's momentum components in the
 Cartesian basis to eliminate the connection terms follows [Vinokur1974](@cite).
+
+Like the spectral `Divergence` it is built from, it differentiates along the
+horizontal directions only, so on an extruded space the vertical flux
+divergence is a separate term. Keep that term in the Cartesian frame too — the
+connection terms it drops are removed by the same rotation — and rotate it back
+with `Geometry.LocalVector`. The docstring below works the pair through.
 
 ```@docs
 cartesian_tensor_divergence

--- a/src/Operators/tensordivergence.jl
+++ b/src/Operators/tensordivergence.jl
@@ -20,27 +20,70 @@
 """
     cartesian_tensor_divergence(T, completion, faceargs...)
 
-Weak-form divergence `∇·T` of a rank-2 flux tensor field `T` (e.g. the momentum
-flux `ρu⊗u`). On a curved space `∇·T` carries a Christoffel connection term on
-`T`'s momentum axis that the weak `Divergence` omits; rotating that axis into the
-global Cartesian basis, where the Christoffel symbols vanish, makes the omission
-exact. So the momentum (second) axis is rotated to Cartesian
-(`Geometry.CartesianTensor`), `Divergence` is applied, and the result rotated
-back to the local frame (`Geometry.LocalVector`); on a plane
-(`CartesianGlobalGeometry`) both rotations are the identity.
+Weak-form horizontal divergence `∇ₕ·T` of a rank-2 flux tensor field `T` (e.g.
+the momentum flux `ρu⊗u`). On a curved space `∇·T` carries a Christoffel
+connection term on `T`'s momentum axis that the weak `Divergence` omits;
+rotating that axis into the global Cartesian basis, where the Christoffel
+symbols vanish, makes the omission exact. So the momentum (second) axis is
+rotated to Cartesian (`Geometry.CartesianTensor`), `Divergence` is applied, and
+the result rotated back to the local frame (`Geometry.LocalVector`); on a plane
+(`CartesianGlobalGeometry`) both rotations are the identity and are skipped.
 
-`T`'s momentum axis must be the full 3D `UVWAxis`; on a 2D horizontal shell
-promote it first, e.g. `(ρu) ⊗ Geometry.project(Geometry.UVWAxis(), u)`.
+Like the spectral `Divergence` it is built from, this differentiates along the
+two horizontal directions only, so on an extruded space the vertical flux
+divergence is a separate term. That term drops the same connection terms, so
+rotate its flux tensor to Cartesian as well before differencing it, as in the
+example below.
+
+The result is a 3D `Geometry.UVWVector`, whose `w` component on the sphere is
+the curvature term — `-|u|²/R` for `u⊗u` under solid-body rotation, the same
+order as the tangential components. A model carrying horizontal-only momentum
+has to drop it, e.g. with
+`Geometry.project(Geometry.UVAxis(), ...)`.
+
+`T`'s momentum (second) axis must be a local orthonormal axis; a `UVAxis` is
+read as a `UVWAxis` with `w == 0`. On a discontinuous space the transport
+(first) axis must be orthonormal too, because `numflux` contracts it against
+the local orthonormal face normal.
 
 `completion` (from [`tendency_completion`](@ref)) couples element interfaces —
 DSS on a CG space, the numerical flux on a DG one, the same CG↔DG switch as
 [`complete_tendency!`](@ref). On a DG space `faceargs...` are the trailing
 arguments of the completion's `numflux` (the Cartesian tensor is its first face
-argument, and the flux must return a `Cartesian123Vector`); on a CG space they
-are unused.
+argument, and the flux must return the momentum vector it produces from that
+tensor, whose `UVW` components are global Cartesian); on a CG space they
+are unused, as is the completion's DSS buffer — the buffer this needs is one
+for its own `UVWVector` result, which it owns — so a model can pass the
+completion it built for its own tendency.
 
-Allocates the result and a Cartesian-tensor scratch field;
-[`cartesian_tensor_divergence!`](@ref) takes both and is allocation-free.
+Allocates the result, and the Cartesian-tensor scratch wherever the rotation is
+not the identity; [`cartesian_tensor_divergence!`](@ref) takes both buffers and
+is allocation-free.
+
+# Examples
+
+The whole `∇·T` on an extruded space, the vertical flux divergence carrying the
+same rotation. `ᶜT` is the flux tensor on cell centers and `ᶠT` the same flux
+on faces:
+
+```julia
+geom = Spaces.global_geometry(axes(ᶜT))
+ᶜcoords = Fields.coordinate_field(axes(ᶜT))
+ᶠcoords = Fields.coordinate_field(axes(ᶠT))
+
+ᶜdivₕ = Operators.cartesian_tensor_divergence(ᶜT, completion)
+
+ᶠTc = @. Geometry.CartesianTensor(ᶠT, geom, ᶠcoords)
+ᶜdivᵥ = Operators.DivergenceF2C().(ᶠTc)
+
+ᶜdivT = @. ᶜdivₕ + Geometry.LocalVector(ᶜdivᵥ, geom, ᶜcoords)
+```
+
+Differencing the local-frame `ᶠT` leaves the connection terms of the vertical
+derivative in place, an error that on a topographic sphere runs larger than the
+divergence itself (1.8x its peak at Ne = 4, GLL{4}, 10 levels). The two terms
+are rotated back one at a time here, which agrees with rotating their sum to
+roundoff, the rotation being linear.
 
 ## References
 
@@ -49,12 +92,14 @@ Allocates the result and a Cartesian-tensor scratch field;
 """
 function cartesian_tensor_divergence(T, completion, faceargs...)
     space = axes(T)
-    coords = Fields.coordinate_field(space)
     FT = Spaces.undertype(space)
-    global_geom = Spaces.global_geometry(space)
-    Tc = @. Geometry.CartesianTensor(T, global_geom, coords)
+    rotation = _momentum_rotation(space)
+    # `_cartesian_momentum` allocates `Tc` already rotated, so this path runs
+    # the three steps itself; routing it through
+    # `cartesian_tensor_divergence!` would rotate a second time.
+    Tc = _cartesian_momentum(T, rotation)
     out = Fields.Field(Geometry.UVWVector{FT}, space)
-    return cartesian_tensor_divergence!(out, Tc, T, completion, faceargs...)
+    return _tensor_divergence_completed!(out, Tc, rotation, completion, faceargs...)
 end
 
 """
@@ -62,28 +107,122 @@ end
 
 In-place [`cartesian_tensor_divergence`](@ref): writes the divergence into the
 local-frame vector field `out`, using the rank-2 field `Tc` as scratch for the
-Cartesian-rotated flux. Neither `out` nor `Tc` may alias `T`. Returns `out`.
+Cartesian-rotated flux. Neither `out` nor `Tc` may alias `T`. `Tc` is untouched
+on a plane, where the rotation is the identity and `T` is differentiated
+directly. Returns `out`.
+
+Rotating the momentum axis widens it to the full 3D `UVWAxis`, so `similar(T)`
+is a wide enough scratch only when `T`'s momentum axis already is, and a
+narrower `Tc` raises an error. Given a `UVAxis` momentum, allocate `Tc` from
+the rotation, as the allocating form does, or promote the momentum vector
+before forming the flux.
 
 Allocation-free given the two buffers.
 """
 function cartesian_tensor_divergence!(out, Tc, T, completion, faceargs...)
-    space = axes(T)
-    coords = Fields.coordinate_field(space)
-    global_geom = Spaces.global_geometry(space)
-    @. Tc = Geometry.CartesianTensor(T, global_geom, coords)
-    # Complete the interfaces in the Cartesian frame, then rotate to local.
-    _tensor_divergence_interior!(out, Tc, completion, faceargs...)
-    @. out = Geometry.LocalVector(out, global_geom, coords)
+    rotation = _momentum_rotation(axes(T))
+    Tcart = _cartesian_momentum!(Tc, T, rotation)
+    return _tensor_divergence_completed!(out, Tcart, rotation, completion, faceargs...)
+end
+
+# The momentum-axis rotation as a field of matrices on the horizontal space,
+# or `nothing` where it is the identity. `local_to_cartesian` reads latitude
+# and longitude alone, so on an extruded space the rotation lives on
+# `horizontal_space(space)` and holds `N_z` times fewer entries than the field
+# it multiplies: 0.42 MiB against 12.66 MiB at Ne = 8, GLL{4}, 30 levels,
+# Float64.
+#
+# It is memoized because `local_to_cartesian` costs four `sind`/`cosd` per node
+# and the operator needs it twice per call: a CG call at that resolution takes
+# 8.9 ms with the cache and 17.7 ms without. The nine numbers per node are
+# released by `Utilities.Cache.clean_cache!()`. `clean_cache!(grid)` does not
+# release them: it filters on the cached value, and the grid appears here in the
+# key, so a sweep over many grids has to call the no-argument form (the same
+# holds for `dg_connectivity` and `_momentum_dss_buffer`). The key omits the
+# global geometry, which holds while `local_to_cartesian` resolves to a single
+# method for spherical geometries; a geometry whose local vertical departs from
+# the radial direction would need its own key.
+#
+# `@inline` so that `horizontal_space` folds into the caller: left as a call it
+# allocates its 16 B wrapper on an extruded space, which the zero-allocation
+# gate in allocs_spectral_ops.jl catches.
+@inline _momentum_rotation(space) =
+    _momentum_rotation(Spaces.global_geometry(space), Spaces.horizontal_space(space))
+
+# On a plane the local orthonormal frame is the global Cartesian frame.
+_momentum_rotation(::Geometry.CartesianGlobalGeometry, hspace) = nothing
+
+function _momentum_rotation(
+    global_geometry::Geometry.AbstractSphericalGlobalGeometry,
+    hspace,
+)
+    coords = Fields.coordinate_field(hspace)
+    RT = Utilities.return_type(
+        Geometry.local_to_cartesian,
+        Tuple{typeof(global_geometry), eltype(coords)},
+    )
+    rotation = get!(
+        Cache.OBJECT_CACHE,
+        (:MomentumRotation, Spaces.grid(hspace), typeof(hspace)),
+    ) do
+        field = Fields.Field(RT, hspace)
+        field .= Geometry.local_to_cartesian.(Ref(global_geometry), coords)
+        return field
+    end
+    # The assertion recovers the concrete field type lost through the untyped
+    # cache, so the caller keeps a statically known type.
+    return rotation::Utilities.return_type(
+        Fields.Field,
+        Tuple{Type{RT}, typeof(hspace)},
+    )
+end
+
+# `G` rotates local→Cartesian, so post-multiplying by `G'` rotates each row's
+# momentum vector the same way ((T*G')[i,j] = Σₖ T[i,k] G[j,k]), and `G'` on
+# the left inverts it on the result vector.
+@inline _rotate_momentum(t, G) = t * adjoint(G)
+
+_cartesian_momentum(T, ::Nothing) = T
+_cartesian_momentum(T, rotation) = @. _rotate_momentum(T, rotation)
+
+_cartesian_momentum!(Tc, T, ::Nothing) = T
+function _cartesian_momentum!(Tc, T, rotation)
+    # The rotation widens a `UVAxis` momentum to the full `UVWAxis`, and
+    # assigning the wider tensor into a narrower field drops the Cartesian `w`
+    # column and returns a wrong answer — off by 36% of the peak value for a
+    # `UVVector` ⊗ `UVVector` flux at Ne = 3 — so the scratch eltype is checked
+    # here. The types are compile-time constants, so the comparison folds away
+    # and the message is built only on the error path.
+    rotated = Utilities.return_type(
+        _rotate_momentum,
+        Tuple{eltype(T), eltype(rotation)},
+    )
+    eltype(Tc) === rotated || error(
+        "cartesian_tensor_divergence! needs a scratch field of eltype \
+         $rotated for a flux tensor of eltype $(eltype(T)), but got \
+         $(eltype(Tc)); `similar(T)` is wide enough only when the momentum \
+         axis of `T` is already the 3D UVWAxis",
+    )
+    @. Tc = _rotate_momentum(T, rotation)
+    return Tc
+end
+
+_local_momentum!(out, ::Nothing) = out
+function _local_momentum!(out, rotation)
+    @. out = adjoint(rotation) * out
     return out
 end
 
 # DG: the weak volume term on a mass-weighted (`WJ`) residual, completed at
 # element faces by `numflux` (and the one-sided boundary flux, when given).
+# The `WJ` normalization and the rotation back to the local frame share one
+# broadcast, so the tail costs one kernel launch and one pass over `out`.
 # `faceargs::Vararg{Any, N}` for the same specialization reason as the face
 # operators it calls into (see `add_numerical_flux_interior!`).
-function _tensor_divergence_interior!(
+function _tensor_divergence_completed!(
     out,
     Tc,
+    rotation,
     completion::NumericalFluxCompletion,
     faceargs::Vararg{Any, N},
 ) where {N}
@@ -97,24 +236,47 @@ function _tensor_divergence_interior!(
         Tc,
         faceargs...,
     )
-    @. out = -out / lgeom.WJ
+    if isnothing(rotation)
+        @. out = -out / lgeom.WJ
+    else
+        @. out = adjoint(rotation) * (-out / lgeom.WJ)
+    end
     return out
 end
 
 # CG: the weak volume term assembled across elements by DSS. `weighted_dss!`
 # leaves orthonormal vectors unprojected (a plain weighted sum), and the
 # momentum components are still in the one global Cartesian basis here, so the
-# two sides of every shared node are summed in the same frame — the rotation to
-# local happens only afterwards, in `cartesian_tensor_divergence!`. `faceargs`
-# are unused: a continuous space imposes interface coupling by DSS, not fluxes.
-function _tensor_divergence_interior!(
+# two sides of a shared node are summed in the same frame — the rotation to
+# local follows the DSS. `faceargs` are unused: a continuous space imposes
+# interface coupling by DSS, not fluxes.
+function _tensor_divergence_completed!(
     out,
     Tc,
+    rotation,
     completion::DSSCompletion,
     faceargs...,
 )
     wdiv = Divergence{WeakForm}()
     @. out = wdiv(Tc)
-    Spaces.weighted_dss!(out, completion.buffer)
-    return out
+    Spaces.weighted_dss!(out, _momentum_dss_buffer(out))
+    return _local_momentum!(out, rotation)
+end
+
+# The DSS buffer for the divergence result, memoized on the grid like the
+# rotation. It is owned here because a `DSSCompletion` carries a buffer sized
+# for the model's tendency, whose eltype is in general not the `UVWVector` this
+# operator assembles, and `weighted_dss!` on a mismatched buffer errors inside
+# the DSS transform.
+function _momentum_dss_buffer(out)
+    space = axes(out)
+    buffer = get!(
+        () -> Spaces.create_dss_buffer(out),
+        Cache.OBJECT_CACHE,
+        (:MomentumDSSBuffer, Spaces.grid(space), typeof(space), eltype(out)),
+    )
+    return buffer::Utilities.return_type(
+        Spaces.create_dss_buffer,
+        Tuple{typeof(out)},
+    )
 end

--- a/test/Operators/spectralelement/allocs_spectral_ops.jl
+++ b/test/Operators/spectralelement/allocs_spectral_ops.jl
@@ -11,6 +11,8 @@ import ClimaCore: Fields, Spaces, Operators, Geometry
 );
 import .TestUtilities as TU
 
+include("utils_tensor_divergence.jl")
+
 # Allocation gates mirroring `benchmark_ops.jl`. Bare operator applications stay
 # at zero allocations and will NOT catch per-slab rebuild allocations (~180 kB
 # per call in a real tendency), so these kernels deliberately compose operators
@@ -54,5 +56,61 @@ u_cross_curl_u!(dest, u, f, curl) = (
         # These two apply a `UnionAll` vector constructor on top of an operator.
         TU.@test_zero_allocations wcurl_curl!(du, u, curl, wcurl)
         TU.@test_zero_allocations u_cross_curl_u!(du, u, f, curl)
+    end
+end
+
+cartesian_tensor_div!(out, Tc, T, completion) = (
+    Operators.cartesian_tensor_divergence!(out, Tc, T, completion);
+    nothing
+)
+
+# The buffers and completion the gate below measures against. The momentum axis
+# is UVW, so `similar(T)` is a wide enough scratch for the rotated tensor.
+function tensor_div_alloc_setup(::Type{FT}, space) where {FT}
+    coords = Fields.coordinate_field(space)
+    v = Geometry.UVVector.(cosd.(coords.lat), sind.(coords.long))
+    m = local_cartesian_field(
+        space,
+        Geometry.Cartesian123Vector(FT(0.3), FT(-0.7), FT(0.5)),
+    )
+    T = v .⊗ m
+    out = Fields.Field(Geometry.UVWVector{FT}, space)
+    completion = tensor_div_completion(
+        space;
+        numflux = Operators.CentralNumericalFlux(identity),
+    )
+    return (out, similar(T), T, completion)
+end
+
+# The tensor divergence reaches two memoized objects — the momentum rotation
+# and, on a continuous space, its own DSS buffer — through the untyped object
+# cache, so a lost type assertion there surfaces here as boxing.
+@testset "Cartesian tensor divergence does not allocate" begin
+    TU.@test_precisions FT begin
+        for discretization in (Spaces.CG(), Spaces.DG())
+            space = tensor_div_sphere_space(FT; helem = 3, discretization)
+            out, Tc, T, completion = tensor_div_alloc_setup(FT, space)
+            TU.@test_zero_allocations cartesian_tensor_div!(
+                out,
+                Tc,
+                T,
+                completion,
+            )
+        end
+    end
+    # On an extruded space the rotation comes from the horizontal space, which
+    # puts `Spaces.horizontal_space` in the hot path, where it allocates 16 B
+    # unless `_momentum_rotation` inlines it (it is marked `@inline` for this).
+    # Float64 alone: that inlining does not turn on precision, and each extruded
+    # space costs ~10 s to specialize.
+    for discretization in (Spaces.CG(), Spaces.DG())
+        space = tensor_div_topography_space(
+            Float64;
+            helem = 3,
+            nz = 6,
+            discretization,
+        )
+        out, Tc, T, completion = tensor_div_alloc_setup(Float64, space)
+        TU.@test_zero_allocations cartesian_tensor_div!(out, Tc, T, completion)
     end
 end

--- a/test/Operators/spectralelement/conv_cartesian_tensor_divergence.jl
+++ b/test/Operators/spectralelement/conv_cartesian_tensor_divergence.jl
@@ -1,13 +1,9 @@
 using Test
-using LinearAlgebra
-using StaticArrays
-using IntervalSets
 import ClimaComms
 ClimaComms.@import_required_backends
 
 import ClimaCore
-import ClimaCore:
-    Fields, Domains, Meshes, Topologies, Spaces, Operators, Geometry, Quadratures
+import ClimaCore: Fields, Geometry, Operators, Spaces
 import ClimaCore.Geometry: ⊗
 
 @isdefined(TU) || include(
@@ -15,237 +11,31 @@ import ClimaCore.Geometry: ⊗
 );
 import .TestUtilities as TU
 
-include("utils_dg.jl") # dg_sphere_space, dg_divergence
+include("utils_tensor_divergence.jl")
 
-# Christoffel-free Cartesian tensor divergence ∇·T
-# (Operators.cartesian_tensor_divergence). The weak Divergence drops the
-# connection term Γⁱ_jk Tʲᵏ ; rotating that axis into the global Cartesian basis makes it exact.
-# The element interfaces are completed by an AbstractTendencyCompletion built
-# from the space, so the same operator runs on DG (interface numerical flux) and
-# CG (DSS) spaces. Verified: (1) an exact algebraic identity that holds to
-# roundoff at any resolution, (2) the connection term being O(1) when omitted,
-# (3) h-refinement convergence to an analytic divergence on both discretizations.
+# h-refinement of `Operators.cartesian_tensor_divergence` against analytic
+# divergences on the sphere, on both discretizations. The design rate for the
+# divergence of a GLL{4} (degree-3) field is 3. Two references: v⊗m with m
+# constant in the Cartesian frame, where the momentum components the derivative
+# sees are constant; and u⊗u for solid-body rotation, where they vary with
+# position and the exact answer carries a radial curvature term of the same
+# order as the tangential ones.
 
-# A cubed-sphere CG spectral-element space (default continuous discretization),
-# the continuous counterpart of `dg_sphere_space`.
-function cg_sphere_space(::Type{FT}; radius = FT(6.371e6), helem = 4, Nq = 4) where {FT}
-    hdomain = Domains.SphereDomain(radius)
-    hmesh = Meshes.EquiangularCubedSphere(hdomain, helem)
-    htopology = Topologies.Topology2D(ClimaComms.SingletonCommsContext(), hmesh)
-    return Spaces.SpectralElementSpace2D(htopology, Quadratures.GLL{Nq}())
-end
-
-# The interface-completion object the operator dispatches on: a
-# NumericalFluxCompletion on a DG space, a DSSCompletion on a CG one. `numflux`
-# is unused on CG spaces but harmless to pass.
-tensor_div_completion(space; numflux) = Operators.tendency_completion(
-    Fields.Field(Geometry.UVWVector{Spaces.undertype(space)}, space);
-    numflux,
+@testset "Cartesian tensor divergence: h-convergence, v⊗m [$name]" for (
+    name,
+    discretization,
+) in (
+    ("DG sphere", Spaces.DG()),
+    ("CG sphere", Spaces.CG()),
 )
-
-# Field of a constant global-Cartesian vector expressed in the local frame. The
-# closure captures the (typed) constant so the bare Tensor does not drag
-# StaticArrays' broadcast style into the Field broadcast.
-function local_cartesian_field(space, vcart::Geometry.Cartesian123Vector)
-    gg = Spaces.global_geometry(space)
-    coords = Fields.coordinate_field(space)
-    rgg = Ref(gg)
-    f(geom, coord) = Geometry.LocalVector(vcart, geom, coord)
-    return f.(rgg, coords)
-end
-
-# Naive un-rotated tensor divergence: the same weak volume term + central
-# interface flux as cartesian_tensor_divergence, but WITHOUT the momentum-axis
-# rotation. On a curved space this omits the connection term.
-function naive_tensor_divergence(T)
-    space = axes(T)
-    lgeom = Fields.local_geometry_field(space)
-    wdiv = Operators.Divergence{Operators.WeakForm}()
-    r = @. wdiv(T) * (-(lgeom.WJ))
-    Operators.add_numerical_flux_interior!(
-        Operators.CentralNumericalFlux(identity), r, T,
-    )
-    return @. -r / lgeom.WJ
-end
-
-# The exact identity holds at any precision, so it runs in Float32 and Float64
-# (with a precision-aware tolerance).
-@testset "Cartesian tensor divergence: exact v⊗m identity (sphere) [$FT]" for FT in
-                                                                              (
-    Float32,
-    Float64,
-)
-    central = Operators.CentralNumericalFlux(identity)
-    # Algebraic identity ⇒ agreement to a few ULP, not the analytic error.
-    rtol = FT == Float32 ? FT(1e-4) : FT(1e-11)
-    for helem in (3, 6)
-        space = dg_sphere_space(FT; helem, Nq = 4)
-        @test !Spaces.is_continuous(space)
-        coords = Fields.coordinate_field(space)
-
-        # constant global-Cartesian momentum, expressed in the local frame
-        mcart = Geometry.Cartesian123Vector(FT(0.3), FT(-0.7), FT(0.5))
-        mloc = local_cartesian_field(space, mcart)
-
-        # arbitrary smooth tangent transport velocity
-        v = @. Geometry.UVVector(
-            sind(coords.long) * cosd(coords.lat),
-            cosd(coords.long),
-        )
-        T = @. v ⊗ mloc  # (UVAxis transport, UVWAxis momentum)
-
-        completion = tensor_div_completion(space; numflux = central)
-        dT = Operators.cartesian_tensor_divergence(T, completion)
-
-        dv = dg_divergence(v)
-        ref = @. dv * mloc
-        maxref = maximum(abs, parent(ref))
-        @test maximum(abs, parent(@. dT - ref)) / maxref < rtol
-    end
-end
-
-@testset "Cartesian tensor divergence: magnitude of missing christoffel terms (sphere) [$FT]" for FT in
-                                                                                                  (
-    Float32,
-    Float64,
-)
-    space = dg_sphere_space(FT; helem = 6, Nq = 4)
-    coords = Fields.coordinate_field(space)
-    mcart = Geometry.Cartesian123Vector(FT(0.3), FT(-0.7), FT(0.5))
-    mloc = local_cartesian_field(space, mcart)
-    v = @. Geometry.UVVector(
-        sind(coords.long) * cosd(coords.lat),
-        cosd(coords.long),
-    )
-    T = @. v ⊗ mloc
-
-    completion = tensor_div_completion(
-        space;
-        numflux = Operators.CentralNumericalFlux(identity),
-    )
-    dT = Operators.cartesian_tensor_divergence(T, completion)
-    dT_naive = naive_tensor_divergence(T)
-    maxref = maximum(abs, parent(dT))
-    # Dropping the connection term is an O(1) error, not roundoff.
-    @test maximum(abs, parent(@. dT_naive - dT)) / maxref > 1e-2
-end
-
-@testset "Cartesian tensor divergence: in-place is allocation-free (sphere)" begin
-    FT = Float64
-    space = dg_sphere_space(FT; helem = 6, Nq = 4)
-    coords = Fields.coordinate_field(space)
-    mcart = Geometry.Cartesian123Vector(FT(0.3), FT(-0.7), FT(0.5))
-    mloc = local_cartesian_field(space, mcart)
-    v = @. Geometry.UVVector(
-        sind(coords.long) * cosd(coords.lat),
-        cosd(coords.long),
-    )
-    T = @. v ⊗ mloc
-    central = Operators.CentralNumericalFlux(identity)
-    completion = tensor_div_completion(space; numflux = central)
-
-    # caller-owned buffers
-    Tc = similar(T)
-    out = Fields.Field(Geometry.UVWVector{FT}, space)
-    # function barrier: type the captured buffers so @allocated sees the true
-    # (heap-boxing-free) cost rather than boxing from @testset soft scope.
-    function alloc_bytes(out, Tc, T, completion)
-        Operators.cartesian_tensor_divergence!(out, Tc, T, completion)  # warm up
-        return @allocated Operators.cartesian_tensor_divergence!(
-            out, Tc, T, completion,
-        )
-    end
-    @test alloc_bytes(out, Tc, T, completion) == 0
-end
-
-@testset "Cartesian tensor divergence: h-convergence to analytic (sphere)" begin
     FT = Float64
     R = FT(6.371e6)
     central = Operators.CentralNumericalFlux(identity)
     helems = (3, 6, 12)
     errs = zeros(FT, length(helems))
     for (i, helem) in enumerate(helems)
-        space = dg_sphere_space(FT; radius = R, helem, Nq = 4)
-        coords = Fields.coordinate_field(space)
-
-        mcart = Geometry.Cartesian123Vector(FT(0.3), FT(-0.7), FT(0.5))
-        mloc = local_cartesian_field(space, mcart)
-
-        # v = (0, cosφ): purely meridional, analytic surface divergence
-        # ∇·v = -2 sinφ / R, so ∇·(v⊗m) = (-2 sinφ / R) m.
-        v = @. Geometry.UVVector(FT(0), cosd(coords.lat))
-        T = @. v ⊗ mloc
-        completion = tensor_div_completion(space; numflux = central)
-        dT = Operators.cartesian_tensor_divergence(T, completion)
-
-        div_v_exact = @. -2 * sind(coords.lat) / R
-        dT_exact = @. div_v_exact * mloc
-        errs[i] = maximum(abs, parent(@. dT - dT_exact))
-    end
-    Δh = [FT(1) / helem for helem in helems]
-    rates = TU.convergence_rate(errs, Δh)
-    @info "Cartesian tensor divergence convergence (sphere)" errs rates
-    @test all(rates .>= 2.5)
-    @test errs[end] < errs[1] / 50
-end
-
-@testset "Cartesian tensor divergence: planar identity path" begin
-    FT = Float64
-    central = Operators.CentralNumericalFlux(identity)
-    # Doubly-periodic plane: global_geometry is CartesianGlobalGeometry, so the
-    # rotations are the identity and the naive form is already exact.
-    L = FT(2π)
-    errs = zeros(FT, 2)
-    nelems = (4, 8)
-    for (i, nelem) in enumerate(nelems)
-        context = ClimaComms.SingletonCommsContext()
-        domain = Domains.RectangleDomain(
-            Geometry.XPoint{FT}(zero(L)) .. Geometry.XPoint{FT}(L),
-            Geometry.YPoint{FT}(zero(L)) .. Geometry.YPoint{FT}(L);
-            x1periodic = true,
-            x2periodic = true,
-        )
-        mesh = Meshes.RectilinearMesh(domain, nelem, nelem)
-        topology = Topologies.Topology2D(context, mesh)
-        space = Spaces.SpectralElementSpace2D(
-            topology,
-            Quadratures.GLL{4}();
-            discretization = Spaces.DG(),
-        )
-        coords = Fields.coordinate_field(space)
-
-        # constant momentum (identity rotation on a plane) with a w-component
-        mcart = Geometry.Cartesian123Vector(FT(0.3), FT(-0.7), FT(0.5))
-        mloc = local_cartesian_field(space, mcart)
-
-        v = @. Geometry.UVVector(sin(coords.x), sin(coords.y))
-        T = @. v ⊗ mloc
-        completion = tensor_div_completion(space; numflux = central)
-        dT = Operators.cartesian_tensor_divergence(T, completion)
-
-        # On a plane the rotation is the identity: cartesian == naive exactly.
-        @test parent(dT) ≈ parent(naive_tensor_divergence(T))
-
-        div_v_exact = @. cos(coords.x) + cos(coords.y)
-        dT_exact = @. div_v_exact * mloc
-        errs[i] = maximum(abs, parent(@. dT - dT_exact))
-    end
-    @test errs[2] < errs[1] / 4
-end
-
-# The same operator, on a continuous (CG) space, completes the interfaces by
-# DSS instead of a numerical flux. The interface completion is applied while the
-# momentum axis is still Cartesian, so DSS sums one global basis; the result
-# converges to the same analytic divergence as the DG path.
-@testset "Cartesian tensor divergence: h-convergence to analytic (CG sphere)" begin
-    FT = Float64
-    R = FT(6.371e6)
-    central = Operators.CentralNumericalFlux(identity)
-    helems = (3, 6, 12)
-    errs = zeros(FT, length(helems))
-    for (i, helem) in enumerate(helems)
-        space = cg_sphere_space(FT; radius = R, helem, Nq = 4)
-        @test Spaces.is_continuous(space)
+        space = tensor_div_sphere_space(FT; radius = R, helem, discretization)
+        @test Spaces.is_continuous(space) == (discretization isa Spaces.CG)
         coords = Fields.coordinate_field(space)
 
         mcart = Geometry.Cartesian123Vector(FT(0.3), FT(-0.7), FT(0.5))
@@ -255,7 +45,6 @@ end
         v = @. Geometry.UVVector(FT(0), cosd(coords.lat))
         T = @. v ⊗ mloc
         completion = tensor_div_completion(space; numflux = central)
-        @test completion isa Operators.DSSCompletion
         dT = Operators.cartesian_tensor_divergence(T, completion)
 
         div_v_exact = @. -2 * sind(coords.lat) / R
@@ -264,7 +53,38 @@ end
     end
     Δh = [FT(1) / helem for helem in helems]
     rates = TU.convergence_rate(errs, Δh)
-    @info "Cartesian tensor divergence convergence (CG sphere)" errs rates
+    @info "Cartesian tensor divergence convergence, v⊗m ($name)" errs rates
     @test all(rates .>= 2.5)
     @test errs[end] < errs[1] / 50
+end
+
+@testset "Cartesian tensor divergence: h-convergence, u⊗u [$name]" for (
+    name,
+    discretization,
+) in (
+    ("DG sphere", Spaces.DG()),
+    ("CG sphere", Spaces.CG()),
+)
+    FT = Float64
+    R = FT(6.371e6)
+    U = FT(20)
+    central = Operators.CentralNumericalFlux(identity)
+    helems = (3, 6, 12)
+    errs = zeros(FT, length(helems))
+    for (i, helem) in enumerate(helems)
+        space = tensor_div_sphere_space(FT; radius = R, helem, discretization)
+        coords = Fields.coordinate_field(space)
+        u = solid_body_velocity(coords, U)
+        T = @. u ⊗ u
+        completion = tensor_div_completion(space; numflux = central)
+        dT = Operators.cartesian_tensor_divergence(T, completion)
+        dT_exact = solid_body_flux_divergence(coords, U, R)
+        errs[i] = maximum(abs, parent(@. dT - dT_exact))
+    end
+    Δh = [FT(1) / helem for helem in helems]
+    rates = TU.convergence_rate(errs, Δh)
+    @info "Cartesian tensor divergence convergence, u⊗u ($name)" errs rates
+    @test all(rates .>= 2.5)
+    # 49.5x (DG) and 51.7x (CG) measured over the 4x refinement.
+    @test errs[end] < errs[1] / 40
 end

--- a/test/Operators/spectralelement/unit_cartesian_tensor_divergence.jl
+++ b/test/Operators/spectralelement/unit_cartesian_tensor_divergence.jl
@@ -1,0 +1,189 @@
+using Test
+using IntervalSets
+import ClimaComms
+ClimaComms.@import_required_backends
+
+import ClimaCore
+import ClimaCore:
+    Domains, Fields, Geometry, Meshes, Operators, Quadratures, Spaces, Topologies
+import ClimaCore.Geometry: ⊗
+
+include("utils_dg.jl")               # dg_sphere_space
+include("utils_tensor_divergence.jl")
+
+# `Operators.cartesian_tensor_divergence` against the identity
+# ∇ₕ·(v⊗m) = (∇ₕ·v) m, which holds for a transport field `v` of any form once
+# `m` is constant in the global Cartesian frame. It is algebraic, so it holds
+# to roundoff at any resolution — including on the terrain-following extruded
+# sphere, where the rotation meets `LatLongZPoint` coordinates and a warped
+# `∂ξ∂x`.
+
+@testset "Cartesian tensor divergence: exact v⊗m identity (sphere) [$FT]" for FT in
+                                                                              (
+    Float32,
+    Float64,
+)
+    central = Operators.CentralNumericalFlux(identity)
+    # Algebraic identity, so the tolerance sits at a few ULP.
+    rtol = FT == Float32 ? FT(1e-4) : FT(1e-11)
+    for helem in (3, 6)
+        space = dg_sphere_space(FT; helem, Nq = 4)
+        @test !Spaces.is_continuous(space)
+        coords = Fields.coordinate_field(space)
+
+        # constant global-Cartesian momentum, expressed in the local frame
+        mcart = Geometry.Cartesian123Vector(FT(0.3), FT(-0.7), FT(0.5))
+        mloc = local_cartesian_field(space, mcart)
+
+        # arbitrary smooth tangent transport velocity
+        v = @. Geometry.UVVector(
+            sind(coords.long) * cosd(coords.lat),
+            cosd(coords.long),
+        )
+        T = @. v ⊗ mloc  # (UVAxis transport, UVWAxis momentum)
+
+        completion = tensor_div_completion(space; numflux = central)
+        dT = Operators.cartesian_tensor_divergence(T, completion)
+
+        dv = completed_divergence(v)
+        ref = @. dv * mloc
+        maxref = maximum(abs, parent(ref))
+        @test maximum(abs, parent(@. dT - ref)) / maxref < rtol
+    end
+end
+
+@testset "Cartesian tensor divergence: exact v⊗m identity (topography) [$FT]" for FT in
+                                                                                  (
+    Float32,
+    Float64,
+)
+    central = Operators.CentralNumericalFlux(identity)
+    rtol = FT == Float32 ? FT(1e-4) : FT(1e-11)
+    for discretization in (Spaces.CG(), Spaces.DG())
+        space = tensor_div_topography_space(FT; helem = 3, nz = 6, discretization)
+        coords = Fields.coordinate_field(space)
+
+        mcart = Geometry.Cartesian123Vector(FT(0.3), FT(-0.7), FT(0.5))
+        mloc = local_cartesian_field(space, mcart)
+        v = @. Geometry.UVVector(
+            sind(coords.long) * cosd(coords.lat),
+            cosd(coords.long),
+        )
+        T = @. v ⊗ mloc
+
+        completion = tensor_div_completion(space; numflux = central)
+        dT = Operators.cartesian_tensor_divergence(T, completion)
+
+        dv = completed_divergence(v)
+        ref = @. dv * mloc
+        maxref = maximum(abs, parent(ref))
+        @test maximum(abs, parent(@. dT - ref)) / maxref < rtol
+    end
+end
+
+@testset "Cartesian tensor divergence: dropped connection term (sphere) [$FT]" for FT in
+                                                                                   (
+    Float32,
+    Float64,
+)
+    space = dg_sphere_space(FT; helem = 6, Nq = 4)
+    coords = Fields.coordinate_field(space)
+    mcart = Geometry.Cartesian123Vector(FT(0.3), FT(-0.7), FT(0.5))
+    mloc = local_cartesian_field(space, mcart)
+    v = @. Geometry.UVVector(
+        sind(coords.long) * cosd(coords.lat),
+        cosd(coords.long),
+    )
+    T = @. v ⊗ mloc
+
+    completion = tensor_div_completion(
+        space;
+        numflux = Operators.CentralNumericalFlux(identity),
+    )
+    dT = Operators.cartesian_tensor_divergence(T, completion)
+    dT_naive = naive_tensor_divergence(T)
+    maxref = maximum(abs, parent(dT))
+    # The connection term contributes at O(1), far above roundoff.
+    @test maximum(abs, parent(@. dT_naive - dT)) / maxref > 1e-2
+end
+
+# A `UVAxis` momentum axis is read as a `UVWAxis` one with `w == 0`, so a model
+# carrying horizontal momentum needs no promotion before forming the flux.
+@testset "Cartesian tensor divergence: two-component momentum axis" begin
+    FT = Float64
+    central = Operators.CentralNumericalFlux(identity)
+    for discretization in (Spaces.CG(), Spaces.DG())
+        space = tensor_div_sphere_space(FT; helem = 3, discretization)
+        coords = Fields.coordinate_field(space)
+        v = @. Geometry.UVVector(
+            sind(coords.long) * cosd(coords.lat),
+            cosd(coords.long),
+        )
+        m2 = @. Geometry.UVVector(cosd(coords.lat), sind(coords.long))
+        m3 = @. Geometry.UVWVector(cosd(coords.lat), sind(coords.long), FT(0))
+        completion = tensor_div_completion(space; numflux = central)
+        T2 = @. v ⊗ m2
+        d2 = Operators.cartesian_tensor_divergence(T2, completion)
+        d3 = Operators.cartesian_tensor_divergence((@. v ⊗ m3), completion)
+        # `T*G'` contracts three components with the padded `w` and two
+        # without, so the two agree to rounding: 3.5 ULP relative measured at
+        # Ne = 3, ~280x inside this bound.
+        @test maximum(abs, parent(d2) .- parent(d3)) <
+              1000 * eps(FT) * maximum(abs, parent(d3))
+
+        # The rotation widens the momentum axis, so `similar(T2)` is too
+        # narrow: assigning into it drops the Cartesian `w` column.
+        out = Fields.Field(Geometry.UVWVector{FT}, space)
+        @test_throws ErrorException Operators.cartesian_tensor_divergence!(
+            out,
+            similar(T2),
+            T2,
+            completion,
+        )
+    end
+end
+
+@testset "Cartesian tensor divergence: planar identity path" begin
+    FT = Float64
+    central = Operators.CentralNumericalFlux(identity)
+    # Doubly-periodic plane: global_geometry is CartesianGlobalGeometry, so the
+    # rotations are the identity and the naive form is already exact.
+    L = FT(2π)
+    errs = zeros(FT, 2)
+    nelems = (4, 8)
+    for (i, nelem) in enumerate(nelems)
+        context = ClimaComms.SingletonCommsContext()
+        domain = Domains.RectangleDomain(
+            Geometry.XPoint{FT}(zero(L)) .. Geometry.XPoint{FT}(L),
+            Geometry.YPoint{FT}(zero(L)) .. Geometry.YPoint{FT}(L);
+            x1periodic = true,
+            x2periodic = true,
+        )
+        mesh = Meshes.RectilinearMesh(domain, nelem, nelem)
+        topology = Topologies.Topology2D(context, mesh)
+        space = Spaces.SpectralElementSpace2D(
+            topology,
+            Quadratures.GLL{4}();
+            discretization = Spaces.DG(),
+        )
+        coords = Fields.coordinate_field(space)
+
+        # constant momentum (identity rotation on a plane) with a w-component
+        mcart = Geometry.Cartesian123Vector(FT(0.3), FT(-0.7), FT(0.5))
+        mloc = local_cartesian_field(space, mcart)
+
+        v = @. Geometry.UVVector(sin(coords.x), sin(coords.y))
+        T = @. v ⊗ mloc
+        completion = tensor_div_completion(space; numflux = central)
+        dT = Operators.cartesian_tensor_divergence(T, completion)
+
+        # On a plane the rotation is the identity, so the naive form and this
+        # one run the same arithmetic and agree bit for bit.
+        @test parent(dT) == parent(naive_tensor_divergence(T))
+
+        div_v_exact = @. cos(coords.x) + cos(coords.y)
+        dT_exact = @. div_v_exact * mloc
+        errs[i] = maximum(abs, parent(@. dT - dT_exact))
+    end
+    @test errs[2] < errs[1] / 4
+end

--- a/test/Operators/spectralelement/utils_tensor_divergence.jl
+++ b/test/Operators/spectralelement/utils_tensor_divergence.jl
@@ -1,0 +1,141 @@
+# Shared helpers for the Cartesian tensor-divergence tests. Definitions only —
+# no top-level @test (see test/README.md on `utils_` files).
+import ClimaComms
+import ClimaCore:
+    Domains,
+    Fields,
+    Geometry,
+    Hypsography,
+    Meshes,
+    Operators,
+    Quadratures,
+    Spaces,
+    Topologies
+import ClimaCore.Geometry: ⊗
+
+# A cubed-sphere spectral-element space on either discretization.
+function tensor_div_sphere_space(
+    ::Type{FT};
+    radius = FT(6.371e6),
+    helem = 4,
+    Nq = 4,
+    discretization = Spaces.CG(),
+    context = ClimaComms.SingletonCommsContext(),
+) where {FT}
+    hdomain = Domains.SphereDomain(radius)
+    hmesh = Meshes.EquiangularCubedSphere(hdomain, helem)
+    htopology = Topologies.Topology2D(context, hmesh)
+    return Spaces.SpectralElementSpace2D(
+        htopology,
+        Quadratures.GLL{Nq}();
+        discretization,
+    )
+end
+
+# The same sphere extruded over terrain: the geometry where the momentum
+# rotation meets `LatLongZPoint` coordinates, a product `WJ`, and a `∂ξ∂x` the
+# warp has tilted. The O(2 km) surface moves `J` by ~13% from the flat grid.
+function tensor_div_topography_space(
+    ::Type{FT};
+    radius = FT(6.371e6),
+    helem = 4,
+    Nq = 4,
+    nz = 10,
+    ztop = FT(3e4),
+    discretization = Spaces.CG(),
+    context = ClimaComms.SingletonCommsContext(),
+) where {FT}
+    hspace = tensor_div_sphere_space(
+        FT;
+        radius,
+        helem,
+        Nq,
+        discretization,
+        context,
+    )
+    vdomain = Domains.IntervalDomain(
+        Geometry.ZPoint{FT}(0),
+        Geometry.ZPoint{FT}(ztop);
+        boundary_names = (:bottom, :top),
+    )
+    vmesh = Meshes.IntervalMesh(vdomain; nelems = nz)
+    vspace =
+        Spaces.CenterFiniteDifferenceSpace(Topologies.IntervalTopology(context, vmesh))
+    hcoords = Fields.coordinate_field(hspace)
+    z_surface = Geometry.ZPoint.(
+        @. FT(2000) * (cosd(hcoords.lat)^2 * sind(3 * hcoords.long) + 1)
+    )
+    return Spaces.ExtrudedFiniteDifferenceSpace(
+        hspace,
+        vspace,
+        Hypsography.LinearAdaption(z_surface),
+    )
+end
+
+# The interface completion the operator dispatches on, built from a
+# model-shaped state: that holds the operator to working with the completion a
+# model already carries.
+function tensor_div_completion(space; numflux)
+    FT = Spaces.undertype(space)
+    state = Fields.Field(
+        NamedTuple{(:ρ, :ρu), Tuple{FT, Geometry.UVVector{FT}}},
+        space,
+    )
+    return Operators.tendency_completion(state; numflux)
+end
+
+# A constant global-Cartesian vector expressed in the local frame. The closure
+# captures the typed constant, which keeps StaticArrays' broadcast style out of
+# the Field broadcast.
+function local_cartesian_field(space, vcart::Geometry.Cartesian123Vector)
+    gg = Spaces.global_geometry(space)
+    coords = Fields.coordinate_field(space)
+    rgg = Ref(gg)
+    f(geom, coord) = Geometry.LocalVector(vcart, geom, coord)
+    return f.(rgg, coords)
+end
+
+# Weak divergence of a vector field, completed across interfaces the same way
+# `cartesian_tensor_divergence` completes the tensor one — the same volume term
+# and central interface flux — since it is the right-hand side of the
+# `∇ₕ·(v⊗m) = (∇ₕ·v) m` identity.
+function completed_divergence(v)
+    wdiv = Operators.Divergence{Operators.WeakForm}()
+    dv = @. -wdiv(v)
+    completion = Operators.tendency_completion(
+        dv;
+        numflux = Operators.CentralNumericalFlux(identity),
+    )
+    Operators.complete_tendency!(completion, dv, v)
+    return @. -dv
+end
+
+# Tensor divergence with the same weak volume term and central interface flux
+# as `cartesian_tensor_divergence` and no momentum-axis rotation, so on a
+# curved space it omits the connection term.
+function naive_tensor_divergence(T)
+    space = axes(T)
+    lgeom = Fields.local_geometry_field(space)
+    wdiv = Operators.Divergence{Operators.WeakForm}()
+    r = @. wdiv(T) * (-(lgeom.WJ))
+    Operators.add_numerical_flux_interior!(
+        Operators.CentralNumericalFlux(identity),
+        r,
+        T,
+    )
+    return @. -r / lgeom.WJ
+end
+
+# ∇·(u⊗u) for the solid-body zonal flow u = U cosφ êλ on a sphere of radius R.
+# The flow is non-divergent, so this is the advective acceleration
+# (u·∇)u = (u²tanφ/R) êφ − (u²/R) êr: Cartesian momentum components that vary
+# with position, and a radial curvature term of the same order as the
+# tangential ones.
+solid_body_velocity(coords, U) =
+    @. Geometry.UVWVector(U * cosd(coords.lat), zero(U), zero(U))
+
+solid_body_flux_divergence(coords, U, R) = @. Geometry.UVWVector(
+    zero(U),
+    U^2 * cosd(coords.lat) * sind(coords.lat) / R,
+    -U^2 * cosd(coords.lat)^2 / R,
+)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,9 +91,13 @@ unit_tests = [
     UnitTest("Spectral elem - sphere hyperdiff vec"     ,"Operators/spectralelement/unit_sphere_hyperdiffusion_vec.jl"; tier = :unit, subsystem = :operators),
     UnitTest("Spectral elem - sphere hyperdiff vec conv" ,"Operators/spectralelement/conv_sphere_hyperdiffusion_vec.jl"; tier = :conv, subsystem = :operators),
     UnitTest("Spectral elem - over-integration"         ,"Operators/spectralelement/unit_overintegration.jl"; meta = :cpu_only, tier = :unit, subsystem = :operators),
-    # `add_numerical_flux_interior!`/`_boundary!` walk faces in a host loop and
-    # scalar-index the data, so tests built on them either wrap the calls in a
-    # scoped `allowscalar` (the two below) or are :cpu_only (the three after).
+    # Spectral Element - Discontinuous Galerkin (DG) operators
+    # The DG interface fluxes have native GPU kernels in ClimaCoreCUDAExt, so
+    # the operators need no `allowscalar`; unit_two_point_fluxes and
+    # unit_sphere_dg_fluxes wrap their whole testset body in one for their own
+    # scalar-indexing assertions. The conv_ sweeps below are :cpu_only, as are
+    # the allocs_ files, whose byte sentinels count CUDA's host-side launch
+    # wrappers.
     UnitTest("Spectral elem - DG two-point fluxes"      ,"Operators/spectralelement/unit_two_point_fluxes.jl"; tier = :unit, subsystem = :operators),
     UnitTest("Spectral elem - DG sphere fluxes"         ,"Operators/spectralelement/unit_sphere_dg_fluxes.jl"; tier = :unit, subsystem = :operators),
     UnitTest("Spectral elem - DG stability properties"  ,"Operators/spectralelement/unit_dg_stability.jl"; tier = :unit, subsystem = :operators),
@@ -102,6 +106,7 @@ unit_tests = [
     UnitTest("Spectral elem - DG extruded sphere"       ,"Operators/spectralelement/unit_extruded_sphere_dg.jl"; tier = :unit, subsystem = :operators),
     UnitTest("Spectral elem - DG extruded plane"        ,"Operators/spectralelement/unit_extruded_plane_dg.jl"; tier = :unit, subsystem = :operators),
     UnitTest("Spectral elem - tendency completion"      ,"Operators/spectralelement/unit_tendency_completion.jl"; tier = :unit, subsystem = :operators),
+    UnitTest("Spectral elem - Cartesian tensor div"     ,"Operators/spectralelement/unit_cartesian_tensor_divergence.jl"; tier = :unit, subsystem = :operators),
     UnitTest("Spectral elem - DG divergence conv"       ,"Operators/spectralelement/conv_dg_divergence.jl"; meta = :cpu_only, tier = :conv, subsystem = :operators),
     UnitTest("Spectral elem - Cartesian tensor div conv","Operators/spectralelement/conv_cartesian_tensor_divergence.jl"; meta = :cpu_only, tier = :conv, subsystem = :operators),
     UnitTest("Operators - broadcast inference"          ,"Operators/inference_operators.jl"; tier = :inference, subsystem = :operators),


### PR DESCRIPTION
Accelerates `cartesian_tensor_divergence` and `cartesian_tensor_divergence!` on CPU and GPU:

- **Memoized 2D rotation field**: `local_to_cartesian` depends only on $(\lambda, \phi)$, so on extruded spaces the rotation field is now memoized on `Spaces.horizontal_space(space)` rather than duplicating $N_z$ levels in 3D. Cuts rotation cache memory by $N_z$ (**30x** at $N_z = 30$) and keeps matrix entries resident in GPU cache during column broadcasts (L1 cache for small problems).
- **DG kernel fusion**: Fused $WJ$ normalization and Cartesian-to-local rotation (`@. out = adjoint(rotation) * (-out / lgeom.WJ)`), eliminating a kernel launch and a global memory round-trip over the 3D tensor field.
- **Robustness & correctness**: Memoizes a dedicated `_momentum_dss_buffer(out)` to fix CG tendency-type mismatch errors present on `main`, checks scratch field widths for 2-component momentum fluxes, and enables native GPU testing across all tensor-divergence test sets.
- **Test cleanup and updates**: Cleans up tests (abstracts out utilities) and expands them slightly

---

## A100 GPU Performance (vs `main`)

Measured on NVIDIA A100-SXM4-40GB on 3D extruded topography grids ($N_q = 4$, $N_z = 30$, 50 synchronized samples):

| Grid & Discretization | `main` | This PR | Speedup |
| :--- | :---: | :---: | :---: |
| **$helem=16$, Float32 CG** | 0.259 ms | **0.237 ms** | **1.09x** |
| **$helem=16$, Float32 DG** | 1.094 ms | **0.240 ms** | **4.56x** |
| **$helem=16$, Float64 CG** | 0.392 ms | **0.358 ms** | **1.09x** |
| **$helem=16$, Float64 DG** | 0.425 ms | **0.374 ms** | **1.14x** |
| **$helem=30$, Float32 CG** | 0.938 ms | **0.794 ms** | **1.18x** |
| **$helem=30$, Float32 DG** | 1.101 ms | **0.967 ms** | **1.14x** |
| **$helem=30$, Float64 CG** | 1.448 ms | **1.269 ms** | **1.14x** |
| **$helem=30$, Float64 DG** | 1.574 ms | **1.399 ms** | **1.13x** |
