### PR TITLE
Fix improper accesses through CUDA.jl

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,13 @@ ClimaCore.jl Release Notes
 main
 -------
 
+v0.16.1
+-------
+- Bugfixes for compatibilty with CUDA.jl v6 [2628](https://github.com/CliMA/ClimaCore.jl/pull/2628)
+
+v0.16.0
+-------
+
 - ![][badge-✨feature/enhancement] The `CommonGrids` and `CommonSpaces`
   constructors that build a horizontal spectral-element grid
   (`ExtrudedCubedSphereGrid`, `CubedSphereGrid`, `Box3DGrid`, `SliceXZGrid`,

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ClimaCore"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
 
 [deps]

--- a/ext/cuda/operators_fd_eager.jl
+++ b/ext/cuda/operators_fd_eager.jl
@@ -149,7 +149,11 @@ element type cannot go out of sync.
            Tuple{v3_type, x_type} : x_type
 end
 
-ClimaCore.Utilities.unsafe_eltype(::CUDA.CuRefType{T}) where {T} = T
+@static if pkgversion(CUDA) < v"6"
+    ClimaCore.Utilities.unsafe_eltype(::CUDA.CuRefType{T}) where {T} = T
+else
+    ClimaCore.Utilities.unsafe_eltype(::CUDA.CUDACore.CuRefType{T}) where {T} = T
+end
 
 """
     has_padding_thread(space)

--- a/ext/cuda/scopes.jl
+++ b/ext/cuda/scopes.jl
@@ -1,5 +1,6 @@
 import UnrolledUtilities: unrolled_map, unrolled_all, unrolled_allequal, unrolled_flatmap
-import CUDA: LLVM # Used by shmem_pointer to emit a shared-memory global.
+import LLVM # Used by shmem_pointer to emit a shared-memory global.
+import CUDA
 
 const THREADS_PER_WARP = 32
 const MAX_WARPS_PER_BLOCK = 32


### PR DESCRIPTION
These break with CUDA v6

<!-- Provide a clear description of the content -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
