### PR TITLE
Support pressure interpolation on multi-col spaces

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@ ClimaCore.jl Release Notes
 main
 -------
 
+- ![][badge-✨feature/enhancement] `Remapping.PressureInterpolator` supports
+  `MultiColumnFiniteDifferenceSpace`, so fields on multiple independent columns
+  can be interpolated to pressure coordinates like fields on extruded or
+  single-column spaces.
+
 v0.16.1
 -------
 - Bugfixes for compatibilty with CUDA.jl v6 [2628](https://github.com/CliMA/ClimaCore.jl/pull/2628)

--- a/src/InputOutput/writers.jl
+++ b/src/InputOutput/writers.jl
@@ -716,7 +716,7 @@ function write!(
     grid = Spaces.grid(space)
     grid_name = write!(writer, grid)
 
-    # topology is only queried on the distributed path: point-cloud spaces
+    # topology is only queried on the distributed path: multi-point and multi-column spaces
     # have no topology and are single-process only
     if !(writer.context isa ClimaComms.SingletonCommsContext) &&
        Spaces.topology(space) isa Topologies.Topology2D

--- a/src/Remapping/interpolate_pressure.jl
+++ b/src/Remapping/interpolate_pressure.jl
@@ -79,6 +79,7 @@ end
         ::Type{FT},
         space::Union{
             Spaces.ExtrudedFiniteDifferenceSpace,
+            Spaces.MultiColumnFiniteDifferenceSpace,
             Spaces.AbstractFiniteDifferenceSpace,
         },
         pressure_levels,
@@ -96,7 +97,10 @@ Given an input `space`, creates a new space where:
 """
 function construct_pressure_space(
     ::Type{FT},
-    space::Spaces.ExtrudedFiniteDifferenceSpace,
+    space::Union{
+        Spaces.ExtrudedFiniteDifferenceSpace,
+        Spaces.MultiColumnFiniteDifferenceSpace,
+    },
     pressure_levels,
 ) where {FT}
     device = ClimaComms.device(space)
@@ -110,11 +114,7 @@ function construct_pressure_space(
         Grids.Flat(),
         space.grid.global_geometry,
     )
-    pressure_space = Spaces.ExtrudedFiniteDifferenceSpace(
-        grid,
-        Spaces.CellFace(),
-    )
-    return pressure_space
+    return Spaces.space(grid, Spaces.CellFace())
 end
 
 function construct_pressure_space(
@@ -191,6 +191,7 @@ end
         pressure_space::Union{
             Spaces.AbstractFiniteDifferenceSpace,
             Spaces.ExtrudedFiniteDifferenceSpace,
+            Spaces.MultiColumnFiniteDifferenceSpace,
         };
         extrapolate = ClimaInterpolations.Interpolation1D.Flat()
     )
@@ -205,6 +206,7 @@ function PressureInterpolator(
     pressure_space::Union{
         Spaces.AbstractFiniteDifferenceSpace,
         Spaces.ExtrudedFiniteDifferenceSpace,
+        Spaces.MultiColumnFiniteDifferenceSpace,
     };
     extrapolate = ClimaInterpolations.Interpolation1D.Flat(),
 )

--- a/src/Remapping/remapping_utils.jl
+++ b/src/Remapping/remapping_utils.jl
@@ -161,7 +161,7 @@ function default_target_hcoords(
     return nothing
 end
 
-# Point-cloud columns have no horizontal interpolation
+# Multi-column spaces have no horizontal interpolation
 function default_target_hcoords(
     space::Union{
         Spaces.MultiColumnFiniteDifferenceSpace,
@@ -172,7 +172,7 @@ function default_target_hcoords(
     return nothing
 end
 
-# Point clouds have no vertical extent
+# Multi-point spaces have no vertical extent
 function default_target_zcoords(
     space::Spaces.MultiPointSpace;
     zresolution = nothing,

--- a/test/InputOutput/unit_multicolumn.jl
+++ b/test/InputOutput/unit_multicolumn.jl
@@ -9,7 +9,7 @@ import Random
 const comms_ctx = ClimaComms.SingletonCommsContext(ClimaComms.device())
 filename = tempname(; cleanup = true)
 
-@testset "HDF5 restart test for multi-column point-cloud spaces" begin
+@testset "HDF5 restart test for multi-column spaces" begin
     Random.seed!(42)
     FT = Float32
     points = [

--- a/test/Remapping/unit_distributed_remapping.jl
+++ b/test/Remapping/unit_distributed_remapping.jl
@@ -973,7 +973,7 @@ if !with_mpi
         zcoords = [Geometry.ZPoint(z) for z in zpts]
 
         # Default target coordinates: no horizontal interpolation for
-        # multi-column spaces, and point-cloud level spaces opt out entirely
+        # multi-column spaces, and multi-point spaces opt out entirely
         @test isnothing(Remapping.default_target_hcoords(cspace))
         @test length(Remapping.default_target_zcoords(cspace)) == 30
         pcs = Spaces.horizontal_space(cspace)

--- a/test/Remapping/unit_interpolate_pressure.jl
+++ b/test/Remapping/unit_interpolate_pressure.jl
@@ -1,5 +1,5 @@
 using Test
-import ClimaCore.CommonSpaces: ExtrudedCubedSphereSpace, ColumnSpace
+import ClimaCore.CommonSpaces: ExtrudedCubedSphereSpace, ColumnSpace, MultiColumnSpace
 import ClimaCore.Remapping
 import ClimaCore.Remapping:
     PressureInterpolator, interpolate_pressure, interpolate_pressure!, update!
@@ -42,6 +42,26 @@ import ClimaInterpolations
         @test pfull_col_space.staggering == Grids.CellFace()
         @test pfull_col_space.grid.topology.mesh.faces ==
               Geometry.PPoint.([0.0, 1.0, 10.0, 100.0])
+
+        multicol_space = MultiColumnSpace(FT;
+            points = [
+                Geometry.LatLongPoint(FT(0), FT(0)),
+                Geometry.LatLongPoint(FT(10), FT(20)),
+            ],
+            z_elem = 10,
+            z_min = 0,
+            z_max = 1,
+            staggering = Grids.CellCenter(),
+        )
+
+        pfull_multicol_space =
+            Remapping.construct_pressure_space(FT, multicol_space, [0.0, 1.0, 10.0, 100.0])
+        @test pfull_multicol_space isa Spaces.MultiColumnFiniteDifferenceSpace
+        @test pfull_multicol_space.grid.horizontal_grid ===
+              multicol_space.grid.horizontal_grid
+        @test pfull_multicol_space.staggering == Grids.CellFace()
+        @test pfull_multicol_space.grid.vertical_grid.topology.mesh.faces ==
+              Geometry.PPoint.([0.0, 1.0, 10.0, 100.0])
     end
 end
 
@@ -61,8 +81,19 @@ for FT in (Float32, Float64)
         z_max = 1,
         staggering = Grids.CellCenter(),
     )
+    multicol_space = MultiColumnSpace(FT;
+        points = [
+            Geometry.LatLongPoint(FT(0), FT(0)),
+            Geometry.LatLongPoint(FT(10), FT(20)),
+            Geometry.LatLongPoint(FT(-30), FT(45)),
+        ],
+        z_elem = 10,
+        z_min = 0,
+        z_max = 1,
+        staggering = Grids.CellCenter(),
+    )
     @testset "Vertical interpolation to pressure coordinates ($FT)" begin
-        for space in (extruded_space, col_space)
+        for space in (extruded_space, col_space, multicol_space)
             pfull_field = fill(FT(1.0), space)
             pfull_field_array = Fields.field2array(pfull_field)
             tmp_pfull_field_array = Array(pfull_field_array)
@@ -131,7 +162,7 @@ for FT in (Float32, Float64)
     end
 
     @testset "Face spaces ($FT)" begin
-        for space in (extruded_space, col_space)
+        for space in (extruded_space, col_space, multicol_space)
             pfull_field = fill(FT(1.0), space)
             pfull_field_view = Fields.field2array(pfull_field)
             tmp_pfull_field_view = Array(pfull_field_view)
@@ -184,7 +215,7 @@ for FT in (Float32, Float64)
 
 
     @testset "Non monotonic pressure and z relationship ($FT)" begin
-        for space in (extruded_space, col_space)
+        for space in (extruded_space, col_space, multicol_space)
             pfull_field = fill(FT(1.0), space)
             pfull_field_view = Fields.field2array(pfull_field)
             tmp_pfull_field_view = Array(pfull_field_view)


### PR DESCRIPTION
This PR adds support for pressure remapping on space of multiple columns/points. This is needed to support diagnostics for spaces of multiple columns: https://github.com/CliMA/ClimaDiagnostics.jl/pull/188. The code was generated by a LLM.